### PR TITLE
Fix MCDU green dot speed

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -22,11 +22,6 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
                 this._registered = true;
             });
         });
-
-        // TODO: Remove
-        if (typeof g_modDebugMgr != "undefined") {
-            g_modDebugMgr.AddConsole(null);
-        }
     }
     Init() {
         super.Init();

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -22,6 +22,11 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
                 this._registered = true;
             });
         });
+
+        // TODO: Remove
+        if (typeof g_modDebugMgr != "undefined") {
+            g_modDebugMgr.AddConsole(null);
+        }
     }
     Init() {
         super.Init();
@@ -92,9 +97,43 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         let dWeight = (this.getWeight() - 47) / (78 - 47);
         return 154 + 44 * dWeight;
     }
-    getCleanTakeOffSpeed() {
-        let dWeight = (this.getWeight() - 47) / (78 - 47);
-        return 170 + 51 * dWeight;
+
+    /**
+     * Get aircraft takeoff and approach green dot speed
+     * Calculation:
+     * Gross weight in thousandths (KG) * 2 + 85 when below FL200
+     * @returns {number}
+     */
+    getPerfGreenDotSpeed() {
+        return ((this.getGrossWeight('kg') / 1000) * 2) + 85;
+    }
+
+    /**
+     * Get the gross weight of the aircraft from the addition
+     * of the ZFW, fuel and payload.
+     * @param unit
+     * @returns {number}
+     */
+    getGrossWeight(unit) {
+        const fuelWeight = SimVar.GetSimVarValue("FUEL TOTAL QUANTITY WEIGHT", unit);
+        const emptyWeight = SimVar.GetSimVarValue("EMPTY WEIGHT", unit);
+        const payloadWeight = this.getPayloadWeight(unit);
+        return Math.round(emptyWeight + fuelWeight + payloadWeight);
+    }
+
+    /**
+     * Get the payload of the aircraft, taking in to account each
+     * payload station
+     * @param unit
+     * @returns {number}
+     */
+    getPayloadWeight(unit) {
+        const payloadCount = SimVar.GetSimVarValue("PAYLOAD STATION COUNT", "number");
+        let payloadWeight = 0;
+        for (let i = 1; i <= payloadCount; i++) {
+            payloadWeight += SimVar.GetSimVarValue(`PAYLOAD STATION WEIGHT:${i}`, unit);
+        }
+        return payloadWeight;
     }
     _onModeSelectedSpeed() {
         if (SimVar.GetSimVarValue("L:A320_FCU_SHOW_SELECTED_SPEED", "number") === 0) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -148,7 +148,7 @@ class CDUPerformancePage {
             sltRetrCell = slatSpeed.toFixed(0) + "[color]green";
         }
         let cleanCell = "---";
-        let cleanSpeed = mcdu.getCleanTakeOffSpeed();
+        let cleanSpeed = mcdu.getPerfGreenDotSpeed();
         if (isFinite(cleanSpeed)) {
             cleanCell = cleanSpeed.toFixed(0) + "[color]green";
         }
@@ -606,7 +606,7 @@ class CDUPerformancePage {
             sltRetrCell = slatSpeed.toFixed(0) + "[color]green";
         }
         let cleanCell = "---";
-        let cleanSpeed = mcdu.getCleanApproachSpeed();
+        let cleanSpeed = mcdu.getPerfGreenDotSpeed();
         if (isFinite(cleanSpeed)) {
             cleanCell = cleanSpeed.toFixed(0) + "[color]green";
         }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

**Summary of Changes**
This fixes the green dot speed that is displayed on the PERF TAKEOFF and APPROACH pages of the MCDU. It utilises the formula from Airbus of:
`(gross weight in thousandths * 2) + 85kts`

It previously referenced random numbers added to the aircraft weight.

