### PR TITLE
animate pfd alt during alignment

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AltimeterIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AltimeterIndicator.js
@@ -49,6 +49,7 @@ class Jet_PFD_AltimeterIndicator extends HTMLElement {
         this.groundLineSVGHeight = 0;
         this.thousandIndicator = null;
         this.targetAltitudeIndicatorSVGText = null;
+        this._delayedAltitude = 0;
         if (this.aircraft == Aircraft.CJ4) {
             this.construct_CJ4();
         }
@@ -1306,6 +1307,17 @@ class Jet_PFD_AltimeterIndicator extends HTMLElement {
     }
     update(_dTime) {
         var altitude = Simplane.getAltitude();
+
+        // This stuff makes the altimeter do a smooth rise to the actual altitude after alignment reaches a certain point
+        const desiredDisplayedAltitude = SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_FIRST", "Bool") === 0
+            ? 0
+            : altitude;
+        const delta = desiredDisplayedAltitude - this._delayedAltitude;
+        if (Math.abs(delta) > 0.01) {
+            this._delayedAltitude += delta * (4 * (_dTime / 1000));
+            altitude = this._delayedAltitude;
+        }
+
         var groundReference = altitude - Simplane.getAltitudeAboveGround();
         var baroMode = Simplane.getPressureSelectedMode(this.aircraft);
         var selectedAltitude;


### PR DESCRIPTION
**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Makes it so the altimeter on the PFD smoothly animates to the current altitude (from 0) once the altimeter becomes avail during alignment.

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->

reference (Partu_Grunt): https://youtu.be/qsQZsPFEf9o?t=67

after my changes: 
![pfd alt align2](https://user-images.githubusercontent.com/3533988/92668651-0390d280-f2d5-11ea-9105-e92c623e09be.gif)
