### PR TITLE
Add additional check for external power availability

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -109,9 +109,9 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         this.updateScreenState();
 
         const engineOn = Simplane.getEngineActive(0) || Simplane.getEngineActive(1);
-        const externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
+        const externalPowerOn = SimVar.GetSimVarValue("EXTERNAL POWER AVAILABLE:1", "Bool") === 1 && SimVar.GetSimVarValue("EXTERNAL POWER ON", "Bool") === 1;
         const apuOn = SimVar.GetSimVarValue("L:APU_GEN_ONLINE", "bool");
-        const isACPowerAvailable = engineOn || apuOn || externalPower;
+        const isACPowerAvailable = engineOn || apuOn || externalPowerOn;
         var DCBus = false;
 
         const ACPowerStateChange = (isACPowerAvailable != this.ACPowerLastState);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #516

**Summary of Changes**
Adds check to ensure external power is both on AND available, not just on.

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->

no external power:
![](https://clapton.dev/u/2009/b0745fd7.jpg)

external power:
![](https://clapton.dev/u/2009/42db2a4f.jpg)

**Additional context**
<!-- Add any other context about the pull request here. -->
This problem resulted in AC power being supplied to systems like the main screens.