### PR TITLE
Change acceleration altitude check from AGL altitude to MSL altitude

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -705,8 +705,8 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
 
         //Changes to climb phase when acceleration altitude is reached
         if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_TAKEOFF && airSpeed > 80) {
-            const agl = Simplane.getAltitudeAboveGround();
-            if (agl > (this.accelerationAltitude || this.thrustReductionAltitude || 1500)) {
+            const msl = Simplane.getAltitude();
+            if (msl > (this.accelerationAltitude || this.thrustReductionAltitude || 1500)) {
                 this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_CLIMB;
             }
         }


### PR DESCRIPTION
Change acceleration altitude check from AGL altitude to MSL altitude

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #552 

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Plane will now look at the barometer altitude to decide when to go into climb phase, rather than the altitude from ground. This is based on feedback from an IRL A320 pilot.