### PR TITLE
Ecam sts fix

### DIFF
--- a/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
+++ b/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
@@ -730,6 +730,48 @@
 	</UseTemplate>
 </Template>
 
+<Template Name="A32NX_ECAM_CLR_BUTTON_Template">
+    <DefaultTemplateParameters>
+        <BASE_NAME>UNKNOWN</BASE_NAME>
+        <NODE_ID>PUSH_ECAM_#BASE_NAME#</NODE_ID>
+        <ANIM_NAME_BUTTON>PUSH_ECAM_#BASE_NAME#</ANIM_NAME_BUTTON>
+        <LED_NODE_ID>PUSH_ECAM_#BASE_NAME#_SEQ2</LED_NODE_ID>
+        <BACKLIGHT_NODE_ID>PUSH_ECAM_#BASE_NAME#_SEQ1</BACKLIGHT_NODE_ID>
+        <WWISE_EVENT_1>radio_push_button_on</WWISE_EVENT_1>
+        <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
+        <WWISE_EVENT_2>radio_push_button_off</WWISE_EVENT_2>
+        <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
+    </DefaultTemplateParameters>
+
+    <Component ID="#NODE_ID#" Node="#NODE_ID#">
+        <UseTemplate Name="ASOBO_GT_Push_Button">
+            <ANIM_NAME>#ANIM_NAME_BUTTON#</ANIM_NAME>
+            <LEFT_SINGLE_CODE>
+                1 (&gt;L:A32NX_BTN_#BASE_NAME#)
+            </LEFT_SINGLE_CODE>
+        </UseTemplate>
+    </Component>
+
+
+    <Component ID="#LED_NODE_ID#" Node="#LED_NODE_ID#">
+        <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
+            <EMISSIVE_CODE>
+                (L:A32NX_ECAM_SFAIL) -1 &gt;
+                (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or
+            </EMISSIVE_CODE>
+        </UseTemplate>
+    </Component>
+
+    <Condition Check="POTENTIOMETER">
+        <True>
+            <Component ID="#BACKLIGHT_NODE_ID#" Node="#BACKLIGHT_NODE_ID#">
+                <UseTemplate Name="ASOBO_GT_Emissive_Potentiometer">
+                </UseTemplate>
+            </Component>
+        </True>
+    </Condition>
+</Template>
+
 <!-- This whole section is modified -->
 <Template Name="ASOBO_ECAM_PAGE_SELECTION_Template">
 	<UseTemplate Name="ASOBO_ECAM_PAGE_BUTTON_Template">
@@ -821,13 +863,13 @@
 		<TOOLTIPID>Test T.O CONFIG</TOOLTIPID>
 	</UseTemplate>
 
-	<UseTemplate Name="ASOBO_ECAM_BUTTON_Template">
+	<UseTemplate Name="A32NX_ECAM_CLR_BUTTON_Template">
 		<BASE_NAME>CLR</BASE_NAME>
 		<PART_ID>ECAM_CLR</PART_ID>
 		<TOOLTIPID>Clear ECAM messages</TOOLTIPID>
 	</UseTemplate>
 
-	<UseTemplate Name="ASOBO_ECAM_BUTTON_Template">
+	<UseTemplate Name="A32NX_ECAM_CLR_BUTTON_Template">
 		<BASE_NAME>CLR2</BASE_NAME>
 		<PART_ID>ECAM_CLR2</PART_ID>
 		<TOOLTIPID>Clear ECAM messages</TOOLTIPID>

--- a/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
+++ b/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
@@ -772,6 +772,36 @@
     </Condition>
 </Template>
 
+<Template Name="A32NX_ECAM_ALL_BUTTON_Template">
+    <DefaultTemplateParameters>
+        <BASE_NAME>UNKNOWN</BASE_NAME>
+        <NODE_ID>PUSH_ECAM_#BASE_NAME#</NODE_ID>
+        <ANIM_NAME_BUTTON>PUSH_ECAM_#BASE_NAME#</ANIM_NAME_BUTTON>
+        <BACKLIGHT_NODE_ID>PUSH_ECAM_#BASE_NAME#_SEQ1</BACKLIGHT_NODE_ID>
+        <WWISE_EVENT_1>radio_push_button_on</WWISE_EVENT_1>
+        <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
+        <WWISE_EVENT_2>radio_push_button_off</WWISE_EVENT_2>
+        <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
+    </DefaultTemplateParameters>
+
+    <Component ID="#NODE_ID#" Node="#NODE_ID#">
+        <UseTemplate Name="ASOBO_GT_Push_Button_Held">
+            <ANIM_NAME>#ANIM_NAME_BUTTON#</ANIM_NAME>
+            <LEFT_SINGLE_CODE>1 (>L:A32NX_BTN_#BASE_NAME#)</LEFT_SINGLE_CODE>
+            <LEFT_LEAVE_CODE>0 (>L:A32NX_BTN_#BASE_NAME#)</LEFT_LEAVE_CODE>
+        </UseTemplate>
+    </Component>
+
+    <Condition Check="POTENTIOMETER">
+        <True>
+            <Component ID="#BACKLIGHT_NODE_ID#" Node="#BACKLIGHT_NODE_ID#">
+                <UseTemplate Name="ASOBO_GT_Emissive_Potentiometer">
+                </UseTemplate>
+            </Component>
+        </True>
+    </Condition>
+</Template>
+
 <!-- This whole section is modified -->
 <Template Name="ASOBO_ECAM_PAGE_SELECTION_Template">
 	<UseTemplate Name="ASOBO_ECAM_PAGE_BUTTON_Template">
@@ -850,6 +880,12 @@
 		<GROUP_INDEX>10</GROUP_INDEX> <!--Change to positive to activate-->
 		<TOOLTIPID>TT:COCKPIT.TOOLTIPS.PUSH_ECAM_FCTL</TOOLTIPID>
 	</UseTemplate>
+
+    <UseTemplate Name="A32NX_ECAM_ALL_BUTTON_Template">
+        <BASE_NAME>ALL</BASE_NAME>
+        <PART_ID>ECAM_ALL</PART_ID>
+        <TOOLTIPID>Cycle through ECAM pages (INOP)</TOOLTIPID>
+    </UseTemplate>
 
 	<UseTemplate Name="ASOBO_ECAM_PAGE_BUTTON_Template">
 		<BASE_NAME>STS</BASE_NAME>

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -2271,12 +2271,6 @@
 				<POTENTIOMETER_SEQ1>85</POTENTIOMETER_SEQ1>
 				<ONLY_SEQ1/>
 			</UseTemplate>
-
-			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
-				<NODE_ID>PUSH_ECAM_RCL</NODE_ID>
-				<POTENTIOMETER_SEQ1>85</POTENTIOMETER_SEQ1>
-				<ONLY_SEQ1/>
-			</UseTemplate>
 		</Component>
 
 		<CameraTitle>ECAM</CameraTitle>

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -2273,19 +2273,9 @@
 			</UseTemplate>
 
 			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
-				<NODE_ID>PUSH_ECAM_CLR</NODE_ID>
-				<POTENTIOMETER_SEQ1>85</POTENTIOMETER_SEQ1>
-			</UseTemplate>
-
-			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 				<NODE_ID>PUSH_ECAM_RCL</NODE_ID>
 				<POTENTIOMETER_SEQ1>85</POTENTIOMETER_SEQ1>
 				<ONLY_SEQ1/>
-			</UseTemplate>
-
-			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
-				<NODE_ID>PUSH_ECAM_CLR2</NODE_ID>
-				<POTENTIOMETER_SEQ1>85</POTENTIOMETER_SEQ1>
 			</UseTemplate>
 		</Component>
 

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -2260,19 +2260,6 @@
 			<POTENTIOMETER>85</POTENTIOMETER>
 		</UseTemplate>
 
-		<Component ID="ECAM_Push_Dummies">
-			<DefaultTemplateParameters>
-				<SEQ1_EMISSIVE_DRIVES_VISIBILITY>False</SEQ1_EMISSIVE_DRIVES_VISIBILITY>
-				<SEQ2_EMISSIVE_DRIVES_VISIBILITY>False</SEQ2_EMISSIVE_DRIVES_VISIBILITY>
-			</DefaultTemplateParameters>
-
-			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
-				<NODE_ID>PUSH_ECAM_ALL</NODE_ID>
-				<POTENTIOMETER_SEQ1>85</POTENTIOMETER_SEQ1>
-				<ONLY_SEQ1/>
-			</UseTemplate>
-		</Component>
-
 		<CameraTitle>ECAM</CameraTitle>
 	</Component>
 
@@ -2964,9 +2951,6 @@
 		</UseTemplate>
 		<UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
 			<NODE_ID>PUSH_ECAM_EMERCANC</NODE_ID>
-		</UseTemplate>
-		<UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
-			<NODE_ID>PUSH_ECAM_ALL</NODE_ID>
 		</UseTemplate>
 		<UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
 			<NODE_ID>PUSH_RADIOL_SEL</NODE_ID>

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -2278,11 +2278,6 @@
 			</UseTemplate>
 
 			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
-				<NODE_ID>PUSH_ECAM_STS</NODE_ID>
-				<POTENTIOMETER_SEQ1>85</POTENTIOMETER_SEQ1>
-			</UseTemplate>
-
-			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 				<NODE_ID>PUSH_ECAM_RCL</NODE_ID>
 				<POTENTIOMETER_SEQ1>85</POTENTIOMETER_SEQ1>
 				<ONLY_SEQ1/>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #797

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* When ECAM STS page is selected, the light on the button is now illuminated
* When there are failures to clear, the ECAM CLR light illuminates.
* Prepared ECAM ALL button for usage. Button can be held, Simvar is A32NX_BTN_ALL
* Backlight of ECAM CLR, RCL, STS and ALL buttons backlight now working

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
Before:
![grafik](https://user-images.githubusercontent.com/39596827/93908062-726f2200-fcfe-11ea-9942-9c67e12735f7.png)
After:
![grafik](https://user-images.githubusercontent.com/39596827/93908015-62efd900-fcfe-11ea-86d1-b127dfe6849d.png)



**Additional context**
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
