### PR TITLE
Update default screen brightness in C&D

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/apron.FLT
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/apron.FLT
@@ -169,13 +169,13 @@ Potentiometer.7=0
 Potentiometer.14=0
 Potentiometer.15=0
 Potentiometer.16=0
-Potentiometer.17=0
-Potentiometer.18=0
-Potentiometer.19=0
-Potentiometer.20=0
-Potentiometer.21=0
-Potentiometer.22=0
-Potentiometer.23=0
+Potentiometer.17=0.1
+Potentiometer.18=0.1
+Potentiometer.19=0.1
+Potentiometer.20=0.1
+Potentiometer.21=0.1
+Potentiometer.22=0.1
+Potentiometer.23=0.1
 
 [AutoPilot.0]
 MasterSwitch=False

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -73,12 +73,12 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         this.topSelfTestTimer = -1;
         this.topSelfTestTimerStarted = false;
         this.topSelfTestLastKnobValue = 1;
-        
+
         this.bottomSelfTestDiv = this.querySelector("#BottomSelfTest");
         this.bottomSelfTestTimer = -1;
         this.bottomSelfTestTimerStarted = false;
         this.bottomSelfTestLastKnobValue = 1;
-        
+
         // Using ternary in case the LVar is undefined
         this.ACPowerLastState = SimVar.GetSimVarValue('L:A32NX_COLD_AND_DARK_SPAWN', 'Bool') ? 0 : 1;
 
@@ -86,18 +86,18 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         this.changePage("DOOR"); // MODIFIED
         this.changePage("DOOR"); // This should get the ECAM into the "unselected" state
         this.localVarUpdater = new LocalVarUpdater();
-        
+
         SimVar.SetSimVarValue("LIGHT POTENTIOMETER:7","FLOAT64",0);
         SimVar.SetSimVarValue("LIGHT POTENTIOMETER:14","FLOAT64",0);
         SimVar.SetSimVarValue("LIGHT POTENTIOMETER:15","FLOAT64",0);
-        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:16","FLOAT64",0);        
-        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:17","FLOAT64",0);
-        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:18","FLOAT64",0);
-        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:19","FLOAT64",0);
-        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:20","FLOAT64",0);
-        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:21","FLOAT64",0);
-        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:22","FLOAT64",0);
-        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:23","FLOAT64",0);
+        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:16","FLOAT64",0);
+        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:17","FLOAT64",0.1);
+        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:18","FLOAT64",0.1);
+        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:19","FLOAT64",0.1);
+        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:20","FLOAT64",0.1);
+        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:21","FLOAT64",0.1);
+        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:22","FLOAT64",0.1);
+        SimVar.SetSimVarValue("LIGHT POTENTIOMETER:23","FLOAT64",0.1);
     }
     onUpdate(_deltaTime) {
         super.onUpdate(_deltaTime);
@@ -107,7 +107,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         }
         this.updateAnnunciations();
         this.updateScreenState();
-        
+
         const engineOn = Simplane.getEngineActive(0) || Simplane.getEngineActive(1);
         const externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
         const apuOn = SimVar.GetSimVarValue("L:APU_GEN_ONLINE", "bool");
@@ -137,15 +137,15 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         /**
          * Self test on top ECAM screen
          **/
-        
+
         let topSelfTestCurrentKnobValue = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:22", "number");
-        
+
         if(((topSelfTestCurrentKnobValue >= 0.1 && this.topSelfTestLastKnobValue < 0.1) || ACPowerStateChange) && isACPowerAvailable && !this.topSelfTestTimerStarted) {
             this.topSelfTestDiv.style.display = "block";
             this.topSelfTestTimer = 14.25;
             this.topSelfTestTimerStarted = true;
         }
-        
+
         if (this.topSelfTestTimer >= 0) {
             this.topSelfTestTimer -= _deltaTime / 1000;
             if (this.topSelfTestTimer <= 0) {
@@ -153,21 +153,21 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
                 this.topSelfTestTimerStarted = false;
             }
         }
-        
+
         this.topSelfTestLastKnobValue = topSelfTestCurrentKnobValue;
 
         /**
          * Self test on bottom ECAM screen
          **/
-        
+
         let bottomSelfTestCurrentKnobValue = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:23", "number");
-        
+
         if(((bottomSelfTestCurrentKnobValue >= 0.1 && this.bottomSelfTestLastKnobValue < 0.1) || ACPowerStateChange) && isACPowerAvailable && !this.bottomSelfTestTimerStarted) {
             this.bottomSelfTestDiv.style.display = "block";
             this.bottomSelfTestTimer = 14.25;
             this.bottomSelfTestTimerStarted = true;
         }
-        
+
         if (this.bottomSelfTestTimer >= 0) {
             this.bottomSelfTestTimer -= _deltaTime / 1000;
             if (this.bottomSelfTestTimer <= 0) {
@@ -175,7 +175,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
                 this.bottomSelfTestTimerStarted = false;
             }
         }
-        
+
         this.bottomSelfTestLastKnobValue = bottomSelfTestCurrentKnobValue;
 
         this.ACPowerLastState = isACPowerAvailable;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #592

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Sets default screen brightness in C&D start to 0.1 (first setting)

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->

![](https://clapton.dev/u/2009/108a2f1f.jpg)

**Additional context**
<!-- Add any other context about the pull request here. -->

See conversation in #592 on the authenticity of this decision.

I feel like even if we wanted to interpret a "cold and dark" state to mean something akin to "this plane has been in storage for a month so everything is just off", the amount of complaints we've gotten from users thinking the screens are broken is a problem on it's own. Just my 2 cents.