### PR TITLE
Issue 596 decel wrong light

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -58,6 +58,7 @@
 1. [LIVERY] Bundle the FlyByWire Livery with the A32NX addon - @devsnek (devsnek)
 1. [ECAM] Added cockpit door video - @Benjozork (Benjamin Dupont)
 1. [MISC] Standby Instrument stays ON if emergency power should be available, bug fixes - @2hwk (2Cas#1022 on discord)
+1. [MISC] Fixed DECEL always show up on left button only - @jokey2k (JoKeY | Markus#0001 on discord)
 
 ## 2020/09
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/ModelBehaviorDefs/A32NX/A32NX_Interior.xml
+++ b/A32NX/ModelBehaviorDefs/A32NX/A32NX_Interior.xml
@@ -513,6 +513,7 @@
         <Component ID="#NODE_ID_DECEL#" Node="#NODE_ID_DECEL#">
             <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
                 <EMISSIVE_CODE>(A:AUTO BRAKE SWITCH CB, Enum) 1 != (A:ACCELERATION BODY Z, feet per second squared) #REF_DECEL_FPSS# &lt;= and (L:XMLVAR_Autobrakes_Level) #AUTOBRAKE_LEVEL# == and (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</EMISSIVE_CODE>
+                <EMISSIVE_DRIVES_VISIBILITY>True</EMISSIVE_DRIVES_VISIBILITY>
             </UseTemplate>
         </Component>
         <Component ID="#NODE_ID_ON#" Node="#NODE_ID_ON#">

--- a/A32NX/ModelBehaviorDefs/A32NX/A32NX_Interior.xml
+++ b/A32NX/ModelBehaviorDefs/A32NX/A32NX_Interior.xml
@@ -445,4 +445,84 @@
         </UseTemplate>
     </Template>
 
+    <!--
+    Template for handling autobrake push buttons
+
+    Clone of Asobo template to fix broken logic
+
+    Takes into account the value of L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position.
+
+    Authors: Asobo / Markus Ullmann (@jokey2k) 18/10/20
+    -->
+    <Template Name="FBW_Airbus_HANDLING_Push_Autobrakes_Template">
+        <DefaultTemplateParameters>
+            <AUTOBRAKE_LEVEL>1</AUTOBRAKE_LEVEL>
+            <WWISE_EVENT_1>autobrake_push_button_on</WWISE_EVENT_1>
+            <WWISE_EVENT_2>autobrake_push_button_off</WWISE_EVENT_2>
+            <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
+            <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
+            <TOOLTIPID>%((L:XMLVAR_RTO_Level) #AUTOBRAKE_LEVEL# ==)%{if}TT:COCKPIT.TOOLTIPS.AUTO_BRK_TURN_OFF%{else}TT:#OFF_TOOLTIP#%{end}</TOOLTIPID>
+            <ENGINES_COUNT>2</ENGINES_COUNT>
+            <REF_DECEL_FPSS>-7</REF_DECEL_FPSS>
+        </DefaultTemplateParameters>
+        <Component ID="#NODE_ID#" Node="#NODE_ID#">
+            <UseTemplate Name="ASOBO_GT_Push_Button">
+                <LEFT_SINGLE_CODE>
+                (A:ANTISKID BRAKES ACTIVE, Bool) ! (L:XMLVAR_Autobrakes_Level) #AUTOBRAKE_LEVEL# == or if{
+                    0 (&gt;L:XMLVAR_Autobrakes_Level)
+                } els{
+                    #AUTOBRAKE_LEVEL# (&gt;L:XMLVAR_Autobrakes_Level)
+                }
+
+                (L:XMLVAR_Autobrakes_Level) 0 == if{
+                    1 (&gt;K:SET_AUTOBRAKE_CONTROL)
+                } els{
+                    (A:SIM ON GROUND, Bool) if{
+                        0 (&gt;K:SET_AUTOBRAKE_CONTROL)
+                    } els{
+                        (L:XMLVAR_Autobrakes_Level) 1 + (&gt;K:SET_AUTOBRAKE_CONTROL)
+                    }
+                }
+                </LEFT_SINGLE_CODE>
+            </UseTemplate>
+
+            <Condition Check="AUTOBRAKE_LEVEL" Match="0">
+                <False>
+                    <UseTemplate Name="ASOBO_GT_Update">
+                        <FREQUENCY>1</FREQUENCY>
+                        <UPDATE_CODE>
+                        (A:AUTO BRAKE SWITCH CB, Enum) s1 0 == if{
+                            (L:XMLVAR_Autobrakes_Level) 0 == if{
+                                #AUTOBRAKE_LEVEL# (&gt;L:XMLVAR_Autobrakes_Level)
+                            }
+                        } els{
+                            l1 1 == if{
+                                0 (&gt;L:XMLVAR_Autobrakes_Level)
+                            } els{
+                                l1 1 - (&gt;L:XMLVAR_Autobrakes_Level)
+                                (A:SIM ON GROUND, Bool) (A:GROUND VELOCITY, Knots) 10 &lt; and if{
+                                    0 (&gt;K:SET_AUTOBRAKE_CONTROL)
+                                }
+                            }
+                        }
+                        </UPDATE_CODE>
+                    </UseTemplate>
+                </False>
+            </Condition>
+        </Component>
+        <Component ID="#NODE_ID_DECEL#" Node="#NODE_ID_DECEL#">
+            <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
+                <EMISSIVE_CODE>(A:AUTO BRAKE SWITCH CB, Enum) 1 != (A:ACCELERATION BODY Z, feet per second squared) #REF_DECEL_FPSS# &lt;= and (L:XMLVAR_Autobrakes_Level) #AUTOBRAKE_LEVEL# == and (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</EMISSIVE_CODE>
+            </UseTemplate>
+        </Component>
+        <Component ID="#NODE_ID_ON#" Node="#NODE_ID_ON#">
+            <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
+                <EMISSIVE_CODE>
+                (L:XMLVAR_Autobrakes_Level) #AUTOBRAKE_LEVEL# == (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or
+                </EMISSIVE_CODE>
+            </UseTemplate>
+        </Component>
+    </Template>
+
+
 </ModelBehaviors>

--- a/A32NX/ModelBehaviorDefs/A32NX/A32NX_Interior.xml
+++ b/A32NX/ModelBehaviorDefs/A32NX/A32NX_Interior.xml
@@ -525,5 +525,22 @@
         </Component>
     </Template>
 
+    <!--
+    Template for handling landing gear indications
+
+    Authors: Benjamin Dupont (@Benjozork) 10/10/20
+    -->
+    <Template Name="FBW_Airbus_LANDING_GEAR_Light_Template">
+        <DefaultTemplateParameters>
+            <NODE_ID>LANDING_GEAR_Light_#ID#</NODE_ID>
+            <PART_ID>LANDING_GEAR_Light</PART_ID>
+            <SIMVAR>GEAR POSITION:#GEAR_ID#</SIMVAR>
+        </DefaultTemplateParameters>
+        <UseTemplate Name="ASOBO_GT_Push_Button_Airliner">
+            <DUMMY_BUTTON>True</DUMMY_BUTTON>
+            <SEQ1_EMISSIVE_CODE>0.01 99.99 (A:#SIMVAR#, Percent) rng (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</SEQ1_EMISSIVE_CODE>
+            <SEQ2_EMISSIVE_CODE>90 100 (A:#SIMVAR#, Percent) rng (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</SEQ2_EMISSIVE_CODE>
+        </UseTemplate>
+    </Template>
 
 </ModelBehaviors>

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -64,9 +64,8 @@
                     </LEFT_SINGLE_CODE>
                 </UseTemplate>
 
-                <!-- In order to only run the updates once, create them for lowest brake level only -->
-                <Condition Check="AUTOBRAKE_LEVEL" Match="1">
-                    <True>
+                <Condition Check="AUTOBRAKE_LEVEL" Match="0">
+                    <False>
                         <UseTemplate Name="ASOBO_GT_Update">
                             <FREQUENCY>1</FREQUENCY>
                             <UPDATE_CODE>
@@ -86,7 +85,7 @@
                             }
                             </UPDATE_CODE>
                         </UseTemplate>
-                    </True>
+                    </False>
                 </Condition>
             </Component>
             <Component ID="#NODE_ID_DECEL#" Node="#NODE_ID_DECEL#">

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -32,76 +32,6 @@
             </UseTemplate>
         </Template>
 
-        <Template Name="A32NX_HANDLING_Push_Autobrakes_Template">
-            <DefaultTemplateParameters>
-                <AUTOBRAKE_LEVEL>1</AUTOBRAKE_LEVEL>
-                <WWISE_EVENT_1>autobrake_push_button_on</WWISE_EVENT_1>
-                <WWISE_EVENT_2>autobrake_push_button_off</WWISE_EVENT_2>
-                <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
-                <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
-                <TOOLTIPID>%((L:XMLVAR_RTO_Level) #AUTOBRAKE_LEVEL# ==)%{if}TT:COCKPIT.TOOLTIPS.AUTO_BRK_TURN_OFF%{else}TT:#OFF_TOOLTIP#%{end}</TOOLTIPID>
-                <ENGINES_COUNT>2</ENGINES_COUNT>
-                <REF_DECEL_FPSS>-7</REF_DECEL_FPSS>
-            </DefaultTemplateParameters>
-            <Component ID="#NODE_ID#" Node="#NODE_ID#">
-                <UseTemplate Name="ASOBO_GT_Push_Button">
-                    <LEFT_SINGLE_CODE>
-                    (A:ANTISKID BRAKES ACTIVE, Bool) ! (L:XMLVAR_Autobrakes_Level) #AUTOBRAKE_LEVEL# == or if{
-                        0 (&gt;L:XMLVAR_Autobrakes_Level)
-                    } els{
-                        #AUTOBRAKE_LEVEL# (&gt;L:XMLVAR_Autobrakes_Level)
-                    }
-
-                    (L:XMLVAR_Autobrakes_Level) 0 == if{
-                        1 (&gt;K:SET_AUTOBRAKE_CONTROL)
-                    } els{
-                        (A:SIM ON GROUND, Bool) if{
-                            0 (&gt;K:SET_AUTOBRAKE_CONTROL)
-                        } els{
-                            (L:XMLVAR_Autobrakes_Level) 1 + (&gt;K:SET_AUTOBRAKE_CONTROL)
-                        }
-                    }
-                    </LEFT_SINGLE_CODE>
-                </UseTemplate>
-
-                <Condition Check="AUTOBRAKE_LEVEL" Match="0">
-                    <False>
-                        <UseTemplate Name="ASOBO_GT_Update">
-                            <FREQUENCY>1</FREQUENCY>
-                            <UPDATE_CODE>
-                            (A:AUTO BRAKE SWITCH CB, Enum) s1 0 == if{
-                                (L:XMLVAR_Autobrakes_Level) 0 == if{
-                                    #AUTOBRAKE_LEVEL# (&gt;L:XMLVAR_Autobrakes_Level)
-                                }
-                            } els{
-                                l1 1 == if{
-                                    0 (&gt;L:XMLVAR_Autobrakes_Level)
-                                } els{
-                                    l1 1 - (&gt;L:XMLVAR_Autobrakes_Level)
-                                    (A:SIM ON GROUND, Bool) (A:GROUND VELOCITY, Knots) 10 &lt; and if{
-                                        0 (&gt;K:SET_AUTOBRAKE_CONTROL)
-                                    }
-                                }
-                            }
-                            </UPDATE_CODE>
-                        </UseTemplate>
-                    </False>
-                </Condition>
-            </Component>
-            <Component ID="#NODE_ID_DECEL#" Node="#NODE_ID_DECEL#">
-                <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
-                    <EMISSIVE_CODE>(A:AUTO BRAKE SWITCH CB, Enum) 1 != (A:ACCELERATION BODY Z, feet per second squared) #REF_DECEL_FPSS# &lt;= and (L:XMLVAR_Autobrakes_Level) #AUTOBRAKE_LEVEL# == and (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</EMISSIVE_CODE>
-                </UseTemplate>
-            </Component>
-            <Component ID="#NODE_ID_ON#" Node="#NODE_ID_ON#">
-                <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
-                    <EMISSIVE_CODE>
-                    (L:XMLVAR_Autobrakes_Level) #AUTOBRAKE_LEVEL# == (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or
-                    </EMISSIVE_CODE>
-                </UseTemplate>
-            </Component>
-        </Template>
-
         <!-- MCDU -->
 
         <Component ID="MCDU">
@@ -972,7 +902,7 @@
             <UseTemplate Name="ASOBO_LANDING_GEAR_Warning_Template">
                 <ANIM_NAME>DECAL_LANDING_INDICATOR</ANIM_NAME>
             </UseTemplate>
-            <UseTemplate Name="A32NX_HANDLING_Push_Autobrakes_Template">
+            <UseTemplate Name="FBW_Airbus_HANDLING_Push_Autobrakes_Template">
                 <NODE_ID>PUSH_AUTOBKR_LO</NODE_ID>
                 <PART_ID>Autobrake_1</PART_ID>
                 <ANIM_NAME>PUSH_AUTOBKR_LO</ANIM_NAME>
@@ -982,7 +912,7 @@
                 <MIN_DECEL_FPSS>-7</MIN_DECEL_FPSS>
                 <OFF_TOOLTIP>COCKPIT.TOOLTIPS.AUTO_BRK_SET_LO</OFF_TOOLTIP>
             </UseTemplate>
-            <UseTemplate Name="A32NX_HANDLING_Push_Autobrakes_Template">
+            <UseTemplate Name="FBW_Airbus_HANDLING_Push_Autobrakes_Template">
                 <NODE_ID>PUSH_AUTOBKR_MED</NODE_ID>
                 <PART_ID>Autobrake_2</PART_ID>
                 <ANIM_NAME>PUSH_AUTOBKR_MED</ANIM_NAME>
@@ -992,7 +922,7 @@
                 <MIN_DECEL_FPSS>-14</MIN_DECEL_FPSS>
                 <OFF_TOOLTIP>COCKPIT.TOOLTIPS.AUTO_BRK_SET_MED</OFF_TOOLTIP>
             </UseTemplate>
-            <UseTemplate Name="A32NX_HANDLING_Push_Autobrakes_Template">
+            <UseTemplate Name="FBW_Airbus_HANDLING_Push_Autobrakes_Template">
                 <NODE_ID>PUSH_AUTOBKR_MAX</NODE_ID>
                 <PART_ID>Autobrake_3</PART_ID>
                 <ANIM_NAME>PUSH_AUTOBKR_MAX</ANIM_NAME>

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -41,6 +41,7 @@
                 <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
                 <TOOLTIPID>%((L:XMLVAR_RTO_Level) #AUTOBRAKE_LEVEL# ==)%{if}TT:COCKPIT.TOOLTIPS.AUTO_BRK_TURN_OFF%{else}TT:#OFF_TOOLTIP#%{end}</TOOLTIPID>
                 <ENGINES_COUNT>2</ENGINES_COUNT>
+                <REF_DECEL_FPSS>-7</REF_DECEL_FPSS>
             </DefaultTemplateParameters>
             <Component ID="#NODE_ID#" Node="#NODE_ID#">
                 <UseTemplate Name="ASOBO_GT_Push_Button">
@@ -90,7 +91,7 @@
             </Component>
             <Component ID="#NODE_ID_DECEL#" Node="#NODE_ID_DECEL#">
                 <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
-                    <EMISSIVE_CODE>(A:AUTO BRAKE SWITCH CB, Enum) 1 != (A:ACCELERATION BODY Z, feet per second squared) #MIN_DECEL_FPSS# &lt;= and (L:XMLVAR_Autobrakes_Level) #AUTOBRAKE_LEVEL# == and (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>(A:AUTO BRAKE SWITCH CB, Enum) 1 != (A:ACCELERATION BODY Z, feet per second squared) #REF_DECEL_FPSS# &lt;= and (L:XMLVAR_Autobrakes_Level) #AUTOBRAKE_LEVEL# == and (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</EMISSIVE_CODE>
                 </UseTemplate>
             </Component>
             <Component ID="#NODE_ID_ON#" Node="#NODE_ID_ON#">

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -90,7 +90,7 @@
             </Component>
             <Component ID="#NODE_ID_DECEL#" Node="#NODE_ID_DECEL#">
                 <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
-                    <EMISSIVE_CODE>(A:AUTO BRAKE SWITCH CB, Enum) 1 != (A:ACCELERATION BODY Z, feet per second squared) #MIN_DECEL_FPSS# &lt;= and (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>(A:AUTO BRAKE SWITCH CB, Enum) 1 != (A:ACCELERATION BODY Z, feet per second squared) #MIN_DECEL_FPSS# &lt;= and (L:XMLVAR_Autobrakes_Level) #AUTOBRAKE_LEVEL# == and (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</EMISSIVE_CODE>
                 </UseTemplate>
             </Component>
             <Component ID="#NODE_ID_ON#" Node="#NODE_ID_ON#">

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -32,7 +32,7 @@
             </UseTemplate>
         </Template>
 
-        <Template Name="ASOBO_HANDLING_Push_Autobrakes_Template">
+        <Template Name="A32NX_HANDLING_Push_Autobrakes_Template">
             <DefaultTemplateParameters>
                 <AUTOBRAKE_LEVEL>1</AUTOBRAKE_LEVEL>
                 <WWISE_EVENT_1>autobrake_push_button_on</WWISE_EVENT_1>
@@ -972,7 +972,7 @@
             <UseTemplate Name="ASOBO_LANDING_GEAR_Warning_Template">
                 <ANIM_NAME>DECAL_LANDING_INDICATOR</ANIM_NAME>
             </UseTemplate>
-            <UseTemplate Name="ASOBO_HANDLING_Push_Autobrakes_Template">
+            <UseTemplate Name="A32NX_HANDLING_Push_Autobrakes_Template">
                 <NODE_ID>PUSH_AUTOBKR_LO</NODE_ID>
                 <PART_ID>Autobrake_1</PART_ID>
                 <ANIM_NAME>PUSH_AUTOBKR_LO</ANIM_NAME>
@@ -982,7 +982,7 @@
                 <MIN_DECEL_FPSS>-7</MIN_DECEL_FPSS>
                 <OFF_TOOLTIP>COCKPIT.TOOLTIPS.AUTO_BRK_SET_LO</OFF_TOOLTIP>
             </UseTemplate>
-            <UseTemplate Name="ASOBO_HANDLING_Push_Autobrakes_Template">
+            <UseTemplate Name="A32NX_HANDLING_Push_Autobrakes_Template">
                 <NODE_ID>PUSH_AUTOBKR_MED</NODE_ID>
                 <PART_ID>Autobrake_2</PART_ID>
                 <ANIM_NAME>PUSH_AUTOBKR_MED</ANIM_NAME>
@@ -992,7 +992,7 @@
                 <MIN_DECEL_FPSS>-14</MIN_DECEL_FPSS>
                 <OFF_TOOLTIP>COCKPIT.TOOLTIPS.AUTO_BRK_SET_MED</OFF_TOOLTIP>
             </UseTemplate>
-            <UseTemplate Name="ASOBO_HANDLING_Push_Autobrakes_Template">
+            <UseTemplate Name="A32NX_HANDLING_Push_Autobrakes_Template">
                 <NODE_ID>PUSH_AUTOBKR_MAX</NODE_ID>
                 <PART_ID>Autobrake_3</PART_ID>
                 <ANIM_NAME>PUSH_AUTOBKR_MAX</ANIM_NAME>

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -32,6 +32,76 @@
             </UseTemplate>
         </Template>
 
+        <Template Name="ASOBO_HANDLING_Push_Autobrakes_Template">
+            <DefaultTemplateParameters>
+                <AUTOBRAKE_LEVEL>1</AUTOBRAKE_LEVEL>
+                <WWISE_EVENT_1>autobrake_push_button_on</WWISE_EVENT_1>
+                <WWISE_EVENT_2>autobrake_push_button_off</WWISE_EVENT_2>
+                <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
+                <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
+                <TOOLTIPID>%((L:XMLVAR_RTO_Level) #AUTOBRAKE_LEVEL# ==)%{if}TT:COCKPIT.TOOLTIPS.AUTO_BRK_TURN_OFF%{else}TT:#OFF_TOOLTIP#%{end}</TOOLTIPID>
+                <ENGINES_COUNT>2</ENGINES_COUNT>
+            </DefaultTemplateParameters>
+            <Component ID="#NODE_ID#" Node="#NODE_ID#">
+                <UseTemplate Name="ASOBO_GT_Push_Button">
+                    <LEFT_SINGLE_CODE>
+                    (A:ANTISKID BRAKES ACTIVE, Bool) ! (L:XMLVAR_Autobrakes_Level) #AUTOBRAKE_LEVEL# == or if{
+                        0 (&gt;L:XMLVAR_Autobrakes_Level)
+                    } els{
+                        #AUTOBRAKE_LEVEL# (&gt;L:XMLVAR_Autobrakes_Level)
+                    }
+
+                    (L:XMLVAR_Autobrakes_Level) 0 == if{
+                        1 (&gt;K:SET_AUTOBRAKE_CONTROL)
+                    } els{
+                        (A:SIM ON GROUND, Bool) if{
+                            0 (&gt;K:SET_AUTOBRAKE_CONTROL)
+                        } els{
+                            (L:XMLVAR_Autobrakes_Level) 1 + (&gt;K:SET_AUTOBRAKE_CONTROL)
+                        }
+                    }
+                    </LEFT_SINGLE_CODE>
+                </UseTemplate>
+
+                <!-- In order to only run the updates once, create them for lowest brake level only -->
+                <Condition Check="AUTOBRAKE_LEVEL" Match="1">
+                    <True>
+                        <UseTemplate Name="ASOBO_GT_Update">
+                            <FREQUENCY>1</FREQUENCY>
+                            <UPDATE_CODE>
+                            (A:AUTO BRAKE SWITCH CB, Enum) s1 0 == if{
+                                (L:XMLVAR_Autobrakes_Level) 0 == if{
+                                    #AUTOBRAKE_LEVEL# (&gt;L:XMLVAR_Autobrakes_Level)
+                                }
+                            } els{
+                                l1 1 == if{
+                                    0 (&gt;L:XMLVAR_Autobrakes_Level)
+                                } els{
+                                    l1 1 - (&gt;L:XMLVAR_Autobrakes_Level)
+                                    (A:SIM ON GROUND, Bool) (A:GROUND VELOCITY, Knots) 10 &lt; and if{
+                                        0 (&gt;K:SET_AUTOBRAKE_CONTROL)
+                                    }
+                                }
+                            }
+                            </UPDATE_CODE>
+                        </UseTemplate>
+                    </True>
+                </Condition>
+            </Component>
+            <Component ID="#NODE_ID_DECEL#" Node="#NODE_ID_DECEL#">
+                <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
+                    <EMISSIVE_CODE>(A:AUTO BRAKE SWITCH CB, Enum) 1 != (A:ACCELERATION BODY Z, feet per second squared) #MIN_DECEL_FPSS# &lt;= and (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</EMISSIVE_CODE>
+                </UseTemplate>
+            </Component>
+            <Component ID="#NODE_ID_ON#" Node="#NODE_ID_ON#">
+                <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
+                    <EMISSIVE_CODE>
+                    (L:XMLVAR_Autobrakes_Level) #AUTOBRAKE_LEVEL# == (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or
+                    </EMISSIVE_CODE>
+                </UseTemplate>
+            </Component>
+        </Template>
+
         <!-- MCDU -->
 
         <Component ID="MCDU">

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -19,19 +19,6 @@
         <Include ModelBehaviorFile="Asobo\Airliner\GlassCockpit.xml"/>
         <Include ModelBehaviorFile="Asobo\Airliner\Airbus.xml"/>
 
-        <Template Name="A32NX_LANDING_GEAR_Light_Template">
-            <DefaultTemplateParameters>
-                <NODE_ID>LANDING_GEAR_Light_#ID#</NODE_ID>
-                <PART_ID>LANDING_GEAR_Light</PART_ID>
-                <SIMVAR>GEAR POSITION:#GEAR_ID#</SIMVAR>
-            </DefaultTemplateParameters>
-            <UseTemplate Name="ASOBO_GT_Push_Button_Airliner">
-                <DUMMY_BUTTON>True</DUMMY_BUTTON>
-                <SEQ1_EMISSIVE_CODE>0.01 99.99 (A:#SIMVAR#, Percent) rng (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</SEQ1_EMISSIVE_CODE>
-                <SEQ2_EMISSIVE_CODE>90 100 (A:#SIMVAR#, Percent) rng (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</SEQ2_EMISSIVE_CODE>
-            </UseTemplate>
-        </Template>
-
         <!-- MCDU -->
 
         <Component ID="MCDU">
@@ -884,17 +871,17 @@
                 <ANIM_NAME>lever_landing_gear</ANIM_NAME>
                 <NODE_ID>LEVER_LANDINGGEAR</NODE_ID>
             </UseTemplate>
-            <UseTemplate Name="A32NX_LANDING_GEAR_Light_Template">
+            <UseTemplate Name="FBW_Airbus_LANDING_GEAR_Light_Template">
                 <NODE_ID>PUSH_AUTOBKR_LDGGEAR_1</NODE_ID>
                 <ID>1</ID>
                 <GEAR_ID>1</GEAR_ID>
             </UseTemplate>
-            <UseTemplate Name="A32NX_LANDING_GEAR_Light_Template">
+            <UseTemplate Name="FBW_Airbus_LANDING_GEAR_Light_Template">
                 <NODE_ID>PUSH_AUTOBKR_LDGGEAR_2</NODE_ID>
                 <ID>2</ID>
                 <GEAR_ID>0</GEAR_ID>
             </UseTemplate>
-            <UseTemplate Name="A32NX_LANDING_GEAR_Light_Template">
+            <UseTemplate Name="FBW_Airbus_LANDING_GEAR_Light_Template">
                 <NODE_ID>PUSH_AUTOBKR_LDGGEAR_3</NODE_ID>
                 <ID>3</ID>
                 <GEAR_ID>2</GEAR_ID>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #596

## Summary of Changes
Ensures the right DECEL light comes up during autobrake usage

## Screenshots (if necessary)
Before
![before](https://user-images.githubusercontent.com/248585/96372036-401ddc80-1165-11eb-901c-7f06ac5ee82f.jpg)

After
![after](https://user-images.githubusercontent.com/248585/96372042-4744ea80-1165-11eb-89a4-55df0137af86.jpg)

## References
Lots of mentions by 320 sim pilot, for example
https://youtu.be/32q0xHybKmA?t=1440
"Decel light should show up medium 'cause that's what we use"

## Additional context
Discord username (if different from GitHub): Jokey | Markus#0001

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
