### PR TITLE
Toga engine fix and ecam updates 

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/engines.cfg
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/engines.cfg
@@ -38,13 +38,13 @@ oil_temp_cooling_constant = 0.21
 oil_temp_heating_constant = 700
 oil_temp_tc = 0.03
 oil_temp_tuning_constant = 1
-oil_press_max = 8640.2
+oil_press_max = 18640.2
 oil_press_tc = 0.8
 oil_press_tuning_constant = 1
 itt_peak_temperature = 2141
 itt_tc = 2
 itt_tuning_constant = 1
-egt_peak_temperature = 1600
+egt_peak_temperature = 1841.7
 egt_tc = 2
 egt_tuning_constant = 1
 fuel_press_max = 2376
@@ -88,9 +88,9 @@ fuel_flow_controller_d = 0.1
 fuel_flow_controller_iboundary = 10
 fuel_flow_controller_dboundary = 100
 max_torque_protection = 0 ; 0 = no protection, value of the torque triggering a protection by automatically limiting the fuelflow
-max_n1_protection = 104 ; 0 = no protection, value of the n1 triggering a protection by automatically limiting the fuelflow
-max_n2_protection = 105 ; 0 = no protection, value of the n2 triggering a protection by automatically limiting the fuelflow
-max_egt_protection = 2000 ; 0 = no protection, value of the egt triggering a protection by automatically limiting the fuelflow
+max_n1_protection = 101.4 ; 0 = no protection, value of the n1 triggering a protection by automatically limiting the fuelflow
+max_n2_protection = 116 ; 0 = no protection, value of the n2 triggering a protection by automatically limiting the fuelflow
+max_egt_protection = 2399.7 ; 0 = no protection, value of the egt triggering a protection by automatically limiting the fuelflow
 
 [JET_ENGINE]
 thrust_scalar = 0.88

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.css
@@ -1,0 +1,121 @@
+﻿:root {
+  --ecamDefaultColour: white;
+  --ecamUnitsColour: #009696;
+  --ecamValueColour: green;
+  --ecamWarningColour: #db7200;
+  --ecamDangerColour: red;
+  --ecamInactiveColour: #db7200;
+  --ecamSeparatorsColour: white; }
+  :root .Separator {
+    stroke: #3c3c3c;
+    stroke-width: 4;
+    fill: none; }
+  :root div {
+    font-family: Roboto-Bold; }
+  :root text {
+    font-family: Roboto-Bold; }
+  :root #PageTitle {
+    fill: var(--ecamDefaultColour);
+    font-size: 25px;
+    text-decoration: underline; }
+
+a320-neo-ecam-gauge {
+  display: inline-block;
+  margin-left: 15%;
+  width: get-vh(640px);
+  height: get-vh(640px); }
+  a320-neo-ecam-gauge text {
+    fill: var(--ecamDefaultColour);
+    font-size: 12px;
+    text-align: center;
+    text-anchor: middle; }
+  a320-neo-ecam-gauge #RootSVG {
+    overflow: visible;
+    width: 100%;
+    height: 100%; }
+    a320-neo-ecam-gauge #RootSVG #MainArc {
+      fill: none; }
+    a320-neo-ecam-gauge #RootSVG #MainArc.active {
+      stroke: var(--ecamDefaultColour); }
+    a320-neo-ecam-gauge #RootSVG #MainArc.inactive {
+      stroke: var(--ecamInactiveColour); }
+    a320-neo-ecam-gauge #RootSVG #RedArc {
+      fill: none;
+      stroke: var(--ecamDangerColour); }
+    a320-neo-ecam-gauge #RootSVG #RedArc.active {
+      display: block; }
+    a320-neo-ecam-gauge #RootSVG #RedArc.inactive {
+      display: none; }
+    a320-neo-ecam-gauge #RootSVG #GraduationsGroup line.InnerMarker {
+      stroke: var(--ecamDefaultColour); }
+    a320-neo-ecam-gauge #RootSVG #GraduationsGroup line.OuterMarker {
+      stroke: #db7200; }
+    a320-neo-ecam-gauge #RootSVG #GraduationsGroup.active {
+      display: block; }
+    a320-neo-ecam-gauge #RootSVG #GraduationsGroup.inactive {
+      display: none; }
+    a320-neo-ecam-gauge #RootSVG #CursorGroup {
+      width: 100%;
+      height: 100%; }
+      a320-neo-ecam-gauge #RootSVG #CursorGroup line {
+        stroke: var(--ecamValueColour);
+        stroke-width: 3; }
+      a320-neo-ecam-gauge #RootSVG #CursorGroup path {
+        fill: none;
+        stroke: var(--ecamDefaultColour);
+        stroke-width: 1px; }
+      a320-neo-ecam-gauge #RootSVG #CursorGroup .active {
+        display: block; }
+      a320-neo-ecam-gauge #RootSVG #CursorGroup .warning {
+        display: block;
+        stroke: var(--ecamWarningColour); }
+      a320-neo-ecam-gauge #RootSVG #CursorGroup .danger {
+        display: block;
+        stroke: var(--ecamDangerColour); }
+      a320-neo-ecam-gauge #RootSVG #CursorGroup .inactive {
+        display: none; }
+    a320-neo-ecam-gauge #RootSVG #OuterDynamicArcObject {
+      fill: none;
+      stroke: var(--ecamValueColour);
+      stroke-width: 4px; }
+    a320-neo-ecam-gauge #RootSVG #OuterDynamicArcObject.active {
+      display: block; }
+    a320-neo-ecam-gauge #RootSVG #OuterDynamicArcObject.inactive {
+      display: none; }
+    a320-neo-ecam-gauge #RootSVG #CurrentValue {
+      text-align: right;
+      text-anchor: end; }
+    a320-neo-ecam-gauge #RootSVG #CurrentValue.active {
+      fill: var(--ecamValueColour);
+      font-size: 15px; }
+    a320-neo-ecam-gauge #RootSVG #CurrentValue.warning {
+      fill: var(--ecamWarningColour);
+      font-size: 15px; }
+    a320-neo-ecam-gauge #RootSVG #CurrentValue.danger {
+      fill: var(--ecamDangerColour);
+      font-size: 15px; }
+    a320-neo-ecam-gauge #RootSVG #CurrentValue.inactive {
+      fill: var(--ecamInactiveColour);
+      font-size: 20px;
+      letter-spacing: 5px; }
+    a320-neo-ecam-gauge #RootSVG #CurrentValueBorder {
+      fill: none;
+      stroke: grey;
+      stroke-width: 3px; }
+    a320-neo-ecam-gauge #RootSVG #ExtraMessage {
+      width: 100%;
+      height: 100%; }
+      a320-neo-ecam-gauge #RootSVG #ExtraMessage rect {
+        fill: black;
+        stroke: grey;
+        stroke-width: 3px; }
+      a320-neo-ecam-gauge #RootSVG #ExtraMessage text {
+        text-align: center;
+        text-anchor: middle;
+        fill: var(--ecamValueColour);
+        font-size: 15px; }
+      a320-neo-ecam-gauge #RootSVG #ExtraMessage .active {
+        display: block; }
+      a320-neo-ecam-gauge #RootSVG #ExtraMessage .inactive {
+        display: none; }
+

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.css
@@ -59,11 +59,11 @@ a320-neo-ecam-gauge {
       height: 100%; }
       a320-neo-ecam-gauge #RootSVG #CursorGroup line {
         stroke: var(--ecamValueColour);
-        stroke-width: 3; }
+        stroke-width: 4; }
       a320-neo-ecam-gauge #RootSVG #CursorGroup path {
         fill: none;
         stroke: var(--ecamDefaultColour);
-        stroke-width: 1px; }
+        stroke-width: 2px; }
       a320-neo-ecam-gauge #RootSVG #CursorGroup .active {
         display: block; }
       a320-neo-ecam-gauge #RootSVG #CursorGroup .warning {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.js
@@ -1,0 +1,384 @@
+var A320_Neo_ECAM_Common;
+(function (A320_Neo_ECAM_Common) {
+    function isEngineDisplayActive(_index) {
+        return ((SimVar.GetSimVarValue("ENG N1 RPM:" + _index, "percent") >= 0.05) || (SimVar.GetSimVarValue("ENG N2 RPM:" + _index, "percent") >= 0.05));
+    }
+    A320_Neo_ECAM_Common.isEngineDisplayActive = isEngineDisplayActive;
+    class GaugeDefinition {
+        constructor() {
+            this.startAngle = -225;
+            this.arcSize = 180;
+            this.minValue = 0;
+            this.maxValue = 100;
+            this.minRedValue = 0;
+            this.maxRedValue = 0;
+            this.warningRange = [0, 0];
+            this.dangerRange = [0, 0];
+            this.cursorLength = 1.0;
+            this.currentValuePos = new Vec2(0.65, 0.65);
+            this.currentValueFunction = null;
+            this.currentValuePrecision = 0;
+            this.currentValueBorderWidth = 0;
+            this.outerIndicatorFunction = null;
+            this.outerDynamicArcFunction = null;
+            this.extraMessageFunction = null;
+        }
+    }
+    A320_Neo_ECAM_Common.GaugeDefinition = GaugeDefinition;
+    class Gauge extends HTMLElement {
+        constructor() {
+            super(...arguments);
+            this.viewBoxSize = new Vec2(100, 100);
+            this.startAngle = -225;
+            this.warningRange = [0, 0];
+            this.dangerRange = [0, 0];
+            this.outerDynamicArcCurrentValues = [0, 0];
+            this.outerDynamicArcTargetValues = [0, 0];
+            this.extraMessageString = "";
+            this.isActive = true;
+        }
+        get mainArcRadius() {
+            return (this.viewBoxSize.x * 0.5 * 0.975);
+        }
+        get graduationInnerLineEndOffset() {
+            return (this.mainArcRadius * 0.875);
+        }
+        get graduationOuterLineEndOffset() {
+            return (this.mainArcRadius * 1.175);
+        }
+        get graduationTextOffset() {
+            return (this.mainArcRadius * 0.625);
+        }
+        get redArcInnerRadius() {
+            return (this.mainArcRadius * 0.95);
+        }
+        get outerIndicatorOffset() {
+            return (this.viewBoxSize.x * 0.04);
+        }
+        get outerIndicatorRadius() {
+            return (this.viewBoxSize.x * 0.035);
+        }
+        get outerDynamicArcRadius() {
+            return (this.mainArcRadius * 1.15);
+        }
+        get currentValueBorderHeight() {
+            return (this.viewBoxSize.y * 0.20);
+        }
+        get extraMessagePosX() {
+            return (this.center.x + (this.viewBoxSize.x * 0.025));
+        }
+        get extraMessagePosY() {
+            return (this.center.y - (this.viewBoxSize.y * 0.025));
+        }
+        get extraMessageBorderPosX() {
+            return (this.extraMessagePosX - (this.viewBoxSize.x * 0.2));
+        }
+        get extraMessageBorderPosY() {
+            return (this.extraMessagePosY - (this.viewBoxSize.y * 0.09));
+        }
+        get extraMessageBorderWidth() {
+            return (this.viewBoxSize.x * 0.4);
+        }
+        get extraMessageBorderHeight() {
+            return (this.viewBoxSize.y * 0.20);
+        }
+        set active(_isActive) {
+            if (this.isActive != _isActive) {
+                this.isActive = _isActive;
+                this.refreshActiveState();
+            }
+        }
+        get active() {
+            return this.isActive;
+        }
+        polarToCartesian(_centerX, _centerY, _radius, _angleInDegrees) {
+            var angleInRadians = _angleInDegrees * (Math.PI / 180.0);
+            return new Vec2(_centerX + (_radius * Math.cos(angleInRadians)), _centerY + (_radius * Math.sin(angleInRadians)));
+        }
+        valueToAngle(_value, _radians) {
+            var valuePercentage = (_value - this.minValue) / (this.maxValue - this.minValue);
+            var angle = (this.startAngle + (valuePercentage * this.arcSize));
+            if (_radians) {
+                angle *= (Math.PI / 180.0);
+            }
+            return angle;
+        }
+        valueToDir(_value) {
+            var angle = this.valueToAngle(_value, true);
+            return (new Vec2(Math.cos(angle), Math.sin(angle)));
+        }
+        init(_gaugeDefinition) {
+            this.startAngle = _gaugeDefinition.startAngle;
+            this.arcSize = _gaugeDefinition.arcSize;
+            this.minValue = _gaugeDefinition.minValue;
+            this.maxValue = _gaugeDefinition.maxValue;
+            this.minRedValue = _gaugeDefinition.minRedValue;
+            this.maxRedValue = _gaugeDefinition.maxRedValue;
+            this.warningRange[0] = _gaugeDefinition.warningRange[0];
+            this.warningRange[1] = _gaugeDefinition.warningRange[1];
+            this.dangerRange[0] = _gaugeDefinition.dangerRange[0];
+            this.dangerRange[1] = _gaugeDefinition.dangerRange[1];
+            this.currentValueFunction = _gaugeDefinition.currentValueFunction;
+            this.currentValuePrecision = _gaugeDefinition.currentValuePrecision;
+            this.outerIndicatorFunction = _gaugeDefinition.outerIndicatorFunction;
+            this.outerDynamicArcFunction = _gaugeDefinition.outerDynamicArcFunction;
+            this.extraMessageFunction = _gaugeDefinition.extraMessageFunction;
+            this.endAngle = this.startAngle + _gaugeDefinition.arcSize;
+            this.center = new Vec2(this.viewBoxSize.x * 0.5, this.viewBoxSize.y * 0.5);
+            this.rootSVG = document.createElementNS(Avionics.SVG.NS, "svg");
+            this.rootSVG.id = "RootSVG";
+            this.rootSVG.setAttribute("viewBox", "0 0 " + this.viewBoxSize.x + " " + this.viewBoxSize.y);
+            this.appendChild(this.rootSVG);
+            this.mainArc = document.createElementNS(Avionics.SVG.NS, "path");
+            this.mainArc.id = "MainArc";
+            {
+                var startPos = this.polarToCartesian(this.center.x, this.center.y, this.mainArcRadius, this.endAngle);
+                var endPos = this.polarToCartesian(this.center.x, this.center.y, this.mainArcRadius, this.startAngle);
+                var largeArcFlag = ((this.endAngle - this.startAngle) <= 180) ? "0" : "1";
+                var d = ["M", startPos.x, startPos.y, "A", this.mainArcRadius, this.mainArcRadius, 0, largeArcFlag, 0, endPos.x, endPos.y].join(" ");
+                this.mainArc.setAttribute("d", d);
+            }
+            this.rootSVG.appendChild(this.mainArc);
+            if (this.minRedValue != this.maxRedValue) {
+                var minRedDir = this.valueToDir(this.minRedValue);
+                var maxRedDir = this.valueToDir(this.maxRedValue);
+                var topRight = new Vec2(this.center.x + (maxRedDir.x * this.mainArcRadius), this.center.y + (maxRedDir.y * this.mainArcRadius));
+                var topLeft = new Vec2(this.center.x + (minRedDir.x * this.mainArcRadius), this.center.y + (minRedDir.y * this.mainArcRadius));
+                var bottomRight = new Vec2(this.center.x + (maxRedDir.x * this.redArcInnerRadius), this.center.y + (maxRedDir.y * this.redArcInnerRadius));
+                var bottomLeft = new Vec2(this.center.x + (minRedDir.x * this.redArcInnerRadius), this.center.y + (minRedDir.y * this.redArcInnerRadius));
+                var d = [
+                    "M", topRight.x, topRight.y,
+                    "A", this.mainArcRadius, this.mainArcRadius, 0, "0", 0, topLeft.x, topLeft.y,
+                    "L", bottomLeft.x, bottomLeft.y,
+                    "M", topRight.x, topRight.y,
+                    "L", bottomRight.x, bottomRight.y,
+                    "A", this.redArcInnerRadius, this.redArcInnerRadius, 0, "0", 0, bottomLeft.x, bottomLeft.y
+                ].join(" ");
+                this.redArc = document.createElementNS(Avionics.SVG.NS, "path");
+                this.redArc.id = "RedArc";
+                this.redArc.setAttribute("d", d);
+                this.rootSVG.appendChild(this.redArc);
+            }
+            this.graduationsGroup = document.createElementNS(Avionics.SVG.NS, "g");
+            this.graduationsGroup.id = "GraduationsGroup";
+            this.rootSVG.appendChild(this.graduationsGroup);
+            var cursorGroup = document.createElementNS(Avionics.SVG.NS, "g");
+            cursorGroup.id = "CursorGroup";
+            this.cursor = document.createElementNS(Avionics.SVG.NS, "line");
+            this.cursor.setAttribute("x1", (this.mainArcRadius * (1 - _gaugeDefinition.cursorLength)).toString());
+            this.cursor.setAttribute("y1", "0");
+            this.cursor.setAttribute("x2", this.mainArcRadius.toString());
+            this.cursor.setAttribute("y2", "0");
+            cursorGroup.setAttribute("transform", "translate(" + this.center.x + ", " + this.center.y + ")");
+            cursorGroup.appendChild(this.cursor);
+            if (this.outerDynamicArcFunction != null) {
+                this.outerDynamicArcObject = document.createElementNS(Avionics.SVG.NS, "path");
+                this.outerDynamicArcObject.id = "OuterDynamicArcObject";
+                this.rootSVG.appendChild(this.outerDynamicArcObject);
+            }
+            if (this.outerIndicatorFunction != null) {
+                this.outerIndicatorObject = document.createElementNS(Avionics.SVG.NS, "path");
+                var radius = this.outerIndicatorRadius;
+                var d = [
+                    "M", (this.mainArcRadius + this.outerIndicatorOffset), "0",
+                    "a", radius, radius, "0 1 0", (radius * 2), "0",
+                    "a", radius, radius, "0 1 0", -(radius * 2), "0"
+                ].join(" ");
+                this.outerIndicatorObject.setAttribute("d", d);
+                cursorGroup.appendChild(this.outerIndicatorObject);
+            }
+            this.rootSVG.appendChild(cursorGroup);
+            var textPosX = this.viewBoxSize.x * _gaugeDefinition.currentValuePos.x;
+            var textPosY = this.viewBoxSize.x * _gaugeDefinition.currentValuePos.y;
+            this.currentValueText = document.createElementNS(Avionics.SVG.NS, "text");
+            this.currentValueText.id = "CurrentValue";
+            this.currentValueText.setAttribute("x", textPosX.toString());
+            this.currentValueText.setAttribute("y", textPosY.toString());
+            this.currentValueText.setAttribute("alignment-baseline", "central");
+            this.rootSVG.appendChild(this.currentValueText);
+            if (_gaugeDefinition.currentValueBorderWidth > 0) {
+                var borderWidth = this.viewBoxSize.x * _gaugeDefinition.currentValueBorderWidth;
+                var borderHeight = this.currentValueBorderHeight;
+                var borderPosX = textPosX - (borderWidth * 0.95);
+                var borderPosY = textPosY - (borderHeight * 0.5);
+                var currentValueBorder = document.createElementNS(Avionics.SVG.NS, "rect");
+                currentValueBorder.id = "CurrentValueBorder";
+                currentValueBorder.setAttribute("x", borderPosX.toString());
+                currentValueBorder.setAttribute("y", borderPosY.toString());
+                currentValueBorder.setAttribute("width", borderWidth.toString());
+                currentValueBorder.setAttribute("height", borderHeight.toString());
+                this.rootSVG.appendChild(currentValueBorder);
+            }
+            if (this.extraMessageFunction != null) {
+                var extraMessageGroup = document.createElementNS(Avionics.SVG.NS, "g");
+                extraMessageGroup.id = "ExtraMessage";
+                this.extraMessageBorder = document.createElementNS(Avionics.SVG.NS, "rect");
+                this.extraMessageBorder.setAttribute("x", this.extraMessageBorderPosX.toString());
+                this.extraMessageBorder.setAttribute("y", this.extraMessageBorderPosY.toString());
+                this.extraMessageBorder.setAttribute("width", this.extraMessageBorderWidth.toString());
+                this.extraMessageBorder.setAttribute("height", this.extraMessageBorderHeight.toString());
+                this.extraMessageBorder.setAttribute("class", "inactive");
+                extraMessageGroup.appendChild(this.extraMessageBorder);
+                this.extraMessageText = document.createElementNS(Avionics.SVG.NS, "text");
+                this.extraMessageText.setAttribute("x", this.extraMessagePosX.toString());
+                this.extraMessageText.setAttribute("y", this.extraMessagePosY.toString());
+                this.extraMessageText.setAttribute("alignment-baseline", "central");
+                this.extraMessageText.setAttribute("class", "inactive");
+                extraMessageGroup.appendChild(this.extraMessageText);
+                this.rootSVG.appendChild(extraMessageGroup);
+            }
+            this.refreshMainValue(this.minValue, true);
+            if (this.outerIndicatorFunction != null) {
+                this.refreshOuterIndicator(0, true);
+            }
+            if (this.outerDynamicArcFunction != null) {
+                this.refreshOuterDynamicArc(0, 0);
+            }
+            this.refreshActiveState();
+        }
+        addGraduation(_value, _showInnerMarker, _text = "", _showOuterMarker = false) {
+            var dir = this.valueToDir(_value);
+            if (_showInnerMarker) {
+                var start = new Vec2(this.center.x + (dir.x * this.mainArcRadius), this.center.y + (dir.y * this.mainArcRadius));
+                var end = new Vec2(this.center.x + (dir.x * this.graduationInnerLineEndOffset), this.center.y + (dir.y * this.graduationInnerLineEndOffset));
+                var marker = document.createElementNS(Avionics.SVG.NS, "line");
+                marker.setAttribute("class", "InnerMarker");
+                marker.setAttribute("x1", start.x.toString());
+                marker.setAttribute("y1", start.y.toString());
+                marker.setAttribute("x2", end.x.toString());
+                marker.setAttribute("y2", end.y.toString());
+                this.graduationsGroup.appendChild(marker);
+            }
+            if (_showOuterMarker) {
+                var start = new Vec2(this.center.x + (dir.x * this.mainArcRadius), this.center.y + (dir.y * this.mainArcRadius));
+                var end = new Vec2(this.center.x + (dir.x * this.graduationOuterLineEndOffset), this.center.y + (dir.y * this.graduationOuterLineEndOffset));
+                var marker = document.createElementNS(Avionics.SVG.NS, "line");
+                marker.setAttribute("class", "OuterMarker");
+                marker.setAttribute("x1", start.x.toString());
+                marker.setAttribute("y1", start.y.toString());
+                marker.setAttribute("x2", end.x.toString());
+                marker.setAttribute("y2", end.y.toString());
+                this.graduationsGroup.appendChild(marker);
+            }
+            if (_text.length > 0) {
+                var pos = new Vec2(this.center.x + (dir.x * this.graduationTextOffset), this.center.y + (dir.y * this.graduationTextOffset));
+                var text = document.createElementNS(Avionics.SVG.NS, "text");
+                text.textContent = _text;
+                text.setAttribute("x", pos.x.toString());
+                text.setAttribute("y", pos.y.toString());
+                text.setAttribute("alignment-baseline", "central");
+                this.graduationsGroup.appendChild(text);
+            }
+        }
+        refreshActiveState() {
+            var style = this.isActive ? "active" : "inactive";
+            if (this.mainArc != null) {
+                this.mainArc.setAttribute("class", style);
+            }
+            if (this.redArc != null) {
+                this.redArc.setAttribute("class", style);
+            }
+            if (this.graduationsGroup != null) {
+                this.graduationsGroup.setAttribute("class", style);
+            }
+            if (this.cursor != null) {
+                this.cursor.setAttribute("class", style);
+            }
+            if (this.outerIndicatorObject != null) {
+                this.outerIndicatorObject.setAttribute("class", style);
+            }
+            if (this.outerDynamicArcObject != null) {
+                this.outerDynamicArcObject.setAttribute("class", style);
+            }
+            if (this.currentValueText != null) {
+                this.currentValueText.setAttribute("class", style);
+                if (!this.isActive) {
+                    this.currentValueText.textContent = "XX";
+                }
+            }
+        }
+        update(_deltaTime) {
+            if (this.isActive) {
+                if (this.currentValueFunction != null) {
+                    this.refreshMainValue(this.currentValueFunction());
+                }
+                if (this.outerIndicatorFunction != null) {
+                    this.refreshOuterIndicator(this.outerIndicatorFunction() * 0.01);
+                }
+                if (this.outerDynamicArcFunction != null) {
+                    this.outerDynamicArcFunction(this.outerDynamicArcTargetValues);
+                    this.refreshOuterDynamicArc(this.outerDynamicArcTargetValues[0], this.outerDynamicArcTargetValues[1]);
+                }
+            }
+            if ((this.extraMessageFunction != null) && (this.extraMessageText != null) && (this.extraMessageBorder != null)) {
+                var extraMessage = this.isActive ? this.extraMessageFunction().toString() : "";
+                if (extraMessage != this.extraMessageString) {
+                    this.extraMessageString = extraMessage;
+                    var style = (this.extraMessageString.length > 0) ? "active" : "inactive";
+                    this.extraMessageText.textContent = this.extraMessageString;
+                    this.extraMessageText.setAttribute("class", style);
+                    this.extraMessageBorder.setAttribute("class", style);
+                }
+            }
+        }
+        refreshMainValue(_value, _force = false) {
+            if ((_value != this.currentValue) || _force) {
+                this.currentValue = _value;
+                var clampedValue = Utils.Clamp(this.currentValue, this.minValue, this.maxValue);
+                var style = "";
+                if ((this.dangerRange[0] != this.dangerRange[1]) && (clampedValue >= this.dangerRange[0]) && (clampedValue <= this.dangerRange[1])) {
+                    style = "danger";
+                }
+                else if ((this.warningRange[0] != this.warningRange[1]) && (clampedValue >= this.warningRange[0]) && (clampedValue <= this.warningRange[1])) {
+                    style = "warning";
+                }
+                else {
+                    style = "active";
+                }
+                if (this.cursor != null) {
+                    var angle = this.valueToAngle(clampedValue, false);
+                    this.cursor.setAttribute("transform", "rotate(" + angle + ")");
+                    this.cursor.setAttribute("class", style);
+                }
+                if (this.currentValueText != null) {
+                    var strValue = this.currentValue.toFixed(this.currentValuePrecision);
+                    this.currentValueText.textContent = strValue;
+                    this.currentValueText.setAttribute("class", style);
+                }
+            }
+        }
+        refreshOuterIndicator(_value, _force = false) {
+            if ((_value != this.outerIndicatorValue) || _force) {
+                this.outerIndicatorValue = _value;
+                if (this.outerIndicatorObject != null) {
+                    var angle = (this.startAngle + (this.outerIndicatorValue * this.arcSize));
+                    this.outerIndicatorObject.setAttribute("transform", "rotate(" + angle + ")");
+                }
+            }
+        }
+        refreshOuterDynamicArc(_start, _end, _force = false) {
+            if ((_start != this.outerDynamicArcCurrentValues[0]) || (_end != this.outerDynamicArcCurrentValues[1]) || _force) {
+                this.outerDynamicArcCurrentValues[0] = Utils.Clamp(_start, this.minValue, this.maxValue);
+                this.outerDynamicArcCurrentValues[1] = Utils.Clamp(_end, this.minValue, this.maxValue);
+                var d = "";
+                if (this.outerDynamicArcCurrentValues[0] != this.outerDynamicArcCurrentValues[1]) {
+                    var startAngle = this.valueToAngle(this.outerDynamicArcCurrentValues[0], true);
+                    var startX = this.center.x + (Math.cos(startAngle) * this.outerDynamicArcRadius);
+                    var startY = this.center.y + (Math.sin(startAngle) * this.outerDynamicArcRadius);
+                    var endAngle = this.valueToAngle(this.outerDynamicArcCurrentValues[1], true);
+                    var endX = this.center.x + (Math.cos(endAngle) * this.outerDynamicArcRadius);
+                    var endY = this.center.y + (Math.sin(endAngle) * this.outerDynamicArcRadius);
+                    var largeArcFlag = ((endAngle - startAngle) <= Math.PI) ? "0 0 0" : "0 1 0";
+                    d = [
+                        "M", endX, endY,
+                        "A", this.outerDynamicArcRadius, this.outerDynamicArcRadius, largeArcFlag, startX, startY
+                    ].join(" ");
+                }
+                this.outerDynamicArcObject.setAttribute("d", d);
+            }
+        }
+    }
+    A320_Neo_ECAM_Common.Gauge = Gauge;
+})(A320_Neo_ECAM_Common || (A320_Neo_ECAM_Common = {}));
+customElements.define('a320-neo-ecam-gauge', A320_Neo_ECAM_Common.Gauge);
+//# sourceMappingURL=A320_Neo_ECAMGauge.js.map

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
@@ -208,12 +208,14 @@ var A320_Neo_LowerECAM_APU;
             gaugeDef2.dangerRange[0] = 1000;
             gaugeDef2.dangerRange[1] = 1200;
             gaugeDef2.currentValueFunction = this.getAPUEGT.bind(this);
+            gaugeDef2.outerDynamicMarkerFunction = this.getAPUEGTWarn.bind(this,"EGTWarn");
             this.apuEGTGauge = window.document.createElement("a320-neo-ecam-gauge");
             this.apuEGTGauge.id = "APU_EGT_Gauge";
             this.apuEGTGauge.init(gaugeDef2);
             this.apuEGTGauge.addGraduation(300, true, "3");
             this.apuEGTGauge.addGraduation(700, true, "7");
             this.apuEGTGauge.addGraduation(1000, true, "10");
+            this.apuEGTGauge.addGraduation(1200,false,"",true,true,"EGTWarn");
             this.apuEGTGauge.active = false
             if (_gaugeDiv != null) {
                 _gaugeDiv.appendChild(this.apuEGTGauge);
@@ -263,25 +265,47 @@ var A320_Neo_LowerECAM_APU;
             return SimVar.GetSimVarValue("APU PCT RPM", "percent");
         }
 
+        //function accepts ID of the marker and returns an array with ID and EGT
+        getAPUEGTWarn(_id){
+            var n = this.getAPUN();
+            var ID_EGT = [];
+            ID_EGT.push(_id);
+            if(n < 11){
+                ID_EGT.push(1200);
+                return ID_EGT;
+            }
+            else if(n <= 15){
+                ID_EGT.push(((-50*n)+1750));
+                return ID_EGT;
+            }
+            else if(n <= 65){
+                ID_EGT.push(((-3*n)+1045));
+                return ID_EGT;
+            }
+            else{
+                ID_EGT.push(((-30/7*n)+1128.6));
+                return ID_EGT;
+            }
+        }
         //Calculates the APU EGT Based on the RPM, APU now reaches peak EGT of 765'C
         getAPUEGTRaw(startup) {
             var n = this.getAPUN();
             if (startup) {
                 if (n < 10) {
                     return 10;
-                } else if(n < 14){
+                } else if(n <= 14){
                     return (90/6*n) - 140;
-                } else if (n < 20) {
+                } else if (n <= 20) {
                     return (215/4*n) - 760;
-                } else if(n < 32){
+                } else if(n <= 32){
                     return (420/11*n) - 481.8;
-                } else if (n < 36) {
+                } else if (n <= 36) {
                     return (20/3*n) + 525;
-                } else if (n < 43) {
+                } else if (n <= 43) {
                     return (-15/6*n) + 888.3;
-                } else if(n < 50){
+                } else if(n <= 50){
                     return (3*n) + 618;
-                } else if(n < 74){
+                } else if(n <= 74){
                     return (-100/13*n) + 1152.3;
                 } else {
                     return (-104/10*n) + 1430;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.js
@@ -5,7 +5,7 @@ var A320_Neo_LowerECAM_Engine;
     Definitions.MIN_GAUGE_OIL = 0;
     Definitions.MAX_GAUGE_OIL = 25;
     Definitions.MIN_GAUGE_PSI = 0;
-    Definitions.MAX_GAUGE_PSI = 100;
+    Definitions.MAX_GAUGE_PSI = 130;       //updated from 100 to 130
     Definitions.MIN_GAUGE_PSI_RED = 0;
     Definitions.MAX_GAUGE_PSI_RED = 17;
     Definitions.MAX_GAUGE_PSI_WARNING = 25;
@@ -144,8 +144,8 @@ var A320_Neo_LowerECAM_Engine;
             this.oilPressureGauge = window.document.createElement("a320-neo-ecam-gauge");
             this.oilPressureGauge.id = "PSI_Gauge";
             this.oilPressureGauge.init(gaugeDef);
-            this.oilPressureGauge.addGraduation(50, true);
-            this.oilPressureGauge.addGraduation(100, true, "100");
+            this.oilPressureGauge.addGraduation(65, true);
+            this.oilPressureGauge.addGraduation(130, true, "");
             if (_gaugeDiv != null) {
                 _gaugeDiv.appendChild(this.oilQuantityGauge);
                 _gaugeDiv.appendChild(this.oilPressureGauge);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -3,9 +3,9 @@ var A320_Neo_UpperECAM;
     class Definitions {
     }
     Definitions.MIN_GAUGE_EGT = 0;
-    Definitions.MAX_GAUGE_EGT = 1000;
+    Definitions.MAX_GAUGE_EGT = 1200;
     Definitions.MIN_GAUGE_EGT_RED = 850;
-    Definitions.MAX_GAUGE_EGT_RED = 1000;
+    Definitions.MAX_GAUGE_EGT_RED = 1200;
     Definitions.MIN_GAUGE_N1 = 0;
     Definitions.MAX_GAUGE_N1 = 110;
     Definitions.THROTTLE_TO_N1_GAUGE = 100 / Definitions.MAX_GAUGE_N1;
@@ -187,7 +187,6 @@ var A320_Neo_UpperECAM;
                         name: "CONFIG",
                         messages: [
                             {
-                                id: "config_flaps",
                                 message: "",
                                 level: 3,
                                 isActive: () => {
@@ -202,7 +201,6 @@ var A320_Neo_UpperECAM;
                                 ]
                             },
                             {
-                                id: "config_spd_brk",
                                 message: "",
                                 level: 3,
                                 isActive: () => {
@@ -217,7 +215,6 @@ var A320_Neo_UpperECAM;
                                 ]
                             },
                             {
-                                id: "config_park_brake",
                                 message: "",
                                 level: 3,
                                 isActive: () => {
@@ -511,14 +508,6 @@ var A320_Neo_UpperECAM;
                                                         return (SimVar.GetSimVarValue("L:XMLVAR_SWITCH_OVHD_INTLT_SEATBELT_Position", "Bool") > 0);
                                                     }),
                                                 new A320_Neo_UpperECAM.MemoItem(
-                                                    "to-memo-cabin",
-                                                    "CABIN",
-                                                    "CHECK",
-                                                    "READY",
-                                                    function() {
-                                                        return (SimVar.GetSimVarValue("L:A32NX_CABIN_READY", "Bool") == 1);
-                                                    }),
-                                                new A320_Neo_UpperECAM.MemoItem(
                                                     "to-memo-splrs",
                                                     "SPLRS",
                                                     "ARM",
@@ -560,14 +549,6 @@ var A320_Neo_UpperECAM;
                                                         "ON",
                                                         function() {
                                                             return (SimVar.GetSimVarValue("L:XMLVAR_SWITCH_OVHD_INTLT_SEATBELT_Position", "Bool") > 0);
-                                                        }),
-                                                    new A320_Neo_UpperECAM.MemoItem(
-                                                        "ldg-memo-cabin",
-                                                        "CABIN",
-                                                        "CHECK",
-                                                        "READY",
-                                                        function() {
-                                                            return (SimVar.GetSimVarValue("L:A32NX_CABIN_READY", "Bool") == 1);
                                                         }),
                                                     new A320_Neo_UpperECAM.MemoItem(
                                                         "ldg-memo-splrs",
@@ -646,17 +627,6 @@ var A320_Neo_UpperECAM;
                 this.updateTakeoffConfigWarnings(true);
             }
 
-            if (SimVar.GetSimVarValue("L:A32NX_BTN_CLR", "Bool") == 1 || SimVar.GetSimVarValue("L:A32NX_BTN_CLR2", "Bool") == 1) {
-                SimVar.SetSimVarValue("L:A32NX_BTN_CLR", "Bool", 0);
-                SimVar.SetSimVarValue("L:A32NX_BTN_CLR2", "Bool", 0);
-                this.leftEcamMessagePanel.clearHighestCategory();
-            }
-
-            if (SimVar.GetSimVarValue("L:A32NX_BTN_RCL", "Bool") == 1) {
-                SimVar.SetSimVarValue("L:A32NX_BTN_RCL", "Bool", 0);
-                this.leftEcamMessagePanel.recall();
-            }
-
             const leftThrottleDetent = Simplane.getEngineThrottleMode(0);
             const rightThrottleDetent = Simplane.getEngineThrottleMode(1);
             const highestThrottleDetent = (leftThrottleDetent >= rightThrottleDetent) ? leftThrottleDetent : rightThrottleDetent;
@@ -666,13 +636,6 @@ var A320_Neo_UpperECAM;
 
             if (Simplane.getCurrentFlightPhase() > 2) {
                 this.activeTakeoffConfigWarnings = [];
-            }
-
-            if (!(this.leftEcamMessagePanel.hasCautions)) SimVar.SetSimVarValue("L:A32NX_MASTER_CAUTION", "Bool", 0);
-            if (!(this.leftEcamMessagePanel.hasWarnings)) SimVar.SetSimVarValue("L:A32NX_MASTER_WARNING", "Bool", 0);
-
-            if ((SimVar.GetSimVarValue("L:PUSH_OVHD_CALLS_ALL", "Bool") == 1) || (SimVar.GetSimVarValue("L:PUSH_OVHD_CALLS_FWD", "Bool") == 1) || (SimVar.GetSimVarValue("L:PUSH_OVHD_CALLS_AFT", "Bool") == 1)) {
-                SimVar.SetSimVarValue("L:A32NX_CABIN_READY", "Bool", 1);
             }
         }
         updateTakeoffConfigWarnings(_test) {
@@ -689,9 +652,6 @@ var A320_Neo_UpperECAM;
                 this.takeoffMemoTimer = 0;
             } else {
                 SimVar.SetSimVarValue("L:A32NX_TO_CONFIG_NORMAL", "Bool", 0);
-                this.leftEcamMessagePanel.recall("config_flaps");
-                this.leftEcamMessagePanel.recall("config_spd_brk");
-                this.leftEcamMessagePanel.recall("config_park_brake");
             }
         }
         getInfoPanelManager() {
@@ -763,6 +723,8 @@ var A320_Neo_UpperECAM;
             this.createN1Gauge();
             this.createEGTGauge();
             this.parent.appendChild(this.divMain);
+            this.timerTOGA = -1;
+            this.throttleMode = Math.max(Simplane.getEngineThrottleMode(0), Simplane.getEngineThrottleMode(1));
         }
         update(_deltaTime) {
             if (this.allGauges != null) {
@@ -773,6 +735,21 @@ var A320_Neo_UpperECAM;
                         this.allGauges[i].update(_deltaTime);
                     }
                 }
+            }
+            var currentThrottleState = Math.max(Simplane.getEngineThrottleMode(0), Simplane.getEngineThrottleMode(1));
+            if(this.throttleMode != currentThrottleState){
+                this.throttleMode = currentThrottleState;
+            }
+            if(this.throttleMode == ThrottleMode.TOGA){
+                if(this.timerTOGA == -1){
+                    this.timerTOGA = 300;
+                }
+                if(this.timerTOGA >= 0){
+                    this.timerTOGA -= _deltaTime/1000;
+                }
+            }
+            else{
+                this.timerTOGA = -1;
             }
         }
         createEGTGauge() {
@@ -789,6 +766,7 @@ var A320_Neo_UpperECAM;
             gaugeDef.currentValueBorderWidth = 0.5;
             gaugeDef.dangerRange[0] = gaugeDef.minRedValue;
             gaugeDef.dangerRange[1] = gaugeDef.maxRedValue;
+            gaugeDef.dangerMinDynamicFunction = this.getModeEGTMax.bind(this);
             gaugeDef.currentValueFunction = this.getEGTGaugeValue.bind(this);
             gaugeDef.currentValuePrecision = 0;
             this.gaugeEGT = window.document.createElement("a320-neo-ecam-gauge");
@@ -815,6 +793,7 @@ var A320_Neo_UpperECAM;
             gaugeDef.maxRedValue = A320_Neo_UpperECAM.Definitions.MAX_GAUGE_N1_RED;
             gaugeDef.dangerRange[0] = gaugeDef.minRedValue;
             gaugeDef.dangerRange[1] = gaugeDef.maxRedValue;
+            gaugeDef.dangerMinDynamicFunction = this.getModeN1Max.bind(this);
             gaugeDef.currentValueFunction = this.getN1GaugeValue.bind(this);
             gaugeDef.currentValuePrecision = 1;
             this.gaugeN1 = window.document.createElement("a320-neo-ecam-gauge");
@@ -829,6 +808,34 @@ var A320_Neo_UpperECAM;
             this.gaugeN1.addGraduation(100, true, "10", true);
             this.divMain.appendChild(this.gaugeN1);
             this.allGauges.push(this.gaugeN1);
+        }
+        getModeEGTMax(){
+            if(this.throttleMode == ThrottleMode.TOGA && this.timerTOGA > 0){
+                return 1060;
+            }
+            else if(this.timerTOGA <0){
+                return 1025;
+            }
+            if(this.throttleMode == ThrottleMode.FLEX_MCT){
+                return 1025;
+            }
+            if(this.throttleMode == ThrottleMode.CLIMB){
+                return 875;
+            }
+            if(this.ThrottleMode == ThrottleMode.AUTO){
+                return 850;
+            }
+            else{
+                return 750;
+            }
+        }
+        getModeN1Max(){
+            if(this.throttleMode == ThrottleMode.TOGA && this.timerTOGA > 0){
+                return 101.5;
+            }
+            else{
+                return 100;
+            }
         }
         getEGTGaugeValue() {
             var engineId = this.index + 1;
@@ -1395,7 +1402,6 @@ var A320_Neo_UpperECAM;
                 2: 0,
                 3: 0
             }
-            this.clearedMessages = [];
         }
         init() {
             super.init();
@@ -1492,50 +1498,23 @@ var A320_Neo_UpperECAM;
 
         
         getActiveFailures() {
-            let output = {};
+            var output = {};
             this.hasActiveFailures = false;
-            this.hasWarnings = false;
-            this.hasCautions = false;
             for (var i = 0; i < this.messages.failures.length; i++) {
                 const messages = this.messages.failures[i].messages;
                 for (var n = 0; n < messages.length; n++) {
                     const message = messages[n];
-                    if (message.id == null) message.id = `${i} ${n}`;
-                    if (message.isActive() && !this.clearedMessages.includes(message.id)) {
+                    if (message.isActive()) {
                         this.hasActiveFailures = true;
-                        if (message.level == 3) this.hasWarnings = true;
-                        if (message.level == 2) this.hasCautions = true;
                         if (output[i] == null) {
                             output[i] = this.messages.failures[i];
                             output[i].messages = [];
                         }
-                        
                         output[i].messages.push(message);
                     }
                 }
             }
             return output;
-        }
-
-        clearHighestCategory() {
-            const activeFailures = this.getActiveFailures();
-            for (const category in activeFailures) {
-                for (const failure of activeFailures[category].messages) {
-                    this.clearedMessages.push(failure.id);
-                }
-                return;
-            }
-        }
-
-        recall(_failure) {
-            if (_failure != null) {
-                const index = this.clearedMessages.indexOf(_failure);
-                if (index > -1) {
-                    this.clearedMessages.splice(index, 1);
-                }
-            } else {
-                this.clearedMessages = [];
-            }
         }
 
         getActiveMessages() {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -852,7 +852,7 @@ var A320_Neo_UpperECAM;
             if(this.throttleMode == ThrottleMode.TOGA && this.timerTOGA > 0){
                 return 1060;
             }
-            else if(this.timerTOGA <0){
+            else if(this.throttleMode == ThrottleMode.TOGA && this.timerTOGA <0){
                 return 1025;
             }
             if(this.throttleMode == ThrottleMode.FLEX_MCT){

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -187,6 +187,7 @@ var A320_Neo_UpperECAM;
                         name: "CONFIG",
                         messages: [
                             {
+                                id: "config_flaps",
                                 message: "",
                                 level: 3,
                                 isActive: () => {
@@ -201,6 +202,7 @@ var A320_Neo_UpperECAM;
                                 ]
                             },
                             {
+                                id: "config_spd_brk",
                                 message: "",
                                 level: 3,
                                 isActive: () => {
@@ -215,6 +217,7 @@ var A320_Neo_UpperECAM;
                                 ]
                             },
                             {
+                                id: "config_park_brake",
                                 message: "",
                                 level: 3,
                                 isActive: () => {
@@ -508,6 +511,14 @@ var A320_Neo_UpperECAM;
                                                         return (SimVar.GetSimVarValue("L:XMLVAR_SWITCH_OVHD_INTLT_SEATBELT_Position", "Bool") > 0);
                                                     }),
                                                 new A320_Neo_UpperECAM.MemoItem(
+                                                    "to-memo-cabin",
+                                                    "CABIN",
+                                                    "CHECK",
+                                                    "READY",
+                                                    function() {
+                                                        return (SimVar.GetSimVarValue("L:A32NX_CABIN_READY", "Bool") == 1);
+                                                    }),
+                                                new A320_Neo_UpperECAM.MemoItem(
                                                     "to-memo-splrs",
                                                     "SPLRS",
                                                     "ARM",
@@ -549,6 +560,14 @@ var A320_Neo_UpperECAM;
                                                         "ON",
                                                         function() {
                                                             return (SimVar.GetSimVarValue("L:XMLVAR_SWITCH_OVHD_INTLT_SEATBELT_Position", "Bool") > 0);
+                                                        }),
+                                                    new A320_Neo_UpperECAM.MemoItem(
+                                                        "ldg-memo-cabin",
+                                                        "CABIN",
+                                                        "CHECK",
+                                                        "READY",
+                                                        function() {
+                                                            return (SimVar.GetSimVarValue("L:A32NX_CABIN_READY", "Bool") == 1);
                                                         }),
                                                     new A320_Neo_UpperECAM.MemoItem(
                                                         "ldg-memo-splrs",
@@ -627,6 +646,16 @@ var A320_Neo_UpperECAM;
                 this.updateTakeoffConfigWarnings(true);
             }
 
+            if (SimVar.GetSimVarValue("L:A32NX_BTN_CLR", "Bool") == 1 || SimVar.GetSimVarValue("L:A32NX_BTN_CLR2", "Bool") == 1) {
+                SimVar.SetSimVarValue("L:A32NX_BTN_CLR", "Bool", 0);
+                SimVar.SetSimVarValue("L:A32NX_BTN_CLR2", "Bool", 0);
+                this.leftEcamMessagePanel.clearHighestCategory();
+            }
+
+            if (SimVar.GetSimVarValue("L:A32NX_BTN_RCL", "Bool") == 1) {
+                SimVar.SetSimVarValue("L:A32NX_BTN_RCL", "Bool", 0);
+                this.leftEcamMessagePanel.recall();
+            }
             const leftThrottleDetent = Simplane.getEngineThrottleMode(0);
             const rightThrottleDetent = Simplane.getEngineThrottleMode(1);
             const highestThrottleDetent = (leftThrottleDetent >= rightThrottleDetent) ? leftThrottleDetent : rightThrottleDetent;
@@ -636,6 +665,13 @@ var A320_Neo_UpperECAM;
 
             if (Simplane.getCurrentFlightPhase() > 2) {
                 this.activeTakeoffConfigWarnings = [];
+            }
+            
+            if (!(this.leftEcamMessagePanel.hasCautions)) SimVar.SetSimVarValue("L:A32NX_MASTER_CAUTION", "Bool", 0);
+            if (!(this.leftEcamMessagePanel.hasWarnings)) SimVar.SetSimVarValue("L:A32NX_MASTER_WARNING", "Bool", 0);
+
+            if ((SimVar.GetSimVarValue("L:PUSH_OVHD_CALLS_ALL", "Bool") == 1) || (SimVar.GetSimVarValue("L:PUSH_OVHD_CALLS_FWD", "Bool") == 1) || (SimVar.GetSimVarValue("L:PUSH_OVHD_CALLS_AFT", "Bool") == 1)) {
+                SimVar.SetSimVarValue("L:A32NX_CABIN_READY", "Bool", 1);
             }
         }
         updateTakeoffConfigWarnings(_test) {
@@ -652,6 +688,9 @@ var A320_Neo_UpperECAM;
                 this.takeoffMemoTimer = 0;
             } else {
                 SimVar.SetSimVarValue("L:A32NX_TO_CONFIG_NORMAL", "Bool", 0);
+                this.leftEcamMessagePanel.recall("config_flaps");
+                this.leftEcamMessagePanel.recall("config_spd_brk");
+                this.leftEcamMessagePanel.recall("config_park_brake");
             }
         }
         getInfoPanelManager() {
@@ -1402,6 +1441,7 @@ var A320_Neo_UpperECAM;
                 2: 0,
                 3: 0
             }
+            this.clearedMessages = [];
         }
         init() {
             super.init();
@@ -1498,24 +1538,50 @@ var A320_Neo_UpperECAM;
 
         
         getActiveFailures() {
-            var output = {};
+            let output = {};
             this.hasActiveFailures = false;
+                        this.hasWarnings = false;
+            this.hasCautions = false;
             for (var i = 0; i < this.messages.failures.length; i++) {
                 const messages = this.messages.failures[i].messages;
                 for (var n = 0; n < messages.length; n++) {
                     const message = messages[n];
+                    if (message.id == null) message.id = `${i} ${n}`;
+                    if (message.isActive() && !this.clearedMessages.includes(message.id)) {
                     if (message.isActive()) {
                         this.hasActiveFailures = true;
                         if (output[i] == null) {
                             output[i] = this.messages.failures[i];
                             output[i].messages = [];
                         }
+                        
                         output[i].messages.push(message);
                     }
                 }
             }
             return output;
         }
+            
+        clearHighestCategory() {
+            const activeFailures = this.getActiveFailures();
+            for (const category in activeFailures) {
+                for (const failure of activeFailures[category].messages) {
+                    this.clearedMessages.push(failure.id);
+                }
+                return;
+            }
+        }
+
+        recall(_failure) {
+            if (_failure != null) {
+                const index = this.clearedMessages.indexOf(_failure);
+                if (index > -1) {
+                    this.clearedMessages.splice(index, 1);
+                }
+            } else {
+                this.clearedMessages = [];
+            }
+        }    
 
         getActiveMessages() {
             const output = [];

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -666,7 +666,7 @@ var A320_Neo_UpperECAM;
             if (Simplane.getCurrentFlightPhase() > 2) {
                 this.activeTakeoffConfigWarnings = [];
             }
-            
+      
             if (!(this.leftEcamMessagePanel.hasCautions)) SimVar.SetSimVarValue("L:A32NX_MASTER_CAUTION", "Bool", 0);
             if (!(this.leftEcamMessagePanel.hasWarnings)) SimVar.SetSimVarValue("L:A32NX_MASTER_WARNING", "Bool", 0);
 
@@ -1535,12 +1535,11 @@ var A320_Neo_UpperECAM;
             }
             this.currentLine++;
         }
-
-        
+  
         getActiveFailures() {
             let output = {};
             this.hasActiveFailures = false;
-                        this.hasWarnings = false;
+            this.hasWarnings = false;
             this.hasCautions = false;
             for (var i = 0; i < this.messages.failures.length; i++) {
                 const messages = this.messages.failures[i].messages;
@@ -1548,8 +1547,9 @@ var A320_Neo_UpperECAM;
                     const message = messages[n];
                     if (message.id == null) message.id = `${i} ${n}`;
                     if (message.isActive() && !this.clearedMessages.includes(message.id)) {
-                    if (message.isActive()) {
                         this.hasActiveFailures = true;
+                        if (message.level == 3) this.hasWarnings = true;
+                        if (message.level == 2) this.hasCautions = true;
                         if (output[i] == null) {
                             output[i] = this.messages.failures[i];
                             output[i].messages = [];
@@ -1578,7 +1578,8 @@ var A320_Neo_UpperECAM;
                 if (index > -1) {
                     this.clearedMessages.splice(index, 1);
                 }
-            } else {
+            } 
+            else {
                 this.clearedMessages = [];
             }
         }    


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #110 

**Summary of Changes** Fixes the haphazard PR  #491 
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Fixed ATHR unstable on TOGA
 - Updated engine N1, EGT and Oil pressure values to match A320Neo engine limits.(temperature is in rankine, pressure in pounds per sq feet)
 - N1 and EGT now have dynamic limits based on throttle state(arrow does not turn red beyond 100%N1 on TOGA upto 101.5% for 5min).
 - TOGA state limits on N1 and EGT are only allowed upto 5min on both engines after which it comes down to MCT limits.

APU Guage now features a dynamic EGT warning marker.

Increased gauge px thickness by 1px.


**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->

![image](https://user-images.githubusercontent.com/19603746/92414862-c7922c00-f173-11ea-99d1-d58169372a77.png)

**Additional context**
<!-- Add any other context about the pull request here. -->
