### PR TITLE
Fix #1054 L/G ECAM Warning

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -58,6 +58,7 @@
 1. [LIVERY] Bundle the FlyByWire Livery with the A32NX addon - @devsnek (devsnek)
 1. [ECAM] Added cockpit door video - @Benjozork (Benjamin Dupont)
 1. [MISC] Standby Instrument stays ON if emergency power should be available, bug fixes - @2hwk (2Cas#1022 on discord)
+1. [ECAM] Landing Gear ECAM warning when too low - @nathaninnes (Nathan Innes)
 
 ## 2020/09
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -105,6 +105,14 @@ var A320_Neo_UpperECAM;
                 return -1;
             }
         }
+        gearNotDownLanding() {
+            const rh = this.getCachedSimVar("RADIO HEIGHT", "feet") <= 750;
+            const flapIndex = Simplane.getFlapsHandleIndex();
+            const gearNotDwnLocked = this.getCachedSimVar("GEAR POSITION", "percent") <= 99;
+            const N1Low = this.getCachedSimVar("ENG N1 RPM:1", "percent") <= 75 || this.getCachedSimVar("ENG N1 RPM:2", "percent") <= 75;
+
+            return (rh && gearNotDwnLocked && N1Low) || (rh && gearNotDwnLocked && flapIndex >= 3);
+        }
         engineFailed(_engine) {
             return (this.getCachedSimVar("ENG FAILED:" + _engine, "Bool") == 1) && !this.getCachedSimVar("ENG ON FIRE:" + _engine) && !Simplane.getIsGrounded();
         }
@@ -423,6 +431,16 @@ var A320_Neo_UpperECAM;
                                 message: "",
                                 level: 3,
                                 isActive: () => Simplane.getIndicatedSpeed() > (A32NX_Selectors.VMAX() + 4),
+                            },
+                        ]
+                    },
+                    {
+                        name: "L/G",
+                        messages: [
+                            {
+                                message: "GEAR NOT DOWN",
+                                level: 3,
+                                isActive: this.gearNotDownLanding,
                             },
                         ]
                     },


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #1054 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Introduced a ECAM & aural warning for when landing gear is not down in the following conditions:
![image](https://user-images.githubusercontent.com/18389085/96290585-c22fc900-0fde-11eb-8dea-da4e3d728b91.png)

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/18389085/96290620-d4aa0280-0fde-11eb-9c1a-6f1aa084edf8.png)



## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![image](https://user-images.githubusercontent.com/18389085/96290585-c22fc900-0fde-11eb-8dea-da4e3d728b91.png)
*Ref. FCOM*
![image](https://user-images.githubusercontent.com/18389085/96290917-43875b80-0fdf-11eb-9b51-aa0e323c8a20.png)
*Ref. ESLD*

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Sabes#8668

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
