### PR TITLE
Fix knob animation value not being accessible

### DIFF
--- a/A32NX/ModelBehaviorDefs/A32NX/A32NX_Interior.xml
+++ b/A32NX/ModelBehaviorDefs/A32NX/A32NX_Interior.xml
@@ -420,6 +420,7 @@
     Main Parameters:
             - NODE_ID               <no default>        The Node ID associated with this knob
             - LOCAL_SIMVAR          <no default>        The LVar that will be used for this knob
+            - ANIM_VAR_TYPE         <I>                 Type of the variable used for the animation
             - MAX_ROT_PERCENT       <100>               The maximum percent out of it's animation the knob can rotate
             - CONVERSION_FORMULA    <optional>          The formula with which the rotation percentage will be transformed into the LOCAL_SIMVAR.
             - INCREMENT             Default: 1          The increment for each click / hold update
@@ -428,17 +429,18 @@
         <DefaultTemplateParameters>
             <MAX_ROT_PERCENT>100</MAX_ROT_PERCENT>
             <CONVERSION_FORMULA></CONVERSION_FORMULA>
+            <ANIM_VAR_TYPE>L</ANIM_VAR_TYPE>
         </DefaultTemplateParameters>
 
         <Update Frequency="40">
-            (I:XMLVAR_#NODE_ID#, percent) #MAX_ROT_PERCENT# min (&gt;I:XMLVAR_#NODE_ID#, percent)
-            (I:XMLVAR_#NODE_ID#, percent) #CONVERSION_FORMULA# (&gt;#LOCAL_SIMVAR#, #LOCAL_SIMVAR_UNITS#)
+            (#ANIM_VAR_TYPE#:XMLVAR_#NODE_ID#, percent) #MAX_ROT_PERCENT# min (&gt;#ANIM_VAR_TYPE#:XMLVAR_#NODE_ID#, percent)
+            (#ANIM_VAR_TYPE#:XMLVAR_#NODE_ID#, percent) #CONVERSION_FORMULA# (&gt;#LOCAL_SIMVAR#, #LOCAL_SIMVAR_UNITS#)
         </Update>
 
         <UseTemplate Name="FBW_Continuous_Knob_Finite_From_Simvar">
             <ANIM_SIMVAR_MIN>0</ANIM_SIMVAR_MIN>
             <ANIM_SIMVAR_MAX>100</ANIM_SIMVAR_MAX>
-            <ANIM_SIMVAR>I:XMLVAR_#NODE_ID#</ANIM_SIMVAR>
+            <ANIM_SIMVAR>#ANIM_VAR_TYPE#:XMLVAR_#NODE_ID#</ANIM_SIMVAR>
             <ANIM_SIMVAR_UNITS>percent</ANIM_SIMVAR_UNITS>
         </UseTemplate>
     </Template>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* Change the FBW knob template to be able to set the animation variable type to LVars, at @ThePilot916's request





<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
