### PR TITLE
Set Emer Exit light to dummy

### DIFF
--- a/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
+++ b/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
@@ -1241,7 +1241,7 @@
 </Template>
 
 <Template Name="ASOBO_AIRLINER_SIGNS_LIGHT_Template">
-	<UseTemplate Name="ASOBO_GT_Push_Button_Airliner">
+	<UseTemplate Name="ASOBO_GT_Push_Button_Airliner_Dummy">
 		<SEQ1_EMISSIVE_CODE>0</SEQ1_EMISSIVE_CODE>
 		<SEQ2_EMISSIVE_CODE>(L:XMLVAR_SWITCH_OVHD_INTLT_EMEREXIT_Position) 2 == (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</SEQ2_EMISSIVE_CODE>
 	</UseTemplate>


### PR DESCRIPTION


<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Changed the type of the Emergency Exit Status light to be 'Dummy', so it does not appear clickable, as it is not a push button

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Benjwri#2516
