### PR TITLE
[ECAM] Improve Lower ENGINE ECAM

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.html
@@ -40,9 +40,9 @@
         <line class="Indicator" x1="250" y1="488" x2="220" y2="490" />
         <line class="Indicator" x1="350" y1="488" x2="380" y2="490" />
 
-        <text id="IGNValueLeft" class="Value" x="275" y="465"></text>
+        <text id="IGNValueLeft" class="Value" x="190" y="435"></text>
         <text id="IGNTitle" class="Title" x="300" y="440"></text>
-        <text id="IGNValueRight" class="Value" x="325" y="465"></text>
+        <text id="IGNValueRight" class="Value" x="410" y="435"></text>
 
         <text id="EngineBleedPressureValueRight" class="Value" x="420" y="490">---</text>
 
@@ -50,13 +50,15 @@
             <g id="StartValveDiagramLeft">
                 <circle r="12" cx="180" cy="456" />
                 <line id="StartValveLeft_CLOSED" x1="168" y1="456" x2="192" y2="456" display="none"></line>
-                <line id="StartValveLeft_OPEN" x1="180" y1="444" x2="180" y2="468" display="none"></line>
+                <line id="StartValveLeft_OPEN" x1="180" y1="436" x2="180" y2="468" display="none"></line>
+                <line id="ValveLeftBleed" x1="180" y1="468" x2="180" y2="476"></line>
             </g>
 
             <g id="StartValveDiagramRight">
                 <circle r="12" cx="420" cy="456" />
                 <line id="StartValveRight_CLOSED" x1="408" y1="456" x2="432" y2="456" display="none"></line>
-                <line id="StartValveRight_OPEN" x1="420" y1="444" x2="420" y2="468" display="none"></line>
+                <line id="StartValveRight_OPEN" x1="420" y1="436" x2="420" y2="468" display="none"></line>
+                <line id="ValveRightBleed" x1="420" y1="468" x2="420" y2="476"></line>
             </g>
         </g>
     </svg>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.js
@@ -51,32 +51,44 @@ var A320_Neo_LowerECAM_Engine;
         }
         updateIGN() {
             var ignLeftTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.NONE;
+            let engineStarting = (SimVar.GetSimVarValue("GENERAL ENG STARTER:1", "bool") === 1) ? true : false;
             var n2Igniting = (SimVar.GetSimVarValue("TURB ENG IS IGNITING:1", "bool") === 1) ? true : false;
             var n2Percent = SimVar.GetSimVarValue("ENG N2 RPM:1", "percent");
-            if (n2Igniting || (n2Percent > 5))
-                ignLeftTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.A;
+            if (engineStarting && n2Igniting && n2Percent > 18 && n2Percent < 55) {
+                if (this.ignRightCurrentState == A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.A)
+                    ignLeftTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.B;
+                else
+                    ignLeftTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.A;
+            }
             var ignRightTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.NONE;
+            engineStarting = (SimVar.GetSimVarValue("GENERAL ENG STARTER:2", "bool") === 1) ? true : false;
             n2Igniting = (SimVar.GetSimVarValue("TURB ENG IS IGNITING:2", "bool") === 1) ? true : false;
             n2Percent = SimVar.GetSimVarValue("ENG N2 RPM:2", "percent");
-            if (n2Igniting || (n2Percent > 5))
-                ignRightTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.B;
+            if (engineStarting && n2Igniting && n2Percent > 18 && n2Percent < 55) {
+                if (this.ignLeftCurrentState == A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.A)
+                    ignRightTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.B;
+                else
+                    ignRightTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.A;
+            }
             var ignNeedRefreshTitle = false;
             if (ignLeftTargetState != this.ignLeftCurrentState) {
-                this.ignLeftCurrentState = ignLeftTargetState;
+                if (ignLeftTargetState != A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.NONE)
+                    this.ignLeftCurrentState = ignLeftTargetState;
                 if (this.ignLeftValueText != null) {
-                    this.ignLeftValueText.textContent = this.getIGNStringFromState(this.ignLeftCurrentState);
+                    this.ignLeftValueText.textContent = this.getIGNStringFromState(ignLeftTargetState);
                 }
                 ignNeedRefreshTitle = true;
             }
             if (ignRightTargetState != this.ignRightCurrentState) {
-                this.ignRightCurrentState = ignRightTargetState;
+                if (ignRightTargetState != A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.NONE)
+                    this.ignRightCurrentState = ignRightTargetState;
                 if (this.ignRightValueText != null) {
-                    this.ignRightValueText.textContent = this.getIGNStringFromState(this.ignRightCurrentState);
+                    this.ignRightValueText.textContent = this.getIGNStringFromState(ignRightTargetState);
                 }
                 ignNeedRefreshTitle = true;
             }
             if (ignNeedRefreshTitle && (this.ignTitleText != null)) {
-                if ((this.ignLeftCurrentState != A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.NONE) || (this.ignRightCurrentState != A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.NONE)) {
+                if ((ignLeftTargetState != A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.NONE) || (ignRightTargetState != A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.NONE)) {
                     this.ignTitleText.textContent = "IGN";
                 }
                 else {
@@ -160,7 +172,13 @@ var A320_Neo_LowerECAM_Engine;
         update(_deltaTime) {
             this.setFuelUsedValue(SimVar.GetSimVarValue("GENERAL ENG FUEL USED SINCE START:" + this.engineIndex, "kg"));
             this.setOilTemperatureValue(SimVar.GetSimVarValue("GENERAL ENG OIL TEMPERATURE:" + this.engineIndex, "celsius"));
-            this.setEngineBleedPressureValue(SimVar.GetSimVarValue("APU BLEED PRESSURE RECEIVED BY ENGINE:" + this.engineIndex, "psi"));
+
+            let bleedPressure = 0;
+            if (SimVar.GetSimVarValue("BLEED AIR APU","Bool")) {
+                bleedPressure = SimVar.GetSimVarValue("L:APU_BLEED_PRESSURE", "psi");
+            }
+            this.setEngineBleedPressureValue(bleedPressure);
+                
             this.setEngineBleedValveState(SimVar.GetSimVarValue("GENERAL ENG STARTER:" + this.engineIndex, "bool"));
             this.setN1VibrationValue(SimVar.GetSimVarValue("TURB ENG VIBRATION:" + this.engineIndex, "Number"));
             this.setN2VibrationValue(SimVar.GetSimVarValue("TURB ENG VIBRATION:" + this.engineIndex, "Number")); // TODO: should have a different value than N1, currently API limited

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.js
@@ -50,30 +50,33 @@ var A320_Neo_LowerECAM_Engine;
             this.updateIGN();
         }
         updateIGN() {
-            var ignLeftTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.NONE;
+            let ignLeftTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.NONE;
             let engineStarting = (SimVar.GetSimVarValue("GENERAL ENG STARTER:1", "bool") === 1) ? true : false;
-            var n2Igniting = (SimVar.GetSimVarValue("TURB ENG IS IGNITING:1", "bool") === 1) ? true : false;
-            var n2Percent = SimVar.GetSimVarValue("ENG N2 RPM:1", "percent");
+            let n2Igniting = (SimVar.GetSimVarValue("TURB ENG IS IGNITING:1", "bool") === 1) ? true : false;
+            let n2Percent = SimVar.GetSimVarValue("ENG N2 RPM:1", "percent");
             if (engineStarting && n2Igniting && n2Percent > 18 && n2Percent < 55) {
-                if (this.ignRightCurrentState == A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.A)
+                if (this.ignRightCurrentState == A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.A) {
                     ignLeftTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.B;
-                else
+                } else {
                     ignLeftTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.A;
+                }
             }
-            var ignRightTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.NONE;
+            let ignRightTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.NONE;
             engineStarting = (SimVar.GetSimVarValue("GENERAL ENG STARTER:2", "bool") === 1) ? true : false;
             n2Igniting = (SimVar.GetSimVarValue("TURB ENG IS IGNITING:2", "bool") === 1) ? true : false;
             n2Percent = SimVar.GetSimVarValue("ENG N2 RPM:2", "percent");
             if (engineStarting && n2Igniting && n2Percent > 18 && n2Percent < 55) {
-                if (this.ignLeftCurrentState == A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.A)
+                if (this.ignLeftCurrentState == A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.A) {
                     ignRightTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.B;
-                else
+                } else {
                     ignRightTargetState = A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.A;
+                }
             }
             var ignNeedRefreshTitle = false;
             if (ignLeftTargetState != this.ignLeftCurrentState) {
-                if (ignLeftTargetState != A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.NONE)
+                if (ignLeftTargetState != A320_Neo_LowerECAM_Engine.Definitions.IGN_STATE.NONE) {
                     this.ignLeftCurrentState = ignLeftTargetState;
+                }
                 if (this.ignLeftValueText != null) {
                     this.ignLeftValueText.textContent = this.getIGNStringFromState(ignLeftTargetState);
                 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #127, #148, #819 and improvement towards #31.

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- available bleed pressure will now appear with no engines started
- igniters will be active between 18-55% N2
- igniters will swap between engines initially
- improved layout and design regarding igniters and valves

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
[https://www.youtube.com/watch?v=qAVQKnlzO7g](https://www.youtube.com/watch?v=qAVQKnlzO7g)

**References**
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
See related issues above.

**Additional context**
<!-- Add any other context about the pull request here. -->
Unsure if the N2 values need to be tweaked, feel free to give input.
Given the state of the bleeds system, only APU bleed is available at this moment.

Known issue: igniters will stop showing after engines are restarted, requires some logic gymnastics and a lot more code to implement it true to life, can see an improvement [here](https://github.com/lousybyte/a32nx/tree/ecam-eng-var).