### PR TITLE
feat(ecam-elec): Add elec ecam js and html

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.html
@@ -28,6 +28,7 @@
             <div id="BottomScreen">
                 <a320-neo-lower-ecam-fuel id="FD" style="display:block"></a320-neo-lower-ecam-fuel>
                 <a320-neo-lower-ecam-engine style="display:none"></a320-neo-lower-ecam-engine> <!-- MODIFIED -->
+                <a320-neo-lower-ecam-elec style="display:none"></a320-neo-lower-ecam-elec> <!-- MODIFIED -->
                 <a320-neo-lower-ecam-apu style="display:none"></a320-neo-lower-ecam-apu>
                 <a320-neo-lower-ecam-bleed style="display:none"></a320-neo-lower-ecam-bleed> <!-- MODIFIED -->
                 <a320-neo-lower-ecam-door style="display:none"></a320-neo-lower-ecam-door> <!-- MODIFIED -->
@@ -70,6 +71,7 @@
 <script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.html"></script> <!-- MODIFIED -->
 <script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.html"></script>
 <script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.html"></script>
+<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Elec.html"></script>
 <script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.html"></script> <!-- MODIFIED -->
 <script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.html"></script> <!-- MODIFIED -->
 <script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.html"></script> <!-- MODIFIED -->

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -94,6 +94,10 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         SimVar.SetSimVarValue("LIGHT POTENTIOMETER:91","FLOAT64",0.1);
         SimVar.SetSimVarValue("LIGHT POTENTIOMETER:92","FLOAT64",0.1);
         SimVar.SetSimVarValue("LIGHT POTENTIOMETER:93","FLOAT64",0.1);
+
+        Include.addScript("/JS/debug.js", function () {
+            g_modDebugMgr.AddConsole(null);
+        });
     }
     onUpdate() {
         const _deltaTime = this.getDeltaTime();

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Elec.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Elec.html
@@ -1,0 +1,267 @@
+﻿<!-- <link rel="stylesheet" href="./A320_Neo_LowerECAM_Fuel.css" /> -->
+
+<style>
+    html {
+        background-color: #111111;
+    }
+    path {
+        stroke-width: 1px;
+        stroke-linecap: square;
+        stroke-linejoin: miter;
+    }
+    .arrow {
+        stroke-width: 0.6px;
+    }
+    text {
+        fill: #EEEEEE;
+        font-family: 'Roboto Mono', monospace;
+        line-height: 1.25;
+        white-space: pre;
+        word-spacing: 0px;
+        font-size: 5.6px;
+        font-weight: 400;
+    }
+    .hidden {
+        display: none;
+    }
+    path {
+        stroke: #EEEEEE;
+
+    }
+    path.green {
+        stroke: green;
+    }
+    rect.bus {
+        fill: #999999;
+    }
+    text.bus {
+        font-weight: 700;
+    }
+    .box {
+        stroke: #EEEEEE;
+        stroke-width: 1px;
+    }
+    text.left {
+        text-anchor: start;
+        text-align: start;
+    }
+    text.right {
+        text-anchor: end;
+        text-align: end;
+    }
+    text.middle {
+        text-anchor: middle;
+        text-align: middle;
+    }
+    text.green {
+        fill: green;
+    }
+    text.amber {
+        fill: #db7200;
+    }
+    text.blue {
+        fill: #009696;
+    }
+    text.small {
+        font-size: 4px;
+    }
+    text.medium {
+        font-size: 5px;
+    }
+    text.large {
+        font-size: 6.5px;
+    }
+    a320-neo-lower-ecam-elec {
+        display: block;
+        position: relative;
+        top: -2%;
+        left: 1.5%;
+        width: 97%;
+        height: 97%;
+    }
+</style>
+
+<script type="text/html" id="LowerECAMElecTemplate">
+    <svg style="background-color: #000000;" version="1.1" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg">
+        <rect id="BAT2_BOX" class="box" x="108" y="4" width="23" height="19" />
+        <text id="BAT2_OFF" class="middle" dominant-baseline="middle" x="119.5" y="15">OFF</text>
+        <text id="BAT2_TITLE" class="right" x="121" y="9.5">BAT</text>
+        <text id="BAT2_TITLE_NUMBER" class="left large" x="122" y="9.5">2</text>
+        <text id="BAT2_VOLTS_VALUE" class="green right" x="121" y="15.5">31</text>
+        <text id="BAT2_VOLTS_UNIT" class="blue left" x="122" y="15.5">V</text>
+        <text id="BAT2_AMPS_VALUE" class="green right" x="121" y="21.5">2</text>
+        <text id="BAT2_AMPS_UNIT" class="blue left" x="122" y="21.5">A</text>
+    
+        <rect id="DCBATBUS_BOX" class="bus" x="62" y="10" width="36" height="7" />
+        <text id="DCBATBUS_TITLE" class="bus green middle" dominant-baseline="middle" x="80" y="14">DC BAT</text>
+    
+        <rect id="BAT1_BOX" class="box" x="29" y="4" width="23" height="19" />
+        <text id="BAT1_OFF" class="middle" dominant-baseline="middle" x="40.5" y="15">OFF</text>
+        <text id="BAT1_TITLE" class="right" x="43" y="9.5">BAT</text>
+        <text id="BAT1_TITLE_NUMBER" class="left large" x="44" y="9.5">1</text>
+        <text id="BAT1_VOLTS_VALUE" class="green right" x="43" y="15.5">25.5</text>
+        <text id="BAT1_VOLTS_UNIT" class="blue left" x="44" y="15.5">V</text>
+        <text id="BAT1_AMPS_VALUE" class="green right" x="43" y="21.5">5.2</text>
+        <text id="BAT1_AMPS_UNIT" class="blue left" x="44" y="21.5">A</text>
+    
+        <rect id="DCBUS2_BOX" class="bus" x="134" y="24" width="23" height="7" />
+        <text id="DCBUS2_TITLE" class="bus green right" x="146.5" y="29.25">DC</text>
+        <text id="DCBUS2_TITLE_NUMBER" class="bus large green left" x="147.5" y="29.25">2</text>
+    
+        <rect id="DCESSBUS_BOX" class="bus" x="62" y="31" width="36" height="7" />
+        <text id="DCESSBUS_TITLE" class="bus green middle" dominant-baseline="middle" x="80" y="35">DC ESS</text>
+        <text id="DCESSBUS_SHED" class="middle small" dominant-baseline="middle" x="80" y="40.5">SHED</text>
+    
+        <rect id="DCBUS1_BOX" class="bus" x="1" y="24" width="23" height="7" />
+        <text id="DCBUS1_TITLE" class="bus green right" x="13.5" y="29.25">DC</text>
+        <text id="DCBUS1_TITLE_NUMBER" class="bus large green left" x="14.5" y="29.25">1</text>
+    
+        <rect id="TR2_BOX" class="box" x="131.5" y="43" width="23" height="20" />
+        <text id="TR2_TITLE"class="right" x="146" y="49.5">TR</text>
+        <text id="TR2_TITLE_NUMBER" class="left large" x="147" y="49.5">2</text>
+        <text id="TR2_VOLTS_VALUE" class="green right" x="146" y="55.5">98</text>
+        <text id="TR2_VOLTS_UNIT" class="blue left" x="147" y="55.5">V</text>
+        <text id="TR2_AMPS_VALUE" class="green right" x="146" y="61.5">7</text>
+        <text id="TR2_AMPS_UNIT" class="blue left" x="147" y="61.5">A</text>
+    
+        <rect id="EMERGEN_BOX" class="box" x="88" y="43" width="27.5" height="20" />
+        <text id="EMERGEN_TITLE" class="middle" x="101.75" y="49.5">EMER GEN</text>
+        <text id="EMERGEN_OFFLINE" class="left medium" dominant-baseline="middle" x="88.25" y="56">EMER GEN</text>
+        <text id="EMERGEN_VOLTS_VALUE" class="green right" x="105" y="55.5">8</text>
+        <text id="EMERGEN_VOLTS_UNIT" class="blue left" x="106" y="55.5">V</text>
+        <text id="EMERGEN_FREQ_VALUE" class="green right" x="105" y="61.5">77</text>
+        <text id="EMERGEN_FREQ_UNIT" class="blue left" x="106" y="61.5">HZ</text>
+    
+        <rect id="ESSTR_BOX" class="box" x="57" y="43" width="22.5" height="20" />
+        <text id="ESSTR_TITLE" class="middle" x="68.25" y="49.5">ESS TR</text>
+        <text id="ESSTR_VOLTS_VALUE" class="green right" x="71" y="55.5">13</text>
+        <text id="ESSTR_VOLTS_UNIT" class="blue left" x="72" y="55.5">V</text>
+        <text id="ESSTR_AMPS_VALUE" class="green right" x="71" y="61.5">2</text>
+        <text id="ESSTR_AMPS_UNIT" class="blue left" x="72" y="61.5">A</text>
+    
+        <rect id="TR1_BOX" class="box" x="3.5" y="43" width="23" height="20" />
+        <text id="TR1_TITLE" class="right" x="18" y="49.5">TR</text>
+        <text id="TR1_TITLE_NUMBER" class="left large" x="19" y="49.5">1</text>
+        <text id="TR1_VOLTS_VALUE" class="green right"  x="18" y="55.5">57</text>
+        <text id="TR1_VOLTS_UNIT" class="blue left" x="19" y="55.5">V</text>
+        <text id="TR1_AMPS_VALUE" class="green right" x="18" y="61.5">4</text>
+        <text id="TR1_AMPS_UNIT" class="blue left" x="19" y="61.5">A</text>
+    
+        <rect id="ACBUS2_BOX" class="bus" x="121" y="71" width="36" height="7" />
+        <text id="ACBUS2_TITLE" class="bus green right" x="141.5" y="76.5">AC</text>
+        <text id="ACBUS2_TITLE_NUMBER" class="bus large green left" x="142.5" y="76.5">2</text>
+    
+        <rect id="ACESSBUS_BOX" class="bus" x="62" y="71" width="36" height="7" />
+        <text id="ACESSBUS_TITLE" class="bus green middle" dominant-baseline="middle" x="80" y="75">AC ESS</text>
+        <text id="ACESSBUS_SHED" class="middle small" dominant-baseline="middle" x="80" y="80.5">SHED</text>
+    
+        <rect id="ACBUS1_BOX" class="bus" x="1" y="71" width="36" height="7" />
+        <text id="ACBUS1_TITLE" class="bus green right" x="18.5" y="76.5">AC</text>
+        <text id="ACBUS1_TITLE_NUMBER" class="bus large green left" x="19.5" y="76.5">1</text>
+    
+        <rect id="GEN2_BOX" class="box" x="131.5" y="92" width="23" height="25" />
+        <text id="GEN2_TITLE" class="right" x="146" y="98">GEN</text>
+        <text id="GEN2_TITLE_NUMBER" class="left large" x="147" y="98">2</text>
+        <text id="GEN2_OFF" class="middle" dominant-baseline="middle" x="143" y="106.5">OFF</text>
+        <text id="GEN2_LOAD_VALUE" class="green right" x="146" y="104">48</text>
+        <text id="GEN2_LOAD_UNIT" class="blue left" x="147" y="104">%</text>
+        <text id="GEN2_VOLTS_VALUE" class="green right" x="146" y="110">201</text>
+        <text id="GEN2_VOLTS_UNIT" class="blue left" x="147" y="110">V</text>
+        <text id="GEN2_FREQ_VALUE" class="green right" x="146" y="116">49</text>
+        <text id="GEN2_FREQ_UNIT" class="blue left" x="147" y="116">HZ</text>
+    
+        <rect id="EXTPWR_BOX" class="box" x="84" y="104" width="25" height="18" />
+        <text id="EXTPWR_TITLE" class="middle" x="96.5" y="109">EXT PWR</text>
+        <text id="EXTPWR_VOLTS_VALUE" class="green right" x="98" y="115">128</text>
+        <text id="EXTPWR_VOLTS_UNIT" class="blue left" x="99" y="115">V</text>
+        <text id="EXTPWR_FREQ_VALUE" class="green right" x="98" y="121">50</text>
+        <text id="EXTPWR_FREQ_UNIT" class="blue left" x="99" y="121">HZ</text>
+    
+        <rect id="APUGEN_BOX" class="box" x="45" y="98" width="25" height="24" />
+        <text id="APUGEN_TITLE" class="middle" x="57.5" y="103">APU GEN</text>
+        <text id="APUGEN_OFF" class="middle" dominant-baseline="middle" x="57.5" y="111">OFF</text>
+        <text id="APUGEN_LOAD_VALUE" class="green right" x="60.5" y="109">81</text>
+        <text id="APUGEN_LOAD_UNIT" class="blue left" x="61.5" y="109">%</text>
+        <text id="APUGEN_VOLTS_VALUE" class="green right" x="60.5" y="115">210</text>
+        <text id="APUGEN_VOLTS_UNIT" class="blue left" x="61.5" y="115">V</text>
+        <text id="APUGEN_FREQ_VALUE" class="green right" x="60.5" y="121">32</text>
+        <text id="APUGEN_FREQ_UNIT" class="blue left" x="61.5" y="121">HZ</text>
+    
+        <rect id="GEN1_BOX" class="box" x="3.5" y="92" width="23" height="25" />
+        <text id="GEN1_TITLE" class="right" x="18" y="98">GEN</text>
+        <text id="GEN1_TITLE_NUMBER" class="left large" x="19" y="98">1</text>
+        <text id="GEN1_OFF" class="middle" dominant-baseline="middle" x="15" y="106.5">OFF</text>
+        <text id="GEN1_LOAD_VALUE" class="green right" x="18" y="104">43</text>
+        <text id="GEN1_LOAD_UNIT" class="blue left" x="19" y="104">%</text>
+        <text id="GEN1_VOLTS_VALUE" class="green right" x="18" y="110">207</text>
+        <text id="GEN1_VOLTS_UNIT" class="blue left" x="19" y="110">V</text>
+        <text id="GEN1_FREQ_VALUE" class="green right" x="18" y="116">8</text>
+        <text id="GEN1_FREQ_UNIT" class="blue left" x="19" y="116">HZ</text>
+    
+        <text id="IDG2_TITLE" class="left" x="137" y="127">IDG</text>
+        <text id="IDG2_TITLE_NUMBER" class="left large" x="147.5" y="127">2</text>
+        <text id="IDG2_TEMP_VALUE" class="green right" x="128" y="127">142</text>
+        <text id="IDG2_TEMP_UNIT" class="blue left" x="129" y="127">°C</text>
+        <text id="IDG2_DISC" class="right" x="151" y="132">DISC</text>
+        <text id="IDG2_LOPR" class="right" x="151" y="132">LO PR</text>
+    
+        <text id="IDG1_TITLE" class="left" x="7.5" y="127">IDG</text>
+        <text id="IDG1_TITLE_NUMBER" class="left large" x="18" y="127">1</text>
+        <text id="IDG1_TEMP_VALUE" class="green right" x="36" y="127">142</text>
+        <text id="IDG1_TEMP_UNIT" class="blue left" x="37" y="127">°C</text>
+        <text id="IDG1_DISC" class="left" x="7.5" y="132">DISC</text>
+        <text id="IDG1_LOPR" class="left" x="7.5" y="132">LO PR</text>
+    
+        <text id="GALLEY_SHED_TOP" class="middle" x="80" y="129">GALLEY</text>
+        <text id="GALLEY_SHED_BOTTOM" class="middle" x="80" y="134">SHED</text>
+    
+        <text id="TITLE_HEADING" class="left" x="1.3" y="7.4">ELEC</text>
+        <path id="TITLE_UNDERLINE" d="m1.5 8.6282h13.2" />
+    
+        <text id="STATINV_TITLE" class="left medium" x="58" y="8">STAT INV</text>
+    
+        <path id="WIRE_XFEED-C" class="green" d="m96.187 85.834h47.9" />
+        <path id="WIRE_XFEED-B" class="green" d="m57.323 85.834h39.381" />
+        <path id="WIRE_XFEED-A" class="green" d="m14.78 85.834h43" />
+        <path id="WIRE_APUGEN_XFEED" class="green" d="m57.588 95.1v-9.5112" />
+        <path id="WIRE_EXTPWR_XFEED" class="green" d="m96.435 101.23v-15.6" />
+        <path id="WIRE_XFEED_AC1" class="green" d="m15.018 80.75v5.3479" />
+        <path id="WIRE_GEN1_XFEED" class="green" d="m15.018 86.05v5.8" />
+        <path id="WIRE_XFEED_AC2" class="green" d="m143.93 80.753v5.3479" />
+        <path id="WIRE_GEN2_XFEED" class="green" d="m143.93 86.05v5.8" />
+        <path id="WIRE_AC2_ACESS" class="green" d="m121.1 74.497h-23.1" />
+        <path id="WIRE_AC1_ACESS" class="green" d="m62.05 74.486h-25.1" />
+        <path id="WIRE_AC1_TR1" class="green" d="m15.018 62.873v8.1054" />
+        <path id="WIRE_TR1_DC1" class="green" d="m15.018 31v12" />
+        <path id="WIRE_ACESS_ESSTR" class="green" d="m68.588 62.869v8.1098" />
+        <path id="WIRE_DC1_DCBAT-A" class="green" d="m69 27.17h-44.983" />
+        <path id="WIRE_DC1_DCBAT-B" class="green" d="m68.934 16.928v10.506" />
+        <path id="WIRE_DCESS_DCBAT" class="green" d="m68.934 27.2v3.8" />
+        <path id="WIRE_DCBAT_BAT2" class="green" d="m104.3 13.539h-6.2711" />
+        <path id="WIRE_BAT2_DCBAT" class="green" d="m107.7 13.539h-6.2735" />
+        <path id="WIRE_DC2_DCBAT-A" class="green" d="m134 27.17h-44.9" />
+        <path id="WIRE_DC2_DCBAT-B" class="green" d="m88.921 16.928v10.506" />
+        <path id="WIRE_BAT1_DCBAT" class="green" d="m58.52 13.539h-6.2711" />
+        <path id="WIRE_DCBAT_BAT1" class="green" d="m62.1 13.539h-6.2735" />
+        <path id="WIRE_AC2_TR2" class="green" d="m143.93 62.873v8.1054" />
+        <path id="WIRE_TR2_DC2" class="green" d="m143.93 31v12" />
+        <path id="WIRE_EMERGEN_ESSTR" class="green" d="m85.072 55.441h-5.4449" />
+        <path id="WIRE_EMERGEN_ACESS" class="green" d="m91.612 62.866v4.3012" />
+        <path id="WIRE_ESSTR_DCESS" class="green" d="m68.921 38v1.8951" />
+    
+        <path id="ARROW_ESSTR_DCESS" class="arrow" d="m67.1 42.02h3.6633l-1.8316-2.3982z" />
+        <path id="ARROW_XFEED_AC1" class="arrow green" d="m13.191 81.005h3.6633l-1.8316-2.3982z" />
+        <path id="ARROW_XFEED_AC2" class="arrow green" d="m142.1 81.005h3.6633l-1.8316-2.3982z" />
+        <path id="ARROW_EXTPWR_XFEED" class="arrow green" d="m94.604 102.9h3.6633l-1.8316-2.3982z" />
+        <path id="ARROW_APUGEN_XFEED" class="arrow green" d="m55.756 97h3.6633l-1.8316-2.3982z" />
+        <path id="ARROW_EMERGEN_ESSTR" class="arrow" d="m87 57.273v-3.6633l-2.3982 1.8316z" />
+        <path id="ARROW_BAT1_DCBAT" class="arrow green" d="m58.687 11.697v3.6633l2.3982-1.8316z" />
+        <path id="ARROW_BAT2_DCBAT" class="arrow green" d="m101.2 15.36v-3.6633l-2.3982 1.8316z" />
+        <path id="ARROW_DCBAT_BAT1" class="arrow green" d="m55.6 15.36v-3.6633l-2.3982 1.8316z" />
+        <path id="ARROW_DCBAT_BAT2" class="arrow green" d="m104.7 11.697v3.6633l2.3982-1.8316z" />
+        <path id="ARROW_EMERGEN_ACESS" class="arrow green" d="m93.444 67.431h-3.6633l1.8316 2.3982z" />
+        <path id="ARROW_BAT1_STATINV" class="arrow" d="m53.687 4.5v3.6633l2.3982-1.8316z" />
+    </svg>
+</script>
+
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Elec.js?13"></script>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Elec.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Elec.js
@@ -1,0 +1,1081 @@
+var A320_Neo_LowerECAM_Elec;
+(function (A320_Neo_LowerECAM_Elec) {
+    const ENUM_BUS = {
+        0: 'OFF',
+        1: 'GEN1',
+        2: 'GEN2',
+        3: 'EXTPWR',
+        4: 'APUGEN',
+        5: 'EMERGEN',
+        6: '???',
+        7: 'TR1',
+        8: 'TR2',
+        9: 'TRESS',
+        10: 'BAT1',
+        11: 'BAT2',
+    }
+
+    class Page extends Airliners.EICASTemplateElement {
+        constructor() {
+            super();
+            this.isInitialised = false;
+        }
+        get templateID() { return "LowerECAMElecTemplate"; }
+        connectedCallback() {
+            super.connectedCallback();
+            TemplateElement.call(this, this.init.bind(this));
+        }
+        init() {
+            this.e_BAT2_BOX = this.querySelector("#BAT2_BOX")
+            this.e_BAT2_OFF = this.querySelector("#BAT2_OFF")
+            this.e_BAT2_TITLE = this.querySelector("#BAT2_TITLE")
+            this.e_BAT2_TITLE_NUMBER = this.querySelector("#BAT2_TITLE_NUMBER")
+            this.e_BAT2_VOLTS_VALUE = this.querySelector("#BAT2_VOLTS_VALUE")
+            this.e_BAT2_VOLTS_UNIT = this.querySelector("#BAT2_VOLTS_UNIT")
+            this.e_BAT2_AMPS_VALUE = this.querySelector("#BAT2_AMPS_VALUE")
+            this.e_BAT2_AMPS_UNIT = this.querySelector("#BAT2_AMPS_UNIT")
+
+            this.e_DCBATBUS_BOX = this.querySelector("#DCBATBUS_BOX")
+            this.e_DCBATBUS_TITLE = this.querySelector("#DCBATBUS_TITLE")
+
+            this.e_BAT1_BOX = this.querySelector("#BAT1_BOX")
+            this.e_BAT1_OFF = this.querySelector("#BAT1_OFF")
+            this.e_BAT1_TITLE = this.querySelector("#BAT1_TITLE")
+            this.e_BAT1_TITLE_NUMBER = this.querySelector("#BAT1_TITLE_NUMBER")
+            this.e_BAT1_VOLTS_VALUE = this.querySelector("#BAT1_VOLTS_VALUE")
+            this.e_BAT1_VOLTS_UNIT = this.querySelector("#BAT1_VOLTS_UNIT")
+            this.e_BAT1_AMPS_VALUE = this.querySelector("#BAT1_AMPS_VALUE")
+            this.e_BAT1_AMPS_UNIT = this.querySelector("#BAT1_AMPS_UNIT")
+
+            this.e_DCBUS2_BOX = this.querySelector("#DCBUS2_BOX")
+            this.e_DCBUS2_TITLE = this.querySelector("#DCBUS2_TITLE")
+            this.e_DCBUS2_TITLE_NUMBER = this.querySelector("#DCBUS2_TITLE_NUMBER")
+
+            this.e_DCESSBUS_BOX = this.querySelector("#DCESSBUS_BOX")
+            this.e_DCESSBUS_TITLE = this.querySelector("#DCESSBUS_TITLE")
+            this.e_DCESSBUS_SHED = this.querySelector("#DCESSBUS_SHED")
+
+            this.e_DCBUS1_BOX = this.querySelector("#DCBUS1_BOX")
+            this.e_DCBUS1_TITLE = this.querySelector("#DCBUS1_TITLE")
+            this.e_DCBUS1_TITLE_NUMBER = this.querySelector("#DCBUS1_TITLE_NUMBER")
+
+            this.e_TR2_BOX = this.querySelector("#TR2_BOX")
+            this.e_TR2_TITLE = this.querySelector("#TR2_TITLE")
+            this.e_TR2_TITLE_NUMBER = this.querySelector("#TR2_TITLE_NUMBER")
+            this.e_TR2_VOLTS_VALUE = this.querySelector("#TR2_VOLTS_VALUE")
+            this.e_TR2_VOLTS_UNIT = this.querySelector("#TR2_VOLTS_UNIT")
+            this.e_TR2_AMPS_VALUE = this.querySelector("#TR2_AMPS_VALUE")
+            this.e_TR2_AMPS_UNIT = this.querySelector("#TR2_AMPS_UNIT")
+
+            this.e_EMERGEN_BOX = this.querySelector("#EMERGEN_BOX")
+            this.e_EMERGEN_TITLE = this.querySelector("#EMERGEN_TITLE")
+            this.e_EMERGEN_OFFLINE = this.querySelector("#EMERGEN_OFFLINE")
+            this.e_EMERGEN_VOLTS_VALUE = this.querySelector("#EMERGEN_VOLTS_VALUE")
+            this.e_EMERGEN_VOLTS_UNIT = this.querySelector("#EMERGEN_VOLTS_UNIT")
+            this.e_EMERGEN_FREQ_VALUE = this.querySelector("#EMERGEN_FREQ_VALUE")
+            this.e_EMERGEN_FREQ_UNIT = this.querySelector("#EMERGEN_FREQ_UNIT")
+
+            this.e_ESSTR_BOX = this.querySelector("#ESSTR_BOX")
+            this.e_ESSTR_TITLE = this.querySelector("#ESSTR_TITLE")
+            this.e_ESSTR_VOLTS_VALUE = this.querySelector("#ESSTR_VOLTS_VALUE")
+            this.e_ESSTR_VOLTS_UNIT = this.querySelector("#ESSTR_VOLTS_UNIT")
+            this.e_ESSTR_AMPS_VALUE = this.querySelector("#ESSTR_AMPS_VALUE")
+            this.e_ESSTR_AMPS_UNIT = this.querySelector("#ESSTR_AMPS_UNIT")
+
+            this.e_TR1_BOX = this.querySelector("#TR1_BOX")
+            this.e_TR1_TITLE = this.querySelector("#TR1_TITLE")
+            this.e_TR1_TITLE_NUMBER = this.querySelector("#TR1_TITLE_NUMBER")
+            this.e_TR1_VOLTS_VALUE = this.querySelector("#TR1_VOLTS_VALUE")
+            this.e_TR1_VOLTS_UNIT = this.querySelector("#TR1_VOLTS_UNIT")
+            this.e_TR1_AMPS_VALUE = this.querySelector("#TR1_AMPS_VALUE")
+            this.e_TR1_AMPS_UNIT = this.querySelector("#TR1_AMPS_UNIT")
+
+            this.e_ACBUS2_BOX = this.querySelector("#ACBUS2_BOX")
+            this.e_ACBUS2_TITLE = this.querySelector("#ACBUS2_TITLE")
+            this.e_ACBUS2_TITLE_NUMBER = this.querySelector("#ACBUS2_TITLE_NUMBER")
+
+            this.e_ACESSBUS_BOX = this.querySelector("#ACESSBUS_BOX")
+            this.e_ACESSBUS_TITLE = this.querySelector("#ACESSBUS_TITLE")
+            this.e_ACESSBUS_SHED = this.querySelector("#ACESSBUS_SHED")
+
+            this.e_ACBUS1_BOX = this.querySelector("#ACBUS1_BOX")
+            this.e_ACBUS1_TITLE = this.querySelector("#ACBUS1_TITLE")
+            this.e_ACBUS1_TITLE_NUMBER = this.querySelector("#ACBUS1_TITLE_NUMBER")
+
+            this.e_GEN2_BOX = this.querySelector("#GEN2_BOX")
+            this.e_GEN2_TITLE = this.querySelector("#GEN2_TITLE")
+            this.e_GEN2_TITLE_NUMBER = this.querySelector("#GEN2_TITLE_NUMBER")
+            this.e_GEN2_OFF = this.querySelector("#GEN2_OFF")
+            this.e_GEN2_LOAD_VALUE = this.querySelector("#GEN2_LOAD_VALUE")
+            this.e_GEN2_LOAD_UNIT = this.querySelector("#GEN2_LOAD_UNIT")
+            this.e_GEN2_VOLTS_VALUE = this.querySelector("#GEN2_VOLTS_VALUE")
+            this.e_GEN2_VOLTS_UNIT = this.querySelector("#GEN2_VOLTS_UNIT")
+            this.e_GEN2_FREQ_VALUE = this.querySelector("#GEN2_FREQ_VALUE")
+            this.e_GEN2_FREQ_UNIT = this.querySelector("#GEN2_FREQ_UNIT")
+
+            this.e_EXTPWR_BOX = this.querySelector("#EXTPWR_BOX")
+            this.e_EXTPWR_TITLE = this.querySelector("#EXTPWR_TITLE")
+            this.e_EXTPWR_VOLTS_VALUE = this.querySelector("#EXTPWR_VOLTS_VALUE")
+            this.e_EXTPWR_VOLTS_UNIT = this.querySelector("#EXTPWR_VOLTS_UNIT")
+            this.e_EXTPWR_FREQ_VALUE = this.querySelector("#EXTPWR_FREQ_VALUE")
+            this.e_EXTPWR_FREQ_UNIT = this.querySelector("#EXTPWR_FREQ_UNIT")
+
+            this.e_APUGEN_BOX = this.querySelector("#APUGEN_BOX")
+            this.e_APUGEN_TITLE = this.querySelector("#APUGEN_TITLE")
+            this.e_APUGEN_OFF = this.querySelector("#APUGEN_OFF")
+            this.e_APUGEN_LOAD_VALUE = this.querySelector("#APUGEN_LOAD_VALUE")
+            this.e_APUGEN_LOAD_UNIT = this.querySelector("#APUGEN_LOAD_UNIT")
+            this.e_APUGEN_VOLTS_VALUE = this.querySelector("#APUGEN_VOLTS_VALUE")
+            this.e_APUGEN_VOLTS_UNIT = this.querySelector("#APUGEN_VOLTS_UNIT")
+            this.e_APUGEN_FREQ_VALUE = this.querySelector("#APUGEN_FREQ_VALUE")
+            this.e_APUGEN_FREQ_UNIT = this.querySelector("#APUGEN_FREQ_UNIT")
+
+            this.e_GEN1_BOX = this.querySelector("#GEN1_BOX")
+            this.e_GEN1_TITLE = this.querySelector("#GEN1_TITLE")
+            this.e_GEN1_TITLE_NUMBER = this.querySelector("#GEN1_TITLE_NUMBER")
+            this.e_GEN1_OFF = this.querySelector("#GEN1_OFF")
+            this.e_GEN1_LOAD_VALUE = this.querySelector("#GEN1_LOAD_VALUE")
+            this.e_GEN1_LOAD_UNIT = this.querySelector("#GEN1_LOAD_UNIT")
+            this.e_GEN1_VOLTS_VALUE = this.querySelector("#GEN1_VOLTS_VALUE")
+            this.e_GEN1_VOLTS_UNIT = this.querySelector("#GEN1_VOLTS_UNIT")
+            this.e_GEN1_FREQ_VALUE = this.querySelector("#GEN1_FREQ_VALUE")
+            this.e_GEN1_FREQ_UNIT = this.querySelector("#GEN1_FREQ_UNIT")
+
+            this.e_IDG2_TITLE = this.querySelector("#IDG2_TITLE")
+            this.e_IDG2_TITLE_NUMBER = this.querySelector("#IDG2_TITLE_NUMBER")
+            this.e_IDG2_TEMP_VALUE = this.querySelector("#IDG2_TEMP_VALUE")
+            this.e_IDG2_TEMP_UNIT = this.querySelector("#IDG2_TEMP_UNIT")
+            this.e_IDG2_DISC = this.querySelector("#IDG2_DISC")
+            this.e_IDG2_LOPR = this.querySelector("#IDG2_LOPR")
+
+            this.e_IDG1_TITLE = this.querySelector("#IDG1_TITLE")
+            this.e_IDG1_TITLE_NUMBER = this.querySelector("#IDG1_TITLE_NUMBER")
+            this.e_IDG1_TEMP_VALUE = this.querySelector("#IDG1_TEMP_VALUE")
+            this.e_IDG1_TEMP_UNIT = this.querySelector("#IDG1_TEMP_UNIT")
+            this.e_IDG1_DISC = this.querySelector("#IDG1_DISC")
+            this.e_IDG1_LOPR = this.querySelector("#IDG1_LOPR")
+
+            this.e_GALLEY_SHED_TOP = this.querySelector("#GALLEY_SHED_TOP")
+            this.e_GALLEY_SHED_BOTTOM = this.querySelector("#GALLEY_SHED_BOTTOM")
+
+            this.e_TITLE_HEADING = this.querySelector("#TITLE_HEADING")
+            this.e_TITLE_UNDERLINE = this.querySelector("#TITLE_UNDERLINE")
+
+            this.e_STATINV_TITLE = this.querySelector("#STATINV_TITLE")
+
+            this.e_WIRE_XFEED_C = this.querySelector("#WIRE_XFEED-C")
+            this.e_WIRE_XFEED_B = this.querySelector("#WIRE_XFEED-B")
+            this.e_WIRE_XFEED_A = this.querySelector("#WIRE_XFEED-A")
+            this.e_WIRE_APUGEN_XFEED = this.querySelector("#WIRE_APUGEN_XFEED")
+            this.e_WIRE_EXTPWR_XFEED = this.querySelector("#WIRE_EXTPWR_XFEED")
+            this.e_WIRE_XFEED_AC1 = this.querySelector("#WIRE_XFEED_AC1")
+            this.e_WIRE_GEN1_XFEED = this.querySelector("#WIRE_GEN1_XFEED")
+            this.e_WIRE_XFEED_AC2 = this.querySelector("#WIRE_XFEED_AC2")
+            this.e_WIRE_GEN2_XFEED = this.querySelector("#WIRE_GEN2_XFEED")
+            this.e_WIRE_AC2_ACESS = this.querySelector("#WIRE_AC2_ACESS")
+            this.e_WIRE_AC1_ACESS = this.querySelector("#WIRE_AC1_ACESS")
+            this.e_WIRE_AC1_TR1 = this.querySelector("#WIRE_AC1_TR1")
+            this.e_WIRE_TR1_DC1 = this.querySelector("#WIRE_TR1_DC1")
+            this.e_WIRE_ACESS_ESSTR = this.querySelector("#WIRE_ACESS_ESSTR")
+            this.e_WIRE_DC1_DCBAT_A = this.querySelector("#WIRE_DC1_DCBAT-A")
+            this.e_WIRE_DC1_DCBAT_B = this.querySelector("#WIRE_DC1_DCBAT-B")
+            this.e_WIRE_DCESS_DCBAT = this.querySelector("#WIRE_DCESS_DCBAT")
+            this.e_WIRE_DCBAT_BAT2 = this.querySelector("#WIRE_DCBAT_BAT2")
+            this.e_WIRE_BAT2_DCBAT = this.querySelector("#WIRE_BAT2_DCBAT")
+            this.e_WIRE_DC2_DCBAT_A = this.querySelector("#WIRE_DC2_DCBAT-A")
+            this.e_WIRE_DC2_DCBAT_B = this.querySelector("#WIRE_DC2_DCBAT-B")
+            this.e_WIRE_BAT1_DCBAT = this.querySelector("#WIRE_BAT1_DCBAT")
+            this.e_WIRE_DCBAT_BAT1 = this.querySelector("#WIRE_DCBAT_BAT1")
+            this.e_WIRE_AC2_TR2 = this.querySelector("#WIRE_AC2_TR2")
+            this.e_WIRE_TR2_DC2 = this.querySelector("#WIRE_TR2_DC2")
+            this.e_WIRE_EMERGEN_ESSTR = this.querySelector("#WIRE_EMERGEN_ESSTR")
+            this.e_WIRE_EMERGEN_ACESS = this.querySelector("#WIRE_EMERGEN_ACESS")
+            this.e_WIRE_ESSTR_DCESS = this.querySelector("#WIRE_ESSTR_DCESS")
+
+            this.e_ARROW_ESSTR_DCESS = this.querySelector("#ARROW_ESSTR_DCESS")
+            this.e_ARROW_XFEED_AC1 = this.querySelector("#ARROW_XFEED_AC1")
+            this.e_ARROW_XFEED_AC2 = this.querySelector("#ARROW_XFEED_AC2")
+            this.e_ARROW_EXTPWR_XFEED = this.querySelector("#ARROW_EXTPWR_XFEED")
+            this.e_ARROW_APUGEN_XFEED = this.querySelector("#ARROW_APUGEN_XFEED")
+            this.e_ARROW_EMERGEN_ESSTR = this.querySelector("#ARROW_EMERGEN_ESSTR")
+            this.e_ARROW_BAT1_DCBAT = this.querySelector("#ARROW_BAT1_DCBAT")
+            this.e_ARROW_BAT2_DCBAT = this.querySelector("#ARROW_BAT2_DCBAT")
+            this.e_ARROW_DCBAT_BAT1 = this.querySelector("#ARROW_DCBAT_BAT1")
+            this.e_ARROW_DCBAT_BAT2 = this.querySelector("#ARROW_DCBAT_BAT2")
+            this.e_ARROW_EMERGEN_ACESS = this.querySelector("#ARROW_EMERGEN_ACESS")
+            this.e_ARROW_BAT1_STATINV = this.querySelector("#ARROW_BAT1_STATINV")
+
+            this.systems = {}
+            this.values = {}
+            this.buses = {}
+            this.internals = {}
+            this.switches = {}
+
+            this.setBAT1_OFF()
+            this.setBAT2_OFF()
+            this.setGEN1_OFF()
+            this.setGEN2_OFF()
+            this.setAPUGEN_OFF()
+            this.setEXTPWR_OFF()
+            this.setESSTR_OFF()
+            this.setEMERGEN_OFF()
+            this.setDCESSBUS_SHED_OFF()
+            this.setACESSBUS_SHED_OFF()
+            this.setIDG1_LOPR_OFF()
+            this.setIDG1_DISC_OFF()
+            this.setIDG2_LOPR_OFF()
+            this.setIDG2_DISC_OFF()
+            this.setGALLEY_SHED_OFF()
+            this.setSTATINV_OFF()
+
+            this.setCONNECTION_DCBAT_BAT1_OFF()
+            this.setCONNECTION_DCBAT_BAT2_OFF()
+            this.setCONNECTION_BAT1_DCBAT_DISCHARGE_OFF()
+            this.setCONNECTION_BAT2_DCBAT_DISCHARGE_OFF()
+            this.setCONNECTION_DCBAT_BAT1_CHARGE_OFF()
+            this.setCONNECTION_DCBAT_BAT2_CHARGE_OFF()
+            this.setCONNECTION_DC1_DCBAT_OFF()
+            this.setCONNECTION_DC2_DCBAT_OFF()
+            this.setCONNECTION_DCESS_DCBAT_OFF()
+            this.setCONNECTION_EMERGEN_ESSTR_OFF()
+            this.setCONNECTION_EMERGEN_ACESS_OFF()
+            this.setCONNECTION_ESSTR_DCESS_OFF()
+            this.setCONNECTION_ACESS_ESSTR_OFF()
+            this.setCONNECTION_APUGEN_XFEED_OFF()
+            this.setCONNECTION_EXTPWR_XFEED_OFF()
+            this.setCONNECTION_AC1_ACESS_OFF()
+            this.setCONNECTION_AC2_ACESS_OFF()
+            this.setCONNECTION_GEN1_AC1_OFF()
+            this.setCONNECTION_GEN2_AC2_OFF()
+            this.setCONNECTION_XFEED_OFF()
+            this.setCONNECTION_AC1_TR1_OFF()
+            this.setCONNECTION_AC2_TR2_OFF()
+            this.setCONNECTION_TR1_DC1_OFF()
+            this.setCONNECTION_TR2_DC2_OFF()
+
+            this.isInitialised = true;
+
+            this.updateVariables()
+            this.systemDraw()
+        }
+
+        update(_deltaTime) {
+            this.systemDraw()
+        }
+
+        updateVariables() {
+            this.systems.BAT1 = this.getSimVar_ONOFF('BATT1_ONLINE')
+            this.systems.BAT2 = this.getSimVar_ONOFF('BATT2_ONLINE')
+            this.values.BAT1_CAP = this.getSimVar_Number('BATT1_CAPACITY')
+            this.values.BAT2_CAP = this.getSimVar_Number('BATT2_CAPACITY')
+            this.values.BAT1_VOLTS = this.getSimVar_Number('BATT1_VOLTAGE')
+            this.values.BAT2_VOLTS = this.getSimVar_Number('BATT2_VOLTAGE')
+            this.values.BAT1_AMPS = this.getSimVar_Number('BATT1_AMPERAGE')
+            this.values.BAT2_AMPS = this.getSimVar_Number('BATT2_AMPERAGE')
+            this.values.DCBAT_LOAD = this.getSimVar_Number('BATT_BUS_LOAD')
+
+            this.systems.EXTPWR = this.getSimVar_ONOFF('EXT_GEN_ONLINE')
+            this.values.EXTPWR_VOLTS = this.getSimVar_Number('EXT_GEN_VOLTAGE')
+            this.values.EXTPWR_AMPS = this.getSimVar_Number('EXT_GEN_AMPERAGE')
+            this.values.EXTPWR_FREQ = this.getSimVar_Number('EXT_GEN_FREQ')
+
+            this.systems.APUGEN = this.getSimVar_ONOFF('APU_GEN_ONLINE')
+            this.values.APUGEN_VOLTS = this.getSimVar_Number('APU_GEN_VOLTAGE')
+            this.values.APUGEN_AMPS = this.getSimVar_Number('APU_GEN_AMPERAGE')
+            this.values.APUGEN_FREQ = this.getSimVar_Number('APU_GEN_FREQ')
+            this.values.APUGEN_LOAD = this.getSimVar_Number('APU_LOAD_PERCENT')
+
+            this.systems.GEN1 = this.getSimVar_ONOFF('GEN1_ONLINE')
+            this.systems.GEN2 = this.getSimVar_ONOFF('GEN2_ONLINE')
+            this.values.GEN1_VOLTS = this.getSimVar_Number('GEN1_VOLTAGE')
+            this.values.GEN2_VOLTS = this.getSimVar_Number('GEN2_VOLTAGE')
+            this.values.GEN1_AMPS = this.getSimVar_Number('GEN1_AMPERAGE')
+            this.values.GEN2_AMPS = this.getSimVar_Number('GEN2_AMPERAGE')
+            this.values.GEN1_FREQ = this.getSimVar_Number('GEN1_FREQ')
+            this.values.GEN2_FREQ = this.getSimVar_Number('GEN2_FREQ')
+            this.values.IDG1_TEMP = this.getSimVar_Number('GEN1_IDG_TEMP')
+            this.values.IDG2_TEMP = this.getSimVar_Number('GEN2_IDG_TEMP')
+
+            this.systems.EMERGEN = this.getSimVar_ONOFF('EMER_ONLINE')
+            this.values.EMERGEN_VOLTS = this.getSimVar_Number('EMER_VOLTAGE')
+            this.values.EMERGEN_AMPS = this.getSimVar_Number('EMER_AMPERAGE')
+            this.values.EMERGEN_FREQ = this.getSimVar_Number('EMER_FREQ')
+
+            this.buses.AC1 = this.getSimVar_BusEnum('AC_BUS1')
+            this.buses.AC2 = this.getSimVar_BusEnum('AC_BUS2')
+            this.buses.ACESS = this.getSimVar_BusEnum('AC_ESS')
+            this.buses.ACSHED = this.getSimVar_BusEnum('AC_SHED')
+            this.buses.GALLEY_SHED = this.getSimVar_BusEnum('GALLEY_SHED')
+            this.buses.DC1 = this.getSimVar_BusEnum('DC_BUS1')
+            this.buses.DC2 = this.getSimVar_BusEnum('DC_BUS2')
+            this.buses.DCBAT = this.getSimVar_BusEnum('DC_BATBUS')
+            this.buses.DCESS = this.getSimVar_BusEnum('DC_ESS')
+            this.buses.DCSHED = this.getSimVar_BusEnum('DC_SHED')
+            this.buses.HOT1 = this.getSimVar_BusEnum('HOT_BUS1')
+            this.buses.HOT2 = this.getSimVar_BusEnum('HOT_BUS2')
+
+            this.systems.TR1 = this.getSimVar_ONOFF('TR1_ONLINE')
+            this.systems.TR2 = this.getSimVar_ONOFF('TR2_ONLINE')
+            this.systems.TRESS = this.getSimVar_ONOFF('TRESS_ONLINE')
+            this.values.TR1_VOLTS = this.getSimVar_Number('TR1_VOLTAGE')
+            this.values.TR2_VOLTS = this.getSimVar_Number('TR2_VOLTAGE')
+            this.values.TRESS_VOLTS = this.getSimVar_Number('TRESS_VOLTAGE')
+            this.values.TR1_AMPS = this.getSimVar_Number('TR1_AMPERAGE')
+            this.values.TR2_AMPS = this.getSimVar_Number('TR2_AMPERAGE')
+            this.values.TRESS_AMPS = this.getSimVar_Number('TRESS_AMPERAGE')
+
+            this.systems.STATINV = this.getSimVar_ONOFF('STATICINV_ONLINE')
+            this.values.STATINV_VOLTS = this.getSimVar_Number('STATICINV_VOLTAGE')
+            this.values.STATINV_AMPS = this.getSimVar_Number('STATICINV_AMPERAGE')
+            this.values.STATINV_FREQ = this.getSimVar_Number('STATICINV_FREQ')
+
+            this.internals.AC_AVAIL = this.getSimVar_Bool('ACPowerAvailable')
+            this.internals.DC_AVAIL = this.getSimVar_Bool('DCPowerAvailable')
+
+            this.switches.ACESS_FEED_AUTO = this.getSimVar_Bool('A32NX_ELEC_ACESSFEED_TOGGLE')
+            this.switches.COMMERCIAL_ON = this.getSimVar_Bool('A32NX_ELEC_COMMERCIAL_TOGGLE')
+            this.switches.GALYCAB_ON = this.getSimVar_Bool('A32NX_ELEC_GALYCAB_TOGGLE')
+        }
+
+        getSimVar_Bool(varName) {
+            return Math.random() > 0.5
+        }
+
+        getSimVar_Number(varName) {
+            return (Math.random() * 300).toFixed(0)
+        }
+
+        getSimVar_ONOFF(varName) {
+            return Math.random() > 0.5 ? 'ON' : 'OFF'
+        }
+
+        getSimVar_BusEnum(varName) {
+            const index = Math.floor(Math.random() * 11)
+            return ENUM_BUS[index]
+        }
+
+        systemDraw() {
+
+            this.switches.ACESS_FEED_AUTO = SimVar.GetSimVarValue('L:A32NX_ELEC_ACESSFEED_TOGGLE', 'bool') !== 0
+
+            // Level 1 - Generators
+            if (this.systems.GEN1 === 'ON') {
+                this.setGEN1_ON()
+                this.setCONNECTION_GEN1_AC1_ON()
+                this.buses.AC1 = 'ON' // move to after gen layer
+                if (this.systems.EXTPWR === 'OFF' && this.systems.APUGEN === 'OFF' && this.systems.GEN2 === 'OFF') {
+                    this.setCONNECTION_XFEED_ON()
+                    this.setCONNECTION_XFEED_AC2_ON()
+                    this.buses.AC2 = 'ON'
+                }
+            } else {
+                this.setGEN1_OFF()
+                this.setCONNECTION_GEN1_XFEED_OFF()
+                if (this.systems.GEN2 === 'OFF' && this.systems.APUGEN === 'OFF' && this.systems.EXTPWR === 'OFF') {
+                    this.setCONNECTION_XFEED_AC1_OFF()
+                }
+            }
+    
+            if (this.systems.GEN2 === 'ON') {
+                this.setGEN2_ON()
+                this.setCONNECTION_GEN2_AC2_ON()
+                this.buses.AC2 = 'ON'
+                if (this.systems.EXTPWR === 'OFF' && this.systems.APUGEN === 'OFF' && this.systems.GEN1 === 'OFF') {
+                    this.setCONNECTION_XFEED_ON()
+                    this.setCONNECTION_XFEED_AC1_ON()
+                    this.buses.AC1 = 'ON'
+                }
+            } else {
+                this.setGEN2_OFF()
+                this.setCONNECTION_GEN2_XFEED_OFF()
+                if (this.systems.GEN1 === 'OFF' && this.systems.APUGEN === 'OFF' && this.systems.EXTPWR === 'OFF') {
+                    this.setCONNECTION_XFEED_AC2_OFF()
+                }
+            }
+    
+            if (this.systems.EXTPWR === 'ON') {
+                this.setCONNECTION_XFEED_OFF()
+                this.setEXTPWR_ON()
+                if (this.systems.GEN1 === 'OFF' || this.systems.GEN2 === 'OFF') {
+                    this.setCONNECTION_EXTPWR_XFEED_ON()
+                    if (this.systems.GEN1 === 'OFF') {
+                        this.setCONNECTION_XFEED_A_ON()
+                        this.setCONNECTION_XFEED_B_ON()
+                        this.setCONNECTION_XFEED_AC1_ON()
+                        this.buses.AC1 = 'ON'
+                    }
+                    if (this.systems.GEN2 === 'OFF') {
+                        this.setCONNECTION_XFEED_C_ON()
+                        this.setCONNECTION_XFEED_AC2_ON()
+                        this.buses.AC2 = 'ON'
+                    }
+                } else {
+                    this.setCONNECTION_EXTPWR_XFEED_OFF()
+                }
+            } else {
+                this.setEXTPWR_OFF()
+                this.setCONNECTION_EXTPWR_XFEED_OFF()
+            }
+    
+            if (this.systems.APUGEN === 'ON') {
+                this.setAPUGEN_ON()
+                if (this.systems.EXTPWR === 'OFF') {
+                    this.setCONNECTION_XFEED_OFF()
+                    if (this.systems.GEN1 === 'OFF' || this.systems.GEN2 === 'OFF') {
+                        this.setCONNECTION_APUGEN_XFEED_ON()
+                        if (this.systems.GEN1 === 'OFF') {
+                            this.setCONNECTION_XFEED_A_ON()
+                            this.setCONNECTION_XFEED_AC1_ON()
+                            this.buses.AC1 = 'ON'
+                        }
+                        if (this.systems.GEN2 === 'OFF') {
+                            this.setCONNECTION_XFEED_B_ON()
+                            this.setCONNECTION_XFEED_C_ON()
+                            this.setCONNECTION_XFEED_AC2_ON()
+                            this.buses.AC2 = 'ON'
+                        }
+                    } else {
+                        this.setCONNECTION_APUGEN_XFEED_OFF()
+                    }
+                } else {
+                    this.setCONNECTION_APUGEN_XFEED_OFF()
+                }
+            } else {
+                this.setAPUGEN_OFF()
+                this.setCONNECTION_APUGEN_XFEED_OFF()
+            }
+    
+            // Level 2 - AC Buses
+            if (this.buses.AC1 === 'ON') {
+                this.setCONNECTION_AC1_TR1_ON()
+                this.systems.TR1 = 'ON'
+                if (this.switches.ACESS_FEED_AUTO === true || this.buses.AC2 === 'OFF') {
+                    this.setCONNECTION_AC1_ACESS_ON()
+                    this.setCONNECTION_AC2_ACESS_OFF()
+                    this.buses.ACESS = 'ON'
+                }
+            }
+            if (this.buses.AC2 === 'ON') {
+                this.setCONNECTION_AC2_TR2_ON()
+                this.systems.TR2 = 'ON'
+                if (this.switches.ACESS_FEED_AUTO === false || this.buses.AC1 === 'OFF') {
+                    this.setCONNECTION_AC2_ACESS_ON()
+                    this.setCONNECTION_AC1_ACESS_OFF()
+                    this.buses.ACESS = 'ON'
+                }
+            }
+            if (this.buses.GALLEY_SHED === true) {
+                this.setGALLEY_SHED_ON()
+            } else {
+                this.setGALLEY_SHED_OFF()
+            }
+    
+            // Level 3 - TR
+            if (this.systems.TR1 === 'ON') {
+                this.setCONNECTION_TR1_DC1_ON()
+                this.buses.DC1 = 'ON'
+            }
+            if (this.systems.TR2 === 'ON') {
+                this.setCONNECTION_TR2_DC2_ON()
+                this.buses.DC2 = 'ON'
+            }
+    
+            // Level 4A - Batteries
+            // if (this.systems.BAT1 === 'ON') {
+            //     this.setBAT1_ON()
+            //     if (this.internal.BAT1_DIR === 'CHARGE') {
+            //         this.setCONNECTION_DCBAT_BAT1_OFF()
+            //         this.setCONNECTION_BAT1_DCBAT_DISCHARGE_OFF()
+            //         this.setCONNECTION_DCBAT_BAT1_CHARGE_ON()
+            //     } else if (this.internal.BAT1_DIR === 'DISCHARGE') {
+            //         this.setCONNECTION_DCBAT_BAT1_OFF()
+            //         this.setCONNECTION_DCBAT_BAT1_CHARGE_OFF()
+            //         this.setCONNECTION_BAT1_DCBAT_DISCHARGE_ON()
+            //     } else if (this.internal.BAT1_DIR === 'IDLE') {
+            //         this.setCONNECTION_DCBAT_BAT1_CHARGE_OFF()
+            //         this.setCONNECTION_BAT1_DCBAT_DISCHARGE_OFF()
+            //         this.setCONNECTION_DCBAT_BAT1_ON()
+            //     } else {
+            //         this.setCONNECTION_DCBAT_BAT1_OFF()
+            //         this.setCONNECTION_DCBAT_BAT1_CHARGE_OFF()
+            //         this.setCONNECTION_BAT1_DCBAT_DISCHARGE_OFF()
+            //     }
+            // } else {
+            //     this.setBAT1_OFF()
+            //     if (this.internal.BAT2_DIR === 'CHARGE') {
+            //         this.setCONNECTION_DCBAT_BAT2_OFF()
+            //         this.setCONNECTION_BAT2_DCBAT_DISCHARGE_OFF()
+            //         this.setCONNECTION_DCBAT_BAT2_CHARGE_ON()
+            //     } else if (this.internal.BAT2_DIR === 'DISCHARGE') {
+            //         this.setCONNECTION_DCBAT_BAT2_OFF()
+            //         this.setCONNECTION_DCBAT_BAT2_CHARGE_OFF()
+            //         this.setCONNECTION_DCBAT_BAT2_DISCHARGE_ON()
+            //     } else if (this.internal.BAT2_DIR === 'IDLE') {
+            //         this.setCONNECTION_DCBAT_BAT2_CHARGE_OFF()
+            //         this.setCONNECTION_BAT2_DCBAT_DISCHARGE_OFF()
+            //         this.setCONNECTION_DCBAT_BAT2_ON()
+            //     } else {
+            //         this.setCONNECTION_DCBAT_BAT2_OFF()
+            //         this.setCONNECTION_DCBAT_BAT2_CHARGE_OFF()
+            //         this.setCONNECTION_BAT2_DCBAT_DISCHARGE_OFF()
+            //     }
+            // }
+    
+            if (this.systems.BAT2 === 'ON') {
+                this.setBAT2_ON()
+            } else {
+                this.setBAT2_OFF()
+            }
+    
+            // Level 4 - DC Buses
+            if (this.buses.DC1 === 'ON') {
+                this.setCONNECTION_DC1_DCBAT_ON()
+                this.buses.DCBAT = 'ON'
+                this.setCONNECTION_DCESS_DCBAT_ON()
+                this.buses.DCESS = 'ON'
+            }
+            if (this.buses.DC2 === 'ON') {
+                
+            }
+    
+        }
+
+        /**
+         * Individual Indicator Controls
+         */
+        setFAULT_TR1_ON() {
+            this.amber(this.e_TR1_TITLE)
+            this.amber(this.e_TR1_TITLE_NUMBER)
+            this.amber(this.e_TR1_VOLTS_VALUE)
+            this.amber(this.e_TR1_AMPS_VALUE)
+        }
+        setFAULT_TR1_OFF() {
+            this.green(this.e_TR1_TITLE)
+            this.green(this.e_TR1_TITLE_NUMBER)
+            this.green(this.e_TR1_VOLTS_VALUE)
+            this.green(this.e_TR1_AMPS_VALUE)
+        }
+
+        setFAULT_TR2_ON() {
+            this.amber(this.e_TR2_TITLE)
+            this.amber(this.e_TR2_TITLE_NUMBER)
+            this.amber(this.e_TR2_VOLTS_VALUE)
+            this.amber(this.e_TR2_AMPS_VALUE)
+        }
+        setFAULT_TR2_OFF() {
+            this.green(this.e_TR2_TITLE)
+            this.green(this.e_TR2_TITLE_NUMBER)
+            this.green(this.e_TR2_VOLTS_VALUE)
+            this.green(this.e_TR2_AMPS_VALUE)
+        }
+
+        setBAT1_ON() {
+            this.hide(this.e_BAT1_OFF)
+            this.show(this.e_BAT1_BOX)
+            this.show(this.e_BAT1_TITLE)
+            this.show(this.e_BAT1_VOLTS_VALUE)
+            this.show(this.e_BAT1_VOLTS_UNIT)
+            this.show(this.e_BAT1_AMPS_VALUE)
+            this.show(this.e_BAT1_AMPS_UNIT)
+        }
+        setBAT1_OFF() {
+            this.show(this.e_BAT1_OFF)
+            this.show(this.e_BAT1_BOX)
+            this.show(this.e_BAT1_TITLE)
+            this.hide(this.e_BAT1_VOLTS_VALUE)
+            this.hide(this.e_BAT1_VOLTS_UNIT)
+            this.hide(this.e_BAT1_AMPS_VALUE)
+            this.hide(this.e_BAT1_AMPS_UNIT)
+        }
+
+        setBAT2_ON() {
+            this.hide(this.e_BAT2_OFF)
+            this.show(this.e_BAT2_BOX)
+            this.show(this.e_BAT2_TITLE)
+            this.show(this.e_BAT2_VOLTS_VALUE)
+            this.show(this.e_BAT2_VOLTS_UNIT)
+            this.show(this.e_BAT2_AMPS_VALUE)
+            this.show(this.e_BAT2_AMPS_UNIT)
+        }
+        setBAT2_OFF() {
+            this.show(this.e_BAT2_OFF)
+            this.show(this.e_BAT2_BOX)
+            this.show(this.e_BAT2_TITLE)
+            this.hide(this.e_BAT2_VOLTS_VALUE)
+            this.hide(this.e_BAT2_VOLTS_UNIT)
+            this.hide(this.e_BAT2_AMPS_VALUE)
+            this.hide(this.e_BAT2_AMPS_UNIT)
+        }
+
+        setGEN1_ON() {
+            this.hide(this.e_GEN1_OFF)
+            this.show(this.e_GEN1_BOX)
+            this.show(this.e_GEN1_TITLE)
+            this.show(this.e_GEN1_TITLE_NUMBER)
+            this.show(this.e_GEN1_LOAD_VALUE)
+            this.show(this.e_GEN1_LOAD_UNIT)
+            this.show(this.e_GEN1_VOLTS_VALUE)
+            this.show(this.e_GEN1_VOLTS_UNIT)
+            this.show(this.e_GEN1_FREQ_VALUE)
+            this.show(this.e_GEN1_FREQ_UNIT)
+        }
+        setGEN1_OFF() {
+            this.show(this.e_GEN1_OFF)
+            this.show(this.e_GEN1_BOX)
+            this.show(this.e_GEN1_TITLE)
+            this.show(this.e_GEN1_TITLE_NUMBER)
+            this.hide(this.e_GEN1_LOAD_VALUE)
+            this.hide(this.e_GEN1_LOAD_UNIT)
+            this.hide(this.e_GEN1_VOLTS_VALUE)
+            this.hide(this.e_GEN1_VOLTS_UNIT)
+            this.hide(this.e_GEN1_FREQ_VALUE)
+            this.hide(this.e_GEN1_FREQ_UNIT)
+        }
+
+        setGEN2_ON() {
+            this.hide(this.e_GEN2_OFF)
+            this.show(this.e_GEN2_BOX)
+            this.show(this.e_GEN2_TITLE)
+            this.show(this.e_GEN2_TITLE_NUMBER)
+            this.show(this.e_GEN2_LOAD_VALUE)
+            this.show(this.e_GEN2_LOAD_UNIT)
+            this.show(this.e_GEN2_VOLTS_VALUE)
+            this.show(this.e_GEN2_VOLTS_UNIT)
+            this.show(this.e_GEN2_FREQ_VALUE)
+            this.show(this.e_GEN2_FREQ_UNIT)
+        }
+        setGEN2_OFF() {
+            this.show(this.e_GEN2_OFF)
+            this.show(this.e_GEN2_BOX)
+            this.show(this.e_GEN2_TITLE)
+            this.show(this.e_GEN2_TITLE_NUMBER)
+            this.hide(this.e_GEN2_LOAD_VALUE)
+            this.hide(this.e_GEN2_LOAD_UNIT)
+            this.hide(this.e_GEN2_VOLTS_VALUE)
+            this.hide(this.e_GEN2_VOLTS_UNIT)
+            this.hide(this.e_GEN2_FREQ_VALUE)
+            this.hide(this.e_GEN2_FREQ_UNIT)
+        }
+
+        setAPUGEN_ON() {
+            this.hide(this.e_APUGEN_OFF)
+            this.show(this.e_APUGEN_BOX)
+            this.show(this.e_APUGEN_TITLE)
+            this.show(this.e_APUGEN_LOAD_VALUE)
+            this.show(this.e_APUGEN_LOAD_UNIT)
+            this.show(this.e_APUGEN_VOLTS_VALUE)
+            this.show(this.e_APUGEN_VOLTS_UNIT)
+            this.show(this.e_APUGEN_FREQ_VALUE)
+            this.show(this.e_APUGEN_FREQ_UNIT)
+        }
+        setAPUGEN_OFF() {
+            this.hide(this.e_APUGEN_OFF)
+            this.hide(this.e_APUGEN_BOX)
+            this.show(this.e_APUGEN_TITLE)
+            this.hide(this.e_APUGEN_LOAD_VALUE)
+            this.hide(this.e_APUGEN_LOAD_UNIT)
+            this.hide(this.e_APUGEN_VOLTS_VALUE)
+            this.hide(this.e_APUGEN_VOLTS_UNIT)
+            this.hide(this.e_APUGEN_FREQ_VALUE)
+            this.hide(this.e_APUGEN_FREQ_UNIT)
+        }
+
+        setEXTPWR_ON() {
+            this.show(this.e_EXTPWR_BOX)
+            this.show(this.e_EXTPWR_TITLE)
+            this.show(this.e_EXTPWR_VOLTS_VALUE)
+            this.show(this.e_EXTPWR_VOLTS_UNIT)
+            this.show(this.e_EXTPWR_FREQ_VALUE)
+            this.show(this.e_EXTPWR_FREQ_UNIT)
+        }
+        setEXTPWR_OFF() {
+            this.hide(this.e_EXTPWR_BOX)
+            this.hide(this.e_EXTPWR_TITLE)
+            this.hide(this.e_EXTPWR_VOLTS_VALUE)
+            this.hide(this.e_EXTPWR_VOLTS_UNIT)
+            this.hide(this.e_EXTPWR_FREQ_VALUE)
+            this.hide(this.e_EXTPWR_FREQ_UNIT)
+        }
+
+        setESSTR_ON() {
+            this.show(this.e_ESSTR_BOX)
+            this.show(this.e_ESSTR_TITLE)
+            this.show(this.e_ESSTR_VOLTS_VALUE)
+            this.show(this.e_ESSTR_VOLTS_UNIT)
+            this.show(this.e_ESSTR_AMPS_VALUE)
+            this.show(this.e_ESSTR_AMPS_UNIT)
+        }
+        setESSTR_OFF() {
+            this.hide(this.e_ESSTR_BOX)
+            this.show(this.e_ESSTR_TITLE)
+            this.hide(this.e_ESSTR_VOLTS_VALUE)
+            this.hide(this.e_ESSTR_VOLTS_UNIT)
+            this.hide(this.e_ESSTR_AMPS_VALUE)
+            this.hide(this.e_ESSTR_AMPS_UNIT)
+        }
+
+        setEMERGEN_ON() {
+            this.hide(this.e_EMERGEN_OFFLINE)
+            this.show(this.e_EMERGEN_BOX)
+            this.show(this.e_EMERGEN_TITLE)
+            this.show(this.e_EMERGEN_VOLTS_VALUE)
+            this.show(this.e_EMERGEN_VOLTS_UNIT)
+            this.show(this.e_EMERGEN_FREQ_VALUE)
+            this.show(this.e_EMERGEN_FREQ_UNIT)
+        }
+        setEMERGEN_OFF() {
+            this.show(this.e_EMERGEN_OFFLINE)
+            this.hide(this.e_EMERGEN_BOX)
+            this.hide(this.e_EMERGEN_TITLE)
+            this.hide(this.e_EMERGEN_VOLTS_VALUE)
+            this.hide(this.e_EMERGEN_VOLTS_UNIT)
+            this.hide(this.e_EMERGEN_FREQ_VALUE)
+            this.hide(this.e_EMERGEN_FREQ_UNIT)
+        }
+
+        setACESSBUS_SHED_ON() {
+            this.show(this.e_ACESSBUS_SHED)
+        }
+        setACESSBUS_SHED_OFF() {
+            this.hide(this.e_ACESSBUS_SHED)
+        }
+
+        setIDG1_LOPR_ON() {
+            this.show(this.e_IDG1_LOPR)
+        }
+        setIDG1_LOPR_OFF() {
+            this.hide(this.e_IDG1_LOPR)
+        }
+
+        setIDG2_LOPR_ON() {
+            this.show(this.e_IDG2_LOPR)
+        }
+        setIDG2_LOPR_OFF() {
+            this.hide(this.e_IDG2_LOPR)
+        }
+
+        setIDG1_DISC_ON() {
+            this.show(this.e_IDG1_DISC)
+        }
+        setIDG1_DISC_OFF() {
+            this.hide(this.e_IDG1_DISC)
+        }
+
+        setIDG2_DISC_ON() {
+            this.show(this.e_IDG2_DISC)
+        }
+        setIDG2_DISC_OFF() {
+            this.hide(this.e_IDG2_DISC)
+        }
+
+        setDCESSBUS_SHED_ON() {
+            this.show(this.e_DCESSBUS_SHED)
+        }
+        setDCESSBUS_SHED_OFF() {
+            this.hide(this.e_DCESSBUS_SHED)
+        }
+
+        setGALLEY_SHED_ON() {
+            this.show(this.e_GALLEY_SHED_TOP)
+            this.show(this.e_GALLEY_SHED_BOTTOM)
+        }
+        setGALLEY_SHED_OFF() {
+            this.hide(this.e_GALLEY_SHED_TOP)
+            this.hide(this.e_GALLEY_SHED_BOTTOM)
+        }
+
+        setSTATINV_ON() {
+            this.show(this.e_STATINV_TITLE)
+            this.show(this.e_ARROW_BAT1_STATINV)
+        }
+        setSTATINV_OFF() {
+            this.hide(this.e_STATINV_TITLE)
+            this.hide(this.e_ARROW_BAT1_STATINV)
+        }
+
+        setCONNECTION_DCBAT_BAT1_ON() {
+            this.show(this.e_WIRE_DCBAT_BAT1)
+            this.show(this.e_WIRE_BAT1_DCBAT)
+        }
+        setCONNECTION_DCBAT_BAT1_OFF() {
+            this.hide(this.e_WIRE_DCBAT_BAT1)
+            this.hide(this.e_WIRE_BAT1_DCBAT)
+        }
+
+        setCONNECTION_DCBAT_BAT2_ON() {
+            this.show(this.e_WIRE_DCBAT_BAT2)
+            this.show(this.e_WIRE_BAT2_DCBAT)
+        }
+        setCONNECTION_DCBAT_BAT2_OFF() {
+            this.hide(this.e_WIRE_DCBAT_BAT2)
+            this.hide(this.e_WIRE_BAT2_DCBAT)
+        }
+
+        setCONNECTION_DCBAT_BAT1_CHARGE_ON() {
+            this.show(this.e_WIRE_DCBAT_BAT1)
+            this.show(this.e_ARROW_DCBAT_BAT1)
+        }
+        setCONNECTION_DCBAT_BAT1_CHARGE_OFF() {
+            this.hide(this.e_WIRE_DCBAT_BAT1)
+            this.hide(this.e_ARROW_DCBAT_BAT1)
+        }
+
+        setCONNECTION_DCBAT_BAT2_CHARGE_ON() {
+            this.show(this.e_WIRE_DCBAT_BAT2)
+            this.show(this.e_ARROW_DCBAT_BAT2)
+        }
+        setCONNECTION_DCBAT_BAT2_CHARGE_OFF() {
+            this.hide(this.e_WIRE_DCBAT_BAT2)
+            this.hide(this.e_ARROW_DCBAT_BAT2)
+        }
+
+        setCONNECTION_BAT1_DCBAT_DISCHARGE_ON() {
+            this.show(this.e_WIRE_BAT1_DCBAT)
+            this.show(this.e_ARROW_BAT1_DCBAT)
+        }
+        setCONNECTION_BAT1_DCBAT_DISCHARGE_OFF() {
+            this.hide(this.e_WIRE_BAT1_DCBAT)
+            this.hide(this.e_ARROW_BAT1_DCBAT)
+        }
+
+        setCONNECTION_BAT2_DCBAT_DISCHARGE_ON() {
+            this.show(this.e_WIRE_BAT2_DCBAT)
+            this.show(this.e_ARROW_BAT2_DCBAT)
+        }
+        setCONNECTION_BAT2_DCBAT_DISCHARGE_OFF() {
+            this.hide(this.e_WIRE_BAT2_DCBAT)
+            this.hide(this.e_ARROW_BAT2_DCBAT)
+        }
+
+        setCONNECTION_DC1_DCBAT_ON() {
+            this.show(this.e_WIRE_DC1_DCBAT_A)
+            this.show(this.e_WIRE_DC1_DCBAT_B)
+        }
+        setCONNECTION_DC1_DCBAT_OFF() {
+            this.hide(this.e_WIRE_DC1_DCBAT_A)
+            this.hide(this.e_WIRE_DC1_DCBAT_B)
+        }
+
+        setCONNECTION_DC2_DCBAT_ON() {
+            this.show(this.e_WIRE_DC2_DCBAT_A)
+            this.show(this.e_WIRE_DC2_DCBAT_B)
+        }
+        setCONNECTION_DC2_DCBAT_OFF() {
+            this.hide(this.e_WIRE_DC2_DCBAT_A)
+            this.hide(this.e_WIRE_DC2_DCBAT_B)
+        }
+
+        setCONNECTION_DCESS_DCBAT_ON() {
+            this.show(this.e_WIRE_DCESS_DCBAT)
+            this.show(this.e_WIRE_DC1_DCBAT_B)
+        }
+        setCONNECTION_DCESS_DCBAT_OFF() {
+            this.hide(this.e_WIRE_DCESS_DCBAT)
+            this.hide(this.e_WIRE_DC1_DCBAT_B)
+        }
+
+        setCONNECTION_ESSTR_DCESS_ON() {
+            this.show(this.e_WIRE_ESSTR_DCESS)
+        }
+        setCONNECTION_ESSTR_DCESS_OFF() {
+            this.hide(this.e_WIRE_ESSTR_DCESS)
+        }
+
+        setCONNECTION_EMERGEN_ESSTR_ON() {
+            this.show(this.e_WIRE_EMERGEN_ESSTR)
+        }
+        setCONNECTION_EMERGEN_ESSTR_OFF() {
+            this.hide(this.e_WIRE_EMERGEN_ESSTR)
+        }
+
+        setCONNECTION_EMERGEN_ACESS_ON() {
+            this.show(this.e_WIRE_EMERGEN_ACESS)
+            this.show(this.e_ARROW_EMERGEN_ACESS)
+        }
+        setCONNECTION_EMERGEN_ACESS_OFF() {
+            this.hide(this.e_WIRE_EMERGEN_ACESS)
+            this.hide(this.e_ARROW_EMERGEN_ACESS)
+        }
+
+        setCONNECTION_ACESS_ESSTR_ON() {
+            this.show(this.e_WIRE_ACESS_ESSTR)
+        }
+        setCONNECTION_ACESS_ESSTR_OFF() {
+            this.hide(this.e_WIRE_ACESS_ESSTR)
+        }
+
+        setCONNECTION_APUGEN_XFEED_ON() {
+            this.show(this.e_WIRE_APUGEN_XFEED)
+            this.show(this.e_ARROW_APUGEN_XFEED)
+        }
+        setCONNECTION_APUGEN_XFEED_OFF() {
+            this.hide(this.e_WIRE_APUGEN_XFEED)
+            this.hide(this.e_ARROW_APUGEN_XFEED)
+        }
+
+        setCONNECTION_EXTPWR_XFEED_ON() {
+            this.show(this.e_WIRE_EXTPWR_XFEED)
+            this.show(this.e_ARROW_EXTPWR_XFEED)
+        }
+        setCONNECTION_EXTPWR_XFEED_OFF() {
+            this.hide(this.e_WIRE_EXTPWR_XFEED)
+            this.hide(this.e_ARROW_EXTPWR_XFEED)
+        }
+
+        setCONNECTION_AC1_ACESS_ON() {
+            this.show(this.e_WIRE_AC1_ACESS)
+        }
+        setCONNECTION_AC1_ACESS_OFF() {
+            this.hide(this.e_WIRE_AC1_ACESS)
+        }
+
+        setCONNECTION_AC2_ACESS_ON() {
+            this.show(this.e_WIRE_AC2_ACESS)
+        }
+        setCONNECTION_AC2_ACESS_OFF() {
+            this.hide(this.e_WIRE_AC2_ACESS)
+        }
+
+        setCONNECTION_GEN1_AC1_ON() {
+            this.show(this.e_WIRE_GEN1_XFEED)
+            this.show(this.e_WIRE_XFEED_AC1)
+            this.show(this.e_ARROW_XFEED_AC1)
+        }
+        setCONNECTION_GEN1_AC1_OFF() {
+            this.hide(this.e_WIRE_GEN1_XFEED)
+            this.hide(this.e_WIRE_XFEED_AC1)
+            this.hide(this.e_ARROW_XFEED_AC1)
+        }
+
+        setCONNECTION_GEN2_AC2_ON() {
+            this.show(this.e_WIRE_GEN2_XFEED)
+            this.show(this.e_WIRE_XFEED_AC2)
+            this.show(this.e_ARROW_XFEED_AC2)
+        }
+        setCONNECTION_GEN2_AC2_OFF() {
+            this.hide(this.e_WIRE_GEN2_XFEED)
+            this.hide(this.e_WIRE_XFEED_AC2)
+            this.hide(this.e_ARROW_XFEED_AC2)
+        }
+
+        setCONNECTION_GEN1_XFEED_ON() {
+            this.show(this.e_WIRE_GEN1_XFEED)
+        }
+        setCONNECTION_GEN1_XFEED_OFF() {
+            this.hide(this.e_WIRE_GEN1_XFEED)
+        }
+
+        setCONNECTION_GEN2_XFEED_ON() {
+            this.show(this.e_WIRE_GEN2_XFEED)
+        }
+        setCONNECTION_GEN2_XFEED_OFF() {
+            this.hide(this.e_WIRE_GEN2_XFEED)
+        }
+
+        setCONNECTION_XFEED_ON() {
+            this.show(this.e_WIRE_XFEED_A)
+            this.show(this.e_WIRE_XFEED_B)
+            this.show(this.e_WIRE_XFEED_C)
+        }
+        setCONNECTION_XFEED_OFF() {
+            this.hide(this.e_WIRE_XFEED_A)
+            this.hide(this.e_WIRE_XFEED_B)
+            this.hide(this.e_WIRE_XFEED_C)
+        }
+
+        setCONNECTION_XFEED_A_ON() {
+            this.show(this.e_WIRE_XFEED_A)
+        }
+        setCONNECTION_XFEED_A_OFF() {
+            this.hide(this.e_WIRE_XFEED_A)
+        }
+
+        setCONNECTION_XFEED_B_ON() {
+            this.show(this.e_WIRE_XFEED_B)
+        }
+        setCONNECTION_XFEED_B_OFF() {
+            this.hide(this.e_WIRE_XFEED_B)
+        }
+
+        setCONNECTION_XFEED_C_ON() {
+            this.show(this.e_WIRE_XFEED_C)
+        }
+        setCONNECTION_XFEED_C_OFF() {
+            this.hide(this.e_WIRE_XFEED_C)
+        }
+
+        setCONNECTION_XFEED_AC1_ON() {
+            this.show(this.e_WIRE_XFEED_AC1)
+            this.show(this.e_ARROW_XFEED_AC1)
+        }
+        setCONNECTION_XFEED_AC1_OFF() {
+            this.hide(this.e_WIRE_XFEED_AC1)
+            this.hide(this.e_ARROW_XFEED_AC1)
+        }
+
+        setCONNECTION_XFEED_AC2_ON() {
+            this.show(this.e_WIRE_XFEED_AC2)
+            this.show(this.e_ARROW_XFEED_AC2)
+        }
+        setCONNECTION_XFEED_AC2_OFF() {
+            this.hide(this.e_WIRE_XFEED_AC2)
+            this.hide(this.e_ARROW_XFEED_AC2)
+        }
+
+        setCONNECTION_AC1_TR1_ON() {
+            this.show(this.e_WIRE_AC1_TR1)
+        }
+        setCONNECTION_AC1_TR1_OFF() {
+            this.hide(this.e_WIRE_AC1_TR1)
+        }
+
+        setCONNECTION_AC2_TR2_ON() {
+            this.show(this.e_WIRE_AC2_TR2)
+        }
+        setCONNECTION_AC2_TR2_OFF() {
+            this.hide(this.e_WIRE_AC2_TR2)
+        }
+
+        setCONNECTION_TR1_DC1_ON() {
+            this.show(this.e_WIRE_TR1_DC1)
+        }
+        setCONNECTION_TR1_DC1_OFF() {
+            this.hide(this.e_WIRE_TR1_DC1)
+        }
+
+        setCONNECTION_TR2_DC2_ON() {
+            this.show(this.e_WIRE_TR2_DC2)
+        }
+        setCONNECTION_TR2_DC2_OFF() {
+            this.hide(this.e_WIRE_TR2_DC2)
+        }
+
+        /**
+         * Element Control
+         */
+        hide(element) {
+            element.classList.add("hidden")
+        }
+
+        show(element) {
+            element.classList.remove("hidden")
+        }
+
+        green(element) {
+            element.classList.remove("amber")
+            element.classList.add("green")
+        }
+
+        amber(element) {
+            element.classList.remove("green")
+            element.classList.add("amber")
+        }
+
+        onEvent(_event) {
+
+        }
+    }
+    A320_Neo_LowerECAM_Elec.Page = Page;
+})(A320_Neo_LowerECAM_Elec || (A320_Neo_LowerECAM_Elec = {}));
+customElements.define("a320-neo-lower-ecam-elec", A320_Neo_LowerECAM_Elec.Page);
+//# sourceMappingURL=A320_Neo_LowerECAM_Elec.js.map

--- a/A32NX/layout.json
+++ b/A32NX/layout.json
@@ -3,1017 +3,1027 @@
         {
             "path": "en-US.locPak",
             "size": 1946,
-            "date": 132461182558595832
-        },
-        {
-            "path": "effects/LIGHT_A32NX_RightRunway.fx",
-            "size": 1205,
-            "date": 132461182558595832
-        },
-        {
-            "path": "effects/LIGHT_A32NX_TakeOff.fx",
-            "size": 1209,
-            "date": 132461182558595832
-        },
-        {
-            "path": "effects/LIGHT_A32NX_CockpitMinimalAmbiantLow.fx",
-            "size": 1281,
-            "date": 132461182558595832
-        },
-        {
-            "path": "effects/LIGHT_A32NX_ScreenBlue.fx",
-            "size": 1282,
-            "date": 132461182558595832
-        },
-        {
-            "path": "effects/LIGHT_A32NX_Glareshield.fx",
-            "size": 1280,
-            "date": 132461182558595832
-        },
-        {
-            "path": "effects/LIGHT_A32NX_TaxiLarge.fx",
-            "size": 1206,
-            "date": 132461182558595832
-        },
-        {
-            "path": "effects/LIGHT_A32NX_LandingLarge.fx",
-            "size": 1208,
-            "date": 132461182558595832
-        },
-        {
-            "path": "effects/LIGHT_A32NX_LeftRunway.fx",
-            "size": 1207,
-            "date": 132461182558595832
-        },
-        {
-            "path": "effects/LIGHT_A32NX_NavigationRed.fx",
-            "size": 1154,
-            "date": 132461182558595832
-        },
-        {
-            "path": "effects/LIGHT_A32NX_CockpitMinimalAmbiant.fx",
-            "size": 1287,
-            "date": 132461182558595832
-        },
-        {
-            "path": "effects/LIGHT_A32NX_CockpitSpotLarge.fx",
-            "size": 1277,
-            "date": 132461182558595832
-        },
-        {
-            "path": "effects/LIGHT_A32NX_CockpitSpot.fx",
-            "size": 1284,
-            "date": 132461182558595832
-        },
-        {
-            "path": "effects/LIGHT_A32NX_BeaconBellyOmni.fx",
-            "size": 1154,
-            "date": 132461182558595832
+            "date": 132447474945090960
         },
         {
             "path": "effects/LIGHT_A32NX_A320_Pedestal.fx",
             "size": 1278,
-            "date": 132461182558595832
+            "date": 132461912625504056
+        },
+        {
+            "path": "effects/LIGHT_A32NX_BeaconBellyOmni.fx",
+            "size": 1154,
+            "date": 132444788276005426
+        },
+        {
+            "path": "effects/LIGHT_A32NX_CockpitMinimalAmbiant.fx",
+            "size": 1287,
+            "date": 132461912625573996
+        },
+        {
+            "path": "effects/LIGHT_A32NX_CockpitMinimalAmbiantLow.fx",
+            "size": 1281,
+            "date": 132461912625633946
+        },
+        {
+            "path": "effects/LIGHT_A32NX_CockpitSpot.fx",
+            "size": 1284,
+            "date": 132461912625693884
+        },
+        {
+            "path": "effects/LIGHT_A32NX_CockpitSpotLarge.fx",
+            "size": 1277,
+            "date": 132461912625743842
+        },
+        {
+            "path": "effects/LIGHT_A32NX_Glareshield.fx",
+            "size": 1280,
+            "date": 132461912625783806
+        },
+        {
+            "path": "effects/LIGHT_A32NX_LandingLarge.fx",
+            "size": 1208,
+            "date": 132444788276185260
+        },
+        {
+            "path": "effects/LIGHT_A32NX_LeftRunway.fx",
+            "size": 1207,
+            "date": 132444788276245214
         },
         {
             "path": "effects/LIGHT_A32NX_LogoLight.fx",
             "size": 1201,
-            "date": 132461182558595832
-        },
-        {
-            "path": "effects/LIGHT_A32NX_NavigationWhite.fx",
-            "size": 1270,
-            "date": 132461182558595832
+            "date": 132461912625843754
         },
         {
             "path": "effects/LIGHT_A32NX_NavigationGreen.fx",
             "size": 1157,
-            "date": 132461182558595832
+            "date": 132461912625893716
+        },
+        {
+            "path": "effects/LIGHT_A32NX_NavigationRed.fx",
+            "size": 1154,
+            "date": 132461912625933670
+        },
+        {
+            "path": "effects/LIGHT_A32NX_NavigationWhite.fx",
+            "size": 1270,
+            "date": 132461912625993622
+        },
+        {
+            "path": "effects/LIGHT_A32NX_RightRunway.fx",
+            "size": 1205,
+            "date": 132444788276295174
+        },
+        {
+            "path": "effects/LIGHT_A32NX_ScreenBlue.fx",
+            "size": 1282,
+            "date": 132461912626033586
+        },
+        {
+            "path": "effects/LIGHT_A32NX_TakeOff.fx",
+            "size": 1209,
+            "date": 132444788276365098
+        },
+        {
+            "path": "effects/LIGHT_A32NX_TaxiLarge.fx",
+            "size": 1206,
+            "date": 132444788276415066
         },
         {
             "path": "html_ui/Fonts/B612Mono-Regular.ttf",
             "size": 140292,
-            "date": 132461182558635836
-        },
-        {
-            "path": "html_ui/Fonts/LiberationMono.ttf.birdfont",
-            "size": 1891789,
-            "date": 132461182558715840
+            "date": 132444788276534950
         },
         {
             "path": "html_ui/Fonts/LiberationMono.ttf",
             "size": 596704,
-            "date": 132461182558675838
+            "date": 132444788276654840
+        },
+        {
+            "path": "html_ui/Fonts/LiberationMono.ttf.birdfont",
+            "size": 1891789,
+            "date": 132444788276774738
         },
         {
             "path": "html_ui/Fonts/LiberationMonoOriginal.ttf",
             "size": 313408,
-            "date": 132461182558755844
+            "date": 132444788277114430
         },
         {
             "path": "html_ui/JS/A32NX_Avionics.js",
             "size": 2785,
-            "date": 132461182558755844
+            "date": 132461912626093538
         },
         {
             "path": "html_ui/JS/A32NX_Selectors.js",
             "size": 552,
-            "date": 132461182558755844
+            "date": 132461912626163468
         },
         {
             "path": "html_ui/JS/A32NX_Util.js",
             "size": 270,
-            "date": 132461182558755844
-        },
-        {
-            "path": "html_ui/Pages/A32NX_Core/A32NX_Core.js",
-            "size": 1389,
-            "date": 132461182558755844
+            "date": 132461912626223414
         },
         {
             "path": "html_ui/Pages/A32NX_Core/A32NX_ADIRS.js",
             "size": 3871,
-            "date": 132461182558755844
-        },
-        {
-            "path": "html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js",
-            "size": 1531,
-            "date": 132461182558755844
-        },
-        {
-            "path": "html_ui/Pages/A32NX_Core/A32NX_GPWS.js",
-            "size": 5852,
-            "date": 132461182558755844
-        },
-        {
-            "path": "html_ui/Pages/A32NX_Core/A32NX_BrakeTemp.js",
-            "size": 5364,
-            "date": 132461182558755844
-        },
-        {
-            "path": "html_ui/Pages/A32NX_Core/A32NX_Electricity.js",
-            "size": 828,
-            "date": 132461182558755844
-        },
-        {
-            "path": "html_ui/Pages/A32NX_Core/README.md",
-            "size": 400,
-            "date": 132461182558755844
+            "date": 132461912626283358
         },
         {
             "path": "html_ui/Pages/A32NX_Core/A32NX_APU.js",
             "size": 3609,
-            "date": 132461182558755844
+            "date": 132461912626363284
         },
         {
-            "path": "html_ui/Pages/VCockpit/Instruments/NavSystems/A320_Neo/A32NX_NavSystem.css",
-            "size": 458,
-            "date": 132461182558875852
+            "path": "html_ui/Pages/A32NX_Core/A32NX_BrakeTemp.js",
+            "size": 5364,
+            "date": 132451639558759820
         },
         {
-            "path": "html_ui/Pages/VCockpit/Instruments/NavSystems/A320_Neo/A32NX_NavSystem.js",
-            "size": 117763,
-            "date": 132461182558875852
+            "path": "html_ui/Pages/A32NX_Core/A32NX_Core.js",
+            "size": 1389,
+            "date": 132461912626423242
         },
         {
-            "path": "html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js",
-            "size": 59525,
-            "date": 132461182558875852
+            "path": "html_ui/Pages/A32NX_Core/A32NX_Electricity.js",
+            "size": 828,
+            "date": 132461912626483178
         },
         {
-            "path": "html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.js",
-            "size": 62114,
-            "date": 132461182558755844
+            "path": "html_ui/Pages/A32NX_Core/A32NX_GPWS.js",
+            "size": 5852,
+            "date": 132461912626553134
         },
         {
-            "path": "html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.html",
-            "size": 5158,
-            "date": 132461182558755844
+            "path": "html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js",
+            "size": 1531,
+            "date": 132461912626613060
+        },
+        {
+            "path": "html_ui/Pages/A32NX_Core/README.md",
+            "size": 400,
+            "date": 132461912626683000
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.css",
             "size": 1734,
-            "date": 132461182558755844
+            "date": 132461912626762928
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.html",
+            "size": 5158,
+            "date": 132461912626842878
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.js",
+            "size": 62114,
+            "date": 132461912626952754
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/Svg/A32NX_SvgMaskElement.js",
             "size": 2569,
-            "date": 132461182558755844
+            "date": 132461912627112612
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/A32NX_BaseAirliners.js",
             "size": 68003,
-            "date": 132461182558755844
+            "date": 132461912627202530
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/A32NX_BaseNDCompass.js",
             "size": 36582,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/EICAS_Common.html",
-            "size": 1715,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.css",
-            "size": 6526,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js",
-            "size": 19405,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/EICAS_Common.js",
-            "size": 4733,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/EICAS_Common.css",
-            "size": 1256,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.html",
-            "size": 6149,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.js",
-            "size": 10679,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.css",
-            "size": 4136,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Status.js",
-            "size": 19667,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Status.css",
-            "size": 2724,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.css",
-            "size": 2294,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_CRZ.css",
-            "size": 1629,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_CRZ.js",
-            "size": 9431,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.css",
-            "size": 2886,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.html",
-            "size": 3091,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.css",
-            "size": 3030,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js",
-            "size": 11817,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_WHEEL.css",
-            "size": 7040,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.html",
-            "size": 4156,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.html",
-            "size": 1122,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_WHEEL.html",
-            "size": 21094,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.js",
-            "size": 23383,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.html",
-            "size": 12279,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.html",
-            "size": 9821,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.js",
-            "size": 5209,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.js",
-            "size": 13236,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Status.html",
-            "size": 738,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.css",
-            "size": 1336,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_CRZ.html",
-            "size": 5075,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.js",
-            "size": 8892,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.css",
-            "size": 1949,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_WHEEL.js",
-            "size": 14406,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.js",
-            "size": 4393,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.html",
-            "size": 3729,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.css",
-            "size": 1934,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.html",
-            "size": 8316,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js",
-            "size": 114453,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.css",
-            "size": 8906,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/SAI/A320_Neo_SAI.html",
-            "size": 2933,
-            "date": 132461182558875852
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/SAI/A320_Neo_SAI.css",
-            "size": 1532,
-            "date": 132461182558875852
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/SAI/A320_Neo_SAI.js",
-            "size": 56753,
-            "date": 132461182558875852
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.html",
-            "size": 10376,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.css",
-            "size": 9099,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A32NX_NDCompass.js",
-            "size": 42792,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A32NX_NDInfo.js",
-            "size": 24685,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js",
-            "size": 26926,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IRSStatus.js",
-            "size": 2916,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MenuPage.js",
-            "size": 482,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NewWaypoint.js",
-            "size": 723,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AvailableFlightPlanPage.js",
-            "size": 814,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PilotsWaypoint.js",
-            "size": 529,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_FuelPredPage.js",
-            "size": 2364,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_ProgressPage.js",
-            "size": 5462,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_GPSMonitor.js",
-            "size": 2742,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_DirectToPage.js",
-            "size": 4782,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_SelectedNavaids.js",
-            "size": 626,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js",
-            "size": 46509,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js",
-            "size": 14193,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_WaypointPage.js",
-            "size": 1482,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU.html",
-            "size": 6813,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_DataIndexPage.js",
-            "size": 2045,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js",
-            "size": 4184,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js",
-            "size": 17511,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AvailableDeparturesPage.js",
-            "size": 7481,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IdentPage.js",
-            "size": 632,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js",
-            "size": 8659,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PositionFrozen.js",
-            "size": 1188,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_SelectWptPage.js",
-            "size": 1711,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js",
-            "size": 25300,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IRSMonitor.js",
-            "size": 1081,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PositionMonitorPage.js",
-            "size": 1668,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_HoldAtPage.js",
-            "size": 3285,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js",
-            "size": 10777,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU.css",
-            "size": 3546,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IRSStatusFrozen.js",
-            "size": 2449,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavaidPage.js",
-            "size": 1524,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js",
-            "size": 2279,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js",
-            "size": 5721,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/RTPI/A320_Neo_RTPI.html",
-            "size": 1178,
-            "date": 132461182558875852
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/RTPI/A320_Neo_RTPI.css",
-            "size": 1669,
-            "date": 132461182558875852
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/RTPI/A320_Neo_RTPI.js",
-            "size": 1346,
-            "date": 132461182558875852
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.css",
-            "size": 3470,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.js",
-            "size": 31019,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.html",
-            "size": 6571,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Clock/A320_Neo_Clock.html",
-            "size": 1409,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Clock/A320_Neo_Clock.js",
-            "size": 6827,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Clock/A320_Neo_Clock.css",
-            "size": 2995,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.css",
-            "size": 10625,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.html",
-            "size": 8573,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AirspeedIndicator.js",
-            "size": 62200,
-            "date": 132461182558875852
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js",
-            "size": 14125,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AttitudeIndicator.js",
-            "size": 42830,
-            "date": 132461182558875852
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/HSIndicator.js",
-            "size": 17658,
-            "date": 132461182558875852
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/ILSIndicator.js",
-            "size": 21590,
-            "date": 132461182558875852
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AltimeterIndicator.js",
-            "size": 40426,
-            "date": 132461182558875852
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/VerticalSpeedIndicator.js",
-            "size": 16386,
-            "date": 132461182558875852
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js",
-            "size": 89634,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FDW/A320_Neo_FDW.js",
-            "size": 19526,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FDW/A320_Neo_FDW.css",
-            "size": 1508,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FDW/A320_Neo_FDW.html",
-            "size": 1324,
-            "date": 132461182558835850
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/ATC/A320_Neo_ATC.html",
-            "size": 1103,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/ATC/A320_Neo_ATC.js",
-            "size": 2132,
-            "date": 132461182558795846
+            "date": 132461912627342406
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/ATC/A320_Neo_ATC.css",
             "size": 1585,
-            "date": 132461182558795846
+            "date": 132452499140260144
         },
         {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.js",
-            "size": 1341,
-            "date": 132461182558795846
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/ATC/A320_Neo_ATC.html",
+            "size": 1103,
+            "date": 132461912627462296
         },
         {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.html",
-            "size": 1275,
-            "date": 132461182558795846
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/ATC/A320_Neo_ATC.js",
+            "size": 2132,
+            "date": 132445383782246496
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.css",
             "size": 1469,
-            "date": 132461182558795846
+            "date": 132461912627562208
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.html",
+            "size": 1275,
+            "date": 132461912627632150
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.js",
+            "size": 1341,
+            "date": 132461912627742044
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BRK/A320_Neo_BRK.css",
             "size": 2170,
-            "date": 132461182558795846
-        },
-        {
-            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BRK/A320_Neo_BRK.js",
-            "size": 12751,
-            "date": 132461182558795846
+            "date": 132444788277823792
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BRK/A320_Neo_BRK.html",
             "size": 2403,
-            "date": 132461182558795846
+            "date": 132461912627821978
         },
         {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/systems.cfg",
-            "size": 18985,
-            "date": 132461182558595832
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BRK/A320_Neo_BRK.js",
+            "size": 12751,
+            "date": 132444788278033602
         },
         {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/final.FLT",
-            "size": 4580,
-            "date": 132461182553955504
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU.css",
+            "size": 3546,
+            "date": 132461912627921894
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU.html",
+            "size": 6813,
+            "date": 132461912628021910
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js",
+            "size": 5721,
+            "date": 132461912628131698
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js",
+            "size": 14193,
+            "date": 132452499140519960
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AvailableDeparturesPage.js",
+            "size": 7481,
+            "date": 132444788278663040
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AvailableFlightPlanPage.js",
+            "size": 814,
+            "date": 132444788278742966
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_DataIndexPage.js",
+            "size": 2045,
+            "date": 132444788278812904
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_DirectToPage.js",
+            "size": 4782,
+            "date": 132444788278882844
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js",
+            "size": 17511,
+            "date": 132461912628211628
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_FuelPredPage.js",
+            "size": 2364,
+            "date": 132445383782355776
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_GPSMonitor.js",
+            "size": 2742,
+            "date": 132461912628331518
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_HoldAtPage.js",
+            "size": 3285,
+            "date": 132461912628411448
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IdentPage.js",
+            "size": 632,
+            "date": 132447474945210846
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js",
+            "size": 10777,
+            "date": 132452499140759738
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IRSMonitor.js",
+            "size": 1081,
+            "date": 132444788279332448
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IRSStatus.js",
+            "size": 2916,
+            "date": 132461912628491374
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IRSStatusFrozen.js",
+            "size": 2449,
+            "date": 132461912628571302
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js",
+            "size": 2279,
+            "date": 132461912628661232
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js",
+            "size": 46509,
+            "date": 132461912628721168
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MenuPage.js",
+            "size": 482,
+            "date": 132444788279981854
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavaidPage.js",
+            "size": 1524,
+            "date": 132444788280151704
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js",
+            "size": 8659,
+            "date": 132452499141119416
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NewWaypoint.js",
+            "size": 723,
+            "date": 132444788280241622
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js",
+            "size": 25300,
+            "date": 132461912628951066
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PilotsWaypoint.js",
+            "size": 529,
+            "date": 132444788280441446
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PositionFrozen.js",
+            "size": 1188,
+            "date": 132461912629120808
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PositionMonitorPage.js",
+            "size": 1668,
+            "date": 132461912629220724
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_ProgressPage.js",
+            "size": 5462,
+            "date": 132444788280631272
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_SelectedNavaids.js",
+            "size": 626,
+            "date": 132444788280761158
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_SelectWptPage.js",
+            "size": 1711,
+            "date": 132444788280691226
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js",
+            "size": 4184,
+            "date": 132444788280821102
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_WaypointPage.js",
+            "size": 1482,
+            "date": 132444788280901032
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Clock/A320_Neo_Clock.css",
+            "size": 2995,
+            "date": 132461912629300658
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Clock/A320_Neo_Clock.html",
+            "size": 1409,
+            "date": 132461912629360592
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Clock/A320_Neo_Clock.js",
+            "size": 6827,
+            "date": 132461912629440524
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.css",
+            "size": 6526,
+            "date": 132461912629520464
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.html",
+            "size": 6398,
+            "date": 132462149066905158
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js",
+            "size": 19518,
+            "date": 132462149066575468
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/EICAS_Common.css",
+            "size": 1256,
+            "date": 132444788285287114
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/EICAS_Common.html",
+            "size": 1715,
+            "date": 132444788285367044
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/EICAS_Common.js",
+            "size": 4733,
+            "date": 132444788285486932
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.css",
+            "size": 4136,
+            "date": 132461912629920090
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.js",
+            "size": 23383,
+            "date": 132461912630000022
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.css",
+            "size": 1934,
+            "date": 132461912630119910
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.html",
+            "size": 3091,
+            "date": 132444788282149990
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js",
+            "size": 11817,
+            "date": 132444788282279816
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.css",
+            "size": 1336,
+            "date": 132444788282389696
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.html",
+            "size": 9821,
+            "date": 132461912630199838
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.js",
+            "size": 4393,
+            "date": 132444788282659462
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_CRZ.css",
+            "size": 1629,
+            "date": 132444788282759386
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_CRZ.html",
+            "size": 5075,
+            "date": 132444788282839298
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_CRZ.js",
+            "size": 9431,
+            "date": 132444788282979188
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.css",
+            "size": 2886,
+            "date": 132461912630339718
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.html",
+            "size": 4156,
+            "date": 132461912630439622
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.js",
+            "size": 5209,
+            "date": 132461912630579504
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Elec.html",
+            "size": 14719,
+            "date": 132462149064976910
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Elec.js",
+            "size": 44623,
+            "date": 132462149065166740
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.css",
+            "size": 1949,
+            "date": 132461912630679410
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.html",
+            "size": 3729,
+            "date": 132444788283438776
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.js",
+            "size": 13236,
+            "date": 132444788283558672
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.css",
+            "size": 3030,
+            "date": 132446383073140684
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.html",
+            "size": 12279,
+            "date": 132446383073220610
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.js",
+            "size": 10679,
+            "date": 132446383073350496
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.css",
+            "size": 2294,
+            "date": 132461912630789316
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.html",
+            "size": 8316,
+            "date": 132444788284018256
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.js",
+            "size": 8892,
+            "date": 132444788284188092
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Status.css",
+            "size": 2724,
+            "date": 132444788284287996
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Status.html",
+            "size": 738,
+            "date": 132444788284347952
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Status.js",
+            "size": 19667,
+            "date": 132444788284437862
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_WHEEL.css",
+            "size": 7040,
+            "date": 132444788284537780
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_WHEEL.html",
+            "size": 21094,
+            "date": 132451639560428316
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_WHEEL.js",
+            "size": 14406,
+            "date": 132451639560598166
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.css",
+            "size": 8906,
+            "date": 132461912630839270
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.html",
+            "size": 1122,
+            "date": 132461912630919196
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js",
+            "size": 114453,
+            "date": 132461912631039090
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.css",
+            "size": 3470,
+            "date": 132451639560907886
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.html",
+            "size": 6571,
+            "date": 132461912631228914
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.js",
+            "size": 31019,
+            "date": 132451639561107708
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FDW/A320_Neo_FDW.css",
+            "size": 1508,
+            "date": 132451639561227598
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FDW/A320_Neo_FDW.html",
+            "size": 1324,
+            "date": 132461912631338816
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FDW/A320_Neo_FDW.js",
+            "size": 19526,
+            "date": 132451639561417448
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.css",
+            "size": 9099,
+            "date": 132461912631448720
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.html",
+            "size": 10376,
+            "date": 132461912631518652
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js",
+            "size": 26926,
+            "date": 132461912631628674
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A32NX_NDCompass.js",
+            "size": 42792,
+            "date": 132461912631828380
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A32NX_NDInfo.js",
+            "size": 24685,
+            "date": 132461912631948306
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.css",
+            "size": 10625,
+            "date": 132461912632118120
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.html",
+            "size": 8573,
+            "date": 132461912632198046
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js",
+            "size": 14125,
+            "date": 132461912632317934
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js",
+            "size": 89634,
+            "date": 132461912632467802
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AirspeedIndicator.js",
+            "size": 62200,
+            "date": 132461912632617666
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AltimeterIndicator.js",
+            "size": 40426,
+            "date": 132461912632767532
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AttitudeIndicator.js",
+            "size": 42830,
+            "date": 132461912632897418
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/HSIndicator.js",
+            "size": 17658,
+            "date": 132461912633117218
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/ILSIndicator.js",
+            "size": 21590,
+            "date": 132461912633217128
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/VerticalSpeedIndicator.js",
+            "size": 16386,
+            "date": 132461912633327050
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/RTPI/A320_Neo_RTPI.css",
+            "size": 1669,
+            "date": 132451639562916108
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/RTPI/A320_Neo_RTPI.html",
+            "size": 1178,
+            "date": 132461912633426950
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/RTPI/A320_Neo_RTPI.js",
+            "size": 1346,
+            "date": 132451639563105916
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/SAI/A320_Neo_SAI.css",
+            "size": 1532,
+            "date": 132444788288134566
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/SAI/A320_Neo_SAI.html",
+            "size": 2933,
+            "date": 132461912633536842
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/SAI/A320_Neo_SAI.js",
+            "size": 56753,
+            "date": 132461912633656734
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/NavSystems/A320_Neo/A32NX_NavSystem.css",
+            "size": 458,
+            "date": 132451639563425624
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/NavSystems/A320_Neo/A32NX_NavSystem.js",
+            "size": 117763,
+            "date": 132461912633816588
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js",
+            "size": 59525,
+            "date": 132461912634026402
         },
         {
             "path": "SimObjects/AirPlanes/Asobo_A320_NEO/approach.FLT",
             "size": 4472,
-            "date": 132461182553955504
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/engines.cfg",
-            "size": 10496,
-            "date": 132461182553955504
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/taxi.flt",
-            "size": 4422,
-            "date": 132461182558595832
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/runway.FLT",
-            "size": 4581,
-            "date": 132461182554915574
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/flight_model.cfg",
-            "size": 27340,
-            "date": 132461182553955504
+            "date": 132461912622687080
         },
         {
             "path": "SimObjects/AirPlanes/Asobo_A320_NEO/apron.FLT",
             "size": 4613,
-            "date": 132461182553955504
+            "date": 132452499139795344
         },
         {
             "path": "SimObjects/AirPlanes/Asobo_A320_NEO/cruise.FLT",
             "size": 4556,
-            "date": 132461182553955504
+            "date": 132461912622736542
         },
         {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/panel/panel.xml",
-            "size": 15590,
-            "date": 132461182554915574
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/engines.cfg",
+            "size": 10496,
+            "date": 132444788263344894
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/final.FLT",
+            "size": 4580,
+            "date": 132461912622786498
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/flight_model.cfg",
+            "size": 27340,
+            "date": 132461912622836454
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/runway.FLT",
+            "size": 4581,
+            "date": 132461912623106218
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/systems.cfg",
+            "size": 18985,
+            "date": 132461912625284276
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/taxi.flt",
+            "size": 4422,
+            "date": 132461912625354192
         },
         {
             "path": "SimObjects/AirPlanes/Asobo_A320_NEO/Checklist/Airbus_A320neo_Checklist.xml",
             "size": 28780,
-            "date": 132461182552635412
+            "date": 132445383779897460
         },
         {
             "path": "SimObjects/AirPlanes/Asobo_A320_NEO/Checklist/Library.xml",
             "size": 111606,
-            "date": 132461182552675414
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_DECALSTEXT_ALBD.TIF.dds",
-            "size": 1048704,
-            "date": 132461182552795422
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_AIRFRAME_DECALS_ALBD.PNG.DDS",
-            "size": 4194432,
-            "date": 132461182552755420
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_INPUTS01_ALBD.PNG.DDS",
-            "size": 2097280,
-            "date": 132461182552995436
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_INPUTS02_ALBD.PNG.dds",
-            "size": 4194432,
-            "date": 132461182553195450
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_INPUTS01_ALBD.PNG.DDS.json",
-            "size": 102,
-            "date": 132461182552995436
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_PEDESTAL_ALBD.PNG.DDS.json",
-            "size": 102,
-            "date": 132461182553955504
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_MAINPANEL_ALBD.PNG.DDS.json",
-            "size": 102,
-            "date": 132461182553195450
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_INPUTS02_ALBD.PNG.DDS.json",
-            "size": 102,
-            "date": 132461182552995436
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_DECALSTEXT_EMIS.PNG.dds",
-            "size": 699192,
-            "date": 132461182552835426
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_DECALSTEXT_ALBD.TIF.DDS.json",
-            "size": 119,
-            "date": 132461182552755420
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_DECALSTEXT_EMIS.PNG.DDS.json",
-            "size": 102,
-            "date": 132461182552795422
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/texture.CFG",
-            "size": 160,
-            "date": 132461182553955504
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_AIRFRAME_DECALS_ALBD.PNG.DDS.json",
-            "size": 119,
-            "date": 132461182552755420
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_MAINPANEL_COMP.PNG.DDS.json",
-            "size": 191,
-            "date": 132461182553755490
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_PEDESTAL_ALBD.PNG.DDS",
-            "size": 4194432,
-            "date": 132461182553955504
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_MAINPANEL_ALBD.PNG.dds",
-            "size": 4194432,
-            "date": 132461182553395464
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_MAINPANEL_COMP.PNG.DDS",
-            "size": 5592560,
-            "date": 132461182553755490
+            "date": 132461912622017188
         },
         {
             "path": "SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO.xml",
             "size": 8828,
-            "date": 132461182553955504
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR_LOD00.bin",
-            "size": 18771072,
-            "date": 132461182554915574
+            "date": 132461912622896398
         },
         {
             "path": "SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml",
             "size": 144720,
-            "date": 132461182553995506
+            "date": 132461912622966338
         },
         {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/FINALFLAPS-old1.wav",
-            "size": 3598578,
-            "date": 132461182558155802
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR_LOD00.bin",
+            "size": 18771072,
+            "date": 132444788265443024
         },
         {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/lefttouch1.wav",
-            "size": 227600,
-            "date": 132461182558515826
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/sound.xml",
-            "size": 37100,
-            "date": 132461182558595832
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/FINALFLAPS.wav",
-            "size": 3598578,
-            "date": 132461182558435822
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/panel/panel.xml",
+            "size": 15590,
+            "date": 132461912623046264
         },
         {
             "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/Asobo_A320_NEO.PC.PCK",
             "size": 59377074,
-            "date": 132461182557275738
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/righttouch1.wav",
-            "size": 282616,
-            "date": 132461182558595832
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/nosetouch.wav",
-            "size": 92680,
-            "date": 132461182558595832
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/hardtouch1.wav",
-            "size": 446026,
-            "date": 132461182558475824
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/righttouch2.wav",
-            "size": 282616,
-            "date": 132461182558595832
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/lefttouch2.wav",
-            "size": 227600,
-            "date": 132461182558595832
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/hardtouch2.wav",
-            "size": 446026,
-            "date": 132461182558515826
+            "date": 132444788275396142
         },
         {
             "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/Asobo_A320_NEO_Improved.PC.PCK",
             "size": 7710497,
-            "date": 132461182557835780
+            "date": 132461912623855536
         },
         {
-            "path": "ModelBehaviorDefs/Asobo/Common/Handling.xml",
-            "size": 59643,
-            "date": 132461182552635412
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/FINALFLAPS-old1.wav",
+            "size": 3598578,
+            "date": 132461912624255190
         },
         {
-            "path": "ModelBehaviorDefs/Asobo/Common/Subtemplates/Fuel_Subtemplates.xml",
-            "size": 53137,
-            "date": 132461182552635412
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/FINALFLAPS.wav",
+            "size": 3598578,
+            "date": 132461912624594872
         },
         {
-            "path": "ModelBehaviorDefs/Asobo/Common/Subtemplates/Electrical_Subtemplates.xml",
-            "size": 73140,
-            "date": 132461182552635412
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/hardtouch1.wav",
+            "size": 446026,
+            "date": 132461912624694784
         },
         {
-            "path": "ModelBehaviorDefs/Asobo/Common/Subtemplates/Deice_Subtemplates.xml",
-            "size": 23038,
-            "date": 132461182552635412
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/hardtouch2.wav",
+            "size": 446026,
+            "date": 132461912624804686
         },
         {
-            "path": "ModelBehaviorDefs/Asobo/Airliner/AirlinerCommon.xml",
-            "size": 46690,
-            "date": 132461182552635412
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/lefttouch1.wav",
+            "size": 227600,
+            "date": 132461912624874620
         },
         {
-            "path": "ModelBehaviorDefs/Asobo/Airliner/FMC.xml",
-            "size": 62768,
-            "date": 132461182552635412
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/lefttouch2.wav",
+            "size": 227600,
+            "date": 132461912624944558
         },
         {
-            "path": "ModelBehaviorDefs/Asobo/Airliner/Airbus.xml",
-            "size": 62587,
-            "date": 132461182552635412
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/nosetouch.wav",
+            "size": 92680,
+            "date": 132461912625004506
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/righttouch1.wav",
+            "size": 282616,
+            "date": 132461912625084436
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/righttouch2.wav",
+            "size": 282616,
+            "date": 132461912625154380
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/sound/sound.xml",
+            "size": 37100,
+            "date": 132461912625214316
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_AIRFRAME_DECALS_ALBD.PNG.DDS",
+            "size": 4194432,
+            "date": 132445383780302008
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_AIRFRAME_DECALS_ALBD.PNG.DDS.json",
+            "size": 119,
+            "date": 132445383780370364
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_DECALSTEXT_ALBD.TIF.dds",
+            "size": 1048704,
+            "date": 132445383780510192
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_DECALSTEXT_ALBD.TIF.DDS.json",
+            "size": 119,
+            "date": 132444788261425714
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_DECALSTEXT_EMIS.PNG.dds",
+            "size": 699192,
+            "date": 132461912622127092
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_DECALSTEXT_EMIS.PNG.DDS.json",
+            "size": 102,
+            "date": 132444788261565582
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_INPUTS01_ALBD.PNG.DDS",
+            "size": 2097280,
+            "date": 132444788262175042
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_INPUTS01_ALBD.PNG.DDS.json",
+            "size": 102,
+            "date": 132444788262234978
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_INPUTS02_ALBD.PNG.dds",
+            "size": 4194432,
+            "date": 132445383780914864
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_INPUTS02_ALBD.PNG.DDS.json",
+            "size": 102,
+            "date": 132444788262284944
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_MAINPANEL_ALBD.PNG.dds",
+            "size": 4194432,
+            "date": 132446383071821880
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_MAINPANEL_ALBD.PNG.DDS.json",
+            "size": 102,
+            "date": 132445383780974798
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_MAINPANEL_COMP.PNG.DDS",
+            "size": 5592560,
+            "date": 132461912622546710
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_MAINPANEL_COMP.PNG.DDS.json",
+            "size": 191,
+            "date": 132461912622626646
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_PEDESTAL_ALBD.PNG.DDS",
+            "size": 4194432,
+            "date": 132444788263045178
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/A320NEO_COCKPIT_PEDESTAL_ALBD.PNG.DDS.json",
+            "size": 102,
+            "date": 132444788263105104
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE/texture.CFG",
+            "size": 160,
+            "date": 132444788263145074
         },
         {
             "path": "ModelBehaviorDefs/A32NX/A32NX_Exterior.xml",
             "size": 4472,
-            "date": 132461182552635412
+            "date": 132461912621457692
+        },
+        {
+            "path": "ModelBehaviorDefs/Asobo/Airliner/Airbus.xml",
+            "size": 62587,
+            "date": 132461912621527628
+        },
+        {
+            "path": "ModelBehaviorDefs/Asobo/Airliner/AirlinerCommon.xml",
+            "size": 46690,
+            "date": 132461912621587582
+        },
+        {
+            "path": "ModelBehaviorDefs/Asobo/Airliner/FMC.xml",
+            "size": 62768,
+            "date": 132461912621647520
+        },
+        {
+            "path": "ModelBehaviorDefs/Asobo/Common/Handling.xml",
+            "size": 59643,
+            "date": 132461912621717456
+        },
+        {
+            "path": "ModelBehaviorDefs/Asobo/Common/Subtemplates/Deice_Subtemplates.xml",
+            "size": 23038,
+            "date": 132461912621787396
+        },
+        {
+            "path": "ModelBehaviorDefs/Asobo/Common/Subtemplates/Electrical_Subtemplates.xml",
+            "size": 73140,
+            "date": 132461912621847342
+        },
+        {
+            "path": "ModelBehaviorDefs/Asobo/Common/Subtemplates/Fuel_Subtemplates.xml",
+            "size": 53137,
+            "date": 132461912621927270
         }
     ]
 }

--- a/A32NX/manifest.json
+++ b/A32NX/manifest.json
@@ -1,3 +1,4 @@
+<<<<<<< Updated upstream
 {
     "creator": "Iceman",
     "release_notes": {
@@ -30,4 +31,38 @@
     "total_package_size": "00000000000105425327",
     "minimum_game_version": "1.7.12",
     "manufacturer": "Airbus"
+=======
+{
+    "creator": "Iceman",
+    "release_notes": {
+        "neutral": {
+            "LastUpdate": "",
+            "OlderHistory": ""
+        }
+    },
+    "package_version": "0.1.51",
+    "title": "A320NX",
+    "dependencies": [
+        {
+            "package_version": "0.1.51",
+            "name": "asobo-aircraft-a320-neo"
+        },
+        {
+            "package_version": "0.1.38",
+            "name": "asobo-vcockpits-instruments-a320-neo"
+        },
+        {
+            "package_version": "0.1.13",
+            "name": "asobo-vcockpits-instruments-airliners"
+        },
+        {
+            "package_version": "0.1.61",
+            "name": "fs-base-aircraft-common"
+        }
+    ],
+    "content_type": "AIRCRAFT",
+    "total_package_size": "00000000000105391728",
+    "minimum_game_version": "1.7.12",
+    "manufacturer": "Airbus"
+>>>>>>> Stashed changes
 }


### PR DESCRIPTION
**Summary of Changes**
This PR adds the Elec page to the ECAM. It adds the HTML, JS and CSS required to display the page.

The HTML contains the SVG which is displayed when the page `display` property is set to `block` and includes the JS.
The JS controls the SVG by reading SimVars and setting the SVG to the appropriate state of the electrical system.

NOTE: The backend of the electrical system does not yet exist in master and is being worked on by ThePilot. This PR's code will simply read random and mock variables for as long as the real SimVars do not get set by the backend so it is safe to merge this PR to master before the backend is ready.


**Screenshots (if necessary)**
![image](https://user-images.githubusercontent.com/12895141/94997730-ae836c00-05b5-11eb-9da8-5ef3fe25b142.png)


**References**
The pilots in Discord... Thanks especially to Tarek :)

Discord username (if different from GitHub): Pineapple
