### PR TITLE
Fix #783 Overspeed Warning

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -53,6 +53,7 @@ var A320_Neo_UpperECAM;
             this.allPanels = [];
             this.simVarCache = {};
             this.frameCount = 0;
+            this._aircraft = Aircraft.A320_NEO;
         }
         get templateID() { return "UpperECAMTemplate"; }
         connectedCallback() {
@@ -71,6 +72,15 @@ var A320_Neo_UpperECAM;
             const mins = Math.ceil(secs/60);
             if (secs > 0) return mins;
             else return -1;
+        }
+        getLimitSpeed() {
+            const currentIAS = Simplane.getIndicatedSpeed();
+            const gearDownLimit = SimVar.GetSimVarValue("GEAR HANDLE POSITION", "Bool") == 1 && currentIAS >= 284;
+            const getIsOverspeed = Simplane.getFlapsLimitSpeed(this.aircraft, Simplane.getFlapsHandleIndex()) + 4;
+             
+            if (currentIAS >= getIsOverspeed || gearDownLimit){
+                return true;
+            }
         }
         engineFailed(_engine) {
             return (this.getCachedSimVar("ENG FAILED:"+_engine, "Bool") == 1) && !this.getCachedSimVar("ENG ON FIRE:"+_engine) && !Simplane.getIsGrounded();
@@ -379,6 +389,18 @@ var A320_Neo_UpperECAM;
                         ]
                     },
                     //Airborne
+                    {
+                        name: "OVERSPEED",
+                        messages: [
+                            {
+                                message: "",
+                                level: 3,
+                                isActive: () => {
+                                    return this.getLimitSpeed();
+                                },
+                            },
+                        ]
+                    },
                     {
                         name: "ENG 1 FIRE",
                         messages: [


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #783 

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Overspeed warning re-implemented. Master caution and ECAM message.

Conditions:
- A/C Speed/Mach above VMO+4kt
- L/G not uplocked or L/G doors not closed and above VLE + 4kt
- A/C Speed above VFE + 4kt, with slats and/or flaps extended.

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
![image](https://user-images.githubusercontent.com/18389085/93826742-cf67cb00-fc5f-11ea-9a0a-dbec81ba28d7.png)
*Entered overspeed with flaps down*

**Additional context**
<!-- Add any other context about the pull request here. -->
![image](https://user-images.githubusercontent.com/18389085/93826818-f6be9800-fc5f-11ea-8ac1-e4f518de09a6.png)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Sabes#8668
