### PR TITLE
Rename the parent folder referenced in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For the Boxed edition:
 
 If the aforementioned methods do not work:
 * You can find your community folder by going into FS2020 general options and enabling developer mode. You will see a menu appear on top. Go to tools and virtual file system. Click on watch bases and your community folder will be listed in one of the folders.
-* Please make sure you're copying the "A32NX" folder into your community package folder, NOT the "msfs-a320neo-master" folder.
+* Please make sure you're copying the "A32NX" folder into your community package folder, NOT the "flybywiresim-a32nx" folder.
 
 ## Developing
 


### PR DESCRIPTION
Since this repository was moved, if you unpack the release .zip, the parent folder (that you should NOT copy) is named "flybywiresim-a32nx" not "msfs-a320neo-master".