### PR TITLE
Make speed tape more responsive

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AirspeedIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AirspeedIndicator.js
@@ -1824,9 +1824,7 @@ class Jet_PFD_AirspeedIndicator extends HTMLElement {
         }
 
         this._lastIASTime = newIASTime;
-
-        let accel = this._computedIASAcceleration;
-        return accel * 10;
+        return this._computedIASAcceleration * 10;
     }
     getAutopilotMode() {
         if (this.aircraft == Aircraft.A320_NEO) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AirspeedIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AirspeedIndicator.js
@@ -1818,28 +1818,14 @@ class Jet_PFD_AirspeedIndicator extends HTMLElement {
         frameIASAcceleration = Math.max(frameIASAcceleration, -10);
         
         if (isFinite(frameIASAcceleration)) {
-            // High pass filter for acceleration: https://en.wikipedia.org/wiki/High-pass_filter
-            // this._computedIASAcceleration = (frameIASAcceleration * this._accelAlpha)
-            //                               + (this._computedIASAcceleration * (1 - this._accelAlpha));
-        
             // Low pass filter for accel : https://en.wikipedia.org/wiki/Low-pass_filter
             this._computedIASAcceleration = this._computedIASAcceleration
                                           + this._accelAlpha * (frameIASAcceleration - this._computedIASAcceleration);
         }
 
         this._lastIASTime = newIASTime;
-        
-        // this._computedIASAcceleration = Math.min(this._computedIASAcceleration, 1.5);
-        // this._computedIASAcceleration = Math.max(this._computedIASAcceleration, -1.5);
 
-        // return frameIASAcceleration * 10;
         let accel = this._computedIASAcceleration;
-
-        // if (Math.abs(accel) < 0.05) {
-        //     accel = 0;
-        // }
-
-        console.log(accel);
         return accel * 10;
     }
     getAutopilotMode() {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AirspeedIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AirspeedIndicator.js
@@ -1819,8 +1819,7 @@ class Jet_PFD_AirspeedIndicator extends HTMLElement {
         
         if (isFinite(frameIASAcceleration)) {
             // Low pass filter for accel : https://en.wikipedia.org/wiki/Low-pass_filter
-            this._computedIASAcceleration = this._computedIASAcceleration
-                                          + this._accelAlpha * (frameIASAcceleration - this._computedIASAcceleration);
+            this._computedIASAcceleration += this._accelAlpha * (frameIASAcceleration - this._computedIASAcceleration);
         }
 
         this._lastIASTime = newIASTime;


### PR DESCRIPTION
Fixes #58

**Summary of Changes**
Use low pass filter to compute the acceleration trend

**Videos**
(before) https://cdn.discordapp.com/attachments/739973060857167912/754242118750568518/before-speedtape.mp4
(after) https://cdn.discordapp.com/attachments/739973060857167912/754242159686844426/after-speedtape2.mp4

**Additional context**
Reference: https://cdn.discordapp.com/attachments/747572666780745828/747661622637494373/speed-trend-vector-comparison_oBL4JKfz.compressed.mp4
