### PR TITLE
[BUGFIX] Prevent ECAM auto page switching when page is selected

### DIFF
--- a/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
+++ b/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
@@ -1477,3 +1477,68 @@
 		<SEQ2_EMISSIVE_CODE>(L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 ==</SEQ2_EMISSIVE_CODE>
 	</UseTemplate>
 </Template>
+
+<Template Name="A32NX_ENGINE_MODE_SELECTOR_TEMPLATE">
+    <DefaultTemplateParameters>
+        <ENGINE_COUNT>2</ENGINE_COUNT>
+    </DefaultTemplateParameters>
+    <UseTemplate Name="A32NX_ENGINE_MODE_SELECTOR_SUBTEMPLATE">
+        <ENGINE_CURRENT>#ENGINE_COUNT#</ENGINE_CURRENT>
+    </UseTemplate>
+</Template>
+
+<Template Name="A32NX_ENGINE_MODE_SELECTOR_SUBTEMPLATE">
+    <DefaultTemplateParameters>
+        <NODE_ID>ENGINE_Switch_Engine_Mode</NODE_ID>
+        <ANIM_NAME>ENGINE_Switch_Engine_Mode</ANIM_NAME>
+        <PART_ID>ENGINE_Switch_Engine_Mode</PART_ID>
+        <SWITCH_DIRECTION>Horizontal</SWITCH_DIRECTION>
+        <ARROW_TYPE>Curved</ARROW_TYPE>
+        <CODE_POS_1></CODE_POS_1>
+        <CODE_POS_2></CODE_POS_2>
+        <SWITCH_POSITION_TYPE>L</SWITCH_POSITION_TYPE>
+        <SWITCH_POSITION_VAR>XMLVAR_ENG_MODE_SEL</SWITCH_POSITION_VAR>
+        <STATE0_TEST>1</STATE0_TEST>
+        <STATE1_TEST>1</STATE1_TEST>
+        <STATE2_TEST>1</STATE2_TEST>
+        <WWISE_EVENT>engine_mode_switch</WWISE_EVENT>
+    </DefaultTemplateParameters>
+    <Condition>
+        <Test>
+            <Greater>
+                <Value>ENGINE_CURRENT</Value>
+                <Number>0</Number>
+            </Greater>
+        </Test>
+        <True>
+            <UseTemplate Name="A32NX_ENGINE_MODE_SELECTOR_SUBTEMPLATE">
+                <CODE_POS_1>
+                    1 (&gt;K:TURBINE_IGNITION_SWITCH_SET#ENGINE_CURRENT#)
+                    #CODE_POS_1#
+                </CODE_POS_1>
+                <CODE_POS_2>
+                    2 (&gt;K:TURBINE_IGNITION_SWITCH_SET#ENGINE_CURRENT#)
+                    #CODE_POS_2#
+                </CODE_POS_2>
+
+                <STATE0_TEST> (A:TURB ENG IGNITION SWITCH EX1:#ENGINE_CURRENT#, Enum) 0 == #STATE0_TEST# and</STATE0_TEST>
+                <STATE1_TEST> (A:TURB ENG IGNITION SWITCH EX1:#ENGINE_CURRENT#, Enum) 1 == #STATE1_TEST# and</STATE1_TEST>
+                <STATE2_TEST> (A:TURB ENG IGNITION SWITCH EX1:#ENGINE_CURRENT#, Enum) 2 == #STATE2_TEST# and</STATE2_TEST>
+                <ENGINE_CURRENT Process="Int">#ENGINE_CURRENT# 1 -</ENGINE_CURRENT>
+            </UseTemplate>
+        </True>
+        <False>
+            <Component ID="#NODE_ID#" Node="#NODE_ID#">
+                <UseTemplate Name="ASOBO_GT_Switch_3States">
+                    <CODE_POS_0>
+                        0 (&gt;K:TURBINE_IGNITION_SWITCH_SET)
+                    </CODE_POS_0>
+                    <CODE_POS_2>
+                        #CODE_POS_2#
+                        (&gt;H:A320_Neo_EICAS_2_Ignition_Start)
+                    </CODE_POS_2>
+                </UseTemplate>
+            </Component>
+        </False>
+    </Condition>
+</Template>

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -588,7 +588,7 @@
 				(A:GENERAL ENG MIXTURE LEVER POSITION:1, Percent over 100) 0.9 &lt; if{ (&gt;K:MIXTURE1_RICH) }
 				(A:GENERAL ENG MIXTURE LEVER POSITION:2, Percent over 100) 0.9 &lt; if{ (&gt;K:MIXTURE2_RICH) }
 			</Update>
-			<UseTemplate Name="ASOBO_ENGINE_Switch_Engine_Mode_Template">
+			<UseTemplate Name="A32NX_ENGINE_MODE_SELECTOR_TEMPLATE">
 				<AIRBUS_TYPE/>
 				<ANIM_NAME>KNOB_ENGINES_MODE</ANIM_NAME>
 				<NODE_ID>KNOB_ENGINES_MODE</NODE_ID>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -68,6 +68,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         this.ApuAboveThresholdTimer = -1; // MODIFIED
         this.MainEngineStarterOffTimer = -1;
         this.CrzCondTimer = 60;
+        this.PrevFailPage = -1;
 
         this.topSelfTestDiv = this.querySelector("#TopSelfTest");
         this.topSelfTestTimer = -1;
@@ -269,14 +270,22 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
                 10: "FTCL",
                 11: "STS"
             }
-
             this.pageNameWhenUnselected = ECAMPageIndices[sFailPage];
+
+            // Disable user selected page when new failure detected
+            if (this.PrevFailPage !== sFailPage) {
+                this.currentPage = -1;
+                SimVar.SetSimVarValue("L:XMLVAR_ECAM_CURRENT_PAGE", "number", -1);
+            }
+        }
+        
+        // switch page when desired page was changed, or new Failure detected
+        if ((this.pageNameWhenUnselected != prevPage && this.currentPage == -1) || (this.PrevFailPage !== sFailPage)) {
+            this.SwitchToPageName(this.LOWER_SCREEN_GROUP_NAME, this.pageNameWhenUnselected);
+
         }
 
-        // switch page when desired page was changed
-        if (this.pageNameWhenUnselected != prevPage && this.currentPage == -1) {
-            this.SwitchToPageName(this.LOWER_SCREEN_GROUP_NAME, this.pageNameWhenUnselected);
-        }
+        this.PrevFailPage = sFailPage;
 
         // modification ends here
     }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -68,6 +68,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         this.ApuAboveThresholdTimer = -1; // MODIFIED
         this.MainEngineStarterOffTimer = -1;
         this.CrzCondTimer = 60;
+        this.PrevFailPage = -1;
 
         this.topSelfTestDiv = this.querySelector("#TopSelfTest");
         this.topSelfTestTimer = -1;
@@ -244,7 +245,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
             }
         } else if ((ToPowerSet || !Simplane.getIsGrounded()) && !crzCond && this.minPageIndexWhenUnselected <= 2) {
             this.pageNameWhenUnselected = "ENG";
-        } else if (crzCond && !(isGearExtended && altitude < 16000) && this.minPageIndexWhenUnselected <= 3) {
+        } else if (crzCond && !(isGearExtended && altitude < 16000)) {
             this.pageNameWhenUnselected = "CRZ";
             this.minPageIndexWhenUnselected = 3;
         } else if (isGearExtended && (altitude < 16000)) {
@@ -254,7 +255,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
 
         const sFailPage = SimVar.GetSimVarValue("L:A32NX_ECAM_SFAIL", "Enum");
 
-        if (sFailPage != -1) {
+        if (sFailPage != -1 && sFailPage != this.PrevFailPage) {
             const ECAMPageIndices = {
                 0: "ENG",
                 1: "BLEED",
@@ -270,7 +271,11 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
                 11: "STS"
             }
 
-            this.pageNameWhenUnselected = ECAMPageIndices[sFailPage];
+            this.changePage(ECAMPageIndices[sFailPage]);
+
+        }
+        if (sFailPage != this.PrevFailPage) {
+            this.PrevFailPage = sFailPage;
         }
 
         // switch page when desired page was changed

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -274,7 +274,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         }
 
         // switch page when desired page was changed
-        if (this.pageNameWhenUnselected != prevPage) {
+        if (this.pageNameWhenUnselected != prevPage && this.currentPage == -1) {
             this.SwitchToPageName(this.LOWER_SCREEN_GROUP_NAME, this.pageNameWhenUnselected);
         }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -68,7 +68,6 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         this.ApuAboveThresholdTimer = -1; // MODIFIED
         this.MainEngineStarterOffTimer = -1;
         this.CrzCondTimer = 60;
-        this.PrevFailPage = -1;
 
         this.topSelfTestDiv = this.querySelector("#TopSelfTest");
         this.topSelfTestTimer = -1;
@@ -255,7 +254,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
 
         const sFailPage = SimVar.GetSimVarValue("L:A32NX_ECAM_SFAIL", "Enum");
 
-        if (sFailPage != -1 && sFailPage != this.PrevFailPage) {
+        if (sFailPage != -1) {
             const ECAMPageIndices = {
                 0: "ENG",
                 1: "BLEED",
@@ -271,11 +270,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
                 11: "STS"
             }
 
-            this.changePage(ECAMPageIndices[sFailPage]);
-
-        }
-        if (sFailPage != this.PrevFailPage) {
-            this.PrevFailPage = sFailPage;
+            this.pageNameWhenUnselected = ECAMPageIndices[sFailPage];
         }
 
         // switch page when desired page was changed


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->

**Summary of Changes**
* Fixes issue where automatic ECAM page selection would override the manually selected page.


**Additional context**
* ~~Maybe a problem: A page triggered by a failure will not override the selected page, I don't know if this is expected behaviour or not~~
* ~~Problem: When Engine mode selector is not in normal, the engine page would come up, but will not go away, somewhere it overrides the currently selected page.~~ Should be fixed now
