### PR TITLE
Fixed fuel display on ECAM as discussed in #283

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.js
@@ -118,12 +118,17 @@ var A320_Neo_LowerECAM_Fuel;
         }
         updateFuelConsumption(_unitFactor) {
             if (this.fuelLevels) {
-                var leftConsumption = SimVar.GetSimVarValue("GENERAL ENG FUEL USED SINCE START:" + 1, "gallon") * _unitFactor * 0.001;
-                var rightConsumption = SimVar.GetSimVarValue("GENERAL ENG FUEL USED SINCE START:" + 2, "gallon") * _unitFactor * 0.001;
-                var totalConsumption = leftConsumption + rightConsumption;
-                this.leftValveValue.textContent = fastToFixed(leftConsumption, 0);
-                this.rightValveValue.textContent = fastToFixed(rightConsumption, 0);
-                this.middleFuelValue.textContent = fastToFixed(totalConsumption, 0);
+                const leftConsumption = SimVar.GetSimVarValue("GENERAL ENG FUEL USED SINCE START:" + 1, "gallon") * _unitFactor * 0.001;
+                const rightConsumption = SimVar.GetSimVarValue("GENERAL ENG FUEL USED SINCE START:" + 2, "gallon") * _unitFactor * 0.001;
+                const totalConsumption = leftConsumption + rightConsumption;
+
+                const leftConsumptionShown = leftConsumption - leftConsumption % 10;
+                const rightConsumptionShown = rightConsumption - rightConsumption % 10;
+                const totalConsumptionShown = leftConsumptionShown + rightConsumptionShown;
+
+                this.leftValveValue.textContent = fastToFixed(leftConsumptionShown, 0);
+                this.rightValveValue.textContent = fastToFixed(rightConsumptionShown, 0);
+                this.middleFuelValue.textContent = fastToFixed(totalConsumptionShown, 0);
             }
             else {
                 this.fuelLevels = SimVar.GetGameVarValue("AIRCRAFT INITIAL FUEL LEVELS", "FuelLevels");
@@ -132,6 +137,7 @@ var A320_Neo_LowerECAM_Fuel;
         updateQuantity(_elem, _simvar, _unitFactor) {
             var quantity = SimVar.GetSimVarValue(_simvar, "gallons");
             quantity *= _unitFactor;
+            quantity -= quantity % 20;
             _elem.textContent = fastToFixed(quantity, 0);
         }
         setAPUState(_isOn, _isActive, _force = false) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.js
@@ -120,10 +120,9 @@ var A320_Neo_LowerECAM_Fuel;
             if (this.fuelLevels) {
                 const leftConsumption = SimVar.GetSimVarValue("GENERAL ENG FUEL USED SINCE START:" + 1, "gallon") * _unitFactor * 0.001;
                 const rightConsumption = SimVar.GetSimVarValue("GENERAL ENG FUEL USED SINCE START:" + 2, "gallon") * _unitFactor * 0.001;
-                const totalConsumption = leftConsumption + rightConsumption;
 
-                const leftConsumptionShown = leftConsumption - leftConsumption % 10;
-                const rightConsumptionShown = rightConsumption - rightConsumption % 10;
+                const leftConsumptionShown = leftConsumption - (leftConsumption % 10);
+                const rightConsumptionShown = rightConsumption - (rightConsumption % 10);
                 const totalConsumptionShown = leftConsumptionShown + rightConsumptionShown;
 
                 this.leftValveValue.textContent = fastToFixed(leftConsumptionShown, 0);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -1176,7 +1176,7 @@ var A320_Neo_UpperECAM;
         }
         setFuelOnBoard(_value, _force = false) {
             if ((this.currentFOBValue != _value) || _force) {
-                this.currentFOBValue = _value - _value % 20;
+                this.currentFOBValue = _value - (_value % 20);
                 if (this.fobValue != null) {
                     this.fobValue.textContent = fastToFixed(this.currentFOBValue, 0);
                 }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -1176,7 +1176,7 @@ var A320_Neo_UpperECAM;
         }
         setFuelOnBoard(_value, _force = false) {
             if ((this.currentFOBValue != _value) || _force) {
-                this.currentFOBValue = _value;
+                this.currentFOBValue = _value - _value % 20;
                 if (this.fobValue != null) {
                     this.fobValue.textContent = fastToFixed(this.currentFOBValue, 0);
                 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #283

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The values shown on the upper ECAM and lower ECAM (FUEL page) are modified according to the constraints discussed in issue #283.
They now have a precision of 20kg for fuel remaining and 10kg for fuel used.
