### PR TITLE
Fix DES phase

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/approach.FLT
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/approach.FLT
@@ -176,6 +176,8 @@ Potentiometer.88=0.5
 Potentiometer.89=0.5
 Potentiometer.90=0.5
 Potentiometer.91=0.5
+Potentiometer.92=0.5
+Potentiometer.93=0.5
 
 [AutoPilot.0]
 MasterSwitch=True

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/cruise.FLT
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/cruise.FLT
@@ -180,6 +180,8 @@ Potentiometer.88=0.5
 Potentiometer.89=0.5
 Potentiometer.90=0.5
 Potentiometer.91=0.5
+Potentiometer.92=0.5
+Potentiometer.93=0.5
 
 [AutoPilot.0]
 MasterSwitch=True

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/final.FLT
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/final.FLT
@@ -179,6 +179,8 @@ Potentiometer.88=0.5
 Potentiometer.89=0.5
 Potentiometer.90=0.5
 Potentiometer.91=0.5
+Potentiometer.92=0.5
+Potentiometer.93=0.5
 
 [AutoPilot.0]
 MasterSwitch=False

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/runway.FLT
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/runway.FLT
@@ -188,6 +188,8 @@ Potentiometer.88=0.5
 Potentiometer.89=0.5
 Potentiometer.90=0.5
 Potentiometer.91=0.5
+Potentiometer.92=0.5
+Potentiometer.93=0.5
 
 [AutoPilot.0]
 MasterSwitch=False

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/taxi.flt
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/taxi.flt
@@ -117,6 +117,8 @@ Potentiometer.88=0.5
 Potentiometer.89=0.5
 Potentiometer.90=0.5
 Potentiometer.91=0.5
+Potentiometer.92=0.5
+Potentiometer.93=0.5
 
 [LocalVars.0]
 XMLVAR_RMP_L_On=1

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -926,6 +926,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             }
 
             if (planeAltitudeMsl > accelerationAltitudeMsl) {
+                console.log('switching to FLIGHT_PHASE_CLIMB: ' + JSON.stringify({planeAltitudeMsl, accelerationAltitudeMsl, prevPhase: this.currentFlightPhase}, null, 2));
                 this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_CLIMB;
                 this.climbTransitionGroundAltitude = null;
             }
@@ -936,23 +937,26 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             const cruiseFlightLevel = this.cruiseFlightLevel * 100;
             if (isFinite(cruiseFlightLevel)) {
                 if (altitude >= 0.96 * cruiseFlightLevel) {
+                    console.log('switching to FLIGHT_PHASE_CRUISE: ' + JSON.stringify({altitude, cruiseFlightLevel, prevPhase: this.currentFlightPhase}, null, 2));
                     this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_CRUISE;
                     Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", ThrottleMode.AUTO);
                 }
             }
         }
-        //Default Asobo logic
+        //(Mostly) Default Asobo logic
         if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_CRUISE) {
             const altitude = SimVar.GetSimVarValue("PLANE ALTITUDE", "feets");
-            const cruiseFlightLevel = this.cruiseFlightLevel;
+            const cruiseFlightLevel = this.cruiseFlightLevel * 100;
             if (isFinite(cruiseFlightLevel)) {
                 if (altitude < 0.94 * cruiseFlightLevel) {
+                    console.log('switching to FLIGHT_PHASE_DESCENT: ' + JSON.stringify({altitude, cruiseFlightLevel, prevPhase: this.currentFlightPhase}, null, 2));
                     this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_DESCENT;
                     Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", ThrottleMode.AUTO);
                 }
             }
         }
         //Default Asobo logic
+        // Switches from any phase to APPR if less than 40 distance(?) from DEST
         if (this.flightPlanManager.getActiveWaypoint() === this.flightPlanManager.getDestination()) {
             if (SimVar.GetSimVarValue("L:FLIGHTPLAN_USE_DECEL_WAYPOINT", "number") != 1) {
                 const lat = SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude");
@@ -963,12 +967,14 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
                     this.connectIls();
                     this.flightPlanManager.activateApproach();
                     if (this.currentFlightPhase != FlightPhase.FLIGHT_PHASE_APPROACH) {
+                        console.log('switching to tryGoInApproachPhase: ' + JSON.stringify({lat, long, dist, prevPhase: this.currentFlightPhase}, null, 2));
                         this.tryGoInApproachPhase();
                     }
                 }
             }
         }
         //Default Asobo logic
+        // Switches from any phase to APPR if less than 3 distance(?) from DECEL
         if (SimVar.GetSimVarValue("L:FLIGHTPLAN_USE_DECEL_WAYPOINT", "number") === 1) {
             if (this.currentFlightPhase != FlightPhase.FLIGHT_PHASE_APPROACH) {
                 if (this.flightPlanManager.decelWaypoint) {
@@ -977,6 +983,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
                     const planeLla = new LatLongAlt(lat, long);
                     const dist = Avionics.Utils.computeGreatCircleDistance(this.flightPlanManager.decelWaypoint.infos.coordinates, planeLla);
                     if (dist < 3) {
+                        console.log('switching to tryGoInApproachPhase (AT DECEL): ' + JSON.stringify({lat, long, dist, prevPhase: this.currentFlightPhase}, null, 2));
                         console.log("Switching into approach. DECEL lat : " + lat + " long " + long);
                         this.tryGoInApproachPhase();
                     }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -442,7 +442,7 @@ class CDUPerformancePage {
         }
         let bottomRowLabels = ["PREV", "NEXT"];
         let bottomRowCells = ["<PHASE", "PHASE>"];
-        if (mcdu.currentFlightPhase === FlightPhase.FLIGHT_PHASE_CLIMB) {
+        if (mcdu.currentFlightPhase === FlightPhase.FLIGHT_PHASE_DESCENT) {
             if (confirmAppr) {
                 bottomRowLabels[0] = "CONFIRM[color]red";
                 bottomRowCells[0] = "←APPR PHASE[color]red";

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AttitudeIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AttitudeIndicator.js
@@ -363,28 +363,28 @@ class Jet_PFD_AttitudeIndicator extends HTMLElement {
                 let cursors = document.createElementNS(Avionics.SVG.NS, "g");
                 {
                     let leftUpper = document.createElementNS(Avionics.SVG.NS, "path");
-                    leftUpper.setAttribute("d", "M-145 2 l0 -8 l62 0 l0 28 l-8 0 l0 -20 l-44 0 Z");
+                    leftUpper.setAttribute("d", "M-145 2 l0 -9 l62 0 l0 28 l-9 0 l0 -19 l-43 0 Z");
                     leftUpper.setAttribute("fill", "url(#Backlight)");
                     leftUpper.setAttribute("stroke", "yellow");
                     leftUpper.setAttribute("stroke-width", "3");
                     leftUpper.setAttribute("stroke-opacity", "1.0");
                     cursors.appendChild(leftUpper);
                     let rightUpper = document.createElementNS(Avionics.SVG.NS, "path");
-                    rightUpper.setAttribute("d", "M145 2 l0 -8 l-62 0 l0 28 l8 0 l0 -20 l44 0 Z");
+                    rightUpper.setAttribute("d", "M145 2 l0 -9 l-62 0 l0 28 l9 0 l0 -19 l43 0 Z");
                     rightUpper.setAttribute("fill", "url(#Backlight)");
                     rightUpper.setAttribute("stroke", "yellow");
                     rightUpper.setAttribute("stroke-width", "3");
                     rightUpper.setAttribute("stroke-opacity", "1.0");
                     cursors.appendChild(rightUpper);
-                    let centerRect = document.createElementNS(Avionics.SVG.NS, "rect");
-                    centerRect.setAttribute("x", "-4");
-                    centerRect.setAttribute("y", "-6");
-                    centerRect.setAttribute("height", "8");
-                    centerRect.setAttribute("width", "8");
-                    centerRect.setAttribute("fill", "url(#Backlight)");
-                    centerRect.setAttribute("stroke", "yellow");
-                    centerRect.setAttribute("stroke-width", "3");
-                    cursors.appendChild(centerRect);
+                    let centerRectFill = document.createElementNS(Avionics.SVG.NS, "rect");
+                    centerRectFill.setAttribute("x", "-4");
+                    centerRectFill.setAttribute("y", "-7");
+                    centerRectFill.setAttribute("height", "8");
+                    centerRectFill.setAttribute("width", "8");
+                    centerRectFill.setAttribute("fill", "url(#Backlight)");
+                    centerRectFill.setAttribute("stroke", "none");
+                    cursors.appendChild(centerRectFill);
+                    // The center rect yellow border is defined lower down so that it renders in front of the green FD bars
                 }
                 this.attitude_root.appendChild(cursors);
                 this.slipSkidTriangle = document.createElementNS(Avionics.SVG.NS, "path");
@@ -419,8 +419,24 @@ class Jet_PFD_AttitudeIndicator extends HTMLElement {
                 this.radioAltitudeGroup.appendChild(this.radioAltitude);
             }
         }
+
         this.flightDirector = new Jet_PFD_FlightDirector.A320_Neo_Handler();
         this.flightDirector.init(this.attitude_root);
+        
+        let cursorsFront = document.createElementNS(Avionics.SVG.NS, "g");
+        {
+            let centerRectBorder = document.createElementNS(Avionics.SVG.NS, "rect");
+            centerRectBorder.setAttribute("x", "-5");
+            centerRectBorder.setAttribute("y", "-8");
+            centerRectBorder.setAttribute("height", "10");
+            centerRectBorder.setAttribute("width", "10");
+            centerRectBorder.setAttribute("fill", "none");
+            centerRectBorder.setAttribute("stroke", "yellow");
+            centerRectBorder.setAttribute("stroke-width", "3");
+            cursorsFront.appendChild(centerRectBorder);
+        }
+        this.attitude_root.appendChild(cursorsFront);
+
         this.applyAttributes();
     }
     construct_B747_8() {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #444
Fixes #843

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes descent phase so that it is at least activated. It's not 100% realistic, it just fixes a small bug in the original asobo code that kept descent phase from activating at all.

Also fixes so Activate appr phase is not an option on the DES page when not actually in the DES phase, but it does show up when in DES phase on the DES page.

Also some more tweaks to the yellow aircraft symbol on the pfd att indicator.
Made the center rect 2 px bigger, and made it so the yellow border goes in front of the green FD bars, but the black rect is behind the green FD bars.

Also sets default brightness for ECAMs to match PFD and ND.

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
![image](https://user-images.githubusercontent.com/3533988/94224246-7c885080-feb7-11ea-887b-389115b85488.png)


**Additional context**
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
