### PR TITLE
[CDU] Automatically fill in thrust reduction altitude and acceleration altitude based on runway height

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -93,7 +93,17 @@ class CDUInitPage {
             let value = mcdu.inOut;
             mcdu.clearUserInput();
             mcdu.tryUpdateFromTo(value, (result) => {
-                if (result) {
+                if (result) {                    
+                    let thrRedAccAltitude;
+                    
+                    const origin = mcdu.flightPlanManager.getOrigin();
+                    if (origin) {
+                        thrRedAccAltitude = origin.altitudeinFP + 1500;
+                    }
+                    
+                    mcdu.thrustReductionAltitude = thrRedAccAltitude;
+                    mcdu.accelerationAltitude = thrRedAccAltitude;
+                    
                     CDUAvailableFlightPlanPage.ShowPage(mcdu);
                 }
             });

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -94,15 +94,7 @@ class CDUInitPage {
             mcdu.clearUserInput();
             mcdu.tryUpdateFromTo(value, (result) => {
                 if (result) {                    
-                    let thrRedAccAltitude;
-                    
-                    const origin = mcdu.flightPlanManager.getOrigin();
-                    if (origin) {
-                        thrRedAccAltitude = origin.altitudeinFP + 1500;
-                    }
-                    
-                    mcdu.thrustReductionAltitude = thrRedAccAltitude;
-                    mcdu.accelerationAltitude = thrRedAccAltitude;
+                    CDUPerformancePage.UpdateThrRedAccFromOrigin(mcdu);
                     
                     CDUAvailableFlightPlanPage.ShowPage(mcdu);
                 }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -47,6 +47,12 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this._onModeManagedHeading();
         this._onModeManagedAltitude();
         SimVar.SetSimVarValue("K:VS_SLOT_INDEX_SET", "number", 1);
+
+        const groundAltitude = (parseInt(SimVar.GetSimVarValue("GROUND ALTITUDE", "feet")) || 0);
+        const thrRedAccAltitude = groundAltitude + 1500;
+
+        this.thrustReductionAltitude = thrRedAccAltitude;
+        this.accelerationAltitude = thrRedAccAltitude;
     }
     Update() {
         super.Update();

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -48,8 +48,12 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this._onModeManagedAltitude();
         SimVar.SetSimVarValue("K:VS_SLOT_INDEX_SET", "number", 1);
 
-        const groundAltitude = (parseInt(SimVar.GetSimVarValue("GROUND ALTITUDE", "feet")) || 0);
-        const thrRedAccAltitude = groundAltitude + 1500;
+        let thrRedAccAltitude;
+
+        let airport = this.flightPlanManager.getOrigin();
+        if (airport) {
+            thrRedAccAltitude = airport.infos.coordinates.alt + 1500;
+        }	
 
         this.thrustReductionAltitude = thrRedAccAltitude;
         this.accelerationAltitude = thrRedAccAltitude;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -47,16 +47,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this._onModeManagedHeading();
         this._onModeManagedAltitude();
 
-        let thrRedAccAltitude;
-        
-        const origin = this.flightPlanManager.getOrigin();
-        
-        if (origin) {
-            thrRedAccAltitude = origin.altitudeinFP + 1500;
-        }
-        
-        this.thrustReductionAltitude = thrRedAccAltitude;
-        this.accelerationAltitude = thrRedAccAltitude;
+        CDUPerformancePage.UpdateThrRedAccFromOrigin(this);
         
         SimVar.SetSimVarValue("K:VS_SLOT_INDEX_SET", "number", 1);
     }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -46,17 +46,19 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         }
         this._onModeManagedHeading();
         this._onModeManagedAltitude();
-        SimVar.SetSimVarValue("K:VS_SLOT_INDEX_SET", "number", 1);
 
         let thrRedAccAltitude;
-
-        let airport = this.flightPlanManager.getOrigin();
-        if (airport) {
-            thrRedAccAltitude = airport.infos.coordinates.alt + 1500;
-        }	
-
+        
+        const origin = this.flightPlanManager.getOrigin();
+        
+        if (origin) {
+            thrRedAccAltitude = origin.altitudeinFP + 1500;
+        }
+        
         this.thrustReductionAltitude = thrRedAccAltitude;
         this.accelerationAltitude = thrRedAccAltitude;
+        
+        SimVar.SetSimVarValue("K:VS_SLOT_INDEX_SET", "number", 1);
     }
     Update() {
         super.Update();

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -666,6 +666,15 @@ class CDUPerformancePage {
             CDUPerformancePage.ShowAPPRPage(mcdu);
         };
     }
+    static UpdateThrRedAccFromOrigin(mcdu) {
+        const origin = mcdu.flightPlanManager.getOrigin();
+        const thrRedAccAltitude = origin && origin.altitudeinFP 
+            ? origin.altitudeinFP + 1500 
+            : undefined;
+
+        mcdu.thrustReductionAltitude = thrRedAccAltitude;
+        mcdu.accelerationAltitude = thrRedAccAltitude;
+    }
 }
 CDUPerformancePage._timer = 0;
 //# sourceMappingURL=A320_Neo_CDU_PerformancePage.js.map


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #578 

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
On plane power on, so either when powering on the plane from C&D or when entering the cockpit when starting the flight from the runway, the current MSL altitude of the ground is determined. That altitude + 1500 will be set into the thrust reduction altitude and the acceleration altitude on the PERF Take Off page, like it would in the real plane.

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
Before: 
![image](https://user-images.githubusercontent.com/4014454/92801437-e54ed380-f3b5-11ea-85dc-fa62c9fee797.png)

After:
![image](https://user-images.githubusercontent.com/4014454/92800832-5b9f0600-f3b5-11ea-8cf1-504e72504ca5.png)
