### PR TITLE
Fix Landing gear Indicator text illumination

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -18,6 +18,19 @@
 	<Include Path="Asobo\Airliner\GlassCockpit.xml"/>
 	<Include Path="Asobo\Airliner\Airbus.xml"/>
 
+<Template Name="A32NX_LANDING_GEAR_Light_Template">
+	<DefaultTemplateParameters>
+		<NODE_ID>LANDING_GEAR_Light_#ID#</NODE_ID>
+		<PART_ID>LANDING_GEAR_Light</PART_ID>
+		<SIMVAR>GEAR POSITION:#GEAR_ID#</SIMVAR>
+	</DefaultTemplateParameters>
+	<UseTemplate Name="ASOBO_GT_Push_Button_Airliner">
+		<DUMMY_BUTTON>True</DUMMY_BUTTON>
+		<SEQ1_EMISSIVE_CODE>0.01 99.99 (A:#SIMVAR#, Percent) rng</SEQ1_EMISSIVE_CODE>
+		<SEQ2_EMISSIVE_CODE>90 100 (A:#SIMVAR#, Percent) rng</SEQ2_EMISSIVE_CODE>
+	</UseTemplate>
+</Template>
+
 <!-- RETROECLAIRAGE #############################################################################################################-->
 	<Component ID="MCDU">
 		<UseTemplate Name="ASOBO_FMC_A320">
@@ -780,29 +793,20 @@
 			<ANIM_NAME>lever_landing_gear</ANIM_NAME>
 			<NODE_ID>LEVER_LANDINGGEAR</NODE_ID>
 		</UseTemplate>
-		<UseTemplate Name="ASOBO_LANDING_GEAR_Light_Template">
+		<UseTemplate Name="A32NX_LANDING_GEAR_Light_Template">
 			<NODE_ID>PUSH_AUTOBKR_LDGGEAR_1</NODE_ID>
 			<ID>1</ID>
-			<INVERT_CONDITION>1</INVERT_CONDITION>
-			<CUSTOM_RANGE>&gt; 90</CUSTOM_RANGE>
 			<GEAR_ID>1</GEAR_ID>
-			<AIRBUS_TYPE/>
 		</UseTemplate>
-		<UseTemplate Name="ASOBO_LANDING_GEAR_Light_Template">
+		<UseTemplate Name="A32NX_LANDING_GEAR_Light_Template">
 			<NODE_ID>PUSH_AUTOBKR_LDGGEAR_2</NODE_ID>
 			<ID>2</ID>
-			<INVERT_CONDITION>1</INVERT_CONDITION>
-			<CUSTOM_RANGE>&gt; 90</CUSTOM_RANGE>
 			<GEAR_ID>0</GEAR_ID>
-			<AIRBUS_TYPE/>
 		</UseTemplate>
-		<UseTemplate Name="ASOBO_LANDING_GEAR_Light_Template">
+		<UseTemplate Name="A32NX_LANDING_GEAR_Light_Template">
 			<NODE_ID>PUSH_AUTOBKR_LDGGEAR_3</NODE_ID>
 			<ID>3</ID>
-			<INVERT_CONDITION>1</INVERT_CONDITION>
-			<CUSTOM_RANGE>&gt; 90</CUSTOM_RANGE>
 			<GEAR_ID>2</GEAR_ID>
-			<AIRBUS_TYPE/>
 		</UseTemplate>
 		<UseTemplate Name="ASOBO_LANDING_GEAR_Warning_Template">
 			<ANIM_NAME>DECAL_LANDING_INDICATOR</ANIM_NAME>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #198 (which was closed by mistake)

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Fix `UNLK` text so it properly illuminates. This PR also replaces the default landing gear light template so it's easier to understand and maintain.

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->

Before:
![](https://clapton.dev/u/2009/1b932108.png)

After:
![](https://clapton.dev/u/2009/c65ab176.png)

After (at night):
![](https://clapton.dev/u/2009/90cdd3b4.png)

**Additional context**
<!-- Add any other context about the pull request here. -->

Funny enough the real fix here was to not do whatever Asobo was doing to calculate if this light should be on. Something about setting a simvar in the same expression block screwed things up. 