### PR TITLE
optically working hold page, missing wp insert + routing

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU.html
@@ -39,7 +39,6 @@
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AvailableDeparturesPage.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js"></script>
-<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_DirectToPage.js"></script>
@@ -62,6 +61,8 @@ MODIFIED BELOW -->
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavaidPage.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NewWaypoint.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PilotsWaypoint.js"></script>
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js"></script>
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_HoldAtPage.js"></script>
 
 <script type="text/html" import-script="/Pages/A32NX_Core/A32NX_ADIRS.js"></script>
 <script type="text/html" import-script="/Pages/A32NX_Core/A32NX_APU.js"></script>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_HoldAtPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_HoldAtPage.js
@@ -1,0 +1,106 @@
+class CDUHoldAtPage {
+    static ShowPage(mcdu, waypoint, waypointIndexFP) {
+        mcdu.clearDisplay();
+        let waypointIdent = "---";
+        if (waypoint) {
+            waypointIdent = waypoint.ident;
+        }
+
+        let holdCourse = 100
+        if (mcdu.holdCourse) {
+            holdCourse = mcdu.holdCourse
+        }
+
+        let holdTurn = "R"
+        if (mcdu.holdTurn) {
+            holdTurn = mcdu.holdTurn
+        }
+
+        let timeComp = "0.0";
+        let distComp = "0.0";
+        if (mcdu.timeComp) {
+            timeComp = mcdu.timeComp
+            distComp = mcdu.distComp
+        }    
+
+        let rteRsvWeight = mcdu.getRouteReservedWeight();
+        let resFuel = "0.0"
+        if (!isNaN(rteRsvWeight)) {
+            resFuel = rteRsvWeight.toFixed(1);
+        }
+
+        let exitTime = "0000"
+        exitTime = FMCMainDisplay.secondsTohhmm(mcdu.flightPlanManager.getDestination().estimatedTimeOfArrivalFP);
+
+        mcdu.setTemplate([
+            ["HOLD AT " + waypointIdent],
+            ["INB CRS", "", ""],
+            [holdCourse +"°[color]blue", "", ""],
+            ["TURN", "", ""],
+            [holdTurn + "[color]blue", "", ""],
+            ["TIME/DIST", "", ""],
+            [timeComp + "/" + distComp + "[color]blue", "", ""],
+            [""],
+            ["","LAST EXIT", ""],
+            ["","UTC FUEL", ""],
+            ["", exitTime + " " +  resFuel + "[color]red",""],
+            ["TMPY[color]yellow", "TMPY[color]yellow"],
+            ["<F-PLN[color]yellow", "INSERT*[color]yellow"]
+        ]);
+
+        mcdu.onLeftInput[0] = () => {
+                let value = mcdu.inOut;
+                if (isNaN(value) || 0 < value > 360) {
+                    mcdu.inOut = "NaN"
+                    return;
+                }
+                mcdu.clearUserInput();
+                mcdu.holdCourse = value
+                CDUHoldAtPage.ShowPage(mcdu, waypoint, waypointIndexFP);
+        };
+
+        mcdu.onLeftInput[1] = () => {
+            let value = mcdu.inOut;
+            if (value != "L" && value != "R") {
+                mcdu.inOut = "ERR FMT"
+                return;
+            }
+            mcdu.clearUserInput();
+            mcdu.holdTurn = value
+            CDUHoldAtPage.ShowPage(mcdu, waypoint, waypointIndexFP);
+        };
+
+        mcdu.onLeftInput[2] = () => {
+            let value = mcdu.inOut;
+            
+            if (!value.includes("/")) {
+                mcdu.inOut = "ERR FMT"
+                return;
+            }
+            let comps = value.split("/", 2);
+            if (comps.length != 2) {
+                mcdu.inOut = "ERR INPUT"
+                return;
+            }
+
+            if (isNaN(comps[0]) || isNaN(comps[1])) {
+                mcdu.inOut = "NaN"
+                return
+            }
+
+            mcdu.clearUserInput();
+            mcdu.timeComp = comps[0]
+            mcdu.distComp = comps[1]
+            CDUHoldAtPage.ShowPage(mcdu, waypoint, waypointIndexFP);
+        };
+
+        mcdu.onLeftInput[5] = () => { 
+            mcdu.holdCourse = null
+            mcdu.timeComp = null 
+            mcdu.distComp = null
+            mcdu.holdTurn = null
+            CDULateralRevisionPage.ShowPage(mcdu, waypoint, waypointIndexFP); 
+        };
+    }
+}
+//# sourceMappingURL=A320_Neo_CDU_HoldAtPage.js.map

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
@@ -32,7 +32,7 @@ class CDULateralRevisionPage {
             ["", "LL WING/INCR/NO"],
             ["[][color]blue", "[ ]°/[ ]°/[][color]blue"],
             ["", "NEXT WPT"],
-            ["<HOLD", "[ ][color]blue"],
+            ["<HOLD[color]blue", "[ ][color]blue"],
             ["ENABLE[color]blue", "NEW DEST"],
             ["←ALTN[color]blue", "[ ][color]blue"],
             [""],
@@ -49,6 +49,7 @@ class CDULateralRevisionPage {
                 }
             });
         };
+        mcdu.onLeftInput[2] = () => { CDUHoldAtPage.ShowPage(mcdu, waypoint, waypointIndexFP); };
         mcdu.onRightInput[4] = () => { A320_Neo_CDU_AirwaysFromWaypointPage.ShowPage(mcdu, waypoint); };
         mcdu.onLeftInput[5] = () => { CDUFlightPlanPage.ShowPage(mcdu); };
     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Starts implementing #673 

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Added Hold page and some functionality to set and validate input values. 
Missing waypoint routing logic, so purely cosmetic so far.
**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
No before as the page is new. 
![image](https://user-images.githubusercontent.com/685754/94697809-7b0ebc00-02ed-11eb-9762-ad2de08a0b73.png)

**References**
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
[A320DP Docs](http://www.a320dp.com/A320_DP/nav-flight-management/sys-14.8.17.html)
**Additional context**
<!-- Add any other context about the pull request here. -->
[Hold Page Demo YT](https://youtu.be/D2iNDQohwDk?t=46)
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): s3p1r0th#8483
