### PR TITLE
Fix non runway specific STARs not showing

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
@@ -48,7 +48,8 @@ class CDUAvailableArrivalsPage {
                 let matchingArrivals = [];
                 if (selectedApproach) {
                     let selectedRunway = selectedApproach.runway;
-                    for (let i = 0; i < airportInfo.arrivals.length; i++) {
+                    //for some reason there is a duplicate of every STAR. the /2 will prevent these duplicates from showing.
+                    for (let i = 0; i < airportInfo.arrivals.length/2; i++) {
                         let arrival = airportInfo.arrivals[i];
                         for (let j = 0; j < arrival.runwayTransitions.length; j++) {
                             let runwayTransition = arrival.runwayTransitions[j];
@@ -57,6 +58,10 @@ class CDUAvailableArrivalsPage {
                                     matchingArrivals.push({ arrival: arrival, arrivalIndex: i });
                                 }
                             }
+                        }
+                        //add the arrival even if it isn't runway specific
+                        if (!arrival.runwayTransitions.length) {
+                            matchingArrivals.push({ arrival: arrival, arrivalIndex: i });
                         }
                     }
                 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #1020 

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* Fixed STARs not showing on arrivals page when they are not runway specific
* Added workaround for duplicate STARs showing on arrivals page

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before:
![image](https://user-images.githubusercontent.com/16512508/94858921-97dbea00-03e8-11eb-89c5-12c840dae187.png)

After:
![image](https://user-images.githubusercontent.com/16512508/94858780-6cf19600-03e8-11eb-86eb-a722884087e1.png)


**References**
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
N/A
**Additional context**
<!-- Add any other context about the pull request here. -->
N/A
