### PR TITLE
[CDU] The AIRWAYS page should only show the waypoints after the curre…

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
@@ -22,6 +22,9 @@ class A320_Neo_CDU_AirwaysFromWaypointPage {
             });
         };
         let showInput = false;
+        let departureWaypoints= mcdu.flightPlanManager.getDepartureWaypoints();
+        let routeWaypoints = mcdu.flightPlanManager.getEnRouteWaypoints();      
+        offset = routeWaypoints.indexOf(waypoint) >= 0 ? routeWaypoints.indexOf(waypoint) + (departureWaypoints.length ? 1 : 0) + 1 : offset;
         for (let i = 0; i < rows.length; i++) {
             if (allRows[i + offset]) {
                 rows[i] = allRows[i + offset];


### PR DESCRIPTION
…nt selected one

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #301
Also fixes an issue with waypoints not being visible sometimes when inserted in the temp plan before commiting.

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The AIRWAYS page should properly show just the enroute waypoints after the current selected one and not all of them. Players are now able to manually enter as many airway connected waypoints as needed.

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
N/A

**Additional context**
<!-- Add any other context about the pull request here. -->
N/A