### PR TITLE
Fix FD in Taxi Checklist (fixes #1403)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -86,6 +86,7 @@
 1. [CAMERA] Modified a couple of the default interior camera angles. - @ZigTag (Falcon#5815), @linkeleven (linkeleven#2557)
 1. [CDU] Add correct UI behavior and colors for airways page - @santii90 (Santiago Vazquez)
 1. [CDU] Add ability to clear MDA/DH and add input logic for both MDA/DH - @paul92ilm (Lussion)
+1. [CHECKLISTS] Fix FD check in Taxi checklist - @Acrobot (Andrzej Pomirski)
 
 ## 2020/09
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)
@@ -99,3 +100,4 @@
 1. [ND] Add DME distances, VOR/ADF needles and functioning ADF2 - @blitzcaster (bltzcstr)
 1. [OVHD] Fixed Battery Indicator Colour - @nathaninnes (Nathan Innes)
 1. [MISC] Removed Fuel Patch from MSFS Update 1.8.3 - @nathaninnes (Nathan Innes)
+1. 

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/Checklist/Library.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/Checklist/Library.xml
@@ -905,10 +905,7 @@
          <CheckpointDesc SubjectTT="TT:Flight Director" ExpectationTT="TT:ON" />
          <Test>
             <TestValue>
-               <Operator OpType="EQUAL">
-                  <Val SimVarName="AUTOPILOT FLIGHT DIRECTOR ACTIVE" Units="Boolean"/>
-                  <Val Value="0"/>
-               </Operator>
+               <Val SimVarName="AUTOPILOT FLIGHT DIRECTOR ACTIVE:1" Units="Boolean"/>
             </TestValue>
             <Action Copilot="True" Condition="TestValueFalse" Once="true" EventID="TOGGLE_FLIGHT_DIRECTOR"/>
             <Instrument Id="AUTOPILOT_PUSH_FLIGHTDIRECTOR"/>


### PR DESCRIPTION
The current condition checks whether FD is turned OFF, instead of ON.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #1403

## Summary of Changes
The current condition in the checklist checks whether FD is turned OFF, instead of ON.

## Screenshots (if necessary)
n/a

## References
n/a

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
n/a

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): acro#2421

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
