### PR TITLE
[MCDU] Default INIT B taxi fuel to match real aircraft

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -47,6 +47,9 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this._onModeManagedHeading();
         this._onModeManagedAltitude();
         SimVar.SetSimVarValue("K:VS_SLOT_INDEX_SET", "number", 1);
+
+        this.taxiFuelWeight = 0.2;
+        CDUInitPage.updateTowIfNeeded(this);
     }
     Update() {
         super.Update();


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #637 

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Make TAXI fuel default value from "empty" to "0.2" as per commonly used AMI. See references.

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
![kuva](https://user-images.githubusercontent.com/24453333/93013966-83f55300-f5b5-11ea-9fff-67900b831ea1.png)

**Additional context**
<!-- Add any other context about the pull request here. -->
References
[IRL pilot comment 1](https://discordapp.com/channels/738864299392630914/739223532269076561/754004668744728577)
[IRL pilot comment2 ](https://discordapp.com/channels/738864299392630914/739223532269076561/754051275397529672)