### PR TITLE
[CDU] Remove decimals from flight plan altitude FL constraints

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -224,7 +224,7 @@ class CDUFlightPlanPage {
                         let altitudeConstraint = "---";
                         if (waypoint.legAltitudeDescription !== 0) {
                             if (mcdu.transitionAltitude >= 100 && waypoint.legAltitude1 > mcdu.transitionAltitude)
-                                altitudeConstraint = "FL" + (waypoint.legAltitude1.toFixed(0) / 100);
+                                altitudeConstraint = "FL" + (waypoint.legAltitude1 / 100).toFixed(0);
                             else
                                 altitudeConstraint = waypoint.legAltitude1.toFixed(0);
                             if (waypoint.legAltitudeDescription === 1) {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes N/A

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes an issue where sometimes random decimals are shown on the flight plan waypoint restrictions when above transition altitude.

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
N/A

**Additional context**
<!-- Add any other context about the pull request here. -->
N/A
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
