### PR TITLE
ECAM clear and recall buttons

### DIFF
--- a/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
+++ b/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
@@ -809,6 +809,21 @@
 		<BASE_NAME>TOCONFIG</BASE_NAME>
 		<TOOLTIPID>Test T.O CONFIG</TOOLTIPID>
 	</UseTemplate>
+
+	<UseTemplate Name="ASOBO_ECAM_BUTTON_Template">
+		<BASE_NAME>CLR</BASE_NAME>
+		<TOOLTIPID>Clear ECAM messages</TOOLTIPID>
+	</UseTemplate>
+
+	<UseTemplate Name="ASOBO_ECAM_BUTTON_Template">
+		<BASE_NAME>CLR2</BASE_NAME>
+		<TOOLTIPID>Clear ECAM messages</TOOLTIPID>
+	</UseTemplate>
+
+	<UseTemplate Name="ASOBO_ECAM_BUTTON_Template">
+		<BASE_NAME>RCL</BASE_NAME>
+		<TOOLTIPID>Recall ECAM messages</TOOLTIPID>
+	</UseTemplate>
 </Template>
 
 <Template Name="ASOBO_AIRBUS_Push_Fuel_Pump_Template">

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -2735,16 +2735,7 @@
 			<NODE_ID>PUSH_ECAM_EMERCANC</NODE_ID>
 		</UseTemplate>
 		<UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
-			<NODE_ID>PUSH_ECAM_CLR</NODE_ID>
-		</UseTemplate>
-		<UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
 			<NODE_ID>PUSH_ECAM_STS</NODE_ID>
-		</UseTemplate>
-		<UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
-			<NODE_ID>PUSH_ECAM_RCL</NODE_ID>
-		</UseTemplate>
-		<UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
-			<NODE_ID>PUSH_ECAM_CLR2</NODE_ID>
 		</UseTemplate>
 		<UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
 			<NODE_ID>PUSH_ECAM_ALL</NODE_ID>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -187,6 +187,7 @@ var A320_Neo_UpperECAM;
                         name: "CONFIG",
                         messages: [
                             {
+                                id: "config_flaps",
                                 message: "",
                                 level: 3,
                                 isActive: () => {
@@ -201,6 +202,7 @@ var A320_Neo_UpperECAM;
                                 ]
                             },
                             {
+                                id: "config_spd_brk",
                                 message: "",
                                 level: 3,
                                 isActive: () => {
@@ -215,6 +217,7 @@ var A320_Neo_UpperECAM;
                                 ]
                             },
                             {
+                                id: "config_park_brake",
                                 message: "",
                                 level: 3,
                                 isActive: () => {
@@ -627,6 +630,17 @@ var A320_Neo_UpperECAM;
                 this.updateTakeoffConfigWarnings(true);
             }
 
+            if (SimVar.GetSimVarValue("L:A32NX_BTN_CLR", "Bool") == 1 || SimVar.GetSimVarValue("L:A32NX_BTN_CLR2", "Bool") == 1) {
+                SimVar.SetSimVarValue("L:A32NX_BTN_CLR", "Bool", 0);
+                SimVar.SetSimVarValue("L:A32NX_BTN_CLR2", "Bool", 0);
+                this.leftEcamMessagePanel.clearHighestCategory();
+            }
+
+            if (SimVar.GetSimVarValue("L:A32NX_BTN_RCL", "Bool") == 1) {
+                SimVar.SetSimVarValue("L:A32NX_BTN_RCL", "Bool", 0);
+                this.leftEcamMessagePanel.recall();
+            }
+
             const leftThrottleDetent = Simplane.getEngineThrottleMode(0);
             const rightThrottleDetent = Simplane.getEngineThrottleMode(1);
             const highestThrottleDetent = (leftThrottleDetent >= rightThrottleDetent) ? leftThrottleDetent : rightThrottleDetent;
@@ -652,6 +666,9 @@ var A320_Neo_UpperECAM;
                 this.takeoffMemoTimer = 0;
             } else {
                 SimVar.SetSimVarValue("L:A32NX_TO_CONFIG_NORMAL", "Bool", 0);
+                this.leftEcamMessagePanel.recall("config_flaps");
+                this.leftEcamMessagePanel.recall("config_spd_brk");
+                this.leftEcamMessagePanel.recall("config_park_brake");
             }
         }
         getInfoPanelManager() {
@@ -1355,6 +1372,7 @@ var A320_Neo_UpperECAM;
                 2: 0,
                 3: 0
             }
+            this.clearedMessages = [];
         }
         init() {
             super.init();
@@ -1457,17 +1475,42 @@ var A320_Neo_UpperECAM;
                 const messages = this.messages.failures[i].messages;
                 for (var n = 0; n < messages.length; n++) {
                     const message = messages[n];
-                    if (message.isActive()) {
+                    if (message.id == null) message.id = `${i} ${n}`;
+                    if (message.isActive() && !this.clearedMessages.includes(message.id)) {
                         this.hasActiveFailures = true;
                         if (output[i] == null) {
                             output[i] = this.messages.failures[i];
                             output[i].messages = [];
                         }
+                        
                         output[i].messages.push(message);
                     }
                 }
             }
             return output;
+        }
+
+        clearHighestCategory() {
+            const activeFailures = this.getActiveFailures();
+            for (const n in activeFailures) {
+                var category = activeFailures[n];
+                console.log(JSON.stringify(category));
+                for (const failure of category.messages) {
+                    this.clearedMessages.push(failure.id);
+                }
+                return;
+            }
+        }
+
+        recall(_failure) {
+            if (_failure != null) {
+                const index = this.clearedMessages.indexOf(_failure);
+                if (index > -1) {
+                    this.clearedMessages.splice(index, 1);
+                }
+            } else {
+                this.clearedMessages = [];
+            }
         }
 
         getActiveMessages() {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -670,7 +670,7 @@ var A320_Neo_UpperECAM;
 
             if (!(this.leftEcamMessagePanel.hasCautions)) SimVar.SetSimVarValue("L:A32NX_MASTER_CAUTION", "Bool", 0);
             if (!(this.leftEcamMessagePanel.hasWarnings)) SimVar.SetSimVarValue("L:A32NX_MASTER_WARNING", "Bool", 0);
-            
+
             if ((SimVar.GetSimVarValue("L:PUSH_OVHD_CALLS_ALL", "Bool") == 1) || (SimVar.GetSimVarValue("L:PUSH_OVHD_CALLS_FWD", "Bool") == 1) || (SimVar.GetSimVarValue("L:PUSH_OVHD_CALLS_AFT", "Bool") == 1)) {
                 SimVar.SetSimVarValue("L:A32NX_CABIN_READY", "Bool", 1);
             }
@@ -1492,7 +1492,7 @@ var A320_Neo_UpperECAM;
 
         
         getActiveFailures() {
-            var output = {};
+            let output = {};
             this.hasActiveFailures = false;
             this.hasWarnings = false;
             this.hasCautions = false;
@@ -1519,10 +1519,8 @@ var A320_Neo_UpperECAM;
 
         clearHighestCategory() {
             const activeFailures = this.getActiveFailures();
-            for (const n in activeFailures) {
-                var category = activeFailures[n];
-                console.log(JSON.stringify(category));
-                for (const failure of category.messages) {
+            for (const category in activeFailures) {
+                for (const failure of activeFailures[category].messages) {
                     this.clearedMessages.push(failure.id);
                 }
                 return;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -651,6 +651,9 @@ var A320_Neo_UpperECAM;
             if (Simplane.getCurrentFlightPhase() > 2) {
                 this.activeTakeoffConfigWarnings = [];
             }
+
+            if (!(this.leftEcamMessagePanel.hasCautions)) SimVar.SetSimVarValue("L:A32NX_MASTER_CAUTION", "Bool", 0);
+            if (!(this.leftEcamMessagePanel.hasWarnings)) SimVar.SetSimVarValue("L:A32NX_MASTER_WARNING", "Bool", 0);
         }
         updateTakeoffConfigWarnings(_test) {
             const flaps = SimVar.GetSimVarValue("FLAPS HANDLE INDEX", "Enum");
@@ -1471,6 +1474,8 @@ var A320_Neo_UpperECAM;
         getActiveFailures() {
             var output = {};
             this.hasActiveFailures = false;
+            this.hasWarnings = false;
+            this.hasCautions = false;
             for (var i = 0; i < this.messages.failures.length; i++) {
                 const messages = this.messages.failures[i].messages;
                 for (var n = 0; n < messages.length; n++) {
@@ -1478,6 +1483,8 @@ var A320_Neo_UpperECAM;
                     if (message.id == null) message.id = `${i} ${n}`;
                     if (message.isActive() && !this.clearedMessages.includes(message.id)) {
                         this.hasActiveFailures = true;
+                        if (message.level == 3) this.hasWarnings = true;
+                        if (message.level == 2) this.hasCautions = true;
                         if (output[i] == null) {
                             output[i] = this.messages.failures[i];
                             output[i].messages = [];


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->


**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
*  Added functional CLR and RCL buttons 
*  Master caution/warning will now automatically deactivate when messages are removed from ecam

The light on the clear button does not illuminate because it is missing a SEQ2 emission texture.