### PR TITLE
Small redesign for the F/CTL rudder axis, add moving rudder limit

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.html
@@ -140,12 +140,17 @@
         </g>
         <g id="rudderAxis">
             <path id="rudderPath" class="MainShape" d="M 350 469 A 100 100 0 0 1 250 469"></path>
-            <path id="rudderLeftLimitGreen" class="GreenShape" d="M246,473 l6,4"></path>
-            <path id="rudderLeftLimitWhite" class="MainShape" d="M253,464 l-6,10"></path>
-            <path id="rudderRightLimitGreen" class="GreenShape" d="M354,473 l-6,4"></path>
-            <path id="rudderRightLimitWhite" class="MainShape" d="M347,464 l6,10"></path>
-            <path id="rudderCenterThick" class="MainShape4" d="M300,482 l0,6"></path>
-            <path id="rudderCenterThin" class="MainShape" d="M300,482 l0,10"></path>
+            <path id="rudderCenter" class="MainShape" d="m302 482-6e-3 6-4 0.01 0.05-6"/>
+            <path id="rudderRightBorder" class="MainShape" d="m343 472 2 5-7 3-2-5"/>
+            <path id="rudderLeftBorder" class="MainShape" d="m257 472-2 5 7 3 2-5"/>
+        </g>
+        <g id="rudderLeftMaxAngle">
+            <path id="rudderLeftLimitGreen" class="GreenShape" d="m250 484 6 3"/>
+            <path id="rudderLeftLimitWhite" class="GreenShape" d="m257 472-7 13"/>
+        </g>
+        <g id="rudderRightMaxAngle">
+            <path id="rudderRightLimitGreen" class="GreenShape" d="m350 484-6 3" />
+            <path id="rudderRightLimitWhite" class="GreenShape" d="m343 472 7 13"/>
         </g>
         <g id="rudderCursor">
             <path id="rudderCircle" class="GreenShape" d="M 292 434 A 8 8 0 0 1 308 434"></path>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.js
@@ -43,6 +43,8 @@ var A320_Neo_LowerECAM_FTCL;
 
             //Rudder
             this.rudderCursor = this.querySelector("#rudderCursor");
+            this.rudderLeftMaxAngle = this.querySelector("#rudderLeftMaxAngle");
+            this.rudderRightMaxAngle = this.querySelector("#rudderRightMaxAngle");
 
             this.isInitialised = true;
         }
@@ -93,8 +95,20 @@ var A320_Neo_LowerECAM_FTCL;
 
             // Update rudder
             const rudderDeflectPct = SimVar.GetSimVarValue("RUDDER DEFLECTION PCT", "percent over 100");
-            const rudderAngle = -rudderDeflectPct * 29.06;
-            this.rudderCursor.setAttribute("transform", `rotate(${rudderAngle} 300 380)`)
+            const rudderAngle = -rudderDeflectPct * 25;
+            this.rudderCursor.setAttribute("transform", `rotate(${rudderAngle} 300 380)`);
+
+            //Update Rudder limits
+            const IndicatedAirspeed = SimVar.GetSimVarValue("AIRSPEED INDICATED", "knots");
+            let MaxAngleNorm = 1;
+            if(IndicatedAirspeed > 380){
+                MaxAngleNorm = 3.4 / 25;
+            } else if(IndicatedAirspeed > 160){
+                MaxAngleNorm = (69.2667 - 0.351818 * IndicatedAirspeed + 0.00047 * IndicatedAirspeed**2) / 25;
+            }
+
+            this.rudderLeftMaxAngle.setAttribute("transform", `rotate(${-26.4 * (1-MaxAngleNorm)} 300 385)`)
+            this.rudderRightMaxAngle.setAttribute("transform", `rotate(${26.4 * (1-MaxAngleNorm)} 300 385)`)
 
             // Update ELAC's and SEC's
             var elac1_On = SimVar.GetSimVarValue("FLY BY WIRE ELAC SWITCH:1", "boolean");


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* Slight redesign to the rudder axis, see this video: https://www.youtube.com/watch?v=HBeFp08XG5M
* Add moving max rudder indicators, according to this graph 
![grafik](https://user-images.githubusercontent.com/39596827/92649642-a2282e00-f2eb-11ea-9332-b819b39c3bcb.png)
provided by @JackZ974. The actual max rudder from the sim matches surprisingly well with this curve.


**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
![Screenshot (126)](https://user-images.githubusercontent.com/39596827/92649756-cc79eb80-f2eb-11ea-9c93-265ec014a8ad.png)
![Screenshot (127)](https://user-images.githubusercontent.com/39596827/92649762-cdab1880-f2eb-11ea-803f-325be3e08204.png)
![Screenshot (128)](https://user-images.githubusercontent.com/39596827/92649764-ce43af00-f2eb-11ea-877f-fd44f58359a5.png)


**Additional context**
<!-- Add any other context about the pull request here. -->
