### PR TITLE
[Fix] Remove glow from tiller

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -713,13 +713,16 @@
                 <MAX_STEERING_VELOCITY>30</MAX_STEERING_VELOCITY>
             </UseTemplate>
 
+
             <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
                 <NODE_ID>PUSH_HANDLE_LEFT_YOKE</NODE_ID>
-                <POTENTIOMETER>85</POTENTIOMETER>
+                <!--<POTENTIOMETER>85</POTENTIOMETER>-->
+                <EMISSIVE_CODE>0</EMISSIVE_CODE>
             </UseTemplate>
             <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
                 <NODE_ID>PUSH_HANDLE_RIGHT_YOKE</NODE_ID>
-                <POTENTIOMETER>85</POTENTIOMETER>
+                <!--<POTENTIOMETER>85</POTENTIOMETER>-->
+                <EMISSIVE_CODE>0</EMISSIVE_CODE>
             </UseTemplate>
 
             <!-- NYI


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #1350

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* Removes the glow from the steering tillers.
* This also removes the text integrated lighting, since the button model and text are in the same mesh. I don't know if the text should have integrated lighting anyways, so it would be nice if someone could comment on that.



<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
