### PR TITLE
Quick IRS Alignment

### DIFF
--- a/A32NX/layout.json
+++ b/A32NX/layout.json
@@ -182,7 +182,7 @@
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js",
-            "size": 35862,
+            "size": 36895,
             "date": "132402817714110148"
         },
         {
@@ -282,17 +282,17 @@
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.css",
-            "size": 1350,
+            "size": 1388,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.html",
-            "size": 9858,
+            "size": 9950,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.js",
-            "size": 3844,
+            "size": 4479,
             "date": "132402817714110148"
         },
         {


### PR DESCRIPTION
We have some people that love the systems of this airbus, but there are a few that are impatient to wait for the IRS to align. 
With one of the other commits earlier, the time it takes for the IRS to align is based on the current latitude of the aircraft which can take a while.

This PR will allow the user to set the IRS 3 knob to ATT while the others are set to NAV. If this conditions are set for 5 seconds the IRS will instantly align so the user doesn't have to wait around if they just want to get up in the air.

I highly suggest once we get a working EFB or MCDU Menu with custom settings, we move the conditions to there so it no longer checks the aircraft systems.