### PR TITLE
[CDU] Add support for magenta color and improve the VERT REV page

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -44,6 +44,7 @@
 1. [FCU] Fixed incrementing the QNH while in hPa mode - @lousybyte (lousybyte)
 1. [CDU] Follow Green Dot speed on approach with flaps clean - @veikkos (Veikko Soininen)
 1. [ND] Fixed cyan heading bug not showing on ND in VOR and LS modes - @AdenFlorian (David Valachovic)
+1. [CDU] Improved the VERT REV page - @lousybyte (lousybyte)
 
 ## 2020/09
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU.css
@@ -116,6 +116,9 @@ a320-neo-cdu-main-display::after {
 .red {
   color: #ff9a00; }
 
+.magenta {
+  color: #f800cc; }
+
 fmc-main-display::before {
   content: " ";
   display: block;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -94,7 +94,7 @@ class FMCMainDisplay extends BaseAirliners {
             color = "white";
         }
         this._title = content.split("[color]")[0];
-        this._titleElement.classList.remove("white", "blue", "yellow", "green", "red");
+        this._titleElement.classList.remove("white", "blue", "yellow", "green", "red", "magenta");
         this._titleElement.classList.add(color);
         this._titleElement.textContent = this._title;
     }
@@ -163,7 +163,7 @@ class FMCMainDisplay extends BaseAirliners {
                 color = "white";
             }
             const e = this._labelElements[row][col];
-            e.classList.remove("white", "blue", "yellow", "green", "red");
+            e.classList.remove("white", "blue", "yellow", "green", "red", "magenta");
             e.classList.add(color);
             label = label.split("[color]")[0];
         }
@@ -208,7 +208,7 @@ class FMCMainDisplay extends BaseAirliners {
                 color = "white";
             }
             const e = this._lineElements[row][col];
-            e.classList.remove("white", "blue", "yellow", "green", "red");
+            e.classList.remove("white", "blue", "yellow", "green", "red", "magenta");
             e.classList.add(color);
             content = content.split("[color]")[0];
         }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Rework of #871

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Added the ability to highlight the text in magenta in the CDU
- Constraints above TRANS ALT will show as FL
- Entering a number below 1000 will insert a FL (e.g. 180 -> FL180)
- Adjusted empty brackets spacing

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![](https://i.postimg.cc/Kj3pJGZs/Untitled.png)
## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->
![](https://i.postimg.cc/t4qwHHD7/ref.png)
![](https://i.postimg.cc/0Qs7L9dB/Screenshot-2020-10-08-113017.png)
## Additional context
<!-- Add any other context about the pull request here. -->
Seems to be different kind of shades of purple in different sources/videos, chose one to be inline with current colors. 
Open to changes.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
