### PR TITLE
[PFD] V/S indicator Update (VerticalSpeedIndicator.js)

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/VerticalSpeedIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/VerticalSpeedIndicator.js
@@ -714,7 +714,7 @@ class Jet_PFD_VerticalSpeedIndicator extends HTMLElement {
                     let altitude = Simplane.getAltitudeAboveGround();
                     if ((altitude < 2500 && altitude > 1000 && vSpeed <= -2000) || (altitude < 1000 && vSpeed <= -1200)) //airbus alerts thresholds
                         alert = true;
-                    if ((vSpeed >=6000) || (vSpeed <= -6000)) alert = true; //airbus alerts thresholds
+                    if ((vSpeed >=6000) || (vSpeed <= -6000)) alert = true; // airbus alerts thresholds
                 }
 
                 if (this.cursorSVGLine) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/VerticalSpeedIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/VerticalSpeedIndicator.js
@@ -716,7 +716,6 @@ class Jet_PFD_VerticalSpeedIndicator extends HTMLElement {
                         alert = true;
                     if ((vSpeed >=6000) || (vSpeed <= -6000)) alert = true; //airbus alerts thresholds
                 }
-                
 
                 if (this.cursorSVGLine) {
                     this.cursorSVGLine.setAttribute("x1", this.cursorPosX1.toString());

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/VerticalSpeedIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/VerticalSpeedIndicator.js
@@ -540,7 +540,7 @@ class Jet_PFD_VerticalSpeedIndicator extends HTMLElement {
         var posY = 0;
         var width = 100;
         var height = 600;
-        this.maxSpeed = 6000;
+        this.maxSpeed = 10000; // was 6000, raised to keep on displaying the values
         this.cursorTextColor = "rgb(26,255,0)";
         if (!this.rootGroup) {
             this.rootGroup = document.createElementNS(Avionics.SVG.NS, "g");
@@ -712,9 +712,12 @@ class Jet_PFD_VerticalSpeedIndicator extends HTMLElement {
                 let alert = false;
                 {
                     let altitude = Simplane.getAltitudeAboveGround();
-                    if ((altitude <= 2500 && vSpeed <= -2000) || (altitude > 2500 && vSpeed <= -6000))
+                    if ((altitude < 2500 && altitude > 1000 && vSpeed <= -2000) || (altitude < 1000 && vSpeed <= -1200)) //airbus alerts thresholds
                         alert = true;
+                    if ((vSpeed >=6000) || (vSpeed <= -6000)) alert = true; //airbus alerts thresholds
                 }
+                
+
                 if (this.cursorSVGLine) {
                     this.cursorSVGLine.setAttribute("x1", this.cursorPosX1.toString());
                     this.cursorSVGLine.setAttribute("y1", this.cursorPosY1.toString());
@@ -727,7 +730,7 @@ class Jet_PFD_VerticalSpeedIndicator extends HTMLElement {
                 }
                 if (this.cursorSVGText) {
                     var displaySpeed = Math.floor(vSpeed / 100);
-                    if (Math.abs(displaySpeed) > 0) {
+                    if (Math.abs(displaySpeed) > 2) {//text is displayed above +/-200ft/min only was 0 
                         this.cursorSVGText.textContent = Math.abs(displaySpeed).toString();
                         let posY;
                         if (displaySpeed > 0)


### PR DESCRIPTION
Changed the v/s alert threshold according to the Airbus FCOM

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->
Update VerticalSpeedIndicator.js
<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #[issue_no]No number
Airbus V/S Alert threshold was not implemented 
![image](https://user-images.githubusercontent.com/23705479/92993933-919bd180-f4fe-11ea-85c6-989933a4a30a.png)

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Implemented the alert threshold
Modified the digital display to start at v/s>200ft/min

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->

![image](https://user-images.githubusercontent.com/23705479/92993929-7fba2e80-f4fe-11ea-97e6-1af94906ce32.png)

**Additional context**
<!-- Add any other context about the pull request here. -->
