### PR TITLE
Adjusted IRS alignment time, ECAM memo, and effect on GPWS buttons

### DIFF
--- a/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
+++ b/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
@@ -1190,7 +1190,7 @@
 	</UseTemplate>
 </Template>
 
-<Template Name="ASOBO_AIRLINER_GPWS_ALIGN_Template">
+<Template Name="A32NX_AIRLINER_GPWS_ALIGN_Template">
 	<UseTemplate Name="ASOBO_GT_Push_Button_Airliner">
 		<ANIM_NAME>#NODE_ID#</ANIM_NAME>
 		<WWISE_EVENT_1>master_apu_switch_on</WWISE_EVENT_1>

--- a/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
+++ b/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
@@ -1190,6 +1190,24 @@
 	</UseTemplate>
 </Template>
 
+<Template Name="ASOBO_AIRLINER_GPWS_ALIGN_Template">
+	<UseTemplate Name="ASOBO_GT_Push_Button_Airliner">
+		<ANIM_NAME>#NODE_ID#</ANIM_NAME>
+		<WWISE_EVENT_1>master_apu_switch_on</WWISE_EVENT_1>
+		<WWISE_EVENT_2>master_apu_switch_off</WWISE_EVENT_2>
+		<Condition Check="WAIT_FOR_ALIGN_TIME">
+			<True>
+				<SEQ1_EMISSIVE_CODE>(L:#NODE_ID#, Bool) ! (L:A320_Neo_ADIRS_STATE, Enum) 0 == (L:A320_Neo_ADIRS_STATE, Enum) 1 == (L:A320_Neo_ADIRS_TIME, seconds) #WAIT_FOR_ALIGN_TIME# &gt; and or and</SEQ1_EMISSIVE_CODE>
+			</True>
+			<False>
+				<SEQ1_EMISSIVE_CODE>(L:A320_Neo_ADIRS_STATE, Enum) 2 != (L:#NODE_ID#, Bool) ! and</SEQ1_EMISSIVE_CODE>
+			</False>
+		</Condition>
+		<SEQ2_EMISSIVE_CODE>(L:#NODE_ID#, Bool)</SEQ2_EMISSIVE_CODE>
+		<LEFT_SINGLE_CODE>(L:#NODE_ID#) ! (>L:#NODE_ID#)</LEFT_SINGLE_CODE>
+	</UseTemplate>
+</Template>
+
 <Template Name="ASOBO_AIRLINER_CALLS_Template">
 	<DefaultTemplateParameters>
 		<ANIM_NAME>#NODE_ID#</ANIM_NAME>

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -2552,13 +2552,15 @@
 
 	<Component ID="Overhead_Misc">
 		<Component ID="Left_Column">
-			<UseTemplate Name="ASOBO_AIRLINER_GPWS_Template">
+			<UseTemplate Name="ASOBO_AIRLINER_GPWS_ALIGN_Template">
 				<NODE_ID>PUSH_OVHD_GPWS_TERR</NODE_ID>
 				<TOOLTIPID>(INOP) TERR</TOOLTIPID>
+				<WAIT_FOR_ALIGN_TIME>120 0.055 (A:GPS POSITION LAT, degree latitude) 2 pow * +</WAIT_FOR_ALIGN_TIME>
 			</UseTemplate>
-			<UseTemplate Name="ASOBO_AIRLINER_GPWS_Template">
+			<UseTemplate Name="ASOBO_AIRLINER_GPWS_ALIGN_Template">
 				<NODE_ID>PUSH_OVHD_GPWS_SYS</NODE_ID>
 				<TOOLTIPID>(INOP) SYS</TOOLTIPID>
+				<WAIT_FOR_ALIGN_TIME>305 0.095 (A:GPS POSITION LAT, degree latitude) 2 pow * + (A:GPS POSITION LAT, degree latitude) 2 / -</WAIT_FOR_ALIGN_TIME>
 			</UseTemplate>
 			<UseTemplate Name="ASOBO_AIRLINER_GPWS_Template">
 				<NODE_ID>PUSH_OVHD_GPWS_GSMODE</NODE_ID>

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -2552,12 +2552,12 @@
 
 	<Component ID="Overhead_Misc">
 		<Component ID="Left_Column">
-			<UseTemplate Name="ASOBO_AIRLINER_GPWS_ALIGN_Template">
+			<UseTemplate Name="A32NX_AIRLINER_GPWS_ALIGN_Template">
 				<NODE_ID>PUSH_OVHD_GPWS_TERR</NODE_ID>
 				<TOOLTIPID>(INOP) TERR</TOOLTIPID>
 				<WAIT_FOR_ALIGN_TIME>120 0.055 (A:GPS POSITION LAT, degree latitude) 2 pow * +</WAIT_FOR_ALIGN_TIME>
 			</UseTemplate>
-			<UseTemplate Name="ASOBO_AIRLINER_GPWS_ALIGN_Template">
+			<UseTemplate Name="A32NX_AIRLINER_GPWS_ALIGN_Template">
 				<NODE_ID>PUSH_OVHD_GPWS_SYS</NODE_ID>
 				<TOOLTIPID>(INOP) SYS</TOOLTIPID>
 				<WAIT_FOR_ALIGN_TIME>305 0.095 (A:GPS POSITION LAT, degree latitude) 2 pow * + (A:GPS POSITION LAT, degree latitude) 2 / -</WAIT_FOR_ALIGN_TIME>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -818,7 +818,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_ATT", "Bool", 0);
             ADIRSState = 1;
             let currentLatitude = SimVar.GetSimVarValue("GPS POSITION LAT", "degree latitude")
-            ADIRSTimer = Math.abs(1.14 * currentLatitude) * 10; //ADIRS ALIGN TIME DEPENDING ON LATITUDE.
+            ADIRSTimer = (Math.pow(currentLatitude, 2) * 0.095) + 310; //ADIRS ALIGN TIME DEPENDING ON LATITUDE.
             SimVar.SetSimVarValue("L:A320_Neo_ADIRS_TIME", "Seconds", ADIRSTimer);
             SimVar.SetSimVarValue("L:A32NX_Neo_ADIRS_START_TIME", "Seconds", ADIRSTimer);
         }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -59,7 +59,7 @@ var A320_Neo_UpperECAM;
         }
         getADIRSMins() {
             const secs = SimVar.GetSimVarValue("L:A320_Neo_ADIRS_TIME", "seconds");
-            const mins = Math.floor(secs/60);
+            const mins = Math.ceil(secs/60);
             if (secs > 0) return mins;
             else return -1;
         }
@@ -351,15 +351,9 @@ var A320_Neo_UpperECAM;
                 ],
                 normal: [
                     {
-                        message: "IR IN ALIGN 0 MN",
-                        isActive: () => {
-                            return this.getADIRSMins() == 0;
-                        }
-                    },
-                    {
                         message: "IR IN ALIGN 1 MN",
                         isActive: () => {
-                            return this.getADIRSMins() == 1;
+                            return this.getADIRSMins() == 0 || this.getADIRSMins() == 1;
                         }
                     },
                     {
@@ -393,15 +387,9 @@ var A320_Neo_UpperECAM;
                         }
                     },
                     {
-                        message: "IR IN ALIGN 7 MN",
-                        isActive: () => {
-                            return this.getADIRSMins() == 7;
-                        }
-                    },
-                    {
                         message: "IR IN ALIGN >7 MN",
                         isActive: () => {
-                            return this.getADIRSMins() > 7;
+                            return this.getADIRSMins() >= 7;
                         }
                     },
                     {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -387,7 +387,7 @@ var A320_Neo_UpperECAM;
                         }
                     },
                     {
-                        message: "IR IN ALIGN >7 MN",
+                        message: "IR IN ALIGN > 7 MN",
                         isActive: () => {
                             return this.getADIRSMins() >= 7;
                         }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -351,45 +351,63 @@ var A320_Neo_UpperECAM;
                 ],
                 normal: [
                     {
-                        message: "IR IN ALIGN 1 MN",
+                        message: "IRS IN ALIGN 1 MN",
                         isActive: () => {
                             return this.getADIRSMins() == 0 || this.getADIRSMins() == 1;
                         }
                     },
                     {
-                        message: "IR IN ALIGN 2 MN",
+                        message: "IRS IN ALIGN 2 MN",
                         isActive: () => {
                             return this.getADIRSMins() == 2;
                         }
                     },
                     {
-                        message: "IR IN ALIGN 3 MN",
+                        message: "IRS IN ALIGN 3 MN",
                         isActive: () => {
                             return this.getADIRSMins() == 3;
                         }
                     },
                     {
-                        message: "IR IN ALIGN 4 MN",
+                        message: "IRS IN ALIGN 4 MN",
                         isActive: () => {
                             return this.getADIRSMins() == 4;
                         }
                     },
                     {
-                        message: "IR IN ALIGN 5 MN",
+                        message: "IRS IN ALIGN 5 MN",
                         isActive: () => {
                             return this.getADIRSMins() == 5;
                         }
                     },
                     {
-                        message: "IR IN ALIGN 6 MN",
+                        message: "IRS IN ALIGN 6 MN",
                         isActive: () => {
                             return this.getADIRSMins() == 6;
                         }
                     },
                     {
-                        message: "IR IN ALIGN >7 MN",
+                        message: "IRS IN ALIGN 7 MN",
                         isActive: () => {
-                            return this.getADIRSMins() >= 7;
+                            return this.getADIRSMins() == 7;
+                        }
+                    },
+                    {
+                        message: "IRS IN ALIGN 8 MN",
+                        isActive: () => {
+                            return this.getADIRSMins() == 8;
+                        }
+                    },
+                    {
+                        message: "IRS IN ALIGN 9 MN",
+                        isActive: () => {
+                            return this.getADIRSMins() == 9;
+                        }
+                    },
+                    {
+                        message: "IRS IN ALIGN >10 MN",
+                        isActive: () => {
+                            return this.getADIRSMins() >= 10;
                         }
                     },
                     {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -351,63 +351,45 @@ var A320_Neo_UpperECAM;
                 ],
                 normal: [
                     {
-                        message: "IRS IN ALIGN 1 MN",
+                        message: "IR IN ALIGN 1 MN",
                         isActive: () => {
                             return this.getADIRSMins() == 0 || this.getADIRSMins() == 1;
                         }
                     },
                     {
-                        message: "IRS IN ALIGN 2 MN",
+                        message: "IR IN ALIGN 2 MN",
                         isActive: () => {
                             return this.getADIRSMins() == 2;
                         }
                     },
                     {
-                        message: "IRS IN ALIGN 3 MN",
+                        message: "IR IN ALIGN 3 MN",
                         isActive: () => {
                             return this.getADIRSMins() == 3;
                         }
                     },
                     {
-                        message: "IRS IN ALIGN 4 MN",
+                        message: "IR IN ALIGN 4 MN",
                         isActive: () => {
                             return this.getADIRSMins() == 4;
                         }
                     },
                     {
-                        message: "IRS IN ALIGN 5 MN",
+                        message: "IR IN ALIGN 5 MN",
                         isActive: () => {
                             return this.getADIRSMins() == 5;
                         }
                     },
                     {
-                        message: "IRS IN ALIGN 6 MN",
+                        message: "IR IN ALIGN 6 MN",
                         isActive: () => {
                             return this.getADIRSMins() == 6;
                         }
                     },
                     {
-                        message: "IRS IN ALIGN 7 MN",
+                        message: "IR IN ALIGN >7 MN",
                         isActive: () => {
-                            return this.getADIRSMins() == 7;
-                        }
-                    },
-                    {
-                        message: "IRS IN ALIGN 8 MN",
-                        isActive: () => {
-                            return this.getADIRSMins() == 8;
-                        }
-                    },
-                    {
-                        message: "IRS IN ALIGN 9 MN",
-                        isActive: () => {
-                            return this.getADIRSMins() == 9;
-                        }
-                    },
-                    {
-                        message: "IRS IN ALIGN >10 MN",
-                        isActive: () => {
-                            return this.getADIRSMins() >= 10;
+                            return this.getADIRSMins() >= 7;
                         }
                     },
                     {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #500 

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- IRS alignment times based on latitude have been re-calculated
- IRS alignment ECAM memo now skips "IR IN ALIGN 0 MN" to match the real aircraft
- IRS alignment ECAM memo now skips "IR IN ALIGN 7 MN" to match the real aircraft
- IRS alignment ECAM memo now rounds up when converting seconds to minutes
- GPWS Terrain button now displays FAULT when IRS not aligned
- GPWS Sys button now displays FAULT when IRS not aligned

- IRS ECAM memo now goes up to >10 MN instead of >7 MN
- "IR IN ALIGN" replaced with updated "IRS IN ALIGN"

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
![image](https://user-images.githubusercontent.com/28059870/92583568-80ce3000-f260-11ea-8f3c-a3416526caec.png)


**Additional context**
<!-- Add any other context about the pull request here. -->
![image](https://user-images.githubusercontent.com/28059870/92595603-a19f8100-f272-11ea-90b8-c95dd6aa6cf2.png)
