### PR TITLE
Fix lower ECAM self-test position

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.css
@@ -206,18 +206,15 @@ a320-neo-eicas-element {
 
 .SelfTestWrapper {
 	position: absolute;
-	left: 0%;
-	top: 0%;
+  left: 0%;
+  top: 0%;
 	width: 100%;
 	height: 100%;
-	border: none; 
+	border: none;
 	display: none;
 }
 
-.SelfTest {
-	position:absolute;
-	top:0%;
-	left: 0%;
-	width: 100%;
-	height:100%;
+
+#BottomScreen .SelfTestWrapper {
+  top: -5%;
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #690 

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

* Fix positioning of lower ECAM self-test position by bumping it up 5%
* Also remove styles for `SelfTest` since it was just making this problem more complex, and it really isn't needed since the element fills the parent wrapper anyway.

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
Before:
![](https://clapton.dev/u/2009/60f0b339.png)
After:
![](https://clapton.dev/u/2009/f82d4ffa.png)

**Additional context**
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username: