### PR TITLE
fix(ecam/door-video): fix door video div hiding self-test

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.css
@@ -314,7 +314,8 @@ a320-neo-eicas-element[index="2"] #Mainframe #BottomScreen {
   width: 100%;
   height: 100%;
   border: none;
-  display: none;
+
+  visibility: hidden;
 }
 
 #BottomScreen #door-video-wrapper {
@@ -331,8 +332,4 @@ a320-neo-eicas-element[index="2"] #Mainframe #BottomScreen {
 
   background-image: url(DoorVideoResources/empty.png);
   background-size: cover;
-}
-
-#BottomScreen .SelfTestWrapper {
-  top: -5%;
 }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -178,7 +178,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         const bottomSelfTestCurrentKnobValue = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:93", "number");
 
         if (((bottomSelfTestCurrentKnobValue >= 0.1 && this.bottomSelfTestLastKnobValue < 0.1) || ACPowerStateChange) && isACPowerAvailable && !this.bottomSelfTestTimerStarted) {
-            this.bottomSelfTestDiv.style.display = "block";
+            this.bottomSelfTestDiv.style.visibility = "visible";
             this.bottomSelfTestTimer = 14.25;
             this.bottomSelfTestTimerStarted = true;
         }
@@ -186,7 +186,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         if (this.bottomSelfTestTimer >= 0) {
             this.bottomSelfTestTimer -= _deltaTime / 1000;
             if (this.bottomSelfTestTimer <= 0) {
-                this.bottomSelfTestDiv.style.display = "none";
+                this.bottomSelfTestDiv.style.visibility = "hidden";
                 this.bottomSelfTestTimerStarted = false;
             }
         }


### PR DESCRIPTION
Fixes  #1232

## Summary of Changes

Fix door video div hiding self-test

## Screenshots (if necessary)

N/A

## References

N/A

## Additional context

N/A

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): someperson#4953

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
