### PR TITLE
feat(ecam/f-ctl): make controls amber when both engines dead

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.css
@@ -1,111 +1,151 @@
 @font-face {
-  font-family: "B612Mono";
-  src: url("/Fonts/B612Mono-Regular.ttf") format("truetype");
-  font-weight: normal;
-  font-style: normal; }
+    font-family: "B612Mono";
+    src: url("/Fonts/B612Mono-Regular.ttf") format("truetype");
+    font-weight: normal;
+    font-style: normal;
+}
 
 @font-face {
-  font-family: "Liberation Mono";
-  src: url("/Fonts/LiberationMono.ttf") format("truetype");
-  font-weight: normal;
-  font-style: normal; }
+    font-family: "Liberation Mono";
+    src: url("/Fonts/LiberationMono.ttf") format("truetype");
+    font-weight: normal;
+    font-style: normal;
+}
 
 :root {
-  --ecamDefaultColour: white;
-  --ecamShapeColour: lightgray;
-  --ecamUnitsColour: #01b8b8;
-  --ecamValueColour: #00b300;
-  --ecamWarningColour: #db7200;
-  --ecamDangerColour: red;
-  --ecamInactiveColour: #db7200;
-  --ecamSeparatorsColour: white;
-  --ecamHydraulicBgColour: #484848; }
-  :root .Separator {
+    --ecamDefaultColour: white;
+    --ecamShapeColour: lightgray;
+    --ecamUnitsColour: #01b8b8;
+    --ecamValueColour: #00b300;
+    --ecamWarningColour: #db7200;
+    --ecamDangerColour: red;
+    --ecamInactiveColour: #db7200;
+    --ecamSeparatorsColour: white;
+    --ecamHydraulicBgColour: #484848;
+}
+
+:root .Separator {
     stroke: #3c3c3c;
     stroke-width: 4;
-    fill: none; }
-  :root div {
-    font-family: "Liberation Mono" !important; }
-  :root text {
-    font-family: "Liberation Mono" !important; }
-  :root #PageTitle {
+    fill: none;
+}
+
+:root div {
+    font-family: "Liberation Mono" !important;
+}
+
+:root text {
+    font-family: "Liberation Mono" !important;
+}
+
+:root #PageTitle {
     fill: var(--ecamDefaultColour);
     font-size: 25px;
-    text-decoration: underline; }
-  
-  a320-neo-lower-ecam-ftcl {
-  display: block;
-  position: absolute;
-  top: -5%;
-  bottom: 5%;
-  left: 0%;
-  width: 100%;
-  height: 100%; }
-  a320-neo-lower-ecam-ftcl text {
-    text-anchor: middle;
-    alignment-baseline: central; }
+    text-decoration: underline;
+}
 
-  a320-neo-lower-ecam-ftcl .MainShape {
+a320-neo-lower-ecam-ftcl {
+    display: block;
+    position: absolute;
+    top: -5%;
+    bottom: 5%;
+    left: 0%;
+    width: 100%;
+    height: 100%;
+}
+
+a320-neo-lower-ecam-ftcl text {
+    text-anchor: middle;
+    alignment-baseline: central;
+}
+
+a320-neo-lower-ecam-ftcl .MainShape {
     fill: transparent;
     stroke: var(--ecamShapeColour);
-    stroke-width: 2; }
+    stroke-width: 2;
+}
 
-  a320-neo-lower-ecam-ftcl .MainShapeWarning {
+a320-neo-lower-ecam-ftcl .MainShapeWarning {
     fill: transparent;
     stroke: var(--ecamDangerColour);
-    stroke-width: 2; }
+    stroke-width: 2;
+}
 
-  a320-neo-lower-ecam-ftcl .MainShape4 {
+a320-neo-lower-ecam-ftcl .MainShape4 {
     fill: transparent;
     stroke: var(--ecamShapeColour);
-    stroke-width: 4; }
+    stroke-width: 4;
+}
 
-  a320-neo-lower-ecam-ftcl .GreenShape {
+a320-neo-lower-ecam-ftcl .GreenShape {
     fill: transparent;
     stroke: var(--ecamValueColour);
-    stroke-width: 2; }
+    stroke-width: 2;
+}
 
-  a320-neo-lower-ecam-ftcl .GreenShapeThick {
+a320-neo-lower-ecam-ftcl .GreenShapeThick {
     fill: transparent;
     stroke: var(--ecamValueColour);
-    stroke-width: 3; }
-  
-  a320-neo-lower-ecam-ftcl .WarningShape {
+    stroke-width: 3;
+}
+
+a320-neo-lower-ecam-ftcl .WarningShape {
     fill: transparent;
     stroke: var(--ecamWarningColour);
-    stroke-width: 2; }
+    stroke-width: 2
+}
 
-  a320-neo-lower-ecam-ftcl .HydBgShape {
+a320-neo-lower-ecam-ftcl .HydBgShape {
     fill: var(--ecamHydraulicBgColour);
-    stroke: none; }
-  
-  a320-neo-lower-ecam-ftcl text.Title {
+    stroke: none;
+}
+
+a320-neo-lower-ecam-ftcl text.Title {
     font-size: 25px;
-    fill: var(--ecamDefaultColour); }
-  a320-neo-lower-ecam-ftcl text.Note {
+    fill: var(--ecamDefaultColour);
+}
+
+a320-neo-lower-ecam-ftcl text.Note {
     font-size: 12pt;
-    fill: var(--ecamDefaultColour); }
-  a320-neo-lower-ecam-ftcl text.Note15 {
+    fill: var(--ecamDefaultColour);
+}
+
+a320-neo-lower-ecam-ftcl text.Note15 {
     font-size: 15pt;
-    fill: var(--ecamDefaultColour); }
-  a320-neo-lower-ecam-ftcl text.Unit {
+    fill: var(--ecamDefaultColour);
+}
+
+a320-neo-lower-ecam-ftcl text.Unit {
     font-size: 14pt;
-    fill: var(--ecamUnitsColour); }
-  a320-neo-lower-ecam-ftcl text.Value {
+    fill: var(--ecamUnitsColour);
+}
+
+a320-neo-lower-ecam-ftcl text.Value {
     font-size: 14pt;
-    fill: var(--ecamValueColour); }
-  a320-neo-lower-ecam-ftcl text.Value12 {
+    fill: var(--ecamValueColour);
+}
+
+a320-neo-lower-ecam-ftcl text.Value12 {
     font-size: 12pt;
-    fill: var(--ecamValueColour); }
-  a320-neo-lower-ecam-ftcl text.Value15 {
+    fill: var(--ecamValueColour);
+}
+
+a320-neo-lower-ecam-ftcl text.Value15 {
     font-size: 15pt;
-    fill: var(--ecamValueColour); }
-  a320-neo-lower-ecam-ftcl text.Value15Warning {
+    fill: var(--ecamValueColour);
+}
+
+a320-neo-lower-ecam-ftcl text.Value15Warning {
     font-size: 15pt;
-    fill: var(--ecamDangerColour); }
-  a320-neo-lower-ecam-ftcl text.ValueWhite {
+    fill: var(--ecamDangerColour);
+}
+
+a320-neo-lower-ecam-ftcl text.ValueWhite {
     font-size: 14pt;
-    fill: var(--ecamDefaultColour); }
-  a320-neo-lower-ecam-ftcl text.Warning {
+    fill: var(--ecamDefaultColour);
+}
+
+a320-neo-lower-ecam-ftcl text.Warning {
     font-size: 18px;
-    fill: var(--ecamWarningColour); }
+    fill: var(--ecamWarningColour);
+}

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.html
@@ -1,7 +1,10 @@
-<link rel="stylesheet" href="./A320_Neo_LowerECAM_FTCL.css" />
+<link rel="stylesheet" href="./A320_Neo_LowerECAM_FTCL.css"/>
 
 <script type="text/html" id="LowerECAMFTCLTemplate">
     <svg viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg">
+
+        <!-- Speedbrakes -->
+
         <g id="speedbrakes">
             <path class="GreenShapeThick" d="M 103 104 l 15 0"></path>
             <path class="GreenShapeThick" d="M 142 99 l 15 0"></path>
@@ -15,14 +18,17 @@
             <path class="GreenShapeThick" d="M 381 89 l -15 0"></path>
             <path class="GreenShapeThick" d="M 343 84 l -15 0"></path>
         </g>
+
         <g id="leftSpeedbrakeGroup">
             <path class="MainShape" d="M98,61 l0,-5 l140,-23 l0,5"></path>
             <path class="MainShape" d="M135,110 l0,5 l105,-12 l0,-5"></path>
         </g>
+
         <g id="rightSpeedbrakeGroup">
             <path class="MainShape" d="M502,61 l0,-5 l-140,-23 l0,5"></path>
             <path class="MainShape" d="M465,110 l0,5 l-105,-12 l0,-5"></path>
         </g>
+
         <g id="speedbrakeHyd">
             <rect class="HydBgShape" x="269" y="14" width="18" height="24" rx="2"></rect>
             <rect class="HydBgShape" x="291" y="14" width="18" height="24" rx="2"></rect>
@@ -32,40 +38,45 @@
             <text id="speedbrakeHyd3" class="Value15" x="322" y="28" text-anchor="middle" alignment-baseline="central">Y</text>
         </g>
 
+        <!-- Left ailerons -->
 
         <g id="leftAileronPointer">
             <path id="leftAileronCursor" class="GreenShape" d="M73,204 l15,-7 l0,14Z"></path>
         </g>
+
         <g id="leftAileronAxis">
             <path class="MainShape" d="M72,164 l-8,0 l0,-20 l8,0 l0,120 l-8,0 l0,-10 l8,0"></path>
             <path class="MainShape" d="M72,200 l-7,0"></path>
             <path class="MainShape" d="M72,205 l-7,0"></path>
             <path class="MainShape" d="M72,210 l-8,0 l0,6 l8,0"></path>
         </g>
+
         <g id="leftAileronHyd">
             <rect class="HydBgShape" x="94" y="233" width="18" height="24" rx="2"></rect>
             <rect class="HydBgShape" x="116" y="233" width="18" height="24" rx="2"></rect>
             <text id="leftAileronHyd1" class="Value15" x="103" y="247" text-anchor="middle" alignment-baseline="central">B</text>
             <text id="leftAileronHyd2" class="Value15" x="125" y="247" text-anchor="middle" alignment-baseline="central">G</text>
         </g>
-        
+
+        <!-- Right ailerons -->
 
         <g id="rightAileronPointer">
             <path id="rightAileronCursor" class="GreenShape" d="M527,204 l-15,-7 l0,14Z"></path>
         </g>
+
         <g id="rightAileronAxis">
             <path class="MainShape" d="M528,164 l8,0 l0,-20 l-8,0 l0,120 l8,0 l0,-10 l-8,0"></path>
             <path class="MainShape" d="M528,200 l7,0"></path>
             <path class="MainShape" d="M528,205 l7,0"></path>
             <path class="MainShape" d="M528,210 l8,0 l0,6 l-8,0"></path>
         </g>
+
         <g id="rightAileronHyd">
             <rect class="HydBgShape" x="466" y="233" width="18" height="24" rx="2"></rect>
             <rect class="HydBgShape" x="488" y="233" width="18" height="24" rx="2"></rect>
             <text id="rightAileronHyd1" class="Value15" x="475" y="247" text-anchor="middle" alignment-baseline="central">G</text>
             <text id="rightAileronHyd2" class="Value15" x="497" y="247" text-anchor="middle" alignment-baseline="central">B</text>
         </g>
-
 
         <g id="elac">
             <path id="elac1" class="MainShape" d="M170,190 l72,0 l0,-26 l-8,0"></path>
@@ -85,14 +96,17 @@
             <text id="secText_3" class="Value15" x="431" y="210" text-anchor="middle" alignment-baseline="central">3</text>
         </g>
 
+        <!-- Left elevator -->
 
         <g id="leftElevatorPointer">
             <path id="leftElevatorCursor" class="GreenShape" d="M169,398 l15,-7 l0,14Z"></path>
         </g>
+
         <g id="leftElevatorAxis">
             <path class="MainShape" d="M168,333 l-8,0 l0,-10 l8,0 l0,116 l-8,0 l0,-10 l8,0"></path>
             <path class="MainShape" d="M168,395 l-7,0 l0,5 l7,0"></path>
         </g>
+
         <g id="leftElevatorHyd">
             <rect class="HydBgShape" x="108" y="407" width="18" height="24" rx="2"></rect>
             <rect class="HydBgShape" x="130" y="407" width="18" height="24" rx="2"></rect>
@@ -100,13 +114,17 @@
             <text id="leftElevatorHyd2" class="Value15" x="139" y="421" text-anchor="middle" alignment-baseline="central">G</text>
         </g>
 
+        <!-- Right elevator -->
+
         <g id="rightElevatorPointer">
             <path id="rightElevatorCursor" class="GreenShape" d="M431,398 l-15,-7 l0,14Z"></path>
         </g>
+
         <g id="rightElevatorAxis">
             <path class="MainShape" d="M432,333 l8,0 l0,-10 l-8,0 l0,116 l8,0 l0,-10 l-8,0"></path>
             <path class="MainShape" d="M432,395 l7,0 l0,5 l-7,0"></path>
         </g>
+
         <g id="rightElevatorHyd">
             <rect class="HydBgShape" x="452" y="407" width="18" height="24" rx="2"></rect>
             <rect class="HydBgShape" x="474" y="407" width="18" height="24" rx="2"></rect>
@@ -114,6 +132,7 @@
             <text id="rightElevatorHyd2" class="Value15" x="483" y="421" text-anchor="middle" alignment-baseline="central">B</text>
         </g>
 
+        <!-- Pitch trim -->
 
         <g id="pitchTrim">
             <text id="pitchTrimText" class="Note15" x="280" y="296" text-anchor="middle" alignment-baseline="central">PITCH TRIM</text>
@@ -127,6 +146,9 @@
             <text id="pitchTrimHyd1" class="Value15" x="369" y="297" text-anchor="middle" alignment-baseline="central">G</text>
             <text id="pitchTrimHyd2" class="Value15" x="391" y="297" text-anchor="middle" alignment-baseline="central">Y</text>
         </g>
+
+        <!-- Stabilizer -->
+
         <g id="stabilizer">
             <text id="pitchTrimText" class="Note15" x="300" y="356" text-anchor="middle" alignment-baseline="central">RUD</text>
             <path id="stabLeft" class="MainShape" d="M268,357 l-55,4 l0,-18 l30,-15"></path>
@@ -134,30 +156,37 @@
             <rect class="HydBgShape" x="269" y="373" width="18" height="24" rx="2"></rect>
             <rect class="HydBgShape" x="291" y="373" width="18" height="24" rx="2"></rect>
             <rect class="HydBgShape" x="313" y="373" width="18" height="24" rx="2"></rect>
-            <text id="speedbrakeHyd1" class="Value15" x="278" y="387" text-anchor="middle" alignment-baseline="central">G</text>
-            <text id="speedbrakeHyd2" class="Value15" x="300" y="387" text-anchor="middle" alignment-baseline="central">B</text>
-            <text id="speedbrakeHyd3" class="Value15" x="322" y="387" text-anchor="middle" alignment-baseline="central">Y</text>
+            <text id="stabHyd1" class="Value15" x="278" y="387" text-anchor="middle" alignment-baseline="central">G</text>
+            <text id="stabHyd2" class="Value15" x="300" y="387" text-anchor="middle" alignment-baseline="central">B</text>
+            <text id="stabHyd3" class="Value15" x="322" y="387" text-anchor="middle" alignment-baseline="central">Y</text>
         </g>
+
+        <!-- Rudder -->
+
         <g id="rudderAxis">
             <path id="rudderPath" class="MainShape" d="M 350 469 A 100 100 0 0 1 250 469"></path>
             <path id="rudderCenter" class="MainShape" d="m302 482-6e-3 6-4 0.01 0.05-6"/>
             <path id="rudderRightBorder" class="MainShape" d="m343 472 2 5-7 3-2-5"/>
             <path id="rudderLeftBorder" class="MainShape" d="m257 472-2 5 7 3 2-5"/>
         </g>
+
         <g id="rudderLeftMaxAngle">
             <path id="rudderLeftLimitGreen" class="GreenShape" d="m250 484 6 3"/>
             <path id="rudderLeftLimitWhite" class="GreenShape" d="m257 472-7 13"/>
         </g>
+
         <g id="rudderRightMaxAngle">
             <path id="rudderRightLimitGreen" class="GreenShape" d="m350 484-6 3" />
             <path id="rudderRightLimitWhite" class="GreenShape" d="m343 472 7 13"/>
         </g>
+
         <g id="rudderCursor">
             <path id="rudderCircle" class="GreenShape" d="M 292 434 A 8 8 0 0 1 308 434"></path>
             <path id="rudderTail" class="GreenShape" d="M292,434 l8,48 l8,-48"></path>
-        </g>
+        </g>v
 
         <!--Texts-->
+
         <g id="texts">
             <text id="pageTitle" class="Title Large" x="45" y="24" text-anchor="middle" alignment-baseline="central" text-decoration="underline">F/CTL</text>
             <text id="speedBrakeText" class="Note15" x="300" y="107" text-anchor="middle" alignment-baseline="central">SPD BRK</text>
@@ -165,11 +194,11 @@
             <text id="leftAileronText2" class="Note15" x="32" y="175" text-anchor="middle" alignment-baseline="central">AIL</text>
             <text id="rightAileronText1" class="Note15" x="568" y="153" text-anchor="middle" alignment-baseline="central">R</text>
             <text id="rightAileronText2" class="Note15" x="568" y="175" text-anchor="middle" alignment-baseline="central">AIL</text>
-            
+
             <text id="leftElevatorText1" class="Note15" x="122" y="328" text-anchor="middle" alignment-baseline="central">L</text>
             <text id="leftElevatorText2" class="Note15" x="122" y="350" text-anchor="middle" alignment-baseline="central">ELEV</text>
             <text id="rightElevatorText1" class="Note15" x="478" y="328" text-anchor="middle" alignment-baseline="central">R</text>
-            <text id="rightElevatorText2" class="Note15" x="478" y="350" text-anchor="middle" alignment-baseline="central">ELEV</text>  
+            <text id="rightElevatorText2" class="Note15" x="478" y="350" text-anchor="middle" alignment-baseline="central">ELEV</text>
         </g>
     </svg>
 </script>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.js
@@ -1,18 +1,22 @@
-var A320_Neo_LowerECAM_FTCL;
+let A320_Neo_LowerECAM_FTCL;
 (function (A320_Neo_LowerECAM_FTCL) {
     class Definitions {
     }
     A320_Neo_LowerECAM_FTCL.Definitions = Definitions;
     class Page extends Airliners.EICASTemplateElement {
+
         constructor() {
             super();
             this.isInitialised = false;
         }
+
         get templateID() { return "LowerECAMFTCLTemplate"; }
+
         connectedCallback() {
             super.connectedCallback();
             TemplateElement.call(this, this.init.bind(this));
         }
+
         init() {
             // ELAC
             this.elac1Shape = this.querySelector("#elac1");
@@ -46,47 +50,66 @@ var A320_Neo_LowerECAM_FTCL;
             this.rudderLeftMaxAngle = this.querySelector("#rudderLeftMaxAngle");
             this.rudderRightMaxAngle = this.querySelector("#rudderRightMaxAngle");
 
+            this.hydraulicsAvailable = true;
+
             this.isInitialised = true;
         }
+
         update(_deltaTime) {
             if (!this.isInitialised) {
                 return;
             }
 
+            // Update hydraulics available state
+
+            const hydraulicsShouldBeAvailable = SimVar.GetSimVarValue("ENG COMBUSTION:1", "Bool") === 0 && SimVar.GetSimVarValue("ENG COMBUSTION:2", "Bool") === 0
+
+            if (hydraulicsShouldBeAvailable !== this.hydraulicsAvailable) {
+                this.hydraulicsAvailable = hydraulicsShouldBeAvailable;
+
+                this.setControlsHydraulicsAvailable(this.hydraulicsAvailable);
+            }
+
             // Update pitch trim
-            var rawPitchTrim = SimVar.GetSimVarValue("ELEVATOR TRIM INDICATOR", "Position 16k") / 1213.6296;
-            // Cap pitch trim at 13.5 up, 4 down
-            if (rawPitchTrim > 16384.0) {
+
+            let rawPitchTrim = SimVar.GetSimVarValue("ELEVATOR TRIM INDICATOR", "Position 16k") / 1213.6296;
+
+            if (rawPitchTrim > 16384.0) { // Cap pitch trim at 13.5 up, 4 down
                 rawPitchTrim = 16384.0;
             } else if (rawPitchTrim < -4854) {
                 rawPitchTrim = -4854;
             }
-            var pitchTrimPctLeading = fastToFixed(Math.floor(Math.abs(rawPitchTrim)), 0);
-            var pitchTrimPctTrailing = fastToFixed(Math.floor((Math.abs(rawPitchTrim) * 10) % 10), 0);
-            var pitchTrimSign = Math.sign(rawPitchTrim);
+
+            const pitchTrimPctLeading = fastToFixed(Math.floor(Math.abs(rawPitchTrim)), 0);
+            const pitchTrimPctTrailing = fastToFixed(Math.floor((Math.abs(rawPitchTrim) * 10) % 10), 0);
+            const pitchTrimSign = Math.sign(rawPitchTrim);
 
             this.pitchTrimLeadingDecimal.textContent = pitchTrimPctLeading;
             this.pitchTrimTrailingDecimal.textContent = pitchTrimPctTrailing;
-            if (pitchTrimSign == -1) {
+
+            if (pitchTrimSign === -1) {
                 this.pitchTrimDirection.textContent = "DN";
             } else {
                 this.pitchTrimDirection.textContent = "UP";
             }
 
             // Update left aileron
-            var leftAileronDeflectPct = SimVar.GetSimVarValue("AILERON LEFT DEFLECTION PCT", "percent over 100");
+
+            const leftAileronDeflectPct = SimVar.GetSimVarValue("AILERON LEFT DEFLECTION PCT", "percent over 100");
             let leftAileronDeflectPctNormalized = leftAileronDeflectPct * 54;
             let laCursorPath = "M73," + (204 + leftAileronDeflectPctNormalized) + " l15,-7 l0,14Z";
             this.leftAileronCursor.setAttribute("d", laCursorPath);
 
             // Update right aileron
-            var rightAileronDeflectPct = SimVar.GetSimVarValue("AILERON RIGHT DEFLECTION PCT", "percent over 100");
+
+            const rightAileronDeflectPct = SimVar.GetSimVarValue("AILERON RIGHT DEFLECTION PCT", "percent over 100");
             let rightAileronDeflectPctNormalized = rightAileronDeflectPct * 54;
             let raCursorPath = "M527," + (204 - rightAileronDeflectPctNormalized) + " l-15,-7 l0,14Z";
             this.rightAileronCursor.setAttribute("d", raCursorPath);
 
             // Update left/right elevators
-            var elevatorDeflectPct = SimVar.GetSimVarValue("ELEVATOR DEFLECTION PCT", "percent over 100");
+
+            const elevatorDeflectPct = SimVar.GetSimVarValue("ELEVATOR DEFLECTION PCT", "percent over 100");
             let elevatorDeflectPctNormalized = elevatorDeflectPct * 52;
             let leCursorPath = "M169," + (398 - elevatorDeflectPctNormalized) + " l15,-7 l0,14Z";
             let reCursorPath = "M431," + (398 - elevatorDeflectPctNormalized) + " l-15,-7 l0,14Z";
@@ -94,11 +117,13 @@ var A320_Neo_LowerECAM_FTCL;
             this.rightElevatorCursor.setAttribute("d", reCursorPath);
 
             // Update rudder
+
             const rudderDeflectPct = SimVar.GetSimVarValue("RUDDER DEFLECTION PCT", "percent over 100");
             const rudderAngle = -rudderDeflectPct * 25;
             this.rudderCursor.setAttribute("transform", `rotate(${rudderAngle} 300 380)`);
 
             //Update Rudder limits
+
             const IndicatedAirspeed = SimVar.GetSimVarValue("AIRSPEED INDICATED", "knots");
             let MaxAngleNorm = 1;
             if(IndicatedAirspeed > 380){
@@ -111,16 +136,17 @@ var A320_Neo_LowerECAM_FTCL;
             this.rudderRightMaxAngle.setAttribute("transform", `rotate(${26.4 * (1-MaxAngleNorm)} 300 385)`)
 
             // Update ELAC's and SEC's
-            var elac1_On = SimVar.GetSimVarValue("FLY BY WIRE ELAC SWITCH:1", "boolean");
-            var elac2_On = SimVar.GetSimVarValue("FLY BY WIRE ELAC SWITCH:2", "boolean");
-            var elac1_Failed = SimVar.GetSimVarValue("FLY BY WIRE ELAC FAILED:1", "boolean");
-            var elac2_Failed = SimVar.GetSimVarValue("FLY BY WIRE ELAC FAILED:2", "boolean");
-            var sec1_On = SimVar.GetSimVarValue("FLY BY WIRE SEC SWITCH:1", "boolean");
-            var sec2_On = SimVar.GetSimVarValue("FLY BY WIRE SEC SWITCH:2", "boolean");
-            var sec3_On = SimVar.GetSimVarValue("FLY BY WIRE SEC SWITCH:3", "boolean");
-            var sec1_Failed = SimVar.GetSimVarValue("FLY BY WIRE SEC FAILED:1", "boolean");
-            var sec2_Failed = SimVar.GetSimVarValue("FLY BY WIRE SEC FAILED:2", "boolean");
-            var sec3_Failed = SimVar.GetSimVarValue("FLY BY WIRE SEC FAILED:3", "boolean");
+
+            const elac1_On = SimVar.GetSimVarValue("FLY BY WIRE ELAC SWITCH:1", "boolean");
+            const elac2_On = SimVar.GetSimVarValue("FLY BY WIRE ELAC SWITCH:2", "boolean");
+            const elac1_Failed = SimVar.GetSimVarValue("FLY BY WIRE ELAC FAILED:1", "boolean");
+            const elac2_Failed = SimVar.GetSimVarValue("FLY BY WIRE ELAC FAILED:2", "boolean");
+            const sec1_On = SimVar.GetSimVarValue("FLY BY WIRE SEC SWITCH:1", "boolean");
+            const sec2_On = SimVar.GetSimVarValue("FLY BY WIRE SEC SWITCH:2", "boolean");
+            const sec3_On = SimVar.GetSimVarValue("FLY BY WIRE SEC SWITCH:3", "boolean");
+            const sec1_Failed = SimVar.GetSimVarValue("FLY BY WIRE SEC FAILED:1", "boolean");
+            const sec2_Failed = SimVar.GetSimVarValue("FLY BY WIRE SEC FAILED:2", "boolean");
+            const sec3_Failed = SimVar.GetSimVarValue("FLY BY WIRE SEC FAILED:3", "boolean");
 
             if (elac1_On && !elac1_Failed) {
                 this.elac1Shape.setAttribute("class", "MainShape");
@@ -129,6 +155,7 @@ var A320_Neo_LowerECAM_FTCL;
                 this.elac1Shape.setAttribute("class", "MainShapeWarning");
                 this.elac1Num.setAttribute("class", "Value15Warning");
             }
+
             if (elac2_On && !elac2_Failed) {
                 this.elac2Shape.setAttribute("class", "MainShape");
                 this.elac2Num.setAttribute("class", "Value15");
@@ -136,6 +163,7 @@ var A320_Neo_LowerECAM_FTCL;
                 this.elac2Shape.setAttribute("class", "MainShapeWarning");
                 this.elac2Num.setAttribute("class", "Value15Warning");
             }
+
             if (sec1_On && !sec1_Failed) {
                 this.sec1Shape.setAttribute("class", "MainShape");
                 this.sec1Num.setAttribute("class", "Value15");
@@ -143,6 +171,7 @@ var A320_Neo_LowerECAM_FTCL;
                 this.sec1Shape.setAttribute("class", "MainShapeWarning");
                 this.sec1Num.setAttribute("class", "Value15Warning");
             }
+
             if (sec2_On && !sec2_Failed) {
                 this.sec2Shape.setAttribute("class", "MainShape");
                 this.sec2Num.setAttribute("class", "Value15");
@@ -150,6 +179,7 @@ var A320_Neo_LowerECAM_FTCL;
                 this.sec2Shape.setAttribute("class", "MainShapeWarning");
                 this.sec2Num.setAttribute("class", "Value15Warning");
             }
+
             if (sec3_On && !sec3_Failed) {
                 this.sec3Shape.setAttribute("class", "MainShape");
                 this.sec3Num.setAttribute("class", "Value15");
@@ -158,6 +188,51 @@ var A320_Neo_LowerECAM_FTCL;
                 this.sec3Num.setAttribute("class", "Value15Warning");
             }
         }
+
+        /**
+         * Sets the availability of control surfaces.
+         *
+         * This temporarily affects all of them as we do not fully model the hydraulic system yet.
+         *
+         * @param state {boolean}
+         * @return {void}
+         */
+        setControlsHydraulicsAvailable(state) {
+            const shapeElements = [
+                "speedbrakes",
+                "leftAileronPointer",
+                "rightAileronPointer",
+                "leftElevatorPointer",
+                "rightElevatorPointer",
+                "rudderCursor"
+            ];
+
+            for (const elementName of shapeElements) {
+                const element = this.querySelector("#" + elementName)
+
+                for (const node of element.children) {
+                    node.setAttribute("class", state ? "WarningShape" : "GreenShape");
+                }
+            }
+
+            const textElements = [
+                "speedbrakeHyd1", "speedbrakeHyd2", "speedbrakeHyd3",
+                "leftAileronHyd1", "leftAileronHyd2",
+                "rightAileronHyd1", "rightAileronHyd2",
+                "leftElevatorHyd1", "leftElevatorHyd2",
+                "rightElevatorHyd1", "rightElevatorHyd2",
+                "pitchTrimLeadingDecimal", "pitchTrimDecimalPoint", "pitchTrimTrailingDecimal", "pitchTrimDirection",
+                "pitchTrimHyd1", "pitchTrimHyd2",
+                "stabHyd1", "stabHyd2", "stabHyd3"
+            ];
+
+            for (const elementName of textElements) {
+                const element = this.querySelector("#" + elementName)
+
+                element.setAttribute("class", state ? "Warning" : "Value15");
+            }
+        }
+
     }
     A320_Neo_LowerECAM_FTCL.Page = Page;
 })(A320_Neo_LowerECAM_FTCL || (A320_Neo_LowerECAM_FTCL = {}));


### PR DESCRIPTION
Partially takes care of #660

**Summary of Changes**

The F/CTL ECAM page will now have controls amber when both engines are not started.

This is temporary behaviour until we have proper modeling of the hydraulic systems.

**Screenshots (if necessary)**

![image](https://user-images.githubusercontent.com/4503241/93037275-090d5600-f610-11ea-9fc4-f57e2a5ff8ab.png)
![image](https://user-images.githubusercontent.com/4503241/93037332-2c380580-f610-11ea-803c-652bb01a0ab7.png)

**Additional context**

N/A