### PR TITLE
Added new secondary ECAM memos

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -442,11 +442,38 @@ var A320_Neo_UpperECAM;
                         }
                     },
                     {
-                        message: "PARK BRK",
+                        message: "SPEED BRK",
                         isActive: () => {
-                            return SimVar.GetSimVarValue("BRAKE PARKING INDICATOR", "Bool") == 1;
+                            return (SimVar.GetSimVarValue("SPOILERS HANDLE POSITION", "position") > 0);
                         }
                     },
+                    {
+                        message: "PARK BRK",
+                        isActive: () => {
+                            return (SimVar.GetSimVarValue("BRAKE PARKING INDICATOR", "Bool") == 1);
+                        }
+                    },
+                    {
+                        message: "HYD PTU",
+                        isActive: () => {
+                            // Rough approximation until hydraulic system fully implemented
+                            // Needs the last 2 conditions because PTU_ON is (incorrectly) permanently set to true during first engine start
+                            return (SimVar.GetSimVarValue("L:XMLVAR_PTU_ON", "Bool") == 1) && (SimVar.GetSimVarValue("ENG N1 RPM:1", "Percent") < 1 || SimVar.GetSimVarValue("ENG N1 RPM:2", "Percent") < 1);
+                        }
+                    },
+                    {
+                        message: "ENG A.ICE",
+                        isActive: () => {
+                            return (SimVar.GetSimVarValue("ENG ANTI ICE:1", "Bool") == 1) || (SimVar.GetSimVarValue("ENG ANTI ICE:2", "Bool") == 1);
+                        }
+                    },
+                    {
+                        message: "WING A.ICE",
+                        isActive: () => {
+                            return (SimVar.GetSimVarValue("STRUCTURAL DEICE SWITCH", "Bool") == 1);
+                        }
+                    },
+
                     {
                         message: "APU BLEED",
                         isActive: () => {
@@ -466,12 +493,6 @@ var A320_Neo_UpperECAM;
                         }
                     },
                     {
-                        message: "SPEED BRK",
-                        isActive: () => {
-                            return (SimVar.GetSimVarValue("SPOILERS HANDLE POSITION", "position") > 0);
-                        }
-                    },
-                    {
                         message: "AUTO BRK LO",
                         isActive: () => {
                             return (SimVar.GetSimVarValue("L:XMLVAR_Autobrakes_Level", "Enum") == 1);
@@ -487,6 +508,12 @@ var A320_Neo_UpperECAM;
                         message: "AUTO BRK MAX",
                         isActive: () => {
                             return (SimVar.GetSimVarValue("L:XMLVAR_Autobrakes_Level", "Enum") == 3);
+                        }
+                    },
+                    {
+                        message: "GPWS FLAP 3",
+                        isActive: () => {
+                            return (SimVar.GetSimVarValue("L:PUSH_OVHD_GPWS_LDG", "Bool") == 1);
                         }
                     }
                 ]


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

**Fixes:** #472 

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Added new secondary ECAM memo for wing anti-ice and engine anti-ice
- Added new secondary ECAM memo for GPWS Flaps 3 mode (tied to INOP Flaps 3 push button)
- Added new secondary ECAM memo for Hydraulic PTU, which is displayed when the PTU sound plays
- Moved speed brake secondary ECAM memo higher up in priority list (referenced from FSLabs A320)

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
![FlightSimulator_aMAHQQSf4p](https://user-images.githubusercontent.com/28059870/92551724-b822e980-f22c-11ea-94b6-c7813a50d409.png)


**Additional context**
<!-- Add any other context about the pull request here. -->
