### PR TITLE
[MCDU] Changing cost index to a 0-99 range

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -229,7 +229,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         if (flapsHandleIndex != 0) {
             return Math.min(maxSpeed, this.getFlapSpeed());
         }
-        let dCI = this.costIndex / 999;
+        let dCI = this.costIndex / 99;
         dCI = dCI * dCI;
         let speed = 290 * (1 - dCI) + 330 * dCI;
         if (SimVar.GetSimVarValue("PLANE ALTITUDE", "feets") < 10000) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -993,7 +993,7 @@ class FMCMainDisplay extends BaseAirliners {
         return false;
     }
     getClbManagedSpeed() {
-        const dCI = this.costIndex / 999;
+        const dCI = this.costIndex / 99;
         const flapsHandleIndex = Simplane.getFlapsHandleIndex();
         if (flapsHandleIndex != 0) {
             return this.getFlapSpeed();
@@ -1005,7 +1005,7 @@ class FMCMainDisplay extends BaseAirliners {
         return speed;
     }
     getCrzManagedSpeed() {
-        let dCI = this.costIndex / 999;
+        let dCI = this.costIndex / 99;
         dCI = dCI * dCI;
         const flapsHandleIndex = SimVar.GetSimVarValue("FLAPS HANDLE INDEX", "Number");
         if (flapsHandleIndex != 0) {
@@ -1018,7 +1018,7 @@ class FMCMainDisplay extends BaseAirliners {
         return speed;
     }
     getDesManagedSpeed() {
-        const dCI = this.costIndex / 999;
+        const dCI = this.costIndex / 99;
         const flapsHandleIndex = Simplane.getFlapsHandleIndex();
         if (flapsHandleIndex != 0) {
             return this.getFlapSpeed();


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #345 

## Summary of Changes
Changed the cost index, so 0-99 inputs in the MCDU are creating an according impact on CLB, CRZ and DES flightphase speeds.


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
I kept the vanilla function to calculate the cost index as it was before. I only changed the range of the given cost index. Before, the function headed for ranges between 0-999, whereas cost indexes in the A320 are more in a range of 0-99 (Pilots confirm?). Therefore an input of a cost range of 20 didn't make any difference from a cost range of 30 (examples). Now it does.

Maybe some fine tuning of the basic speeds of the flightphases has to be done. Have to check the impact on higher values (like 80).

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): RogePete

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
