### PR TITLE
Fixed ZFW/ZFWCG bug due to new custom font

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -1232,8 +1232,8 @@ class FMCMainDisplay extends BaseAirliners {
         let zfw = 0;
         let zfwcg = 0;
         if (s) {
-            if (s.includes("/")) {
-                const sSplit = s.split("/");
+            if (s.includes("")) {
+                const sSplit = s.split("|");
                 zfw = parseFloat(sSplit[0]);
                 zfwcg = parseFloat(sSplit[1]);
             } else {
@@ -1396,7 +1396,7 @@ class FMCMainDisplay extends BaseAirliners {
                 this.showErrorMessage("FORMAT ERROR");
                 return false;
             }
-        } else { // Until the +- button on the MCDU actually shows a plus sign
+        } else if (s.includes("+")) { // Until the +- button on the MCDU actually shows a plus sign
             wind = parseFloat(s);
             this._windDir = "TL";
             if (isFinite(wind)) {
@@ -2153,7 +2153,14 @@ class FMCMainDisplay extends BaseAirliners {
             } else if (input === "DOT") {
                 this.inOut += ".";
             } else if (input === "PLUSMINUS") {
-                this.inOut += "-";
+                const val = this.inOut;
+                if (val === "") {
+                    this.inOut = "-";
+                } else if (val === "-") {
+                    this.inOut = "+";
+                } else if (val === "+") {
+                    this.inOut = "-";
+                }
             } else if (input === "Localizer") {
                 this._apLocalizerOn = !this._apLocalizerOn;
             } else if (input.length === 2 && input[0] === "L") {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #1265
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- The new custom font uses a different character to represent slashes, I changed the parser at https://github.com/flybywiresim/a32nx/blob/74e2661c42aae84b1ac2715096921343dc425574/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js#L1236
- Made the PLUS/MINUS button actually shows plus signs now.

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Lucky38i

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
