### PR TITLE
Improve upper ECAM visuals

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+<!-- ⚠⚠ Please follow the format provided ⚠⚠ -->
+<!-- Always use "1." at the start instead of "2. " or "X. " as GitHub will auto renumber everything. -->
+<!-- Use the following format below -->
+<!--  1. [Changed Area] Title of changes - @github username (Name)  -->
+## Changes from 2020/09 to 2020/10
+
+1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -13,3 +13,4 @@
 6. [ECAM] Decreased length and thickness of inner markers on N1 and EGT gauges - @wpine215 (Iceman)
 7. [ECAM] Modified upper ECAM thrust state indicator position and text alignment - @wpine215 (Iceman)
 8. [ECAM] Modified upper ECAM separator position and thickness; added rounded line ends - @wpine215 (Iceman)
+9. [ECAM] Modified spacing between engine and text elements on upper ECAM

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,3 +6,10 @@
 ## Changes from 2020/09 to 2020/10
 
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)
+2. [ECAM] Increased flap/slat SVG thickness and updated colors - @wpine215 (Iceman)
+3. [ECAM] Changed flap/slat marker shape from circles to parallelograms - @wpine215 (Iceman)
+4. [ECAM] Increased font size for upper ECAM elements - @wpine215 (Iceman)
+5. [ECAM] Updated bounding box dimensions for upper ECAM N1 and EGT gauge values - @wpine215 (Iceman)
+6. [ECAM] Decreased length and thickness of inner markers on N1 and EGT gauges - @wpine215 (Iceman)
+7. [ECAM] Modified upper ECAM thrust state indicator position and text alignment - @wpine215 (Iceman)
+8. [ECAM] Modified upper ECAM separator position and thickness; added rounded line ends - @wpine215 (Iceman)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.css
@@ -59,7 +59,7 @@ a320-neo-ecam-gauge {
       height: 100%; }
       a320-neo-ecam-gauge #RootSVG #CursorGroup line {
         stroke: var(--ecamValueColour);
-        stroke-width: 4; }
+        stroke-width: 2; }
       a320-neo-ecam-gauge #RootSVG #CursorGroup path {
         fill: none;
         stroke: var(--ecamDefaultColour);
@@ -87,21 +87,21 @@ a320-neo-ecam-gauge {
       text-anchor: end; }
     a320-neo-ecam-gauge #RootSVG #CurrentValue.active {
       fill: var(--ecamValueColour);
-      font-size: 15px; }
+      font-size: 20px; }
     a320-neo-ecam-gauge #RootSVG #CurrentValue.warning {
       fill: var(--ecamWarningColour);
-      font-size: 15px; }
+      font-size: 20px; }
     a320-neo-ecam-gauge #RootSVG #CurrentValue.danger {
       fill: var(--ecamDangerColour);
-      font-size: 15px; }
+      font-size: 20px; }
     a320-neo-ecam-gauge #RootSVG #CurrentValue.inactive {
       fill: var(--ecamInactiveColour);
       font-size: 20px;
       letter-spacing: 5px; }
     a320-neo-ecam-gauge #RootSVG #CurrentValueBorder {
       fill: none;
-      stroke: grey;
-      stroke-width: 3px; }
+      stroke: lightblue;
+      stroke-width: 2px; }
     a320-neo-ecam-gauge #RootSVG #ExtraMessage {
       width: 100%;
       height: 100%; }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.js
@@ -44,7 +44,7 @@ var A320_Neo_ECAM_Common;
             return (this.viewBoxSize.x * 0.5 * 0.975);
         }
         get graduationInnerLineEndOffset() {
-            return (this.mainArcRadius * 0.875);
+            return (this.mainArcRadius * 0.9);
         }
         get graduationOuterLineEndOffset() {
             return (this.mainArcRadius * 1.175);
@@ -203,9 +203,9 @@ var A320_Neo_ECAM_Common;
             this.rootSVG.appendChild(this.currentValueText);
             if (_gaugeDefinition.currentValueBorderWidth > 0) {
                 var borderWidth = this.viewBoxSize.x * _gaugeDefinition.currentValueBorderWidth;
-                var borderHeight = this.currentValueBorderHeight;
+                var borderHeight = this.currentValueBorderHeight * 1.2;
                 var borderPosX = textPosX - (borderWidth * 0.95);
-                var borderPosY = textPosY - (borderHeight * 0.5);
+                var borderPosY = textPosY - (borderHeight * 0.55);
                 var currentValueBorder = document.createElementNS(Avionics.SVG.NS, "rect");
                 currentValueBorder.id = "CurrentValueBorder";
                 currentValueBorder.setAttribute("x", borderPosX.toString());

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.css
@@ -5,10 +5,10 @@
   --ecamWarningColour: #db7200;
   --ecamDangerColour: red;
   --ecamInactiveColour: #db7200;
-  --ecamSeparatorsColour: white; }
+  --ecamSeparatorsColour: #aaaaaa; }
   :root .Separator {
-    stroke: #3c3c3c;
-    stroke-width: 4;
+    stroke: var(--ecamSeparatorsColour);
+    stroke-width: 3;
     fill: none; }
   :root div {
     font-family: Roboto-Bold; }
@@ -32,36 +32,44 @@ a320-neo-upper-ecam {
     position: absolute;
     left: 20%;
     width: 60%;
-    top: 3%;
+    top: 5%;
     height: 48%;
     display: flex;
     justify-content: center; }
     a320-neo-upper-ecam #EnginesPanel .engine {
       width: 100%;
       height: 100%;
-      margin-left: 1%; }
+      padding-left: 100px;
+      padding-right:200px;
+      /* padding-right: 150px; */
+      /* margin-left: 1%;  */
+    }
     a320-neo-upper-ecam #EnginesPanel #GaugeInfo {
       position: absolute;
       left: 23%;
       width: 50%;
-      top: -5%;
+      top: -8%;
       height: 100%; }
       a320-neo-upper-ecam #EnginesPanel #GaugeInfo div {
         position: relative;
         color: var(--ecamDefaultColour);
-        font-size: 32px;
+        font-size: 45px;
         text-align: center; }
       a320-neo-upper-ecam #EnginesPanel #GaugeInfo .STATUS {
         height: 25%; }
       a320-neo-upper-ecam #EnginesPanel #GaugeInfo .SLOT1_TITLE {
-        height: 5%; }
+        height: 7%; }
       a320-neo-upper-ecam #EnginesPanel #GaugeInfo .SLOT1_UNIT {
-        height: 22%;
+        height: 20%;
+        font-size: 38px;
         color: var(--ecamUnitsColour); }
       a320-neo-upper-ecam #EnginesPanel #GaugeInfo .SLOT2_TITLE {
-        height: 5%; }
+        height: 7%; }
       a320-neo-upper-ecam #EnginesPanel #GaugeInfo .SLOT2_UNIT {
-        height: 25%;
+        height: 26%;
+        font-size: 38px;
+        margin-left: -22px;
+        letter-spacing: -6px;
         color: var(--ecamUnitsColour); }
     a320-neo-upper-ecam #EnginesPanel #LineStyleInfos {
       position: absolute;
@@ -73,11 +81,12 @@ a320-neo-upper-ecam {
         width: 100%;
         height: 100%; }
       a320-neo-upper-ecam #EnginesPanel #LineStyleInfos text {
-        font-size: 32px;
+        font-size: 45px;
         text-anchor: middle; }
       a320-neo-upper-ecam #EnginesPanel #LineStyleInfos .Title {
         fill: var(--ecamDefaultColour); }
       a320-neo-upper-ecam #EnginesPanel #LineStyleInfos .Unit {
+        font-size: 38px;
         fill: var(--ecamUnitsColour); }
       a320-neo-upper-ecam #EnginesPanel #LineStyleInfos .Value {
         fill: var(--ecamValueColour); }
@@ -98,15 +107,16 @@ a320-neo-upper-ecam {
       top: 1%;
       height: 50%;
       right: 5%;
-      width: 25%; }
+      width: 8%; }
       a320-neo-upper-ecam #InfoTopPanel #Status #ThrottleState {
         right: 20%;
-        text-align: right; }
+        text-align: left; }
       a320-neo-upper-ecam #InfoTopPanel #Status #ThrottleValue {
         top: 12%;
         right: 15%;
         text-align: right;
-        content: "\00b0"; }
+        /* content: "\00b0";  */
+      }
       a320-neo-upper-ecam #InfoTopPanel #Status #ThrottleValue::after {
         content: "%";
         color: var(--ecamUnitsColour); }
@@ -132,8 +142,8 @@ a320-neo-upper-ecam {
       a320-neo-upper-ecam #InfoTopPanel #Status #FlexTemperature.inactive {
         display: none; }
     a320-neo-upper-ecam #InfoTopPanel #FuelOnBoard {
-      top: 90%;
-      left: 3%;
+      top: 95%;
+      left: 1.5%;
       width: 32%; }
       a320-neo-upper-ecam #InfoTopPanel #FuelOnBoard #Title {
         color: var(--ecamDefaultColour);
@@ -145,6 +155,9 @@ a320-neo-upper-ecam {
       a320-neo-upper-ecam #InfoTopPanel #FuelOnBoard #Unit {
         color: var(--ecamUnitsColour);
         right: 0%;
+        font-size: 38px;
+        margin-top: 5px;
+        margin-left: -10px;
         text-align: right; }
   a320-neo-upper-ecam #FlapsPanel {
     position: absolute;
@@ -166,16 +179,19 @@ a320-neo-upper-ecam {
         fill: var(--ecamDefaultColour); }
       a320-neo-upper-ecam #FlapsPanel #DiagramSVG .shape {
         fill: none;
-        stroke: #3c3c3c; }
+        stroke-width: 3px;
+        stroke: #555555; }
       a320-neo-upper-ecam #FlapsPanel #DiagramSVG .currentArrow {
         fill: none;
+        stroke-width: 3px;
         stroke: var(--ecamValueColour); }
       a320-neo-upper-ecam #FlapsPanel #DiagramSVG .targetArrow {
         fill: none;
+        stroke-width: 3px;
         stroke: var(--ecamUnitsColour); }
   a320-neo-upper-ecam #InfoBottomLeftPanel, a320-neo-upper-ecam #left-msg {
     position: absolute;
-    left: 3%;
+    left: 1.35%;
     width: 55%;
     top: 68%;
     height: 30%; }
@@ -186,7 +202,7 @@ a320-neo-upper-ecam {
       text-align: left; }
   a320-neo-upper-ecam #InfoBottomRightPanel, a320-neo-upper-ecam #right-msg {
     position: absolute;
-    left: 67.5%;
+    left: 67%;
     width: 30%;
     top: 68%;
     height: 30%; }
@@ -197,7 +213,7 @@ a320-neo-upper-ecam {
       text-align: left; }
   a320-neo-upper-ecam #to-memo, a320-neo-upper-ecam #ldg-memo {
     position: absolute;
-    left: 3%;
+    left: 1.35%;
     width: 55%;
     top: 68%;
     height: 30%; }
@@ -253,3 +269,14 @@ a320-neo-upper-ecam {
     top: 0%;
     height: 100%; }
 
+
+  a320-neo-ecam-gauge #RootSVG #CurrentValue {
+    font-size: 20px !important; }
+
+  a320-neo-ecam-gauge #RootSVG #CurrentValueBorder {
+    fill: none;
+    stroke: lightblue;
+    stroke-width: 1px; }
+
+  a320-neo-ecam-gauge #RootSVG #GraduationsGroup line.InnerMarker {
+    stroke-width: 1px !important; }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.html
@@ -3,9 +3,9 @@
 <script type="text/html" id="UpperECAMTemplate">
     <div id="Separators">
         <svg viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg">
-            <line class="Separator" x1="0" y1="402" x2="345" y2="402" />
-            <line class="Separator" x1="405" y1="402" x2="600" y2="402" />
-            <line class="Separator" x1="375" y1="420" x2="375" y2="570" />
+            <line class="Separator" x1="0" y1="402" x2="345" y2="402" stroke-linecap="round" />
+            <line class="Separator" x1="405" y1="402" x2="600" y2="402" stroke-linecap="round" />
+            <line class="Separator" x1="375" y1="415" x2="375" y2="575" stroke-linecap="round" />
             <g id="overflow-arrow">
                 <path d="M 375 572 l 0 15 l -3 0 l 3 5 l 3 -5 l -3 0" stroke="green" fill="green" stroke="transparent" stroke-width="4" />
             </g>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -46,6 +46,32 @@ var A320_Neo_UpperECAM;
         return circleElement;
     }
     A320_Neo_UpperECAM.createSVGCircle = createSVGCircle;
+    function createSlatParallelogram(_class, _cx, _cy) {
+        var parElement = document.createElementNS(Avionics.SVG.NS, "polygon");
+        const _w = 5;
+        const _h = 6;
+        const _ox = 2;
+        const _oy = 1;
+        let _ppoints = String(_cx - _w) + "," + String(_cy - _oy) + " " + String(_cx - _w - _ox) + "," + String(_cy + _h) + " " + String(_cx + _w) + "," + String(_cy + _oy) + " " + String(_cx + _w + _ox) + "," + String(_cy - _h);
+        parElement.setAttribute("class", _class);
+        parElement.setAttribute("points", _ppoints);
+        return parElement;
+    }
+    A320_Neo_UpperECAM.createSlatParallelogram = createSlatParallelogram;
+    function createFlapParallelogram(_class, _cx, _cy) {
+        var parElement = document.createElementNS(Avionics.SVG.NS, "polygon");
+        const _w = 4;
+        const _h = 5;
+        const _ox = 2;
+        const _oy = -3;
+        let _ppoints = String(_cx - _w) + "," + String(_cy - _oy) + " " + String(_cx - _w - _ox) + "," + String(_cy - _h) + " " + String(_cx + _w) + "," + String(_cy + _oy) + " " + String(_cx + _w + _ox) + "," + String(_cy + _h);
+        parElement.setAttribute("class", _class);
+        parElement.setAttribute("points", _ppoints);
+        return parElement;
+    }
+    A320_Neo_UpperECAM.createFlapParallelogram = createFlapParallelogram;
+    
+    
     class Display extends Airliners.EICASTemplateElement {
         constructor() {
             super();
@@ -1358,7 +1384,7 @@ var A320_Neo_UpperECAM;
             gaugeDef.cursorLength = 0.4;
             gaugeDef.currentValuePos.x = 0.75;
             gaugeDef.currentValuePos.y = 0.5;
-            gaugeDef.currentValueBorderWidth = 0.5;
+            gaugeDef.currentValueBorderWidth = 0.55;
             gaugeDef.dangerRange[0] = gaugeDef.minRedValue;
             gaugeDef.dangerRange[1] = gaugeDef.maxRedValue;
             gaugeDef.dangerMinDynamicFunction = this.getModeEGTMax.bind(this);
@@ -1381,7 +1407,7 @@ var A320_Neo_UpperECAM;
             gaugeDef.minRedValue = A320_Neo_UpperECAM.Definitions.MIN_GAUGE_N1_RED;
             gaugeDef.currentValuePos.x = 1.0;
             gaugeDef.currentValuePos.y = 0.75;
-            gaugeDef.currentValueBorderWidth = 0.55;
+            gaugeDef.currentValueBorderWidth = 0.68;
             gaugeDef.outerIndicatorFunction = this.getN1GaugeThrottleValue.bind(this);
             gaugeDef.outerDynamicArcFunction = this.getN1GaugeAutopilotThrottleValues.bind(this);
             gaugeDef.extraMessageFunction = this.getN1GaugeExtraMessage.bind(this);
@@ -1483,12 +1509,13 @@ var A320_Neo_UpperECAM;
                 var line = document.createElementNS(Avionics.SVG.NS, "line");
                 line.setAttribute("x1", this.getLineX1());
                 line.setAttribute("x2", this.getLineX2());
-                line.setAttribute("y1", "85%");
-                line.setAttribute("y2", "70%");
-                line.style.stroke = "rgb(60, 60, 60)";
-                line.style.strokeWidth = "2";
+                line.setAttribute("y1", "72%");
+                line.setAttribute("y2", "58%");
+                line.setAttribute("stroke-linecap", "round")
+                line.style.stroke = "rgb(255, 255, 255)";
+                line.style.strokeWidth = "4";
                 _svgRoot.appendChild(line);
-                this.valueText = A320_Neo_UpperECAM.createSVGText("--.-", "Value", this.getValueTextX(), "100%", "bottom");
+                this.valueText = A320_Neo_UpperECAM.createSVGText("--.-", "Value", this.getValueTextX(), "88%", "bottom");
                 _svgRoot.appendChild(this.valueText);
             }
             this.refresh(false, 0, 0, true);
@@ -1512,21 +1539,21 @@ var A320_Neo_UpperECAM;
     }
     A320_Neo_UpperECAM.LinesStyleComponent_Base = LinesStyleComponent_Base;
     class LinesStyleComponent_Left extends LinesStyleComponent_Base {
-        getLineX1() { return "37%"; }
-        getLineX2() { return "43%"; }
-        getValueTextX() { return "25%"; }
+        getLineX1() { return "34%"; }
+        getLineX2() { return "42%"; }
+        getValueTextX() { return "18%"; }
     }
     A320_Neo_UpperECAM.LinesStyleComponent_Left = LinesStyleComponent_Left;
     class LinesStyleComponent_Right extends LinesStyleComponent_Base {
-        getLineX1() { return "63%"; }
-        getLineX2() { return "57%"; }
-        getValueTextX() { return "75%"; }
+        getLineX1() { return "66%"; }
+        getLineX2() { return "58%"; }
+        getValueTextX() { return "82%"; }
     }
     A320_Neo_UpperECAM.LinesStyleComponent_Right = LinesStyleComponent_Right;
     class LinesStyleInfo {
         constructor(_divMain, _bottomValue) {
             var svgRoot = document.createElementNS(Avionics.SVG.NS, "svg");
-            svgRoot.appendChild(A320_Neo_UpperECAM.createSVGText(this.getTitle(), "Title", "50%", "75%", "bottom"));
+            svgRoot.appendChild(A320_Neo_UpperECAM.createSVGText(this.getTitle(), "Title", "50%", "65%", "bottom"));
             svgRoot.appendChild(A320_Neo_UpperECAM.createSVGText(this.getUnit(), "Unit", "50%", "100%", "bottom"));
             this.leftComponent = new LinesStyleComponent_Left(svgRoot);
             this.rightComponent = new LinesStyleComponent_Right(svgRoot);
@@ -1663,7 +1690,7 @@ var A320_Neo_UpperECAM;
                                 }
                             case ThrottleMode.CLIMB:
                                 {
-                                    this.throttleState.textContent = "CL";
+                                    this.throttleState.textContent = "CLB";
                                     break;
                                 }
                             case ThrottleMode.AUTO:
@@ -1725,7 +1752,7 @@ var A320_Neo_UpperECAM;
         constructor() {
             super(...arguments);
             this.viewBoxSize = new Vec2(500, 125);
-            this.dotSize = 4;
+            this.dotSize = 5;
             this.slatArrowPathD = "m20,-12 l-31,6 l0,17, l23,-5 l10,-20";
             this.slatDotPositions = [
                 new Vec2(160, 37),
@@ -1803,10 +1830,10 @@ var A320_Neo_UpperECAM;
             this.hideOnInactiveGroup.appendChild(this.currentStateText);
             var dotSizeStr = this.dotSize.toString();
             for (var i = 1; i < this.slatDotPositions.length; ++i) {
-                this.hideOnInactiveGroup.appendChild(A320_Neo_UpperECAM.createSVGCircle("dot", dotSizeStr, this.slatDotPositions[i].x.toString(), this.slatDotPositions[i].y.toString()));
+                this.hideOnInactiveGroup.appendChild(A320_Neo_UpperECAM.createSlatParallelogram("dot", this.slatDotPositions[i].x, this.slatDotPositions[i].y));
             }
             for (var i = 1; i < this.flapDotPositions.length; ++i) {
-                this.hideOnInactiveGroup.appendChild(A320_Neo_UpperECAM.createSVGCircle("dot", dotSizeStr, this.flapDotPositions[i].x.toString(), this.flapDotPositions[i].y.toString()));
+                this.hideOnInactiveGroup.appendChild(A320_Neo_UpperECAM.createFlapParallelogram("dot", this.flapDotPositions[i].x, this.flapDotPositions[i].y));
             }
             this.deactivate();
             this.cockpitSettings = SimVar.GetGameVarValue("", "GlassCockpitSettings");


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #867

**Changelog**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Increased flap/slat SVG thickness and updated colors
- Changed flap/slat markers from circles to parallelograms
- Increased text sizes for all elements
- Updated bounding box for N1 and EGT gauge values
- Decreased thickness and length of N1 and EGT inner markers
- Modified ECAM thrust state position and alignment
- Modified ECAM memo separator position and thickness; added rounded ends

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->

**Before:** 
![image](https://user-images.githubusercontent.com/28059870/94353153-85099400-003b-11eb-8033-07c11c969ed3.png)

**After:**
![image](https://user-images.githubusercontent.com/28059870/94353156-9357b000-003b-11eb-83af-edf9578d89dd.png)



<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
