### PR TITLE
refactor: clean up ADIRS knob/light templates

### DIFF
--- a/A32NX/ModelBehaviorDefs/A32NX/A32NX_Interior_Generics.xml
+++ b/A32NX/ModelBehaviorDefs/A32NX/A32NX_Interior_Generics.xml
@@ -129,7 +129,7 @@
     <!--
     Template for rigging uncovered push buttons
 
-    Takes into account the value of L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position.
+    Takes into account the value of L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position, for the annotated light test.
 
     Main Parameters:
             - NODE_ID               <no default>    Switch node ID   (anim name will be same)
@@ -141,7 +141,8 @@
             - DISABLE_SEQ1          Not present     If present, the SEQ1 emissive is disabled
             - DISABLE_SEQ2          Not present     If present, the SEQ2 emissive is disabled
             - DUMMY_BUTTON          Not present     If true, the button will be a dummy button (not pressable, only emissive)
-    Authors: Benjamin Dupont (@Benjozork) 12/10/20
+
+    Authors: Benjamin Dupont (@Benjozork), lukecologne 12/10/20
     -->
     <Template Name="FBW_Push_Toggle">
         <UseTemplate Name="ASOBO_GT_Push_Button_Airliner">

--- a/A32NX/ModelBehaviorDefs/A32NX/Interior/A32NX_Interior_ADIRS.xml
+++ b/A32NX/ModelBehaviorDefs/A32NX/Interior/A32NX_Interior_ADIRS.xml
@@ -1,0 +1,58 @@
+<ModelBehaviors>
+
+    <!--
+    Template for rigging ADIRS knobs.
+
+    Main parameters:
+            - ID        <no default>    ADIRS knob #
+    -->
+    <Template Name="FBW_Airbus_ADIRS_Knob">
+        <DefaultTemplateParameters>
+            <PART_ID>ADIRS_Knob</PART_ID>
+
+            <NODE_ID>KNOB_OVHD_ADIRS_#ID#</NODE_ID>
+            <ANIM_NAME>KNOB_OVHD_ADIRS_#ID#</ANIM_NAME>
+            <WWISE_EVENT>autopilot_knob</WWISE_EVENT>
+            <WWISE_EVENT_1>autopilot_knob_push_button_on</WWISE_EVENT_1>
+            <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
+            <WWISE_EVENT_2>autopilot_knob_push_button_off</WWISE_EVENT_2>
+            <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
+
+            <KNOB_NUM_STATE>3</KNOB_NUM_STATE>
+            <KNOB_POSITION_TYPE>L</KNOB_POSITION_TYPE>
+            <KNOB_POSITION_VAR>A320_Neo_ADIRS_KNOB_#ID#</KNOB_POSITION_VAR>
+            <ANIMCURSOR_MAX>1</ANIMCURSOR_MAX>
+        </DefaultTemplateParameters>
+
+        <Component ID="#NODE_ID#" Node="#NODE_ID#">
+            <UseTemplate Name="ASOBO_GT_Switch_#KNOB_NUM_STATE#States">
+                <SWITCH_DIRECTION>Horizontal</SWITCH_DIRECTION>
+                <ARROW_TYPE>Curved</ARROW_TYPE>
+                <SWITCH_POSITION_TYPE>#KNOB_POSITION_TYPE#</SWITCH_POSITION_TYPE>
+                <SWITCH_POSITION_VAR>#KNOB_POSITION_VAR#</SWITCH_POSITION_VAR>
+            </UseTemplate>
+        </Component>
+    </Template>
+
+    <!--
+    Template for rigging ADIRS lights.
+
+    Main parameters:
+            - ID        <no default>    ADIRS light #
+    -->
+    <Template Name="FBW_Airbus_ADIRS_Light">
+        <DefaultTemplateParameters>
+            <NODE_ID>PUSH_OVHD_ADIRS_IR#ID#</NODE_ID>
+        </DefaultTemplateParameters>
+
+        <!-- Dummy button, using the FAULT variable -->
+        <UseTemplate Name="FBW_Push_Toggle">
+            <TOGGLE_SIMVAR>L:A320_Neo_ADIRS_ALIGN_LIGHT_#ID#</TOGGLE_SIMVAR>
+
+            <SEQ1_CODE>(L:A32NX_ADIRS_#ID#_FAULT, Bool)</SEQ1_CODE>
+
+            <DUMMY_BUTTON/>
+        </UseTemplate>
+    </Template>
+
+</ModelBehaviors>

--- a/A32NX/ModelBehaviorDefs/A32NX/Interior/A32NX_Interior_Includes.xml
+++ b/A32NX/ModelBehaviorDefs/A32NX/Interior/A32NX_Interior_Includes.xml
@@ -1,5 +1,6 @@
 <ModelBehaviors>
-    <Include RelativeFile="A32NX_Interior_Misc.xml"/>
+    <Include RelativeFile="A32NX_Interior_ADIRS.xml"/>
     <Include RelativeFile="A32NX_Interior_Elec.xml"/>
     <Include RelativeFile="A32NX_Interior_Fire.xml"/>
+    <Include RelativeFile="A32NX_Interior_Misc.xml"/>
 </ModelBehaviors>

--- a/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
+++ b/A32NX/ModelBehaviorDefs/Asobo/Airliner/Airbus.xml
@@ -1177,41 +1177,6 @@
 		</Component>
 	</Template>
 
-	<Template Name="ASOBO_AIRLINER_ADIRS_Knob_Template">
-		<DefaultTemplateParameters>
-			<PART_ID>ADIRS_Knob</PART_ID>
-			<ID>1</ID>
-		</DefaultTemplateParameters>
-
-		<UseTemplate Name="ASOBO_AIRLINER_ADIRS_Knob_SubTemplate">
-		</UseTemplate>
-	</Template>
-	<Template Name="ASOBO_AIRLINER_ADIRS_Knob_SubTemplate">
-		<DefaultTemplateParameters>
-			<NODE_ID>KNOB_OVHD_ADIRS_#ID#</NODE_ID>
-			<ANIM_NAME>KNOB_OVHD_ADIRS_#ID#</ANIM_NAME>
-			<WWISE_EVENT>autopilot_knob</WWISE_EVENT>
-			<WWISE_EVENT_1>autopilot_knob_push_button_on</WWISE_EVENT_1>
-			<NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
-			<WWISE_EVENT_2>autopilot_knob_push_button_off</WWISE_EVENT_2>
-			<NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
-
-			<KNOB_NUM_STATE>3</KNOB_NUM_STATE>
-			<KNOB_POSITION_TYPE>L</KNOB_POSITION_TYPE>
-			<KNOB_POSITION_VAR>A320_Neo_ADIRS_KNOB_#ID#</KNOB_POSITION_VAR>
-			<ANIMCURSOR_MAX>1</ANIMCURSOR_MAX>
-		</DefaultTemplateParameters>
-
-		<Component ID="#NODE_ID#" Node="#NODE_ID#">
-			<UseTemplate Name="ASOBO_GT_Switch_#KNOB_NUM_STATE#States">
-				<SWITCH_DIRECTION>Horizontal</SWITCH_DIRECTION>
-				<ARROW_TYPE>Curved</ARROW_TYPE>
-				<SWITCH_POSITION_TYPE>#KNOB_POSITION_TYPE#</SWITCH_POSITION_TYPE>
-				<SWITCH_POSITION_VAR>#KNOB_POSITION_VAR#</SWITCH_POSITION_VAR>
-			</UseTemplate>
-		</Component>
-	</Template>
-
 	<Template Name = "ASOBO_AIRBUS_Chronometer_Button">
 		<DefaultTemplateParameters>
 			<HELPID/>
@@ -1223,20 +1188,6 @@
 		<UseTemplate Name="ASOBO_AIRLINER_SubNodes_Setter_Template">
 			<TEMPLATE_TO_CALL>ASOBO_GT_Push_Button_Airliner</TEMPLATE_TO_CALL>
 			<LEFT_SINGLE_CODE>(L:#NODE_ID#) ! (>L:#NODE_ID#)</LEFT_SINGLE_CODE>
-		</UseTemplate>
-	</Template>
-
-	<Template Name="ASOBO_AIRLINER_ADIRS_LIGHT_Template">
-		<DefaultTemplateParameters>
-			<ID>1</ID>
-		</DefaultTemplateParameters>
-		<UseTemplate Name="ASOBO_AIRLINER_ADIRS_LIGHT_SubTemplate"></UseTemplate>
-	</Template>
-
-	<Template Name="ASOBO_AIRLINER_ADIRS_LIGHT_SubTemplate">
-		<UseTemplate Name="ASOBO_GT_Push_Button_Airliner">
-			<SEQ1_EMISSIVE_CODE>(L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 ==</SEQ1_EMISSIVE_CODE>
-			<SEQ2_EMISSIVE_CODE>(L:A320_Neo_ADIRS_ALIGN_LIGHT_#ID#, Bool) (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or</SEQ2_EMISSIVE_CODE>
 		</UseTemplate>
 	</Template>
 

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -1701,32 +1701,32 @@
                         <NODE_ID>PUSH_DOORPANEL_VIDEO</NODE_ID>
                         <HOLD_SIMVAR>L:PUSH_DOORPANEL_VIDEO</HOLD_SIMVAR>
                     </UseTemplate>
-                    <UseTemplate Name="ASOBO_AIRLINER_ADIRS_LIGHT_Template">
+
+                    <!-- ADIRS -->
+
+                    <UseTemplate Name="FBW_Airbus_ADIRS_Light">
                         <ID>1</ID>
-                        <NODE_ID>PUSH_OVHD_ADIRS_IR1</NODE_ID>
                     </UseTemplate>
-                    <UseTemplate Name="ASOBO_AIRLINER_ADIRS_LIGHT_Template">
+                    <UseTemplate Name="FBW_Airbus_ADIRS_Light">
                         <ID>2</ID>
-                        <NODE_ID>PUSH_OVHD_ADIRS_IR2</NODE_ID>
                     </UseTemplate>
-                    <UseTemplate Name="ASOBO_AIRLINER_ADIRS_LIGHT_Template">
+                    <UseTemplate Name="FBW_Airbus_ADIRS_Light">
                         <ID>3</ID>
-                        <NODE_ID>PUSH_OVHD_ADIRS_IR3</NODE_ID>
                     </UseTemplate>
 
-                    <UseTemplate Name="ASOBO_AIRLINER_ADIRS_Knob_Template">
+                    <UseTemplate Name="FBW_Airbus_ADIRS_Knob">
                         <ID>1</ID>
                         <ANIM_CODE>50</ANIM_CODE>
                         <NODE_ID>KNOB_OVHD_ADIRS_1</NODE_ID>
                         <ANIM_NAME>KNOB_OVHD_ADIRS_1</ANIM_NAME>
                     </UseTemplate>
-                    <UseTemplate Name="ASOBO_AIRLINER_ADIRS_Knob_Template">
+                    <UseTemplate Name="FBW_Airbus_ADIRS_Knob">
                         <ID>2</ID>
                         <ANIM_CODE>50</ANIM_CODE>
                         <NODE_ID>KNOB_OVHD_ADIRS_2</NODE_ID>
                         <ANIM_NAME>KNOB_OVHD_ADIRS_2</ANIM_NAME>
                     </UseTemplate>
-                    <UseTemplate Name="ASOBO_AIRLINER_ADIRS_Knob_Template">
+                    <UseTemplate Name="FBW_Airbus_ADIRS_Knob">
                         <ID>3</ID>
                         <ANIM_CODE>50</ANIM_CODE>
                         <NODE_ID>KNOB_OVHD_ADIRS_3</NODE_ID>

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -14,6 +14,18 @@
     - Holds the start time in seconds that the ADIRS TIMER will count down from
     - Used to have certain things turn on based on a percentage of the total alignment time
     
+- A32NX_ADIRS_1_FAULT
+    - Bool
+    - Whether the "FAULT" indication is shown on the OVHD ADIRS panel for ADIRS 1
+
+- A32NX_ADIRS_2_FAULT
+    - Bool
+    - Whether the "FAULT" indication is shown on the OVHD ADIRS panel for ADIRS 2
+
+- A32NX_ADIRS_3_FAULT
+    - Bool
+    - Whether the "FAULT" indication is shown on the OVHD ADIRS panel for ADIRS 3
+    
 - A32NX_BRAKE_TEMPERATURE_{1,2,3,4}
     - celsius
     - represents the brake temperature of the rear wheels


### PR DESCRIPTION
## Summary of Changes

* Clean-up of ADIRS ModelBehaviors (knob + light templates)
* Added functionality to "FAULT" indication (simvar `L:A32NX_ADIRS_X_FAULT`)
* Needed for #1355

Discord username (if different from GitHub): someperson#4953

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
