### PR TITLE
Active waypoint now shows again when switching back ND from ROSE VOR/…

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A32NX_NDInfo.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A32NX_NDInfo.js
@@ -108,7 +108,7 @@ class Jet_MFD_NDInfo extends HTMLElement {
         const wpETE = SimVar.GetSimVarValue("GPS WP ETE", "seconds"); // ETE is not available in Simplane 🙄
         const utcTime = SimVar.GetGlobalVarValue("ZULU TIME", "seconds");
         const utcETA = wpETE > 0 ? (utcTime + wpETE) % 86400 : 0;
-        this.setWaypoint(Simplane.getNextWaypointName(), Math.round(Simplane.getNextWaypointTrack()), Simplane.getNextWaypointDistance(), utcETA);
+        this.setWaypoint(Simplane.getNextWaypointName(), Math.round(Simplane.getNextWaypointTrack()), Simplane.getNextWaypointDistance(), utcETA, true);
     }
     setGroundSpeed(_speed, _force = false) {
         if ((_speed != this.currentGroundSpeed) || _force) {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #1250 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Active waypoint now shows again when switching back ND from ROSE VOR/ILS to NAV

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before:
VOR then NAV
![image](https://user-images.githubusercontent.com/17742637/95926488-bbc20700-0dbc-11eb-93ac-6b1a859039b0.png)
![image](https://user-images.githubusercontent.com/17742637/95926568-e90eb500-0dbc-11eb-8ba2-167427b64806.png)

Now:
VOR then NAV
![image](https://user-images.githubusercontent.com/17742637/95926488-bbc20700-0dbc-11eb-93ac-6b1a859039b0.png)
![image](https://user-images.githubusercontent.com/17742637/95926513-caa8b980-0dbc-11eb-8953-4beb9c27ad00.png)



## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Externo#2359

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
