### PR TITLE
fix(typescript): add some more simvar unit types

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1,8 +1,10 @@
 declare global {
 
-    type NumberSimVarUnit = ("number" | "Number") | ("bool" | "Bool") | "Enum" | "lbs" | "kg" | "degree" | ("Percent" | "percent")
-        | "Volts" | "Amperes" | "Hertz" | "PSI" | "celsius"
-    type TextSimVarUnit = "Text" | "string"
+    type NumberSimVarUnit = ("number" | "Number") | ("SINT32") | ("bool" | "Bool" | "Boolean" | "boolean") | "Enum" | "lbs" | "kg" | ("Degrees" | "degree")
+        | "radians" | ("Percent" | "percent") | ("Feet" | "feet" | "feets") | "Volts" | "Amperes" | "Hertz" | "PSI" | "celsius" | "degree latitude"
+        | "degree longitude" | "Meters per second" | "Position" | ("Knots" | "knots") | "Seconds"
+
+    type TextSimVarUnit = "Text" | "string" | ("Knots" | "knots")
 
     const SimVar: {
         GetSimVarValue(name: string, type: NumberSimVarUnit): number

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -4,7 +4,7 @@ declare global {
         | "radians" | ("Percent" | "percent") | ("Feet" | "feet" | "feets") | "Volts" | "Amperes" | "Hertz" | "PSI" | "celsius" | "degree latitude"
         | "degree longitude" | "Meters per second" | "Position" | ("Knots" | "knots") | "Seconds"
 
-    type TextSimVarUnit = "Text" | "string" | ("Knots" | "knots")
+    type TextSimVarUnit = "Text" | "string"
 
     const SimVar: {
         GetSimVarValue(name: string, type: NumberSimVarUnit): number


### PR DESCRIPTION
**Summary of Changes**

This PR adds quite a lot of simvar unit types. Some of them have very inconsistent spelling and capitalization in the original code, might wanna clean that up at some point.

**Screenshots (if necessary)**

N/A

**Additional context**

N/A