### PR TITLE
Patch #911 Lower ECAM DOOR Page

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,3 +12,4 @@
 5. [CDU] Fixed a crash when trying to replace a waypoint in the flight plan - @lousybyte (lousybyte)
 6. [EXTERIOR] Fixed issue in engine rotation animation that made it rotate too quickly - @lukecologne (lukecologne)
 7. [PFD] Remove code related to unrelevant aircraft - @1Revenger1 (Avery Black)
+1. [ECAM] Lower ECAM DOOR Page Colour Fix - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.css
@@ -16,7 +16,6 @@
   --ecamUnitsColour: #01b8b8;
   --ecamValueColour: #00b300;
   --ecamWarningColour: #db7200;
-  --ecamAmberColour: #ffbf00;
   --ecamDoorWarningColour: #fd8000;
   --ecamDangerColour: red;
   --ecamInactiveColour: #db7200;
@@ -87,7 +86,7 @@ a320-neo-lower-ecam-door {
   a320-neo-lower-ecam-door text.NoteLargeAmber {
     font-size: 15pt;
     word-spacing: -4px;
-    fill: var(--ecamAmberColour); }
+    fill: var(--ecamWarningColour); }
   a320-neo-lower-ecam-door text.Unit {
     font-size: 14pt;
     fill: var(--ecamUnitsColour); }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Patches #911 

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Changed Amber colour on ECAM DOOR Page from Yellow to Amber.

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

Before:
![image](https://user-images.githubusercontent.com/18389085/94389093-cc307b80-0146-11eb-8de6-274a60f67708.png)

After:
![image](https://user-images.githubusercontent.com/18389085/94389104-d5b9e380-0146-11eb-9a50-0480a84d240e.png)


**References**
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
Feedback from @Ares1378 A320 Pilot

**Additional context**
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Sabes#8668
