### PR TITLE
Make the ADIRS align timer respect the in-game time.

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -881,12 +881,6 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
     }
     updateADIRS() {
 
-        //Get the time since last update
-        var now = Date.now();
-        if (this.lastTime == null) this.lastTime = now;
-        var deltaTime = now - this.lastTime;
-        this.lastTime = now;
-
         var AllADIRSOn = ((SimVar.GetSimVarValue("L:A320_Neo_ADIRS_KNOB_1", "Enum") >= 1) && (SimVar.GetSimVarValue("L:A320_Neo_ADIRS_KNOB_2", "Enum") >= 1) && (SimVar.GetSimVarValue("L:A320_Neo_ADIRS_KNOB_3", "Enum") >= 1));
         var SomeADIRSOn = ((SimVar.GetSimVarValue("L:A320_Neo_ADIRS_KNOB_1", "Enum") >= 1) || (SimVar.GetSimVarValue("L:A320_Neo_ADIRS_KNOB_2", "Enum") >= 1) || (SimVar.GetSimVarValue("L:A320_Neo_ADIRS_KNOB_3", "Enum") >= 1));
         var ADIRSState = SimVar.GetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum");
@@ -916,7 +910,17 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
 
         if (ADIRSState == 1 && SimVar.GetSimVarValue("L:A320_Neo_ADIRS_IN_ALIGN", "Bool") == 1) {
             if (ADIRSTimer > 0) {
-                ADIRSTimer -= deltaTime/1000;
+                //Get the time since last update
+                let ztime = SimVar.GetGlobalVarValue("ZULU TIME", "Seconds");
+                var now = Number.parseInt(ztime);
+                if (this.lastTime == null) this.lastTime = now;
+
+                // calculate time ellapsed since last run
+                var deltaTime = now - this.lastTime;
+                this.lastTime = now;
+
+                // update timer
+                ADIRSTimer -= deltaTime;
                 SimVar.SetSimVarValue("L:A320_Neo_ADIRS_TIME", "Seconds", ADIRSTimer);
                 const ADIRSTimerStartTime = SimVar.GetSimVarValue("L:A32NX_Neo_ADIRS_START_TIME", "Seconds");
                 const secondsIntoAlignment = ADIRSTimerStartTime - ADIRSTimer;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

The ADIRS timer was using real world time to update its timer, which means it completely disregarded sim rate. This patch makes the timer take acceleration of the simrate in account. In essence, the timer now follows the same time as the aircraft clock.

As a tiny optimization bonus, we only calculate the delta when ADIRS is in alignment.

**Additional context**
<!-- Add any other context about the pull request here. -->

The original code used `Date.now()` which returns the current time from the computer running the simulation. With this patch, we'll instead use the simvar `ZULU TIME` which holds the time _in sim_. We use Zulu Time instead of the sim's local time to avoid having to deal with things like timezone changes (i.e. daylight time.)

There are other similar real world timers instead of in-game time elsewhere in the code (e.g. the 40s self-test timer, and the flight phase reset) and we could also change those in subsequent PRs if desired.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): GrinningLlama
