### PR TITLE
Revert "Hotfix to make av fan loop sound playing in external view"

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/sound/sound.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/sound/sound.xml
@@ -108,7 +108,7 @@
             <WwiseRTPC SimVar="ELECTRICAL MAIN BUS VOLTAGE" Units="VOLTS" Index="1" RTPCName="SIMVAR_ELECTRICAL_MAIN_BUS_VOLTAGE_A4_R4" />
         </Sound>
 
-        <Sound WwiseEvent="AVventloop" WwiseData="true" ViewPoint="Inside" ApplyCockpitReverb="true" FadeOutType="2" FadeOutTime="4" SimVar="ELECTRICAL MAIN BUS VOLTAGE" Units="VOLTS" Index="1">
+        <Sound WwiseEvent="AVventloop" WwiseData="true" ApplyCockpitReverb="true" FadeOutType="2" FadeOutTime="4" SimVar="ELECTRICAL MAIN BUS VOLTAGE" Units="VOLTS" Index="1">
             <Range LowerBound="28" />
             <WwiseRTPC SimVar="ELECTRICAL MAIN BUS VOLTAGE" Units="VOLTS" Index="1" RTPCName="SIMVAR_ELECTRICAL_MAIN_BUS_VOLTAGE_A4_R4" />
         </Sound>


### PR DESCRIPTION
Reverts flybywiresim/a32nx#1070

This actually made it so every time you switch into the external view and back inside the sounds take about 5 seconds to start up again, very abruptly god damnit wwise. For now I guess the fan sounds will have to play on the outside. I have been trying to fix this for a while and people have been reporting this issue over and over again so I guess this is a pretty big issue. I would like to revert it to what it was before which made it so it played on the outside but no abrupt change that makes you jump in your seat 5 seconds after switching your view.

sorry about so many PRs in the recent days, there is a bug which i try to fix which causes another bug, you know the cycle :(