### PR TITLE
build(type-definitions): add initial type definition file

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1,0 +1,47 @@
+declare global {
+
+    type NumberSimVarUnit = ("number" | "Number") | ("bool" | "Bool") | "Enum" | "lbs" | "kg" | "degree"
+    type TextSimVarUnit = "Text" | "string"
+
+    const SimVar: {
+        GetSimVarValue(name: string, type: NumberSimVarUnit): number
+        GetSimVarValue(name: string, type: TextSimVarUnit): string
+
+        SetSimVarValue(name: string, type: NumberSimVarUnit, value: number): void
+        SetSimVarValue(name: string, type: TextSimVarUnit, value: string): void
+    }
+
+    const Simplane: {
+        getVerticalSpeed(): number
+        getAltitude(): number
+        getHeadingMagnetic(): number
+
+        getIsGrounded(): boolean
+
+        getTotalAirTemperature(): number
+        getAmbientTemperature(): number
+
+        getAutoPilotAirspeedManaged(): boolean
+        getAutoPilotHeadingManaged(): boolean
+
+        getAutoPilotMachModeActive(): boolean
+    };
+
+    enum FlightPhase {
+        FLIGHT_PHASE_TAKEOFF,
+        FLIGHT_PHASE_CLIMB,
+        FLIGHT_PHASE_CRUISE,
+        FLIGHT_PHASE_APPROACH,
+        FLIGHT_PHASE_GOAROUND
+    }
+
+    enum ThrottleMode {
+        CLIMB,
+        FLEX_MCT,
+        TOGA,
+        AUTO
+    }
+
+}
+
+export {};


### PR DESCRIPTION
**Summary of Changes**

This PR adds base TypeScript definitions files.

This does not modify any JS code and does not interact with MSFS in any way. This is purely for convenience and development. Any modern text editor (VSCode, IntelliJ-based IDEs, etc.) will automatically detect those files and use them for type checking JavaScript files. The advantage of this is that currently, editors might report functions as non-existent due to the non-standard and builtin functions used by the code. With these type definitions, this problem is alleviated as the editor can now use them to understand that those values and functions do exist.

That assistance can always be disabled if it is problematic in any way.

It is encouraged to add onto those definitions when coming across a function that is undefined, according to the editor. 

**Screenshots (if necessary)**

![image](https://user-images.githubusercontent.com/4503241/92340512-a99bcd00-f088-11ea-8adb-4aeca8c15d89.png)

**Additional context**

N/A
