### PR TITLE
[ECAM] Correct the orientation for the valves in the lower ENGINE ECAM

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.html
@@ -49,14 +49,14 @@
         <g id="StartValveDiagrams">
             <g id="StartValveDiagramLeft">
                 <circle r="12" cx="180" cy="456" />
-                <line id="StartValveLeft_OPEN" x1="168" y1="456" x2="192" y2="456" display="none"></line>
-                <line id="StartValveLeft_CLOSED" x1="180" y1="444" x2="180" y2="468" display="none"></line>
+                <line id="StartValveLeft_CLOSED" x1="168" y1="456" x2="192" y2="456" display="none"></line>
+                <line id="StartValveLeft_OPEN" x1="180" y1="444" x2="180" y2="468" display="none"></line>
             </g>
 
             <g id="StartValveDiagramRight">
                 <circle r="12" cx="420" cy="456" />
-                <line id="StartValveRight_OPEN" x1="408" y1="456" x2="432" y2="456" display="none"></line>
-                <line id="StartValveRight_CLOSED" x1="420" y1="444" x2="420" y2="468" display="none"></line>
+                <line id="StartValveRight_CLOSED" x1="408" y1="456" x2="432" y2="456" display="none"></line>
+                <line id="StartValveRight_OPEN" x1="420" y1="444" x2="420" y2="468" display="none"></line>
             </g>
         </g>
     </svg>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
N/A

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Correct the default orientation of the valves in the lower ENGINE ECAM, should be vertical for open and viceversa.

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
N/A

**Additional context**
<!-- Add any other context about the pull request here. -->
[https://youtu.be/Zsk72luNZvc?t=717](https://youtu.be/Zsk72luNZvc?t=717)