### PR TITLE
[FCU] Added background lighting at night (Update A320_Neo_FCU.css)

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.css
@@ -74,7 +74,7 @@
 a320-neo-fcu-element {
   width: 100%;
   height: 100%;
-  background-color: black;
+  background-color: rgba(17, 10, 1, 0.884);
   font-family: Roboto-Bold;
   position: relative;
   overflow: hidden; }
@@ -88,7 +88,7 @@ a320-neo-fcu-element {
       height: 8%;
       display: block;
       position: absolute;
-      background-color: rgba(17, 10, 1, 0.726); }
+      background-color: rgba(17, 10, 1, 0.884); }
       a320-neo-fcu-element #Mainframe #LargeScreen #Speed {
         width: 20%;
         height: 100%;
@@ -125,7 +125,7 @@ a320-neo-fcu-element {
       display: block;
       position: absolute;
       top: 8%;
-      background-color: rgba(17, 10, 1, 0.726);}
+      background-color: rgba(17, 10, 1, 0.884);}
       a320-neo-fcu-element #Mainframe #SmallScreen #Selected, a320-neo-fcu-element #Mainframe #SmallScreen #Standar {
         width: 100%;
         height: 100%;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.css
@@ -88,7 +88,7 @@ a320-neo-fcu-element {
       height: 8%;
       display: block;
       position: absolute;
-      background-color: black; }
+      background-color: rgba(17, 10, 1, 0.726); }
       a320-neo-fcu-element #Mainframe #LargeScreen #Speed {
         width: 20%;
         height: 100%;
@@ -125,7 +125,7 @@ a320-neo-fcu-element {
       display: block;
       position: absolute;
       top: 8%;
-      background-color: black; }
+      background-color: rgba(17, 10, 1, 0.726);}
       a320-neo-fcu-element #Mainframe #SmallScreen #Selected, a320-neo-fcu-element #Mainframe #SmallScreen #Standar {
         width: 100%;
         height: 100%;


### PR DESCRIPTION
Added a dark background color that shows up at night. emulates the backlighting of the LCD screen. 
The background color still varies with the brightness button under the glareshield.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #[issue_no]

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Modified the background color in the css

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
Before:
![image](https://user-images.githubusercontent.com/23705479/93281770-77e7dc00-f7d5-11ea-8b2e-8c4623561133.png)
After:
![image](https://user-images.githubusercontent.com/23705479/93281498-e37d7980-f7d4-11ea-98f3-a040d4deabb3.png)
Full brightness:
![image](https://user-images.githubusercontent.com/23705479/93281533-f55f1c80-f7d4-11ea-9799-5bdeb8ea1125.png)
Daylight:
![image](https://user-images.githubusercontent.com/23705479/93281602-13c51800-f7d5-11ea-954e-631d37da1f55.png)
IRL:
![image](https://user-images.githubusercontent.com/23705479/93281657-30f9e680-f7d5-11ea-8f0a-46b08b194a4c.png)

**Additional context**
<!-- Add any other context about the pull request here. -->
No incidence on the behaviour
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
