### PR TITLE
Fix #957 Battery Indicators

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,3 +14,4 @@
 7. [PFD] Remove code related to unrelevant aircraft - @1Revenger1 (Avery Black)
 8. [ECAM] Lower ECAM DOOR Page Colour Fix - @nathaninnes (Nathan Innes)
 9. [ND] Add DME distances, VOR/ADF needles and functioning ADF2 - @blitzcaster (bltzcstr)
+1. [OVHD] Fixed Battery Indicator Colour - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.css
@@ -60,10 +60,11 @@ a320-neo-bat {
     height: 100%; }
   a320-neo-bat text {
     font-family: Digital;
-    fill: #66767a; }
+    fill: #db7200; }
   a320-neo-bat text.value {
-    font-size: 50px;
+    font-size: 60px;
     text-anchor: end; }
   a320-neo-bat text.unit {
-    font-size: 30px;
+    font-size: 25px;
+    font-family: 'Roboto-Bold';
     text-anchor: start; }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.html
@@ -4,9 +4,9 @@
     <div id="AlwaysOn" state="on">
         <svg viewBox="0 0 200 100">
             <text id="BAT1" class="value" x="75%" y="45%">0.0</text>
-            <text class="unit" x="75%" y="30%">V</text>
+            <text class="unit" x="75%" y="45%">V</text>
             <text id="BAT2" class="value" x="75%" y="95%">0.0</text>
-            <text class="unit" x="75%" y="80%">V</text>
+            <text class="unit" x="75%" y="95%">V</text>
         </svg>
     </div>
 </script>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.js
@@ -14,18 +14,21 @@ var A320_Neo_BAT;
         }
         Update() {
             super.Update();
-            if ((this.batTexts != null) && (this.batTexts.length == 2) && (this.batValues != null) && (this.batValues.length == 2)) {
 
-                for (var i = 0; i < 2; ++i) {
-                    if (this.batTexts[i] != null) {
-                        var batValue = SimVar.GetSimVarValue("ELECTRICAL BATTERY BUS VOLTAGE", "Volts");
-                        if (batValue != this.batValues[i]) {
-                            this.batValues[i] = batValue;
-                            this.batTexts[i].textContent = this.batValues[i].toFixed(1);
-                        }
-                    }
+            const lightsTest = SimVar.GetSimVarValue("L:XMLVAR_LTS_Test", "Bool");
+            this.lightsTest = lightsTest;
+
+            if (lightsTest){
+                for (let i = 0; i < 2; ++i) {
+                    this.batTexts[i].textContent = "88.8";
                 }
-            }
+            }else {
+                for (let i = 0; i < 2; ++i) {
+                    const batValue = SimVar.GetSimVarValue("ELECTRICAL BATTERY BUS VOLTAGE", "Volts");
+                    this.batValues[i] = batValue;
+                    this.batTexts[i].textContent = this.batValues[i].toFixed(1);
+                }
+            }  
         }
     }
     A320_Neo_BAT.Display = Display;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #957 

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Battery Indicators on the OVHD Panel have been changed from WHITE to AMBER.
- Font Size Increased.
- ANN LT shows BATT "88.8v".

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before:
![image](https://user-images.githubusercontent.com/18389085/94562780-a9dd5180-025d-11eb-9aee-d04351fd5f2a.png)

After:
![image](https://user-images.githubusercontent.com/18389085/94562679-887c6580-025d-11eb-8622-ac559fd427be.png)


**References**
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![image](https://user-images.githubusercontent.com/18389085/94562804-b5307d00-025d-11eb-8687-551f1ec0f56f.png)

**Additional context**
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Sabes#8668
