### PR TITLE
Acceleration altitude should be MSL instead of AGL

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -795,17 +795,16 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
                 this.climbTransitionGroundAltitude = null;
             }
         }
-        
         //Changes to climb phase when acceleration altitude is reached
         if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_TAKEOFF && airSpeed > 80) {
             const planeAltitudeMsl = Simplane.getAltitude();
             let accelerationAltitudeMsl = (this.accelerationAltitude || this.thrustReductionAltitude);
             
-            if(!accelerationAltitudeMsl) {     
-                if(!this.climbTransitionGroundAltitude) {
-                    let airport = this.flightPlanManager.getOrigin();
-                    if (airport) {
-                        this.climbTransitionGroundAltitude = airport.infos.coordinates.alt;
+            if (!accelerationAltitudeMsl) {     
+                if (!this.climbTransitionGroundAltitude) {
+                    const origin = this.flightPlanManager.getOrigin();
+                    if (origin) {
+                        this.climbTransitionGroundAltitude = origin.altitudeinFP;
                     }
 
                     if (!this.climbTransitionGroundAltitude) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -799,8 +799,8 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_TAKEOFF && airSpeed > 80) {
             const planeAltitudeMsl = Simplane.getAltitude();
             let accelerationAltitudeMsl = (this.accelerationAltitude || this.thrustReductionAltitude);
-            
-            if (!accelerationAltitudeMsl) {     
+
+            if (!accelerationAltitudeMsl) {
                 if (!this.climbTransitionGroundAltitude) {
                     const origin = this.flightPlanManager.getOrigin();
                     if (origin) {
@@ -811,10 +811,10 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
                         this.climbTransitionGroundAltitude = (parseInt(SimVar.GetSimVarValue("GROUND ALTITUDE", "feet")) || 0);
                     }
                 }
-                
+
                 accelerationAltitudeMsl = this.climbTransitionGroundAltitude + 1500;
             }
-            
+
             if (planeAltitudeMsl > accelerationAltitudeMsl) {
                 this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_CLIMB;
                 this.climbTransitionGroundAltitude = null;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -674,6 +674,9 @@ class CDUPerformancePage {
 
         mcdu.thrustReductionAltitude = thrRedAccAltitude;
         mcdu.accelerationAltitude = thrRedAccAltitude;
+        
+        SimVar.SetSimVarValue("L:AIRLINER_THR_RED_ALT", "Number", thrRedAccAltitude || 0);
+        SimVar.SetSimVarValue("L:AIRLINER_ACC_ALT", "Number", thrRedAccAltitude || 0);
     }
 }
 CDUPerformancePage._timer = 0;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -674,7 +674,7 @@ class CDUPerformancePage {
 
         mcdu.thrustReductionAltitude = thrRedAccAltitude;
         mcdu.accelerationAltitude = thrRedAccAltitude;
-        
+
         SimVar.SetSimVarValue("L:AIRLINER_THR_RED_ALT", "Number", thrRedAccAltitude || 0);
         SimVar.SetSimVarValue("L:AIRLINER_ACC_ALT", "Number", thrRedAccAltitude || 0);
     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #552 
Fixes #733

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Most credit to @RikvanD1997 (see commits). Hope you don't mind me opening the PR! Opened PR as previous one had a mishap and there was another bug report too which this change fixes.

- Change acceleration altitude to be based on from "Above Ground Level" to "Main Sea Level" as in real A320
- Fix issue where "LVR CLB" is shown on FMA too early due to missing THR RED/ACC information on Simplanes's state.

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->


**Additional context**
<!-- Add any other context about the pull request here. -->
[Reference](https://discordapp.com/channels/738864299392630914/739223532269076561/753381220523442277)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): VeGe-#4631
