### PR TITLE
Update manifest-base.json

### DIFF
--- a/manifest-base.json
+++ b/manifest-base.json
@@ -10,24 +10,24 @@
   "title": "A32NX",
   "dependencies": [
     {
-      "package_version": "0.1.51",
+      "package_version": "0.1.58",
       "name": "asobo-aircraft-a320-neo"
     },
     {
-      "package_version": "0.1.38",
+      "package_version": "0.1.52",
       "name": "asobo-vcockpits-instruments-a320-neo"
     },
     {
-      "package_version": "0.1.13",
+      "package_version": "0.1.53",
       "name": "asobo-vcockpits-instruments-airliners"
     },
     {
-      "package_version": "0.1.61",
+      "package_version": "0.1.66",
       "name": "fs-base-aircraft-common"
     }
   ],
   "content_type": "AIRCRAFT",
-  "total_package_size": "00000000000176088117",
-  "minimum_game_version": "1.7.12",
+  "total_package_size": "00000000000221782906",
+  "minimum_game_version": "1.9.5",
   "manufacturer": "Airbus"
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
Updated dependencies version and mininum game version.
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): [Guilherme Farias#9971](https://discordapp.com/channels/@me/207215431654572032)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
