### PR TITLE
Add functionality to CABIN PRESS knobs

### DIFF
--- a/A32NX/ModelBehaviorDefs/A32NX/A32NX_Interior.xml
+++ b/A32NX/ModelBehaviorDefs/A32NX/A32NX_Interior.xml
@@ -142,7 +142,7 @@
             <SEQ1_EMISSIVE_DRIVES_VISIBILITY>False</SEQ1_EMISSIVE_DRIVES_VISIBILITY>
             <WWISE_EVENT>fmc_push_button_on</WWISE_EVENT>
             <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
-            <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2> 
+            <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
         </DefaultTemplateParameters>
 
         <Component ID="SWITCH_MP#DCDU_SIDE#_DIM" Node="SWITCH_MP#DCDU_SIDE#_DIM">
@@ -163,7 +163,7 @@
                 <STATE0_TIMER>0.01</STATE0_TIMER>
                 <MOMENTARY_REPEAT_FREQUENCY>5</MOMENTARY_REPEAT_FREQUENCY>
                 <MOMENTARY_SWITCH/>
-                
+
                 <Condition Valid="BRT_DIM_SWITCH_DIRECTION">
                     <SWITCH_DIRECTION>#BRT_DIM_SWITCH_DIRECTION#</SWITCH_DIRECTION>
                 </Condition>
@@ -172,7 +172,7 @@
                 </Condition>
             </UseTemplate>
         </Component>
-        
+
         <Component ID="SWITCH_MP#DCDU_SIDE#_DIM_SEQ1" Node="SWITCH_MP#DCDU_SIDE#_DIM_SEQ1">
 			<UseTemplate Name="ASOBO_GT_Emissive_Gauge">
 				<EMISSIVE_CODE>(A:LIGHT POTENTIOMETER:#POTENTIOMETER_ID#, Percent over 100)</EMISSIVE_CODE>
@@ -184,8 +184,9 @@
     Template for rigging DCDU generic buttons
 
     Main Parameters:
-            - NODE_ID           <no default>    Name of the button
-            - PUSH_CODE         <no default>    Code to run on push of button
+            - NODE_ID           <no default>    Node-ID of the button
+            - PLANE_NAME        <no default>    Plane project name
+            - HTML_EVENT_ID     <no default>    HTML-Event that will be fired when the button is pushed
             - POTENTIOMETER_ID  85              Potentiometer ID for emissive sequence 1
 
     Authors: Benjamin Dupont (@Benjozork) 10/10/20
@@ -197,7 +198,7 @@
             <WWISE_EVENT_1>fmc_push_button_on</WWISE_EVENT_1>
             <WWISE_EVENT_2>fmc_push_button_off</WWISE_EVENT_2>
             <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
-            <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2> 
+            <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
         </DefaultTemplateParameters>
 
         <UseTemplate Name="ASOBO_GT_Push_Button_Airliner">
@@ -233,10 +234,12 @@
     Takes into account the value of L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position.
 
     Main Parameters:
-           - TOGGLE_NODE_ID        <no default>    Switch node ID   (anim name will be same)
-           - TOGGLE_SIMVAR         <no default>    SimVar to contain the toggle state
-           - SEQ1_CODE             0               Sequence 1 emissive code
-           - SEQ1_CODE             0               Sequence 2 emissive code
+            - TOGGLE_NODE_ID        <no default>    Switch node ID   (anim name will be same)
+            - TOGGLE_SIMVAR         <no default>    SimVar to contain the toggle state
+            - SHOULD_ANIM_TOGGLE    <no default>    If not present, the switch returns to it's orignial position. (Normal behaviour)
+                                                    If present, the switch will stay pressed.
+            - SEQ1_CODE             0               Sequence 1 emissive code
+            - SEQ1_CODE             0               Sequence 2 emissive code
 
     Authors: Benjamin Dupont (@Benjozork) 12/10/20
     -->
@@ -253,6 +256,10 @@
             <LEFT_SINGLE_CODE>
                 (#TOGGLE_SIMVAR#, Bool) ! (&gt;#TOGGLE_SIMVAR#)
             </LEFT_SINGLE_CODE>
+
+            <Condition Check="SHOULD_ANIM_TOGGLE">
+                <DOWN_STATE_CODE>(#TOGGLE_SIMVAR#)</DOWN_STATE_CODE>
+            </Condition>
 
             <Condition Valid="SEQ1_CODE">
                 <True>
@@ -274,6 +281,7 @@
         </UseTemplate>
     </Template>
 
+
     <!--
     Template for rigging covered push buttons
 
@@ -283,6 +291,8 @@
            - TOGGLE_NODE_ID     <no default>    Switch node ID                              (anim name will be same)
            - LOCK_NODE_ID       <no default>    Lock node ID                                (anim name will be same)
            - TOGGLE_SIMVAR      <no default>    SimVar to contain the toggle state
+           - SHOULD_ANIM_TOGGLE <no default>    If not present, the switch returns to it's orignial position. (Normal behaviour)
+                                                If present, the switch will stay pressed.
            - SEQ1_CODE          0               Sequence 1 emissive code
            - SEQ1_CODE          0               Sequence 2 emissive code
            - INVERTED           False           Whether or not the switch is OFF by default
@@ -311,6 +321,10 @@
                 (#TOGGLE_SIMVAR#, Bool) ! (&gt;#TOGGLE_SIMVAR#)
             </LEFT_SINGLE_CODE>
 
+            <Condition Check="SHOULD_ANIM_TOGGLE">
+                <DOWN_STATE_CODE>(#TOGGLE_SIMVAR#)</DOWN_STATE_CODE>
+            </Condition>
+
             <Condition Check="SEQ1_CODE">
                 <True>
                     <SEQ1_EMISSIVE_CODE>#SEQ1_CODE# (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</SEQ1_EMISSIVE_CODE>
@@ -338,6 +352,7 @@
         </UseTemplate>
     </Template>
 
+
     <!--
     Template for defining panel lighting knobs tied to potentiometers
 
@@ -360,6 +375,71 @@
         </DefaultTemplateParameters>
 
         <UseTemplate Name="ASOBO_LIGHTING_Knob_SubTemplate">
+        </UseTemplate>
+    </Template>
+
+
+    <!--
+    Template for rigging springloaded 3-State switches. (Springloaded both up and down)
+
+    Main Parameters:
+            - ANIM_SIMVAR       <no default>    The Simvar that is controlled via this switch, Prefix (for example L:) must be included
+            - INVERT_ANIM       <0>             If the associated animation should be reversed
+            - NODE_ID           <no default>    The Node ID associated with this switch
+    -->
+    <Template Name="FBW_3State_Springloaded_Switch">
+        <DefaultTemplateParameters>
+            <WWISE_EVENT>wing_light_switch_on</WWISE_EVENT>
+            <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
+            <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
+        </DefaultTemplateParameters>
+
+        <Component ID="#NODE_ID#" Node="#NODE_ID#">
+            <UseTemplate Name="ASOBO_GT_Switch_3States">
+                <UPARROW>UpArrow</UPARROW>
+                <DOWNARROW>DownArrow</DOWNARROW>
+                <LEFTARROW/>
+                <RIGHTARROW/>
+                <CURSOR/>
+                <ANIM_NAME>#NODE_ID#</ANIM_NAME>
+                <CODE_POS_0>0 (&gt;#ANIM_SIMVAR#, number)</CODE_POS_0>
+                <CODE_POS_1>1 (&gt;#ANIM_SIMVAR#, number)</CODE_POS_1>
+                <CODE_POS_2>2 (&gt;#ANIM_SIMVAR#, number)</CODE_POS_2>
+                <STATE_MAX_TIMER>0.01</STATE_MAX_TIMER>
+                <STATE0_TIMER>0.01</STATE0_TIMER>
+                <MOMENTARY_REPEAT_FREQUENCY>5</MOMENTARY_REPEAT_FREQUENCY>
+                <MOMENTARY_SWITCH/>
+            </UseTemplate>
+        </Component>
+    </Template>
+
+
+    <!--
+    Template for rigging a knob where the animation doesn't match up with the maximum knob travel.
+
+    Main Parameters:
+            - NODE_ID               <no default>        The Node ID associated with this knob
+            - LOCAL_SIMVAR          <no default>        The LVar that will be used for this knob
+            - MAX_ROT_PERCENT       <100>               The maximum percent out of it's animation the knob can rotate
+            - CONVERSION_FORMULA    <optional>          The formula with which the rotation percentage will be transformed into the LOCAL_SIMVAR.
+            - INCREMENT             Default: 1          The increment for each click / hold update
+    -->
+    <Template Name="FBW_Continuous_Knob_Limited_From_Simvar">
+        <DefaultTemplateParameters>
+            <MAX_ROT_PERCENT>100</MAX_ROT_PERCENT>
+            <CONVERSION_FORMULA></CONVERSION_FORMULA>
+        </DefaultTemplateParameters>
+
+        <Update Frequency="40">
+            (I:XMLVAR_#NODE_ID#, percent) #MAX_ROT_PERCENT# min (&gt;I:XMLVAR_#NODE_ID#, percent)
+            (I:XMLVAR_#NODE_ID#, percent) #CONVERSION_FORMULA# (&gt;#LOCAL_SIMVAR#, #LOCAL_SIMVAR_UNITS#)
+        </Update>
+
+        <UseTemplate Name="FBW_Continuous_Knob_Finite_From_Simvar">
+            <ANIM_SIMVAR_MIN>0</ANIM_SIMVAR_MIN>
+            <ANIM_SIMVAR_MAX>100</ANIM_SIMVAR_MAX>
+            <ANIM_SIMVAR>I:XMLVAR_#NODE_ID#</ANIM_SIMVAR>
+            <ANIM_SIMVAR_UNITS>percent</ANIM_SIMVAR_UNITS>
         </UseTemplate>
     </Template>
 

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -753,7 +753,7 @@
                 <DefaultTemplateParameters>
                     <PLANE_NAME>A32NX</PLANE_NAME>
                 </DefaultTemplateParameters>
-            
+
                 <UseTemplate Name="ASOBO_LIGHTING_Knob_Potentiometer_Template">
                     <POTENTIOMETER>88</POTENTIOMETER>
                     <NODE_ID>KNOB_EFIS_CS_PFD</NODE_ID>
@@ -825,7 +825,7 @@
                 <DefaultTemplateParameters>
                     <PLANE_NAME>A32NX</PLANE_NAME>
                 </DefaultTemplateParameters>
-            
+
                 <UseTemplate Name="ASOBO_LIGHTING_Knob_Potentiometer_Template">
                     <POTENTIOMETER>90</POTENTIOMETER>
                     <NODE_ID>KNOB_EFIS_FO_PFD</NODE_ID>
@@ -1565,10 +1565,10 @@
                 </UseTemplate>
 
                 <UseTemplate Name="ASOBO_LIGHTING_Panel_Emissive_Template">
-                <NODE_ID>LIGHTS_OVHD</NODE_ID>
-                <SIMVAR_INDEX>4</SIMVAR_INDEX>
-                <POTENTIOMETER>86</POTENTIOMETER>
-            </UseTemplate>
+                    <NODE_ID>LIGHTS_OVHD</NODE_ID>
+                    <SIMVAR_INDEX>4</SIMVAR_INDEX>
+                    <POTENTIOMETER>86</POTENTIOMETER>
+                </UseTemplate>
 
                 <UseTemplate Name="ASOBO_LIGHTING_Switch_Light_Cabin_Template">
                     <POTENTIOMETER>7</POTENTIOMETER>
@@ -2513,6 +2513,42 @@
                     <TOGGLE_SIMVAR>L:A32NX_OVHD_APU_AUTOEXITING_TEST</TOGGLE_SIMVAR>
 
                     <SEQ1_CODE>(L:A32NX_OVHD_APU_AUTOEXITING_TEST, Bool) (L:A32NX_OVHD_APU_AUTOEXITING_TEST_STATUS, Bool) and</SEQ1_CODE>
+                </UseTemplate>
+            </Component>
+
+            <Component ID="Overhead_CabinPress">
+                <Component ID="KNOB_OVHD_CABINPRESS_LDGELEV" Node="KNOB_OVHD_CABINPRESS_LDGELEV">
+                    <UseTemplate Name="FBW_Continuous_Knob_Limited_From_Simvar">
+                        <NODE_ID>KNOB_OVHD_CABINPRESS_LDGELEV</NODE_ID>
+                        <ANIM_NAME>KNOB_OVHD_CABINPRESS_LDGELEV</ANIM_NAME>
+                        <LOCAL_SIMVAR>L:A32NX_LANDING_ELEVATION</LOCAL_SIMVAR>
+                        <LOCAL_SIMVAR_UNITS>feet</LOCAL_SIMVAR_UNITS>
+                        <INCREMENT>0.5</INCREMENT>
+                        <MAX_ROT_PERCENT>88</MAX_ROT_PERCENT>
+                        <CONVERSION_FORMULA>193.182 * 2000 -</CONVERSION_FORMULA>
+                    </UseTemplate>
+                </Component>
+
+                <UseTemplate Name="FBW_3State_Springloaded_Switch">
+                    <NODE_ID>SWITCH_OVHD_CABINPRESS_MANVSCTL</NODE_ID>
+                    <ANIM_SIMVAR>L:A32NX_MAN_VS_CONTROL</ANIM_SIMVAR>
+                    <INVERT_ANIM>1</INVERT_ANIM>
+                </UseTemplate>
+
+                <UseTemplate Name="FBW_Push_Toggle">
+                    <TOGGLE_NODE_ID>PUSH_OVHD_CABINPRESS_MODESEL</TOGGLE_NODE_ID>
+                    <TOGGLE_SIMVAR>L:A32NX_CAB_PRESS_MODE_MAN</TOGGLE_SIMVAR>
+                    <SHOULD_ANIM_TOGGLE/>
+                    <SEQ1_CODE>(L:A32NX_CAB_PRESS_SYS_FAULT)</SEQ1_CODE>
+                    <SEQ2_CODE>(L:A32NX_CAB_PRESS_MODE_MAN)</SEQ2_CODE>
+                </UseTemplate>
+
+                <UseTemplate Name="FBW_Covered_Push_Toggle">
+                    <TOGGLE_NODE_ID>PUSH_OVHD_CABINPRESS_DITCHING</TOGGLE_NODE_ID>
+                    <LOCK_NODE_ID>LOCK_OVHD_CABINPRESS_DITCHING</LOCK_NODE_ID>
+                    <TOGGLE_SIMVAR>L:A32NX_DITCHING</TOGGLE_SIMVAR>
+                    <SHOULD_ANIM_TOGGLE/>
+                    <SEQ2_CODE>(L:A32NX_DITCHING)</SEQ2_CODE>
                 </UseTemplate>
             </Component>
 
@@ -3560,21 +3596,6 @@
             </UseTemplate>
             <UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
                 <NODE_ID>PUSH_OVHD_FUEL_MODESEL</NODE_ID>
-            </UseTemplate>
-            <UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
-                <NODE_ID>SWITCH_OVHD_CABINPRESS_MANVSCTL</NODE_ID>
-            </UseTemplate>
-            <UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
-                <NODE_ID>PUSH_OVHD_CABINPRESS_MODESEL</NODE_ID>
-            </UseTemplate>
-            <UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
-                <NODE_ID>KNOB_OVHD_CABINPRESS_LDGELEV</NODE_ID>
-            </UseTemplate>
-            <UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
-                <NODE_ID>LOCK_OVHD_CABINPRESS_DITCHING</NODE_ID>
-            </UseTemplate>
-            <UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
-                <NODE_ID>PUSH_OVHD_CABINPRESS_DITCHING</NODE_ID>
             </UseTemplate>
             <UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
                 <NODE_ID>PUSH_OVHD_CARGOVENT_AFTISOL</NODE_ID>

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -245,3 +245,24 @@
 - A32NX_OVHD_HYD_LEAK_MEASUREMENT_Y_LOCK
     - Bool
     - True if "HYD LEAK MEASUREMENT Y" switch lock is down
+    
+- A32NX_LANDING_ELEVATION
+    - Number in feet
+    - Minimum -2000, maximum 15000
+    
+- A32NX_MAN_VS_CONTROL
+    - Number, either 0,1 or 2
+    - 0 if switch is in up position, 1 if switch is neutral, 2 if switch is down.
+    
+- A32NX_CAB_PRESS_MODE_MAN
+    - Bool
+    - True if CABIN PRESS MODE SEL is in manual mode
+    
+- A32NX_CAB_PRESS_SYS_FAULT
+    - Bool
+    - Determines if the FAULT light on the CABIN PRESS MODE SEL pushbutton
+      should be on
+    
+- A32NX_DITCHING
+    - Bool
+    - True if DITCHING mode is enabled


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* Adds functionality to the MAN V/S CTL switch, the CAB PRESS MODE SEL pushbutton, the LDG ELEVATION knob, and the guarded DITCHING pushbutton.

* Known issues: 
   * The LDG ELEVATION knob should have a pull functionality, to select the manual mode (pushed in is auto). This isn't possible since there is no animation for that.
   * The way the animations works for pushbuttons that should stay in isn't quite right, that needs to be done in the model animation as well
   * The DITCHING pushbutton has no emissive

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![grafik](https://user-images.githubusercontent.com/39596827/96273062-32cee980-0fcf-11eb-936e-9d9fca220cec.png)
![grafik](https://user-images.githubusercontent.com/39596827/96273171-52fea880-0fcf-11eb-9255-c3428638aa62.png)
![grafik](https://user-images.githubusercontent.com/39596827/96273212-5d20a700-0fcf-11eb-8eba-67ce5ce5584f.png)
(Note that the scale in the model goes from -2000 to 15000, so i went with that.)

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
* No changelog since no proper functionality was added.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
