### PR TITLE
fix: improve lower ECAM styling

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/EICAS_Common.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/EICAS_Common.css
@@ -40,8 +40,8 @@ eicas-common-display {
     height: 25%;
 }
 eicas-common-display line {
-    stroke: var(--displayGrey) !important;
-    stroke-width: 6;
+    stroke: var(--displayWhite) !important;
+    stroke-width: 3;
 }
 eicas-common-display text {
     font-size: 20px;
@@ -55,5 +55,8 @@ eicas-common-display text.Value {
 }
 eicas-common-display text.Unit {
     fill: var(--displayCyan) !important;
+}
+eicas-common-display text.Small {
+  font-size: 18px !important;
 }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/EICAS_Common.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/EICAS_Common.html
@@ -11,27 +11,28 @@
         </g>
 
         <g id="TAT">
-            <text class="Title" x="74" y="70" text-anchor="end">TAT</text>
-            <text id="TATValue" x="112" y="70" text-anchor="middle">--</text>
-            <text class="Unit" x="150" y="70" text-anchor="start">&#176;C</text>
+            <text class="Title" x="74" y="63" text-anchor="end">TAT</text>
+            <text id="TATValue" x="112" y="63" text-anchor="middle">--</text>
+            <text class="Unit" x="150" y="62" text-anchor="start">&#176;C</text>
         </g>
 
         <g id="SAT">
-            <text class="Title" x="74" y="95" text-anchor="end">SAT</text>
-            <text id="SATValue" x="112" y="95" text-anchor="middle">--</text>
-            <text class="Unit" x="150" y="95" text-anchor="start">&#176;C</text>
+            <text class="Title" x="74" y="87" text-anchor="end">SAT</text>
+            <text id="SATValue" x="112" y="87" text-anchor="middle">--</text>
+            <text class="Unit" x="150" y="87" text-anchor="start">&#176;C</text>
         </g>
 
         <g id="Clock">
-            <text id="HoursValue" class="Value" x="280" y="90" text-anchor="end">--</text>
-            <text class="Unit" x="300" y="90" text-anchor="middle">H</text>
-            <text id="MinutesValue" class="Value" x="320" y="90" text-anchor="start">--</text>
+            <text id="HoursValue" class="Value" x="287" y="87" text-anchor="end">--</text>
+            <text class="Unit" x="300" y="87" text-anchor="middle">H</text>
+            <text id="MinutesValue" class="Value Small" x="317" y="87" text-anchor="start">--</text>
         </g>
 
         <g id="GW">
-            <text class="Title" x="438" y="70" text-anchor="end">GW</text>
-            <text id="GWValue" class="Value" x="495" y="70" text-anchor="middle">--</text>
-            <text id="GWUnit" class="Unit" x="545" y="70" text-anchor="start">KG</text>
+            <text class="Title" x="445" y="63" text-anchor="end">GW</text>
+
+            <text id="GWValue" class="Value" x="542" y="63" text-anchor="end">--</text>
+            <text id="GWUnit" class="Unit" x="562" y="61" text-anchor="start">KG</text>
         </g>
     </svg>
 </script>


### PR DESCRIPTION
## Summary of Changes

- Match indicators and lines to be closer to IRL

## Screenshots (if necessary)

Before:
![image](https://user-images.githubusercontent.com/4503241/97229231-67505b80-17ae-11eb-8202-21ca5a41f2a2.png)

After:
![image](https://user-images.githubusercontent.com/4503241/97229183-556eb880-17ae-11eb-9106-3106af95cd8f.png)

## References

https://www.youtube.com/watch?v=VUjfYWNijA8

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): someperson#4953

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
