### PR TITLE
[MCDU] Fix takeoff speed to V2+10

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -678,7 +678,8 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             }
             if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_TAKEOFF) {
                 if (this.isAirspeedManaged()) {
-                    let speed = this.getCleanTakeOffSpeed();
+                    // getCleanTakeOffSpeed is a final fallback and not truth to reality
+                    const speed = isFinite(this.v2Speed) ? this.v2Speed + 10 : this.getCleanTakeOffSpeed();
                     this.setAPManagedSpeed(speed, Aircraft.A320_NEO);
                 }
             }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #643 

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Aircraft should aim for V2+10 at takeoff until climb phase is achieved. Fix includes only CDU part. PFD support seems to be lacking and is to be fixed separately.

**Note**: For me at least MSFS doesn't do great job keeping the speed but at least it's better than the old +190kt target which is clearly wrong.

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->

**Additional context**
<!-- Add any other context about the pull request here. -->
[Discord ref](https://discordapp.com/channels/738864299392630914/739223532269076561/755091076238409760)
[From Issue](http://www.a320dp.com/A320_DP/nav-autoflight/sys-13.3.16.html)