### PR TITLE
Add spoiler functionality to F/CTL ECAM page, adjust ELAC/SEC warning color

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 1. [Sounds] Added new sounds for fuel pumps, flaps, ground roll and rattles, touchdowns, and wind - @hotshotp (Boris)
 
+4. [ECAM] ELAC/SEC warning color fix, added spoiler functionality to ECAM page - @wpine215 (Iceman)
+
 ## Changes from 2020/09 to 2020/10
 
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)
@@ -23,4 +25,3 @@
 9. [ND] Add DME distances, VOR/ADF needles and functioning ADF2 - @blitzcaster (bltzcstr)
 10. [OVHD] Fixed Battery Indicator Colour - @nathaninnes (Nathan Innes)
 11. [MISC] Removed Fuel Patch from MSFS Update 1.8.3 - @nathaninnes (Nathan Innes)
-12. [ECAM] ELAC/SEC warning color fix, added spoiler functionality to ECAM page - @wpine215 (Iceman)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -23,3 +23,4 @@
 9. [ND] Add DME distances, VOR/ADF needles and functioning ADF2 - @blitzcaster (bltzcstr)
 10. [OVHD] Fixed Battery Indicator Colour - @nathaninnes (Nathan Innes)
 11. [MISC] Removed Fuel Patch from MSFS Update 1.8.3 - @nathaninnes (Nathan Innes)
+12. [ECAM] ELAC/SEC warning color fix, added spoiler functionality to ECAM page - @wpine215 (Iceman)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.css
@@ -67,7 +67,7 @@ a320-neo-lower-ecam-ftcl .MainShape {
 
 a320-neo-lower-ecam-ftcl .MainShapeWarning {
     fill: transparent;
-    stroke: var(--ecamDangerColour);
+    stroke: var(--ecamWarningColour);
     stroke-width: 2;
 }
 
@@ -137,7 +137,7 @@ a320-neo-lower-ecam-ftcl text.Value15 {
 
 a320-neo-lower-ecam-ftcl text.Value15Warning {
     font-size: 15pt;
-    fill: var(--ecamDangerColour);
+    fill: var(--ecamWarningColour);
 }
 
 a320-neo-lower-ecam-ftcl text.ValueWhite {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.html
@@ -4,7 +4,6 @@
     <svg viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg">
 
         <!-- Speedbrakes -->
-
         <g id="speedbrakes">
             <path class="GreenShapeThick" d="M 103 104 l 15 0"></path>
             <path class="GreenShapeThick" d="M 142 99 l 15 0"></path>
@@ -17,6 +16,34 @@
             <path class="GreenShapeThick" d="M 420 94 l -15 0"></path>
             <path class="GreenShapeThick" d="M 381 89 l -15 0"></path>
             <path class="GreenShapeThick" d="M 343 84 l -15 0"></path>
+        </g>
+
+        <g id="speedbrake_arrows">
+            <path id="a5l" class="GreenShape" d="M 111 104 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="a4l" class="GreenShape" d="M 150 99 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="a3l" class="GreenShape" d="M 188 94 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="a2l" class="GreenShape" d="M 227 89 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="a1l" class="GreenShape" d="M 265 84 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+
+            <path id="a5r" class="GreenShape" d="M 489 104 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="a4r" class="GreenShape" d="M 450 99 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="a3r" class="GreenShape" d="M 412 94 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="a2r" class="GreenShape" d="M 373 89 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="a1r" class="GreenShape" d="M 335 84 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+        </g>
+
+        <g id="speedbrake_text">
+            <text id="n5l" class="Value15Warning" x="111" y="95" text-anchor="middle" alignment-baseline="central">5</text>
+            <text id="n4l" class="Value15Warning" x="150" y="90" text-anchor="middle" alignment-baseline="central">4</text>
+            <text id="n3l" class="Value15Warning" x="188" y="85" text-anchor="middle" alignment-baseline="central">3</text>
+            <text id="n2l" class="Value15Warning" x="227" y="80" text-anchor="middle" alignment-baseline="central">2</text>
+            <text id="n1l" class="Value15Warning" x="265" y="75" text-anchor="middle" alignment-baseline="central">1</text>
+
+            <text id="n5r" class="Value15Warning" x="489" y="95" text-anchor="middle" alignment-baseline="central">5</text>
+            <text id="n4r" class="Value15Warning" x="450" y="90" text-anchor="middle" alignment-baseline="central">4</text>
+            <text id="n3r" class="Value15Warning" x="412" y="85" text-anchor="middle" alignment-baseline="central">3</text>
+            <text id="n2r" class="Value15Warning" x="373" y="80" text-anchor="middle" alignment-baseline="central">2</text>
+            <text id="n1r" class="Value15Warning" x="335" y="75" text-anchor="middle" alignment-baseline="central">1</text>
         </g>
 
         <g id="leftSpeedbrakeGroup">

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.html
@@ -19,31 +19,31 @@
         </g>
 
         <g id="speedbrake_arrows">
-            <path id="a5l" class="GreenShape" d="M 111 104 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
-            <path id="a4l" class="GreenShape" d="M 150 99 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
-            <path id="a3l" class="GreenShape" d="M 188 94 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
-            <path id="a2l" class="GreenShape" d="M 227 89 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
-            <path id="a1l" class="GreenShape" d="M 265 84 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="arrow5_left" class="GreenShape" d="M 111 104 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="arrow4_left" class="GreenShape" d="M 150 99 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="arrow3_left" class="GreenShape" d="M 188 94 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="arrow2_left" class="GreenShape" d="M 227 89 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="arrow1_left" class="GreenShape" d="M 265 84 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
 
-            <path id="a5r" class="GreenShape" d="M 489 104 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
-            <path id="a4r" class="GreenShape" d="M 450 99 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
-            <path id="a3r" class="GreenShape" d="M 412 94 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
-            <path id="a2r" class="GreenShape" d="M 373 89 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
-            <path id="a1r" class="GreenShape" d="M 335 84 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="arrow5_right" class="GreenShape" d="M 489 104 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="arrow4_right" class="GreenShape" d="M 450 99 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="arrow3_right" class="GreenShape" d="M 412 94 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="arrow2_right" class="GreenShape" d="M 373 89 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
+            <path id="arrow1_right" class="GreenShape" d="M 335 84 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0"></path>
         </g>
 
         <g id="speedbrake_text">
-            <text id="n5l" class="Value15Warning" x="111" y="95" text-anchor="middle" alignment-baseline="central">5</text>
-            <text id="n4l" class="Value15Warning" x="150" y="90" text-anchor="middle" alignment-baseline="central">4</text>
-            <text id="n3l" class="Value15Warning" x="188" y="85" text-anchor="middle" alignment-baseline="central">3</text>
-            <text id="n2l" class="Value15Warning" x="227" y="80" text-anchor="middle" alignment-baseline="central">2</text>
-            <text id="n1l" class="Value15Warning" x="265" y="75" text-anchor="middle" alignment-baseline="central">1</text>
+            <text id="num5_left" class="Value15Warning" x="111" y="95" text-anchor="middle" alignment-baseline="central">5</text>
+            <text id="num4_left" class="Value15Warning" x="150" y="90" text-anchor="middle" alignment-baseline="central">4</text>
+            <text id="num3_left" class="Value15Warning" x="188" y="85" text-anchor="middle" alignment-baseline="central">3</text>
+            <text id="num2_left" class="Value15Warning" x="227" y="80" text-anchor="middle" alignment-baseline="central">2</text>
+            <text id="num1_left" class="Value15Warning" x="265" y="75" text-anchor="middle" alignment-baseline="central">1</text>
 
-            <text id="n5r" class="Value15Warning" x="489" y="95" text-anchor="middle" alignment-baseline="central">5</text>
-            <text id="n4r" class="Value15Warning" x="450" y="90" text-anchor="middle" alignment-baseline="central">4</text>
-            <text id="n3r" class="Value15Warning" x="412" y="85" text-anchor="middle" alignment-baseline="central">3</text>
-            <text id="n2r" class="Value15Warning" x="373" y="80" text-anchor="middle" alignment-baseline="central">2</text>
-            <text id="n1r" class="Value15Warning" x="335" y="75" text-anchor="middle" alignment-baseline="central">1</text>
+            <text id="num5_right" class="Value15Warning" x="489" y="95" text-anchor="middle" alignment-baseline="central">5</text>
+            <text id="num4_right" class="Value15Warning" x="450" y="90" text-anchor="middle" alignment-baseline="central">4</text>
+            <text id="num3_right" class="Value15Warning" x="412" y="85" text-anchor="middle" alignment-baseline="central">3</text>
+            <text id="num2_right" class="Value15Warning" x="373" y="80" text-anchor="middle" alignment-baseline="central">2</text>
+            <text id="num1_right" class="Value15Warning" x="335" y="75" text-anchor="middle" alignment-baseline="central">1</text>
         </g>
 
         <g id="leftSpeedbrakeGroup">

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.js
@@ -45,10 +45,25 @@ let A320_Neo_LowerECAM_FTCL;
             this.leftElevatorCursor = this.querySelector("#leftElevatorCursor");
             this.rightElevatorCursor = this.querySelector("#rightElevatorCursor");
 
-            //Rudder
+            // Rudder
             this.rudderCursor = this.querySelector("#rudderCursor");
             this.rudderLeftMaxAngle = this.querySelector("#rudderLeftMaxAngle");
             this.rudderRightMaxAngle = this.querySelector("#rudderRightMaxAngle");
+
+            // Spoiler arrows
+            this.spoiler_a5l = this.querySelector("#a5l");
+            this.spoiler_a4l = this.querySelector("#a4l");
+            this.spoiler_a3l = this.querySelector("#a3l");
+            this.spoiler_a2l = this.querySelector("#a2l");
+            this.spoiler_a1l = this.querySelector("#a1l");
+            this.spoiler_a5r = this.querySelector("#a5r");
+            this.spoiler_a4r = this.querySelector("#a4r");
+            this.spoiler_a3r = this.querySelector("#a3r");
+            this.spoiler_a2r = this.querySelector("#a2r");
+            this.spoiler_a1r = this.querySelector("#a1r");
+
+            // Spoiler text
+            this.spoilertext = this.querySelector("#speedbrake_text");
 
             this.hydraulicsAvailable = true;
 
@@ -61,7 +76,6 @@ let A320_Neo_LowerECAM_FTCL;
             }
 
             // Update hydraulics available state
-
             const hydraulicsShouldBeAvailable = SimVar.GetSimVarValue("ENG COMBUSTION:1", "Bool") === 0 && SimVar.GetSimVarValue("ENG COMBUSTION:2", "Bool") === 0
 
             if (hydraulicsShouldBeAvailable !== this.hydraulicsAvailable) {
@@ -71,10 +85,10 @@ let A320_Neo_LowerECAM_FTCL;
             }
 
             // Update pitch trim
-
             let rawPitchTrim = SimVar.GetSimVarValue("ELEVATOR TRIM INDICATOR", "Position 16k") / 1213.6296;
 
-            if (rawPitchTrim > 16384.0) { // Cap pitch trim at 13.5 up, 4 down
+            // Cap pitch trim at 13.5 up, 4 down
+            if (rawPitchTrim > 16384.0) {
                 rawPitchTrim = 16384.0;
             } else if (rawPitchTrim < -4854) {
                 rawPitchTrim = -4854;
@@ -94,21 +108,18 @@ let A320_Neo_LowerECAM_FTCL;
             }
 
             // Update left aileron
-
             const leftAileronDeflectPct = SimVar.GetSimVarValue("AILERON LEFT DEFLECTION PCT", "percent over 100");
             let leftAileronDeflectPctNormalized = leftAileronDeflectPct * 54;
             let laCursorPath = "M73," + (204 + leftAileronDeflectPctNormalized) + " l15,-7 l0,14Z";
             this.leftAileronCursor.setAttribute("d", laCursorPath);
 
             // Update right aileron
-
             const rightAileronDeflectPct = SimVar.GetSimVarValue("AILERON RIGHT DEFLECTION PCT", "percent over 100");
             let rightAileronDeflectPctNormalized = rightAileronDeflectPct * 54;
             let raCursorPath = "M527," + (204 - rightAileronDeflectPctNormalized) + " l-15,-7 l0,14Z";
             this.rightAileronCursor.setAttribute("d", raCursorPath);
 
             // Update left/right elevators
-
             const elevatorDeflectPct = SimVar.GetSimVarValue("ELEVATOR DEFLECTION PCT", "percent over 100");
             let elevatorDeflectPctNormalized = elevatorDeflectPct * 52;
             let leCursorPath = "M169," + (398 - elevatorDeflectPctNormalized) + " l15,-7 l0,14Z";
@@ -117,13 +128,11 @@ let A320_Neo_LowerECAM_FTCL;
             this.rightElevatorCursor.setAttribute("d", reCursorPath);
 
             // Update rudder
-
             const rudderDeflectPct = SimVar.GetSimVarValue("RUDDER DEFLECTION PCT", "percent over 100");
             const rudderAngle = -rudderDeflectPct * 25;
             this.rudderCursor.setAttribute("transform", `rotate(${rudderAngle} 300 380)`);
 
-            //Update Rudder limits
-
+            // Update rudder limits
             const IndicatedAirspeed = SimVar.GetSimVarValue("AIRSPEED INDICATED", "knots");
             let MaxAngleNorm = 1;
             if(IndicatedAirspeed > 380){
@@ -136,7 +145,6 @@ let A320_Neo_LowerECAM_FTCL;
             this.rudderRightMaxAngle.setAttribute("transform", `rotate(${26.4 * (1-MaxAngleNorm)} 300 385)`)
 
             // Update ELAC's and SEC's
-
             const elac1_On = SimVar.GetSimVarValue("FLY BY WIRE ELAC SWITCH:1", "boolean");
             const elac2_On = SimVar.GetSimVarValue("FLY BY WIRE ELAC SWITCH:2", "boolean");
             const elac1_Failed = SimVar.GetSimVarValue("FLY BY WIRE ELAC FAILED:1", "boolean");
@@ -186,7 +194,89 @@ let A320_Neo_LowerECAM_FTCL;
             } else {
                 this.sec3Shape.setAttribute("class", "MainShapeWarning");
                 this.sec3Num.setAttribute("class", "Value15Warning");
-            }
+            } 
+
+            if (this.hydraulicsAvailable) {
+                // Show hydraulic numbers and hide everything else
+                this.spoilertext.setAttribute("visibility", "visible");
+                this.spoiler_a5l.setAttribute("visibility", "hidden");
+                this.spoiler_a4l.setAttribute("visibility", "hidden");
+                this.spoiler_a3l.setAttribute("visibility", "hidden");
+                this.spoiler_a2l.setAttribute("visibility", "hidden");
+                this.spoiler_a1l.setAttribute("visibility", "hidden");
+                this.spoiler_a5r.setAttribute("visibility", "hidden");
+                this.spoiler_a4r.setAttribute("visibility", "hidden");
+                this.spoiler_a3r.setAttribute("visibility", "hidden");
+                this.spoiler_a2r.setAttribute("visibility", "hidden");
+                this.spoiler_a1r.setAttribute("visibility", "hidden");
+            } else {
+                // Update spoiler variables
+                const spoilersArmed = SimVar.GetSimVarValue("SPOILERS ARMED", "boolean");
+                const leftSpoilerDeflectPct = SimVar.GetSimVarValue("SPOILERS LEFT POSITION", "percent over 100");
+                const rightSpoilerDeflectPct = SimVar.GetSimVarValue("SPOILERS RIGHT POSITION", "percent over 100");
+                const planeOnGround = SimVar.GetSimVarValue("SIM ON GROUND", "boolean");
+                const eng1_mode = SimVar.GetSimVarValue("GENERAL ENG THROTTLE MANAGED MODE:1", "number");
+                const eng2_mode = SimVar.GetSimVarValue("GENERAL ENG THROTTLE MANAGED MODE:2", "number");
+                const gspeed = SimVar.GetSimVarValue("SURFACE RELATIVE GROUND SPEED", "feet_per_second");
+
+                // Disable hydraulic numbers
+                this.spoilertext.setAttribute("visibility", "hidden");
+
+                // Update left speedbrakes and aileron
+                if (leftSpoilerDeflectPct > 0.07) {
+                    console.log("left aileron pct: " + String(leftAileronDeflectPct));
+                    console.log("left splr pct: " + String(leftSpoilerDeflectPct));
+                    if (leftAileronDeflectPct < -0.05) {
+                        this.spoiler_a5l.setAttribute("visibility", "visible");
+                    } else {
+                        this.spoiler_a5l.setAttribute("visibility", "hidden");
+                    }
+                    this.spoiler_a4l.setAttribute("visibility", "visible");
+                    this.spoiler_a3l.setAttribute("visibility", "visible");
+                    this.spoiler_a2l.setAttribute("visibility", "visible");
+                } else {
+                    this.spoiler_a5l.setAttribute("visibility", "hidden");
+                    this.spoiler_a4l.setAttribute("visibility", "hidden");
+                    this.spoiler_a3l.setAttribute("visibility", "hidden");
+                    this.spoiler_a2l.setAttribute("visibility", "hidden");
+                }
+
+                // Update right speedbrakes and aileron
+                if (rightSpoilerDeflectPct > 0.07) {
+                    if (rightAileronDeflectPct > 0.05) {
+                        this.spoiler_a5r.setAttribute("visibility", "visible");
+                    } else {
+                        this.spoiler_a5r.setAttribute("visibility", "hidden");
+                    }
+                    this.spoiler_a4r.setAttribute("visibility", "visible");
+                    this.spoiler_a3r.setAttribute("visibility", "visible");
+                    this.spoiler_a2r.setAttribute("visibility", "visible");
+                } else {
+                    this.spoiler_a5r.setAttribute("visibility", "hidden");
+                    this.spoiler_a4r.setAttribute("visibility", "hidden");
+                    this.spoiler_a3r.setAttribute("visibility", "hidden");
+                    this.spoiler_a2r.setAttribute("visibility", "hidden");
+                }
+
+                // Ground spoilers deployed
+                if (spoilersArmed && planeOnGround && gspeed > 45 && eng1_mode <= 2 && eng2_mode <= 2) {
+                    if (leftSpoilerDeflectPct > 0.0625) {
+                        this.spoiler_a1l.setAttribute("visibility", "visible");
+                        this.spoiler_a5l.setAttribute("visibility", "visible");
+                    } else {
+                        this.spoiler_a1l.setAttribute("visibility", "hidden");
+                    }
+                    if (rightSpoilerDeflectPct > 0.0625) {
+                        this.spoiler_a1r.setAttribute("visibility", "visible");
+                        this.spoiler_a5r.setAttribute("visibility", "visible");
+                    } else {
+                        this.spoiler_a1r.setAttribute("visibility", "hidden");
+                    }
+                } else {
+                    this.spoiler_a1l.setAttribute("visibility", "hidden");
+                    this.spoiler_a1r.setAttribute("visibility", "hidden");
+                }
+            }  
         }
 
         /**

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.js
@@ -51,16 +51,16 @@ let A320_Neo_LowerECAM_FTCL;
             this.rudderRightMaxAngle = this.querySelector("#rudderRightMaxAngle");
 
             // Spoiler arrows
-            this.spoiler_a5l = this.querySelector("#a5l");
-            this.spoiler_a4l = this.querySelector("#a4l");
-            this.spoiler_a3l = this.querySelector("#a3l");
-            this.spoiler_a2l = this.querySelector("#a2l");
-            this.spoiler_a1l = this.querySelector("#a1l");
-            this.spoiler_a5r = this.querySelector("#a5r");
-            this.spoiler_a4r = this.querySelector("#a4r");
-            this.spoiler_a3r = this.querySelector("#a3r");
-            this.spoiler_a2r = this.querySelector("#a2r");
-            this.spoiler_a1r = this.querySelector("#a1r");
+            this.spoiler_arrow5_left = this.querySelector("#arrow5_left");
+            this.spoiler_arrow4_left = this.querySelector("#arrow4_left");
+            this.spoiler_arrow3_left = this.querySelector("#arrow3_left");
+            this.spoiler_arrow2_left = this.querySelector("#arrow2_left");
+            this.spoiler_arrow1_left = this.querySelector("#arrow1_left");
+            this.spoiler_arrow5_right = this.querySelector("#arrow5_right");
+            this.spoiler_arrow4_right = this.querySelector("#arrow4_right");
+            this.spoiler_arrow3_right = this.querySelector("#arrow3_right");
+            this.spoiler_arrow2_right = this.querySelector("#arrow2_right");
+            this.spoiler_arrow1_right = this.querySelector("#arrow1_right");
 
             // Spoiler text
             this.spoilertext = this.querySelector("#speedbrake_text");
@@ -199,16 +199,16 @@ let A320_Neo_LowerECAM_FTCL;
             if (this.hydraulicsAvailable) {
                 // Show hydraulic numbers and hide everything else
                 this.spoilertext.setAttribute("visibility", "visible");
-                this.spoiler_a5l.setAttribute("visibility", "hidden");
-                this.spoiler_a4l.setAttribute("visibility", "hidden");
-                this.spoiler_a3l.setAttribute("visibility", "hidden");
-                this.spoiler_a2l.setAttribute("visibility", "hidden");
-                this.spoiler_a1l.setAttribute("visibility", "hidden");
-                this.spoiler_a5r.setAttribute("visibility", "hidden");
-                this.spoiler_a4r.setAttribute("visibility", "hidden");
-                this.spoiler_a3r.setAttribute("visibility", "hidden");
-                this.spoiler_a2r.setAttribute("visibility", "hidden");
-                this.spoiler_a1r.setAttribute("visibility", "hidden");
+                this.spoiler_arrow5_left.setAttribute("visibility", "hidden");
+                this.spoiler_arrow4_left.setAttribute("visibility", "hidden");
+                this.spoiler_arrow3_left.setAttribute("visibility", "hidden");
+                this.spoiler_arrow2_left.setAttribute("visibility", "hidden");
+                this.spoiler_arrow1_left.setAttribute("visibility", "hidden");
+                this.spoiler_arrow5_right.setAttribute("visibility", "hidden");
+                this.spoiler_arrow4_right.setAttribute("visibility", "hidden");
+                this.spoiler_arrow3_right.setAttribute("visibility", "hidden");
+                this.spoiler_arrow2_right.setAttribute("visibility", "hidden");
+                this.spoiler_arrow1_right.setAttribute("visibility", "hidden");
             } else {
                 // Update spoiler variables
                 const spoilersArmed = SimVar.GetSimVarValue("SPOILERS ARMED", "boolean");
@@ -224,57 +224,55 @@ let A320_Neo_LowerECAM_FTCL;
 
                 // Update left speedbrakes and aileron
                 if (leftSpoilerDeflectPct > 0.07) {
-                    console.log("left aileron pct: " + String(leftAileronDeflectPct));
-                    console.log("left splr pct: " + String(leftSpoilerDeflectPct));
                     if (leftAileronDeflectPct < -0.05) {
-                        this.spoiler_a5l.setAttribute("visibility", "visible");
+                        this.spoiler_arrow5_left.setAttribute("visibility", "visible");
                     } else {
-                        this.spoiler_a5l.setAttribute("visibility", "hidden");
+                        this.spoiler_arrow5_left.setAttribute("visibility", "hidden");
                     }
-                    this.spoiler_a4l.setAttribute("visibility", "visible");
-                    this.spoiler_a3l.setAttribute("visibility", "visible");
-                    this.spoiler_a2l.setAttribute("visibility", "visible");
+                    this.spoiler_arrow4_left.setAttribute("visibility", "visible");
+                    this.spoiler_arrow3_left.setAttribute("visibility", "visible");
+                    this.spoiler_arrow2_left.setAttribute("visibility", "visible");
                 } else {
-                    this.spoiler_a5l.setAttribute("visibility", "hidden");
-                    this.spoiler_a4l.setAttribute("visibility", "hidden");
-                    this.spoiler_a3l.setAttribute("visibility", "hidden");
-                    this.spoiler_a2l.setAttribute("visibility", "hidden");
+                    this.spoiler_arrow5_left.setAttribute("visibility", "hidden");
+                    this.spoiler_arrow4_left.setAttribute("visibility", "hidden");
+                    this.spoiler_arrow3_left.setAttribute("visibility", "hidden");
+                    this.spoiler_arrow2_left.setAttribute("visibility", "hidden");
                 }
 
                 // Update right speedbrakes and aileron
                 if (rightSpoilerDeflectPct > 0.07) {
                     if (rightAileronDeflectPct > 0.05) {
-                        this.spoiler_a5r.setAttribute("visibility", "visible");
+                        this.spoiler_arrow5_right.setAttribute("visibility", "visible");
                     } else {
-                        this.spoiler_a5r.setAttribute("visibility", "hidden");
+                        this.spoiler_arrow5_right.setAttribute("visibility", "hidden");
                     }
-                    this.spoiler_a4r.setAttribute("visibility", "visible");
-                    this.spoiler_a3r.setAttribute("visibility", "visible");
-                    this.spoiler_a2r.setAttribute("visibility", "visible");
+                    this.spoiler_arrow4_right.setAttribute("visibility", "visible");
+                    this.spoiler_arrow3_right.setAttribute("visibility", "visible");
+                    this.spoiler_arrow2_right.setAttribute("visibility", "visible");
                 } else {
-                    this.spoiler_a5r.setAttribute("visibility", "hidden");
-                    this.spoiler_a4r.setAttribute("visibility", "hidden");
-                    this.spoiler_a3r.setAttribute("visibility", "hidden");
-                    this.spoiler_a2r.setAttribute("visibility", "hidden");
+                    this.spoiler_arrow5_right.setAttribute("visibility", "hidden");
+                    this.spoiler_arrow4_right.setAttribute("visibility", "hidden");
+                    this.spoiler_arrow3_right.setAttribute("visibility", "hidden");
+                    this.spoiler_arrow2_right.setAttribute("visibility", "hidden");
                 }
 
                 // Ground spoilers deployed
                 if (spoilersArmed && planeOnGround && gspeed > 45 && eng1_mode <= 2 && eng2_mode <= 2) {
                     if (leftSpoilerDeflectPct > 0.0625) {
-                        this.spoiler_a1l.setAttribute("visibility", "visible");
-                        this.spoiler_a5l.setAttribute("visibility", "visible");
+                        this.spoiler_arrow1_left.setAttribute("visibility", "visible");
+                        this.spoiler_arrow5_left.setAttribute("visibility", "visible");
                     } else {
-                        this.spoiler_a1l.setAttribute("visibility", "hidden");
+                        this.spoiler_arrow1_left.setAttribute("visibility", "hidden");
                     }
                     if (rightSpoilerDeflectPct > 0.0625) {
-                        this.spoiler_a1r.setAttribute("visibility", "visible");
-                        this.spoiler_a5r.setAttribute("visibility", "visible");
+                        this.spoiler_arrow1_right.setAttribute("visibility", "visible");
+                        this.spoiler_arrow5_right.setAttribute("visibility", "visible");
                     } else {
-                        this.spoiler_a1r.setAttribute("visibility", "hidden");
+                        this.spoiler_arrow1_right.setAttribute("visibility", "hidden");
                     }
                 } else {
-                    this.spoiler_a1l.setAttribute("visibility", "hidden");
-                    this.spoiler_a1r.setAttribute("visibility", "hidden");
+                    this.spoiler_arrow1_left.setAttribute("visibility", "hidden");
+                    this.spoiler_arrow1_right.setAttribute("visibility", "hidden");
                 }
             }  
         }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

**Summary of Changes**
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Added arrows to F/CTL spoiler indicators which reflect position of individual speedbrakes
- If no hydraulic pressure (simulated with engine running state), display numbers instead.
- Change ELAC/SEC warning color from red to amber

**Screenshots (if necessary)**
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![FlightSimulator_6wlPFDNS7M](https://user-images.githubusercontent.com/28059870/94990542-fde08280-054a-11eb-8e18-be3f20b89328.jpg)


**References**
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

**Additional context**
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Iceman#5540
