### PR TITLE
[CDU] Add the ability to set the ZFWCG automatically and allow entering the ZFWCG without specifying the ZFW

### DIFF
--- a/A32NX/html_ui/JS/Services/FuelPayload.js
+++ b/A32NX/html_ui/JS/Services/FuelPayload.js
@@ -1,0 +1,36 @@
+class PayloadValue extends RangeDataValue {
+    constructor() {
+        super(...arguments);
+        this.__Type = "PayloadValue";
+    }
+}
+class ContactPoint {
+}
+class FuelPayloadData {
+}
+class BalanceData {
+}
+class ShapeData {
+}
+class FuelPayloadListener extends ViewListener.ViewListener {
+    constructor(name) {
+        super(name);
+    }
+    onFuelPayloadDataUpdated(callback) {
+        this.on("SetFuelPayloadData", callback);
+    }
+    onBalanceDataUpdated(callback) {
+        this.on("SetBalanceData", callback);
+    }
+    onShapeDataUpdated(callback) {
+        this.on("SetShapeData", callback);
+    }
+    resetFuelPayload() {
+        this.trigger("FUEL_RESET");
+    }
+}
+function RegisterFuelPayloadListener(callback) {
+    return RegisterViewListenerT("JS_LISTENER_FUEL_PAYLOAD", callback, FuelPayloadListener);
+}
+checkAutoload();
+//# sourceMappingURL=FuelPayload.js.map

--- a/A32NX/html_ui/JS/Services/FuelPayload.js
+++ b/A32NX/html_ui/JS/Services/FuelPayload.js
@@ -33,4 +33,3 @@ function RegisterFuelPayloadListener(callback) {
     return RegisterViewListenerT("JS_LISTENER_FUEL_PAYLOAD", callback, FuelPayloadListener);
 }
 checkAutoload();
-//# sourceMappingURL=FuelPayload.js.map

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -198,7 +198,7 @@ class CDUInitPage {
         mcdu.onRightInput[0] = async () => {
             let value = mcdu.inOut;
             mcdu.clearUserInput();
-            if (await mcdu.trySetZFWCG(value)) {
+            if (mcdu.trySetZFWCG(value)) {
                 CDUInitPage.updateTowIfNeeded(mcdu);
                 CDUInitPage.ShowPage2(mcdu);
             }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -198,7 +198,7 @@ class CDUInitPage {
         mcdu.onRightInput[0] = async () => {
             let value = mcdu.inOut;
             mcdu.clearUserInput();
-            if (await mcdu.trySetZeroFuelWeightZFWCG(value)) {
+            if (await mcdu.trySetZFWCG(value)) {
                 CDUInitPage.updateTowIfNeeded(mcdu);
                 CDUInitPage.ShowPage2(mcdu);
             }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -853,7 +853,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this._balanceData = data.balance;
     }
 
-    async trySetZFWCG(input, useLbs = false) {
+    trySetZFWCG(input, useLbs = false) {
         let zfw = NaN;
         let zfwcg = NaN;
         if (input) {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes https://github.com/flybywiresim/a32nx/issues/605

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- pressing the button with no input or with just the ZFW will automatically set the ZFWCG as well
- you can now /input to insert the ZFWCG only without repeating the ZFW

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
N/A

**Additional context**
<!-- Add any other context about the pull request here. -->
The ZFWCG value is copied from the sim's fuel planning, you will need to update it in the CDU every time you change the fuel/load.