### PR TITLE
Selftest after off status knobs

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.css
@@ -203,3 +203,21 @@ a320-neo-eicas-element {
 .blue-text {
   color: #009696;
 }
+
+.SelfTestWrapper {
+	position: absolute;
+	left: 0%;
+	top: 0%;
+	width: 100%;
+	height: 100%;
+	border: none; 
+	display: none;
+}
+
+.SelfTest {
+	position:absolute;
+	top:0%;
+	left: 0%;
+	width: 100%;
+	height:100%;
+}

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.html
@@ -6,6 +6,13 @@
         <div id="Electricity" state="off">
             <div id="TopScreen">
                 <a320-neo-upper-ecam id="UpperECAM"></a320-neo-upper-ecam>
+				<div class="SelfTestWrapper" id="TopSelfTest">
+					<svg class="SelfTest" viewBox="0 0 600 600">
+						<rect fill="black" x="0" y="0" width="100%" height="100%"></rect>
+						<text class="self_test_text" fill="green" text-anchor="middle" x="50%" y="50%" font-size="30px" style="font-family: 'Roboto' !important">SELF TEST IN PROGRESS</text>
+						<text class="self_test_text2" fill="green" text-anchor="middle" x="50%" y="56%" font-size="30px" style="font-family: 'Roboto' !important">(MAX 40 SECONDS)</text>
+					</svg>
+				</div>
             </div>
 
             <div id="BottomScreen">
@@ -16,13 +23,13 @@
                 <a320-neo-lower-ecam-door style="display:none"></a320-neo-lower-ecam-door> <!-- MODIFIED -->
                 <a320-neo-lower-ecam-ftcl style="display:none"></a320-neo-lower-ecam-ftcl> <!-- MODIFIED -->
                 <eicas-common-display id="CommonDisplay"></eicas-common-display>
-            </div>
-            <div style="position: absolute; left: 0%; top: 0%; width: 100%; height: 100%; border: none;" id="SelfTestDiv">
-                <svg id="SelfTest" viewBox="0 0 600 600" style="position:absolute; top:0%; left: 0%; width: 100%; height:100%;">
-                    <rect fill="black" x="0" y="0" width="100%" height="100%"></rect>
-                    <text id="self_test_text" fill="green" text-anchor="middle" x="50%" y="50%" font-size="30px" style="font-family: 'Roboto' !important">SELF TEST IN PROGRESS</text>
-                    <text id="self_test_text2" fill="green" text-anchor="middle" x="50%" y="56%" font-size="30px" style="font-family: 'Roboto' !important">(MAX 40 SECONDS)</text>
-                </svg>
+				<div class="SelfTestWrapper" id="BottomSelfTest">
+					<svg class="SelfTest" viewBox="0 0 600 600">
+						<rect fill="black" x="0" y="0" width="100%" height="100%"></rect>
+						<text class="self_test_text" fill="green" text-anchor="middle" x="50%" y="50%" font-size="30px" style="font-family: 'Roboto' !important">SELF TEST IN PROGRESS</text>
+						<text class="self_test_text2" fill="green" text-anchor="middle" x="50%" y="56%" font-size="30px" style="font-family: 'Roboto' !important">(MAX 40 SECONDS)</text>
+					</svg>
+				</div>
             </div>
         </div>
     </div>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -36,7 +36,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         this.topSelfTestTimer = -1;
         this.topSelfTestTimerStarted = false;
         this.topSelfTestLastKnobValue = 1;
-                
+        
         this.bottomSelfTestDiv = this.querySelector("#BottomSelfTest");
         this.bottomSelfTestTimer = -1;
         this.bottomSelfTestTimerStarted = false;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -36,14 +36,14 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         this.topSelfTestTimer = -1;
         this.topSelfTestTimerStarted = false;
         this.topSelfTestLastKnobValue = 1;
-				
+                
         this.bottomSelfTestDiv = this.querySelector("#BottomSelfTest");
         this.bottomSelfTestTimer = -1;
         this.bottomSelfTestTimerStarted = false;
         this.bottomSelfTestLastKnobValue = 1;
-		
-		this.APULastValue = false;
-		this.externalPowerLastValue = false;
+        
+        this.APULastValue = false;
+        this.externalPowerLastValue = false;
 
         this.doorPageActivated = false;
         this.EngineStarter = 0;
@@ -73,8 +73,8 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         var engineOn = Simplane.getEngineActive(0) || Simplane.getEngineActive(1);
         var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
         var apuOn = SimVar.GetSimVarValue("L:APU_GEN_ONLINE", "bool");
-		let apuStatusChanged = (apuOn != this.APULastValue);
-		let externalPowerChanged = (externalPower != this.externalPowerLastValue);
+        let apuStatusChanged = (apuOn != this.APULastValue);
+        let externalPowerChanged = (externalPower != this.externalPowerLastValue);
 
         var isACPowerAvailable = engineOn || apuOn || externalPower;
         var DCBus = false;
@@ -95,52 +95,52 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
             SimVar.SetSimVarValue("L:ACPowerAvailable","bool",0);
         }
 
-		/**
-		 * Self test on top ECAM screen
-		 **/
-		
-		let topSelfTestCurrentKnobValue = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:22", "number");
-		
-		if(((topSelfTestCurrentKnobValue >= 0.1 && this.topSelfTestLastKnobValue < 0.1) || (externalPowerChanged || apuStatusChanged)) && !this.topSelfTestTimerStarted) {
-			this.topSelfTestDiv.style.display = "block";
+        /**
+         * Self test on top ECAM screen
+         **/
+        
+        let topSelfTestCurrentKnobValue = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:22", "number");
+        
+        if(((topSelfTestCurrentKnobValue >= 0.1 && this.topSelfTestLastKnobValue < 0.1) || (externalPowerChanged || apuStatusChanged)) && !this.topSelfTestTimerStarted) {
+            this.topSelfTestDiv.style.display = "block";
             this.topSelfTestTimer = 14.25;
             this.topSelfTestTimerStarted = true;
-		}
-		
+        }
+        
         if (this.topSelfTestTimer >= 0) {
             this.topSelfTestTimer -= _deltaTime / 1000;
             if (this.topSelfTestTimer <= 0) {
                 this.topSelfTestDiv.style.display = "none";
-				this.topSelfTestTimerStarted = false;
+                this.topSelfTestTimerStarted = false;
             }
         }
-		
-		this.topSelfTestLastKnobValue = topSelfTestCurrentKnobValue;
+        
+        this.topSelfTestLastKnobValue = topSelfTestCurrentKnobValue;
 
-		/**
-		 * Self test on bottom ECAM screen
-		 **/
-		
-		let bottomSelfTestCurrentKnobValue = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:23", "number");
-		
-		if(((bottomSelfTestCurrentKnobValue >= 0.1 && this.bottomSelfTestLastKnobValue < 0.1) || (externalPowerChanged || apuStatusChanged)) && !this.bottomSelfTestTimerStarted) {
-			this.bottomSelfTestDiv.style.display = "block";
+        /**
+         * Self test on bottom ECAM screen
+         **/
+        
+        let bottomSelfTestCurrentKnobValue = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:23", "number");
+        
+        if(((bottomSelfTestCurrentKnobValue >= 0.1 && this.bottomSelfTestLastKnobValue < 0.1) || (externalPowerChanged || apuStatusChanged)) && !this.bottomSelfTestTimerStarted) {
+            this.bottomSelfTestDiv.style.display = "block";
             this.bottomSelfTestTimer = 14.25;
             this.bottomSelfTestTimerStarted = true;
-		}
-		
+        }
+        
         if (this.bottomSelfTestTimer >= 0) {
             this.bottomSelfTestTimer -= _deltaTime / 1000;
             if (this.bottomSelfTestTimer <= 0) {
                 this.bottomSelfTestDiv.style.display = "none";
-				this.bottomSelfTestTimerStarted = false;
+                this.bottomSelfTestTimerStarted = false;
             }
         }
-		
-		this.bottomSelfTestLastKnobValue = bottomSelfTestCurrentKnobValue;
+        
+        this.bottomSelfTestLastKnobValue = bottomSelfTestCurrentKnobValue;
 
-		this.APULastValue = apuOn;
-		this.externalPowerLastValue = externalPower;
+        this.APULastValue = apuOn;
+        this.externalPowerLastValue = externalPower;
 
         // modification start here
         var currentAPUMasterState = SimVar.GetSimVarValue("FUELSYSTEM VALVE SWITCH:8", "Bool");  

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -31,9 +31,20 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
 
         this.lastAPUMasterState = 0; // MODIFIED
         this.externalPowerWhenApuMasterOnTimer = -1; // MODIFIED
-        this.selfTestDiv = this.querySelector("#SelfTestDiv");
-        this.selfTestTimer = -1;
-        this.selfTestTimerStarted = false;
+
+        this.topSelfTestDiv = this.querySelector("#TopSelfTest");
+        this.topSelfTestTimer = -1;
+        this.topSelfTestTimerStarted = false;
+        this.topSelfTestLastKnobValue = 1;
+				
+        this.bottomSelfTestDiv = this.querySelector("#BottomSelfTest");
+        this.bottomSelfTestTimer = -1;
+        this.bottomSelfTestTimerStarted = false;
+        this.bottomSelfTestLastKnobValue = 1;
+		
+		this.APULastValue = false;
+		this.externalPowerLastValue = false;
+
         this.doorPageActivated = false;
         this.EngineStarter = 0;
         this.EngineStart == 0
@@ -62,6 +73,8 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         var engineOn = Simplane.getEngineActive(0) || Simplane.getEngineActive(1);
         var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
         var apuOn = SimVar.GetSimVarValue("L:APU_GEN_ONLINE", "bool");
+		let apuStatusChanged = (apuOn != this.APULastValue);
+		let externalPowerChanged = (externalPower != this.externalPowerLastValue);
 
         var isACPowerAvailable = engineOn || apuOn || externalPower;
         var DCBus = false;
@@ -82,22 +95,52 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
             SimVar.SetSimVarValue("L:ACPowerAvailable","bool",0);
         }
 
-        // Check if engine is on so self test doesn't appear when not starting from cold and dark
-        if (engineOn) {
-            this.selfTestDiv.style.display = "none";
-            this.selfTestTimerStarted = true;
-        }
-        // Check if external power is on & timer not already started
-        if ((externalPower || apuOn) && !this.selfTestTimerStarted) {
-            this.selfTestTimer = 14.25;
-            this.selfTestTimerStarted = true;
-        } // timer
-        if (this.selfTestTimer >= 0) {
-            this.selfTestTimer -= _deltaTime / 1000;
-            if (this.selfTestTimer <= 0) {
-                this.selfTestDiv.style.display = "none";
+		/**
+		 * Self test on top ECAM screen
+		 **/
+		
+		let topSelfTestCurrentKnobValue = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:22", "number");
+		
+		if(((topSelfTestCurrentKnobValue >= 0.1 && this.topSelfTestLastKnobValue < 0.1) || (externalPowerChanged || apuStatusChanged)) && !this.topSelfTestTimerStarted) {
+			this.topSelfTestDiv.style.display = "block";
+            this.topSelfTestTimer = 14.25;
+            this.topSelfTestTimerStarted = true;
+		}
+		
+        if (this.topSelfTestTimer >= 0) {
+            this.topSelfTestTimer -= _deltaTime / 1000;
+            if (this.topSelfTestTimer <= 0) {
+                this.topSelfTestDiv.style.display = "none";
+				this.topSelfTestTimerStarted = false;
             }
         }
+		
+		this.topSelfTestLastKnobValue = topSelfTestCurrentKnobValue;
+
+		/**
+		 * Self test on bottom ECAM screen
+		 **/
+		
+		let bottomSelfTestCurrentKnobValue = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:23", "number");
+		
+		if(((bottomSelfTestCurrentKnobValue >= 0.1 && this.bottomSelfTestLastKnobValue < 0.1) || (externalPowerChanged || apuStatusChanged)) && !this.bottomSelfTestTimerStarted) {
+			this.bottomSelfTestDiv.style.display = "block";
+            this.bottomSelfTestTimer = 14.25;
+            this.bottomSelfTestTimerStarted = true;
+		}
+		
+        if (this.bottomSelfTestTimer >= 0) {
+            this.bottomSelfTestTimer -= _deltaTime / 1000;
+            if (this.bottomSelfTestTimer <= 0) {
+                this.bottomSelfTestDiv.style.display = "none";
+				this.bottomSelfTestTimerStarted = false;
+            }
+        }
+		
+		this.bottomSelfTestLastKnobValue = bottomSelfTestCurrentKnobValue;
+
+		this.APULastValue = apuOn;
+		this.externalPowerLastValue = externalPower;
 
         // modification start here
         var currentAPUMasterState = SimVar.GetSimVarValue("FUELSYSTEM VALVE SWITCH:8", "Bool");  

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.html
@@ -118,7 +118,7 @@
                 </div>
             </div>
 
-            <div style="position: absolute; left: 0%; top: 0%; width: 100%; height: 100%; border: none;" id="SelfTestDiv">
+            <div style="position: absolute; left: 0%; top: 0%; width: 100%; height: 100%; border: none; display: none;" id="SelfTestDiv">
                 <svg id="SelfTest" viewBox="0 0 600 600" style="position:absolute; top:0%; left: 0%; width: 100%; height:100%;">
                     <rect fill="black" x="0" y="0" width="100%" height="100%"></rect>
                     <text id="self_test_text" fill="green" text-anchor="middle" x="50%" y="50%" font-size="30px">SELF TEST IN PROGRESS</text>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
@@ -150,7 +150,6 @@ class A320_Neo_MFD_MainPage extends NavSystemPage {
 		}
 		
         if (this.selfTestTimer >= 0) {
-            console.log(this.selfTestTimer)
             this.selfTestTimer -= _deltaTime / 1000;
             if (this.selfTestTimer <= 0) {
                 this.selfTestDiv.style.display = "none";

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
@@ -91,14 +91,14 @@ class A320_Neo_MFD_MainPage extends NavSystemPage {
         this.info.showILS(this.showILS);
 
         //SELF TEST
-        this.selfTestDiv = document.querySelector('#SelfTestDiv');
+        this.selfTestDiv = document.querySelector("#SelfTestDiv");
         this.selfTestTimerStarted = false;
         this.selfTestTimer = -1;
         this.selfTestLastKnobValueFO = 1;
         this.selfTestLastKnobValueCAP = 1;
 
-		this.APULastValue = false;
-		this.externalPowerLastValue = false;
+        this.APULastValue = false;
+        this.externalPowerLastValue = false;
 
         this.electricity = this.gps.getChildById("Electricity")
     }
@@ -126,38 +126,35 @@ class A320_Neo_MFD_MainPage extends NavSystemPage {
         var engineOn = Simplane.getEngineActive(0) || Simplane.getEngineActive(1);
         var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
         var apuOn = SimVar.GetSimVarValue("APU SWITCH", "bool");
-		let apuStatusChanged = (apuOn != this.APULastValue);
-		let externalPowerChanged = (externalPower != this.externalPowerLastValue);
+        let apuStatusChanged = (apuOn != this.APULastValue);
+        let externalPowerChanged = (externalPower != this.externalPowerLastValue);
         
          /**
-		 * Self test on MFD screen
+         * Self test on MFD screen
          * TODO: Seperate both MFD screens, currently if the FO changes its screen, it also tests the screen for the captain and vice versa
-		 **/
-		 	
-		let selfTestCurrentKnobValueFO = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:21", "number");
+         **/
+             
+        let selfTestCurrentKnobValueFO = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:21", "number");
         let selfTestCurrentKnobValueCAP = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:19", "number");
-		
-		if(
-            (
-                (selfTestCurrentKnobValueFO >= 0.1 && this.selfTestLastKnobValueFO < 0.1) ||
-                (selfTestCurrentKnobValueCAP >= 0.1 && this.selfTestLastKnobValueCAP < 0.1) ||
-                (externalPowerChanged || apuStatusChanged)) &&
-                !this.selfTestTimerStarted
-            ) {
-			this.selfTestDiv.style.display = "block";
+
+        const FOKnobChanged = (selfTestCurrentKnobValueFO >= 0.1 && this.selfTestLastKnobValueFO < 0.1);
+        const CAPKnobChanged = (selfTestCurrentKnobValueCAP >= 0.1 && this.selfTestLastKnobValueCAP < 0.1);
+        
+        if((FOKnobChanged || CAPKnobChanged || (externalPowerChanged || apuStatusChanged)) && !this.selfTestTimerStarted) {
+            this.selfTestDiv.style.display = "block";
             this.selfTestTimer = 14.25;
             this.selfTestTimerStarted = true;
-		}
-		
+        }
+        
         if (this.selfTestTimer >= 0) {
             this.selfTestTimer -= _deltaTime / 1000;
             if (this.selfTestTimer <= 0) {
                 this.selfTestDiv.style.display = "none";
-				this.selfTestTimerStarted = false;
+                this.selfTestTimerStarted = false;
             }
         }
-		
-		this.selfTestLastKnobValueFO = selfTestCurrentKnobValueFO
+        
+        this.selfTestLastKnobValueFO = selfTestCurrentKnobValueFO
         this.selfTestLastKnobValueCAP = selfTestCurrentKnobValueCAP
         
         this.APULastValue = apuOn;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
@@ -89,9 +89,17 @@ class A320_Neo_MFD_MainPage extends NavSystemPage {
         this.showILS = SimVar.GetSimVarValue("L:BTN_LS_FILTER_ACTIVE", "bool");
         this.compass.showILS(this.showILS);
         this.info.showILS(this.showILS);
-        this.selfTestDiv = this.gps.getChildById("SelfTestDiv");
-        this.selfTestTimer = -1;
+
+        //SELF TEST
+        this.selfTestDiv = document.querySelector('#SelfTestDiv');
         this.selfTestTimerStarted = false;
+        this.selfTestTimer = -1;
+        this.selfTestLastKnobValueFO = 1;
+        this.selfTestLastKnobValueCAP = 1;
+
+		this.APULastValue = false;
+		this.externalPowerLastValue = false;
+
         this.electricity = this.gps.getChildById("Electricity")
     }
     onUpdate(_deltaTime) {
@@ -118,26 +126,45 @@ class A320_Neo_MFD_MainPage extends NavSystemPage {
         var engineOn = Simplane.getEngineActive(0) || Simplane.getEngineActive(1);
         var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
         var apuOn = SimVar.GetSimVarValue("APU SWITCH", "bool");
-
-        this.updateScreenState();
-
-        if (engineOn) {
-            this.selfTestDiv.style.display = "none";
+		let apuStatusChanged = (apuOn != this.APULastValue);
+		let externalPowerChanged = (externalPower != this.externalPowerLastValue);
+        
+         /**
+		 * Self test on MFD screen
+         * TODO: Seperate both MFD screens, currently if the FO changes its screen, it also tests the screen for the captain and vice versa
+		 **/
+		 	
+		let selfTestCurrentKnobValueFO = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:21", "number");
+        let selfTestCurrentKnobValueCAP = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:19", "number");
+		
+		if(
+            (
+                (selfTestCurrentKnobValueFO >= 0.1 && this.selfTestLastKnobValueFO < 0.1) ||
+                (selfTestCurrentKnobValueCAP >= 0.1 && this.selfTestLastKnobValueCAP < 0.1) ||
+                (externalPowerChanged || apuStatusChanged)) &&
+                !this.selfTestTimerStarted
+            ) {
+			this.selfTestDiv.style.display = "block";
+            this.selfTestTimer = 14.25;
             this.selfTestTimerStarted = true;
-        }
-        // Check if external power is on & timer not already started
-        if ((externalPower || apuOn) && !this.selfTestTimerStarted) {
-            this.selfTestTimer = 13.75;
-            this.selfTestTimerStarted = true;
-        }
-        // Timer
+		}
+		
         if (this.selfTestTimer >= 0) {
+            console.log(this.selfTestTimer)
             this.selfTestTimer -= _deltaTime / 1000;
             if (this.selfTestTimer <= 0) {
                 this.selfTestDiv.style.display = "none";
+				this.selfTestTimerStarted = false;
             }
         }
+		
+		this.selfTestLastKnobValueFO = selfTestCurrentKnobValueFO
+        this.selfTestLastKnobValueCAP = selfTestCurrentKnobValueCAP
         
+        this.APULastValue = apuOn;
+        this.externalPowerLastValue = externalPower;
+
+        this.updateScreenState();        
     }
 
     updateScreenState() {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.html
@@ -46,7 +46,7 @@
                 <airbus-fma id="FMA"></airbus-fma>
                 <jet-pfd-ils-indicator id="ILS"></jet-pfd-ils-indicator>
             </div>
-            <div style="position: absolute; left: 0%; top: 0%; width: 100%; height: 100%; border: none;" id="SelfTestDiv">
+            <div style="position: absolute; left: 0%; top: 0%; width: 100%; height: 100%; border: none; display: none;" id="SelfTestDiv">
                 <svg id="SelfTest" viewBox="0 0 600 600" style="position:absolute; top:0%; left: 0%; width: 100%; height:100%;">
                     <rect fill="black" x="0" y="0" width="100%" height="100%"></rect>
                     <text id="self_test_text" fill="green" text-anchor="middle" x="50%" y="50%" font-size="30px">SELF TEST IN PROGRESS</text>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
@@ -146,7 +146,7 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
 
 		/**
 		 * Self test on PFD screen
-         * TODO: Seperate both PFD screens, currently if the FO changes its screen, it also tests the screen for the captain and vice versa
+         * TODO: Seperate both PFD screens, currently if the FO changes its screen, it also tests the screen for the captain and vice versa.
 		 **/
 		 	
 		let selfTestCurrentKnobValueFO = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:20", "number");
@@ -193,10 +193,8 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
 
     updateScreenState() {
         if (SimVar.GetSimVarValue("L:ACPowerAvailable","bool")) {
-            //this.electricity.style.display = "block";
             this.electricity.style.display = "block"
         } else {
-            //this.electricity.style.display = "none";
             this.electricity.style.display = "none"
         }
     }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
@@ -57,7 +57,7 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
     }
     init() {
         super.init();
-		
+        
         this.showILS = SimVar.GetSimVarValue("L:BTN_LS_FILTER_ACTIVE", "bool");
         this.ils.showILS(this.showILS);
         this.compass.showILS(this.showILS);
@@ -86,10 +86,10 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
         this.selfTestTimer = -1;
         this.selfTestLastKnobValueFO = 1;
         this.selfTestLastKnobValueCAP = 1;
-		
-		this.APULastValue = false;
-		this.externalPowerLastValue = false;
-		
+        
+        this.APULastValue = false;
+        this.externalPowerLastValue = false;
+        
         this.electricity = document.querySelector('#Electricity')
     }
     onUpdate(_deltaTime) {
@@ -139,40 +139,37 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
         var engineOn = Simplane.getEngineActive(0) || Simplane.getEngineActive(1);
         var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
         var apuOn = SimVar.GetSimVarValue("APU SWITCH", "bool");
-		let apuStatusChanged = (apuOn != this.APULastValue);
-		let externalPowerChanged = (externalPower != this.externalPowerLastValue);
+        let apuStatusChanged = (apuOn != this.APULastValue);
+        let externalPowerChanged = (externalPower != this.externalPowerLastValue);
 
         var isPowerAvailable = engineOn || apuOn || externalPower;
 
-		/**
-		 * Self test on PFD screen
+        /**
+         * Self test on PFD screen
          * TODO: Seperate both PFD screens, currently if the FO changes its screen, it also tests the screen for the captain and vice versa.
-		 **/
-		 	
-		let selfTestCurrentKnobValueFO = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:20", "number");
-		let selfTestCurrentKnobValueCAP = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:18", "number");
-		
-		if(
-            (
-                (selfTestCurrentKnobValueFO >= 0.1 && this.selfTestLastKnobValueFO < 0.1) ||
-                (selfTestCurrentKnobValueCAP >= 0.1 && this.selfTestLastKnobValueCAP < 0.1) ||
-                (externalPowerChanged || apuStatusChanged)) &&
-                !this.selfTestTimerStarted
-            ) {
-			this.selfTestDiv.style.display = "block";
+         **/
+        
+        let selfTestCurrentKnobValueFO = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:20", "number");
+        let selfTestCurrentKnobValueCAP = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:18", "number");
+        
+        const FOKnobChanged = (selfTestCurrentKnobValueFO >= 0.1 && this.selfTestLastKnobValueFO < 0.1);
+        const CAPKnobChanged = (selfTestCurrentKnobValueCAP >= 0.1 && this.selfTestLastKnobValueCAP < 0.1);
+        
+        if((FOKnobChanged || CAPKnobChanged || (externalPowerChanged || apuStatusChanged)) && !this.selfTestTimerStarted) {
+            this.selfTestDiv.style.display = "block";
             this.selfTestTimer = 14.25;
             this.selfTestTimerStarted = true;
-		}
-		
+        }
+        
         if (this.selfTestTimer >= 0) {
             this.selfTestTimer -= _deltaTime / 1000;
             if (this.selfTestTimer <= 0) {
                 this.selfTestDiv.style.display = "none";
-				this.selfTestTimerStarted = false;
+                this.selfTestTimerStarted = false;
             }
         }
-		
-		this.selfTestLastKnobValueFO = selfTestCurrentKnobValueFO
+        
+        this.selfTestLastKnobValueFO = selfTestCurrentKnobValueFO
         this.selfTestLastKnobValueCAP = selfTestCurrentKnobValueCAP
 
         this.APULastValue = apuOn;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
@@ -57,6 +57,7 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
     }
     init() {
         super.init();
+		
         this.showILS = SimVar.GetSimVarValue("L:BTN_LS_FILTER_ACTIVE", "bool");
         this.ils.showILS(this.showILS);
         this.compass.showILS(this.showILS);
@@ -80,9 +81,16 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
         this.hasInitialized = true;
 
         //SELF TEST
-        this.selfTestDiv = this.gps.getChildById("SelfTestDiv");
+        this.selfTestDiv = document.querySelector('#SelfTestDiv');
         this.selfTestTimerStarted = false;
-        this.electricity = this.gps.getChildById("Electricity")
+        this.selfTestTimer = -1;
+        this.selfTestLastKnobValueFO = 1;
+        this.selfTestLastKnobValueCAP = 1;
+		
+		this.APULastValue = false;
+		this.externalPowerLastValue = false;
+		
+        this.electricity = document.querySelector('#Electricity')
     }
     onUpdate(_deltaTime) {
         super.onUpdate();
@@ -131,26 +139,46 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
         var engineOn = Simplane.getEngineActive(0) || Simplane.getEngineActive(1);
         var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
         var apuOn = SimVar.GetSimVarValue("APU SWITCH", "bool");
+		let apuStatusChanged = (apuOn != this.APULastValue);
+		let externalPowerChanged = (externalPower != this.externalPowerLastValue);
 
         var isPowerAvailable = engineOn || apuOn || externalPower;
-        this.updateScreenState();
 
-        if (engineOn) {
-            this.selfTestDiv.style.display = "none";
+		/**
+		 * Self test on PFD screen
+         * TODO: Seperate both PFD screens, currently if the FO changes its screen, it also tests the screen for the captain and vice versa
+		 **/
+		 	
+		let selfTestCurrentKnobValueFO = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:20", "number");
+		let selfTestCurrentKnobValueCAP = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:18", "number");
+		
+		if(
+            (
+                (selfTestCurrentKnobValueFO >= 0.1 && this.selfTestLastKnobValueFO < 0.1) ||
+                (selfTestCurrentKnobValueCAP >= 0.1 && this.selfTestLastKnobValueCAP < 0.1) ||
+                (externalPowerChanged || apuStatusChanged)) &&
+                !this.selfTestTimerStarted
+            ) {
+			this.selfTestDiv.style.display = "block";
+            this.selfTestTimer = 14.25;
             this.selfTestTimerStarted = true;
-        }
-        // Check if external power is on & timer not already started
-        if ((externalPower || apuOn) && !this.selfTestTimerStarted) {
-            this.selfTestTimer = 13;
-            this.selfTestTimerStarted = true;
-        }
-        // Timer
-        if (this.selfTestTimer != null) {
+		}
+		
+        if (this.selfTestTimer >= 0) {
             this.selfTestTimer -= _deltaTime / 1000;
             if (this.selfTestTimer <= 0) {
                 this.selfTestDiv.style.display = "none";
+				this.selfTestTimerStarted = false;
             }
         }
+		
+		this.selfTestLastKnobValueFO = selfTestCurrentKnobValueFO
+        this.selfTestLastKnobValueCAP = selfTestCurrentKnobValueCAP
+
+        this.APULastValue = apuOn;
+        this.externalPowerLastValue = externalPower;
+        
+        this.updateScreenState();
     }
     onEvent(_event) {
         switch (_event) {
@@ -165,9 +193,11 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
 
     updateScreenState() {
         if (SimVar.GetSimVarValue("L:ACPowerAvailable","bool")) {
-            this.electricity.style.display = "block";
+            //this.electricity.style.display = "block";
+            this.electricity.style.display = "block"
         } else {
-            this.electricity.style.display = "none";
+            //this.electricity.style.display = "none";
+            this.electricity.style.display = "none"
         }
     }
     


### PR DESCRIPTION
This puts the panels in "self-test" mode after the knob has been turned from off to another position.

Known issue: We can't seperate the panels yet so when the FO turns his knob to off and back to something, the captains side will also self test. This can be fixed when we can seperate the panels somehow.