### PR TITLE
fix(ecam/wheel): fix auto brake quantity showing in amber

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_WHEEL.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_WHEEL.js
@@ -275,6 +275,9 @@ var A320_Neo_LowerECAM_WHEEL;
                 this.hide(this.view.center.accuOnly);
 
                 this.makeGreen(this.view.brakes.autobrake.title);
+                this.makeGreen(this.view.brakes.autobrake.quantity.min);
+                this.makeGreen(this.view.brakes.autobrake.quantity.med);
+                this.makeGreen(this.view.brakes.autobrake.quantity.max);
             } else {
                 this.view.spoilers.numbers.forEach(number => this.show(number));
                 this.view.spoilers.lines.forEach(line => this.makeAmber(line));


### PR DESCRIPTION
## Summary of Changes

AUTO BRK level would always show in amber because of an omission in the hydraulics available update.

## Screenshots (if necessary)

Pretty self explanatory.

## References

N/A

## Additional context

N/A

Discord username (if different from GitHub): someperson#4953

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
