### PR TITLE
fix: improve FUEL page styling

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.css
@@ -1,7 +1,7 @@
 @import url("/CSS/A32NX_Display_Common.css");
 
 :root {
-    --bodyHeightScale: 1;
+  --bodyHeightScale: 1;
 }
 
 
@@ -10,6 +10,7 @@
     visibility: visible;
   }
 }
+
 @keyframes TemporaryHide {
   0%, 100% {
     visibility: hidden;
@@ -23,14 +24,16 @@
   width: 100%;
   z-index: 10;
 }
+
 #Electricity {
   width: 100%;
   height: 100%;
 }
+
 #Electricity[state=off] {
   display: none;
 }
-  
+
 a320-neo-lower-ecam-fuel {
   display: block;
   position: absolute;
@@ -40,70 +43,90 @@ a320-neo-lower-ecam-fuel {
   width: 100%;
   height: 100%;
 }
-a320-neo-lower-ecam-fuel .MainShape {
+
+.MainShape {
   fill: transparent;
   stroke: var(--displayLightGrey);
-  stroke-width: 5;
-}
-a320-neo-lower-ecam-fuel .FlowShape {
-  fill: rgba(13,20,35,1);
-  stroke: var(--displayGreen);
   stroke-width: 3;
 }
-a320-neo-lower-ecam-fuel .ValvePumpActive {
-  fill: rgba(13,20,35,1);
+
+.FlowShape {
+  fill: rgba(13, 20, 35, 1);
   stroke: var(--displayGreen);
-  stroke-width: 3;
+  stroke-width: 2;
 }
-a320-neo-lower-ecam-fuel .ValvePumpInactive {
-  fill: rgba(13,20,35,1);
+
+.ValvePumpActive {
+  fill: rgba(13, 20, 35, 1);
+  stroke: var(--displayGreen);
+  stroke-width: 2;
+}
+
+.ValvePumpInactive {
+  fill: rgba(13, 20, 35, 1);
   stroke: var(--displayAmber);
-  stroke-width: 3;
+  stroke-width: 2;
 }
 
-
-a320-neo-lower-ecam-fuel text {
+text {
   font-size: 20px;
 }
-a320-neo-lower-ecam-fuel text.Title {
+
+text.Title {
   fill: var(--displayWhite);
 }
-a320-neo-lower-ecam-fuel text.Value {
+
+text.Value {
   fill: var(--displayGreen);
 }
-a320-neo-lower-ecam-fuel text.Unit {
+
+text.Unit {
   fill: var(--displayCyan);
 }
-a320-neo-lower-ecam-fuel text.Large {
+
+text.Tiny {
+  font-size: 15px !important;
+}
+
+text.XSmall {
+  font-size: 17px !important;
+}
+
+text.Small {
+  font-size: 20px !important;
+}
+
+text.Large {
   font-weight: bold;
-  font-size: 22px;
-}
-a320-neo-lower-ecam-fuel text.XLarge {
-  font-size: 25px;
-}
-a320-neo-lower-ecam-fuel text.Small {
-  font-size: 20px;
+  font-size: 22px !important;
 }
 
+text.XLarge {
+  font-size: 25px !important;
+}
 
-a320-neo-lower-ecam-fuel #APU text {
+#APU text {
   font-size: 20px;
   fill: var(--displayWhite);
   stroke-width: 0;
 }
-a320-neo-lower-ecam-fuel #APU path {
+
+#APU path {
   stroke-width: 3;
 }
-a320-neo-lower-ecam-fuel #APU.active {
+
+#APU.active {
   stroke: var(--displayGreen);
 }
-a320-neo-lower-ecam-fuel #APU.active text {
+
+#APU.active text {
   fill: var(--displayGreen) !important;
 }
-a320-neo-lower-ecam-fuel #APU.warning {
+
+#APU.warning {
   stroke: var(--displayWarning);
 }
-a320-neo-lower-ecam-fuel #APU.inactive {
+
+#APU.inactive {
   stroke: var(--displayWhite);
 }
-  

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.html
@@ -125,18 +125,21 @@
 
 
         <g id="FuelFlow">
-            <text id="ffTitleTop" class="Title Small" x="20" y="445" text-anchor="start">F.FLOW</text>
-            <text id="ffTitleBottom" class="Title Small" x="35" y="465" text-anchor="start">1+2</text>
-            <text id="ffSeparator" class="Title Small" x="90" y="465">:</text>
-            <text id="ffValue" class="Value Small" x="205" y="465" text-anchor="end">56</text>
-            <text id="ffUnit" class="Unit Small" x="215" y="465" text-anchor="start">KG/MIN</text>
+            <text id="ffTitleTop" class="Title XSmall" x="22" y="447" text-anchor="start">F.FLOW</text>
+            <text id="ffTitleBottom" class="Title XSmall" x="39" y="465" text-anchor="start">1+2</text>
+            <text id="ffSeparator" class="Title XSmall" x="91" y="465">:</text>
+
+            <text id="ffValue" class="Value Tiny" x="205" y="465" text-anchor="end">56</text>
+            <text id="ffUnit" class="Unit Tiny" x="217" y="465" text-anchor="start">KG/MIN</text>
         </g>
 
         <g id="fob">
-            <text id="fobTitle" class="Title Large" x="24" y="496" text-anchor="start">FOB</text>
-            <text id="fobSeparator" class="Title Large" x="90" y="495">:</text>
-            <text id="fobValue" class="Value" x="205" y="495" font-size="20" text-anchor="end">1000</text>
-            <text id="fobUnit" class="Unit" x="215" y="495" font-size="18" text-anchor="start">KG</text>
+            <text id="fobTitle" class="Title Small" x="22" y="497" text-anchor="start">FOB</text>
+            <text id="fobSeparator" class="Title Small" x="90" y="497">:</text>
+
+            <text id="fobValue" class="Value Small" x="205" y="497" text-anchor="end">1000</text>
+            <text id="fobUnit" class="Unit Tiny" x="217" y="497" text-anchor="start">KG</text>
+
             <rect id="fobBorder" class="MainShape" x="12" y="475" width="245" height="30" />
         </g>
 
@@ -144,22 +147,25 @@
         <g id="texts">
             <text id="pageTitle" class="Title XLarge" x="42" y="24" text-anchor="middle" alignment-baseline="central" text-decoration="underline">FUEL</text>
 
-            <text id="middleTitle1" class="Title Small" x="300" y="20" text-anchor="middle" alignment-baseline="central">F.USED</text>
-            <text id="middleTitle2" class="Title Small" x="300" y="40" text-anchor="middle" alignment-baseline="central">1+2</text>
-            <text id="middleFuelValue" class="Value XLarge" x="300" y="60" text-anchor="middle" alignment-baseline="central">1400</text>
-            <text id="middleFuelUnit" class="Unit Large" x="300" y="80" text-anchor="middle" alignment-baseline="central">KG</text>
+            <!-- F.USED -->
+            <text id="middleTitle1" class="Title XSmall" x="300" y="18" text-anchor="middle" alignment-baseline="central">F.USED</text>
+            <text id="middleTitle2" class="Title XSmall" x="300" y="35" text-anchor="middle" alignment-baseline="central">1+2</text>
+            <text id="middleFuelValue" class="Value Small" x="300" y="55" text-anchor="middle" alignment-baseline="central">1400</text>
+            <text id="middleFuelUnit" class="Unit XSmall" x="300" y="82" text-anchor="middle" alignment-baseline="central">KG</text>
 
+            <!-- Used fuel engine number -->
             <text id="rightValveId" class="Title XLarge" x="160" y="38" text-anchor="middle">1</text>
             <text id="leftValveId" class="Title XLarge" x="440" y="38" text-anchor="middle">2</text>
 
-            <text id="leftValveValue" class="Value XLarge" x="160" y="62" text-anchor="middle">700</text>
-            <text id="rightValveValue" class="Value XLarge" x="440" y="62" text-anchor="middle">700</text>
+            <!-- Used fuel -->
+            <text id="leftValveValue" class="Value Large" x="160" y="61" text-anchor="middle">700</text>
+            <text id="rightValveValue" class="Value Large" x="440" y="61" text-anchor="middle">700</text>
 
-            <text id="leftOuterTankValue" class="Value XLarge" x="73" y="280" text-anchor="end" alignment-baseline="central">100</text>
-            <text id="leftInnerTankValue" class="Value XLarge" x="190" y="280" text-anchor="end" alignment-baseline="central">200</text>
-            <text id="centerTankValue" class="Value XLarge" x="332" y="305" text-anchor="end" alignment-baseline="central">300</text>
-            <text id="rightInnerTankValue" class="Value XLarge" x="470" y="280" text-anchor="end" alignment-baseline="central">400</text>
-            <text id="rightOuterTankValue" class="Value XLarge" x="578" y="280" text-anchor="end" alignment-baseline="central">500</text>
+            <text id="leftOuterTankValue" class="Value Large" x="73" y="280" text-anchor="end" alignment-baseline="central">100</text>
+            <text id="leftInnerTankValue" class="Value Large" x="182" y="280" text-anchor="end" alignment-baseline="central">200</text>
+            <text id="centerTankValue" class="Value Large" x="332" y="305" text-anchor="end" alignment-baseline="central">300</text>
+            <text id="rightInnerTankValue" class="Value Large" x="478" y="280" text-anchor="end" alignment-baseline="central">400</text>
+            <text id="rightOuterTankValue" class="Value Large" x="578" y="280" text-anchor="end" alignment-baseline="central">500</text>
         </g>
     </svg>
 </script>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.js
@@ -154,6 +154,7 @@ var A320_Neo_LowerECAM_Fuel;
                 this.fuelFlowUnit.textContent = "LBS/MIN";
                 this.middleFuelUnit.textContent = "LBS";
             }
+
             this.setAPUState(SimVar.GetSimVarValue("FUELSYSTEM VALVE SWITCH:8", "Bool"), SimVar.GetSimVarValue("FUELSYSTEM VALVE OPEN:8", "Bool"));
         }
         onEvent(_event) {


### PR DESCRIPTION
## Summary of Changes

- Imprroved FUEL page styling to more closely match IRL

## Screenshots (if necessary)

Before:
![image](https://user-images.githubusercontent.com/4503241/97114792-0438c900-16c9-11eb-863d-e6e8d812adf3.png)

After:
![image](https://user-images.githubusercontent.com/4503241/97114845-495cfb00-16c9-11eb-9249-8df919d2c449.png)

## References

https://www.youtube.com/watch?v=5r0HsCmV4vU&list=PLizmZUECr7f2sL0c6nruV60MWcqFp_vaw&index=17

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): someperson#4953

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
