### PR TITLE
Port Upper ECAM changes from 1.8.3

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -1595,8 +1595,8 @@ var A320_Neo_UpperECAM;
             super.update(_deltaTime);
             if (Simplane.getEngineActive(0) || Simplane.getEngineActive(1)) {
                 var throttleMode = Math.max(Simplane.getEngineThrottleMode(0), Simplane.getEngineThrottleMode(1));
+                var throttleValue = Simplane.getEngineThrottleMaxThrust(1);
                 if (Simplane.getCurrentFlightPhase() < FlightPhase.FLIGHT_PHASE_CLIMB) {
-                    var throttleValue = Math.max(Simplane.getEngineThrottle(0), Simplane.getEngineThrottle(1));
                     if (throttleMode == ThrottleMode.FLEX_MCT) {
                         this.setThrottle(true, throttleValue, throttleMode, true);
                         var flexTemp = Simplane.getFlexTemperature();
@@ -1608,7 +1608,7 @@ var A320_Neo_UpperECAM;
                     }
                 }
                 else {
-                    this.setThrottle(true, Math.max(Simplane.getEngineCommandedN1(0), Simplane.getEngineCommandedN1(1)), throttleMode);
+                    this.setThrottle(true, throttleValue, throttleMode);
                     this.setFlexTemperature(false);
                 }
             }
@@ -1820,7 +1820,7 @@ var A320_Neo_UpperECAM;
             super.update(_deltaTime);
             var slatsAngle = (SimVar.GetSimVarValue("LEADING EDGE FLAPS LEFT ANGLE", "degrees") + SimVar.GetSimVarValue("LEADING EDGE FLAPS RIGHT ANGLE", "degrees")) * 0.5;
             var flapsAngle = (SimVar.GetSimVarValue("TRAILING EDGE FLAPS LEFT ANGLE", "degrees") + SimVar.GetSimVarValue("TRAILING EDGE FLAPS RIGHT ANGLE", "degrees")) * 0.5;
-            var handleIndex = SimVar.GetSimVarValue("FLAPS HANDLE INDEX", "number");
+            var handleIndex = Simplane.getFlapsHandleIndex();
             let slatsTargetIndex = handleIndex;
             let flapsTargetIndex = handleIndex;
             var slatsAngleChanged = (this.currentSlatsAngle != slatsAngle);
@@ -1900,7 +1900,7 @@ var A320_Neo_UpperECAM;
                             }
                         case 4:
                             {
-                                this.currentStateText.textContent = "F";
+                                this.currentStateText.textContent = "FULL";
                                 break;
                             }
                         default:

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -1820,7 +1820,7 @@ var A320_Neo_UpperECAM;
             super.update(_deltaTime);
             var slatsAngle = (SimVar.GetSimVarValue("LEADING EDGE FLAPS LEFT ANGLE", "degrees") + SimVar.GetSimVarValue("LEADING EDGE FLAPS RIGHT ANGLE", "degrees")) * 0.5;
             var flapsAngle = (SimVar.GetSimVarValue("TRAILING EDGE FLAPS LEFT ANGLE", "degrees") + SimVar.GetSimVarValue("TRAILING EDGE FLAPS RIGHT ANGLE", "degrees")) * 0.5;
-            var handleIndex = Simplane.getFlapsHandleIndex();
+            var handleIndex = Simplane.getFlapsHandleIndex(true);
             let slatsTargetIndex = handleIndex;
             let flapsTargetIndex = handleIndex;
             var slatsAngleChanged = (this.currentSlatsAngle != slatsAngle);

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -36,6 +36,12 @@ declare global {
 
         getAutoPilotMachModeActive(): number
         getEngineActive(_engineIndex: number): number
+        getEngineThrottle(_engineIndex: number): number
+        getEngineThrottleMaxThrust(_engineIndex: number): number
+        getEngineCommandedN1(_engineIndex: number): number
+
+        //Seems to implement caching behaviour, can be overridden with forceSimVarCall
+        getFlapsHandleIndex(forceSimVarCall?: boolean): number
     };
 
     const Utils: {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* Update UpperEcam.js with new changes (#719)
* Update `types.d.ts` with Simplane functions

**Additional context**
<!-- Add any other context about the pull request here. -->
* Flaps are functionally the same, except for a caching feature in `Simplane.getFlapsHandleIndex()`, which doesn't seem to cause any issues. Also can be overridden if necessary.
* Changes to the throttle mode do not seem to break anything after a short testing.
