### PR TITLE
make some FMAs have permanent box

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/A32NX_BaseAirliners.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/A32NX_BaseAirliners.js
@@ -179,6 +179,7 @@ var Airliners;
             this.IndependentElements = new NavSystemElementGroup([]);
             this.selector = _selector;
             this.element = this.IndependentElements;
+            this.getDeltaTime = A32NX_Util.createDeltaTimeCalculator(this._lastTime);
         }
         init() {
             super.init();
@@ -187,7 +188,8 @@ var Airliners;
                 this.screen = root.querySelector(this.selector);
             }
         }
-        onUpdate(_deltaTime) {
+        onUpdate() {
+            const _deltaTime = this.getDeltaTime();
             super.onUpdate(_deltaTime);
             if (this.screen != null) {
                 this.screen.update(_deltaTime);
@@ -216,13 +218,15 @@ var Airliners;
             if (root != null) {
                 this.page = root.querySelector(this.selector);
             }
+            this.getDeltaTime = A32NX_Util.createDeltaTimeCalculator(this._lastTime);
         }
         onEnter() {
             if (this.page != null) {
                 this.page.style.display = "block";
             }
         }
-        onUpdate(_deltaTime) {
+        onUpdate() {
+            const _deltaTime = this.getDeltaTime();
             if (this.page != null) {
                 this.page.update(_deltaTime);
             }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
@@ -215,10 +215,12 @@ class A320_Neo_PFD_VSpeed extends NavSystemElement {
         this.vsi = this.gps.getChildById("VSpeed");
         this.vsi.aircraft = Aircraft.A320_NEO;
         this.vsi.gps = this.gps;
+        this.getDeltaTime = A32NX_Util.createDeltaTimeCalculator(this._lastTime);
     }
     onEnter() {
     }
-    onUpdate(_deltaTime) {
+    onUpdate() {
+        const _deltaTime = this.getDeltaTime();
         var vSpeed = Math.round(Simplane.getVerticalSpeed());
         this.vsi.setAttribute("vspeed", vSpeed.toString());
         if (Simplane.getAutoPilotVerticalSpeedHoldActive()) {
@@ -243,10 +245,12 @@ class A320_Neo_PFD_Airspeed extends NavSystemElement {
         this.airspeed = this.gps.getChildById("Airspeed");
         this.airspeed.aircraft = Aircraft.A320_NEO;
         this.airspeed.gps = this.gps;
+        this.getDeltaTime = A32NX_Util.createDeltaTimeCalculator(this._lastTime);
     }
     onEnter() {
     }
-    onUpdate(_deltaTime) {
+    onUpdate() {
+        const _deltaTime = this.getDeltaTime();
         this.airspeed.update(_deltaTime);
     }
     onExit() {
@@ -262,10 +266,12 @@ class A320_Neo_PFD_Altimeter extends NavSystemElement {
         this.altimeter = this.gps.getChildById("Altimeter");
         this.altimeter.aircraft = Aircraft.A320_NEO;
         this.altimeter.gps = this.gps;
+        this.getDeltaTime = A32NX_Util.createDeltaTimeCalculator(this._lastTime);
     }
     onEnter() {
     }
-    onUpdate(_deltaTime) {
+    onUpdate() {
+        const _deltaTime = this.getDeltaTime();
         this.altimeter.update(_deltaTime);
     }
     onExit() {
@@ -290,10 +296,12 @@ class A320_Neo_PFD_Attitude extends NavSystemElement {
         this.hsi = this.gps.getChildById("Horizon");
         this.hsi.aircraft = Aircraft.A320_NEO;
         this.hsi.gps = this.gps;
+        this.getDeltaTime = A32NX_Util.createDeltaTimeCalculator(this._lastTime);
     }
     onEnter() {
     }
-    onUpdate(_deltaTime) {
+    onUpdate() {
+        const _deltaTime = this.getDeltaTime();
         if (this.hsi) {
             this.hsi.update(_deltaTime);
 
@@ -330,10 +338,12 @@ class A320_Neo_PFD_Compass extends NavSystemElement {
         this.hsi = this.gps.getChildById("Compass");
         this.hsi.aircraft = Aircraft.A320_NEO;
         this.hsi.gps = this.gps;
+        this.getDeltaTime = A32NX_Util.createDeltaTimeCalculator(this._lastTime);
     }
     onEnter() {
     }
-    onUpdate(_deltaTime) {
+    onUpdate() {
+        const _deltaTime = this.getDeltaTime();
         this.hsi.update(_deltaTime);
     }
     onExit() {
@@ -352,10 +362,12 @@ class A320_Neo_PFD_NavStatus extends NavSystemElement {
         this.fma.aircraft = Aircraft.A320_NEO;
         this.fma.gps = this.gps;
         this.isInitialized = true;
+        this.getDeltaTime = A32NX_Util.createDeltaTimeCalculator(this._lastTime);
     }
     onEnter() {
     }
-    onUpdate(_deltaTime) {
+    onUpdate() {
+        const _deltaTime = this.getDeltaTime();
         if (this.fma != null) {
             this.fma.update(_deltaTime);
         }
@@ -370,10 +382,12 @@ class A320_Neo_PFD_ILS extends NavSystemElement {
         this.ils = this.gps.getChildById("ILS");
         this.ils.aircraft = Aircraft.A320_NEO;
         this.ils.gps = this.gps;
+        this.getDeltaTime = A32NX_Util.createDeltaTimeCalculator(this._lastTime);
     }
     onEnter() {
     }
-    onUpdate(_deltaTime) {
+    onUpdate() {
+        const _deltaTime = this.getDeltaTime();
         if (this.ils) {
             this.ils.update(_deltaTime);
         }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
@@ -207,9 +207,27 @@ var Airbus_FMA;
                     this.hideHighlight();
                 }
             }
+            // Temporary fix for FMA blinking until css animations work again
+            if (this.blink) {
+                if (Math.sin((Date.now() / 1000) * Math.PI * 2) > 0) {
+                    if (this.blinkIsVisible) {
+                        this.blinkIsVisible = false;
+                        this.divRef.style.visibility = 'hidden';
+                    }
+                } else {
+                    if (!this.blinkIsVisible) {
+                        this.blinkIsVisible = true;
+                        this.divRef.style.visibility = 'visible';
+                    }
+                }
+            }
         }
         setMainText(_text, _style) {
             var changed = this.setText(_text, _style);
+            this.blink = _style === Airbus_FMA.MODE_STATE.ACTIVE_BLINK;
+            if (!this.blink) {
+                this.divRef.style.visibility = 'visible';
+            }
             if (_text.length <= 0) {
                 this.hideHighlight();
             }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
@@ -191,6 +191,7 @@ var Airbus_FMA;
         init() {
             super.init();
             this.highlightStyle = Airbus_FMA.HIGHLIGHT_STYLE.NONE;
+            this.highlightPermanent = false;
             this.hideHighlight();
             if (this.subLeft != null) {
                 this.subLeft.init();
@@ -200,7 +201,7 @@ var Airbus_FMA;
             }
         }
         update(_deltaTime) {
-            if (this.highlightTime > 0) {
+            if (!this.highlightPermanent && this.highlightTime > 0) {
                 this.highlightTime -= _deltaTime;
                 if (this.highlightTime <= 0) {
                     this.hideHighlight();
@@ -238,8 +239,9 @@ var Airbus_FMA;
                 this.subRight.setText(_textRight, _styleRight);
             }
         }
-        setHighlightStyle(_highlightStyle) {
+        setHighlightStyle(_highlightStyle, _permanent = false) {
             this.highlightStyle = _highlightStyle;
+            this.highlightPermanent = _permanent;
         }
         showHighlight() {
             if (this.divRef != null) {
@@ -303,6 +305,7 @@ var Airbus_FMA;
                 this.divRef.style.borderBottom = "none";
             }
             this.highlightTime = 0;
+            this.highlightPermanent = false;
         }
     }
     Airbus_FMA.Row = Row;
@@ -340,11 +343,11 @@ var Airbus_FMA;
             }
             this.updateChild(_deltaTime);
         }
-        setRowHighlightStyle(_row, _highlightStyle) {
+        setRowHighlightStyle(_row, _highlightStyle, _permanent = false) {
             if (this.rows != null) {
                 if ((_row >= 0) && (_row < this.rows.length)) {
                     if (this.rows[_row] != null) {
-                        this.rows[_row].setHighlightStyle(_highlightStyle);
+                        this.rows[_row].setHighlightStyle(_highlightStyle, _permanent);
                     }
                 }
             }
@@ -391,22 +394,22 @@ var Airbus_FMA;
                 switch (this.currentRow1And2State) {
                     case Column1.ROW_1_2_STATE.MANTOGA:
                         {
-                            this.setRowHighlightStyle(0, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_BOTTOM);
-                            this.setRowHighlightStyle(1, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_TOP);
+                            this.setRowHighlightStyle(0, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_BOTTOM, true);
+                            this.setRowHighlightStyle(1, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_TOP, true);
                             this.setRowText(0, "MAN", Airbus_FMA.MODE_STATE.STATUS);
                             this.setRowText(1, "TOGA", Airbus_FMA.MODE_STATE.STATUS);
                             break;
                         }
                     case Column1.ROW_1_2_STATE.TOGA:
                         {
-                            this.setRowHighlightStyle(0, Airbus_FMA.HIGHLIGHT_STYLE.FULL);
+                            this.setRowHighlightStyle(0, Airbus_FMA.HIGHLIGHT_STYLE.FULL, true);
                             this.setRowText(0, "TOGA", Airbus_FMA.MODE_STATE.STATUS);
                             break;
                         }
                     case Column1.ROW_1_2_STATE.MANFLX:
                         {
-                            this.setRowHighlightStyle(0, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_BOTTOM);
-                            this.setRowHighlightStyle(1, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_TOP);
+                            this.setRowHighlightStyle(0, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_BOTTOM, true);
+                            this.setRowHighlightStyle(1, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_TOP, true);
                             this.setRowText(0, "MAN", Airbus_FMA.MODE_STATE.STATUS);
                             let temperatureText = Airbus_FMA.CurrentPlaneState.flexTemperature >= 0 ? "+" : "-";
                             temperatureText += Airbus_FMA.CurrentPlaneState.flexTemperature.toFixed(0);
@@ -415,16 +418,16 @@ var Airbus_FMA;
                         }
                     case Column1.ROW_1_2_STATE.MANMCT:
                         {
-                            this.setRowHighlightStyle(0, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_BOTTOM);
-                            this.setRowHighlightStyle(1, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_TOP);
+                            this.setRowHighlightStyle(0, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_BOTTOM, true);
+                            this.setRowHighlightStyle(1, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_TOP, true);
                             this.setRowText(0, "MAN", Airbus_FMA.MODE_STATE.STATUS);
                             this.setRowText(1, "MCT", Airbus_FMA.MODE_STATE.STATUS);
                             break;
                         }
                     case Column1.ROW_1_2_STATE.MANTHR:
                         {
-                            this.setRowHighlightStyle(0, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_BOTTOM_WARNING);
-                            this.setRowHighlightStyle(1, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_TOP_WARNING);
+                            this.setRowHighlightStyle(0, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_BOTTOM_WARNING, true);
+                            this.setRowHighlightStyle(1, Airbus_FMA.HIGHLIGHT_STYLE.OPEN_TOP_WARNING, true);
                             this.setRowText(0, "MAN", Airbus_FMA.MODE_STATE.STATUS);
                             this.setRowText(1, "THR", Airbus_FMA.MODE_STATE.STATUS);
                             break;
@@ -455,13 +458,13 @@ var Airbus_FMA;
                         }
                     case Column1.ROW_1_2_STATE.AFLOOR:
                         {
-                            this.setRowHighlightStyle(0, Airbus_FMA.HIGHLIGHT_STYLE.FULL_WARNING);
+                            this.setRowHighlightStyle(0, Airbus_FMA.HIGHLIGHT_STYLE.FULL_WARNING, true);
                             this.setRowText(0, "A.FLOOR", Airbus_FMA.MODE_STATE.ENGAGED);
                             break;
                         }
                     case Column1.ROW_1_2_STATE.TOGALK:
                         {
-                            this.setRowHighlightStyle(0, Airbus_FMA.HIGHLIGHT_STYLE.FULL_WARNING);
+                            this.setRowHighlightStyle(0, Airbus_FMA.HIGHLIGHT_STYLE.FULL_WARNING, true);
                             this.setRowText(0, "TOGA LK", Airbus_FMA.MODE_STATE.ENGAGED);
                             break;
                         }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #862

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Makes some FMAs have permanent boxes based on this site:
I believe if it has a box around it on that site, then it means it should always have a  box.
http://www.a320dp.com/A320_DP/nav-autoflight/sys-13.3.0.html

Also fixes FMA box timers so that that last only 10 seconds instead of ~20 seconds.
I applied that fix to all PFD elements and ECAM pages.

Also fixes blinking FMAs, like LVR CLB so that it will blink.

Here is also a video showing that MAN TOGA seems to be permanent boxed: https://www.youtube.com/watch?reload=9&v=ECV3IBkzZLc

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->


**Additional context**
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
