### PR TITLE
[Fix] Include some of the Asobo 1.10.7 changes

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.js
@@ -100,9 +100,6 @@ class MapInstrument extends ISvgMapRootElement {
         this.isBushTrip = false;
     }
     get flightPlanManager() {
-        if (this.gps) {
-            return this.gps.currFlightPlanManager;
-        }
         return this._flightPlanManager;
     }
     setNPCAirplaneManagerTCASMode(mode) {
@@ -318,9 +315,6 @@ class MapInstrument extends ISvgMapRootElement {
             if (arg instanceof BaseInstrument) {
                 this.instrument = arg;
                 this.selfManagedInstrument = false;
-                if (this.instrument instanceof NavSystem) {
-                    this.gps = this.instrument;
-                }
             } else {
                 this.instrument = document.createElement("base-instrument");
                 this.selfManagedInstrument = true;
@@ -330,21 +324,15 @@ class MapInstrument extends ISvgMapRootElement {
             }
         } else {
         }
-        if (this.gps) {
-            if (!this.gps.currFlightPlanManager) {
-                this.gps.currFlightPlanManager = new FlightPlanManager(this.instrument);
-                this.gps.currFlightPlanManager.registerListener();
-            }
-            this.gps.addEventListener("FlightStart", this.onFlightStart.bind(this));
+        this._flightPlanManager = this.instrument.flightPlanManager;
+        if (this._flightPlanManager) {
+            this.instrument.addEventListener("FlightStart", this.onFlightStart.bind(this));
         } else {
-            if (!this._flightPlanManager) {
-                this._flightPlanManager = new FlightPlanManager(this.instrument);
-                this._flightPlanManager.registerListener();
-            }
+            this._flightPlanManager = new FlightPlanManager(this.instrument);
         }
         let bingMapId = this.bingId;
-        if (this.gps && this.gps.urlConfig.index) {
-            bingMapId += "_GPS" + this.gps.urlConfig.index;
+        if (this.instrument.urlConfig.index) {
+            bingMapId += "_GPS" + this.instrument.urlConfig.index;
         }
         this.bingMap = this.getElementsByTagName("bing-map")[0];
         this.bingMap.setMode(this.eBingMode);
@@ -855,9 +843,9 @@ class MapInstrument extends ISvgMapRootElement {
             const setConfig = () => {
                 if (this.navMap.configLoaded) {
                     for (let i = 0; i < 3; i++) {
-                        const bingConfig = new BingMapsConfig();
-                        if (bingConfig.load(this.navMap.config, i)) {
-                            this.bingMap.addConfig(bingConfig);
+                        const conf = this.navMap.config.generateBing(i);
+                        if (conf) {
+                            this.bingMap.addConfig(conf);
                         }
                     }
                     this.bingMap.setConfig(this.bingMapConfigId);
@@ -881,12 +869,12 @@ class MapInstrument extends ISvgMapRootElement {
             };
             loadSVGConfig();
             const setBingConfig = () => {
-                if (svgConfigLoaded && (!this.gps || this.gps.isComputingAspectRatio())) {
+                if (svgConfigLoaded && this.instrument.isComputingAspectRatio()) {
                     for (let i = 0; i < 3; i++) {
-                        const bingConfig = new BingMapsConfig();
-                        if (bingConfig.load(svgConfig, i)) {
-                            bingConfig.aspectRatio = (this.gps && this.gps.isAspectRatioForced()) ? this.gps.getForcedScreenRatio() : 1.0;
-                            this.bingMap.addConfig(bingConfig);
+                        const conf = svgConfig.generateBing(i);
+                        if (conf) {
+                            conf.aspectRatio = (this.instrument.isAspectRatioForced()) ? this.instrument.getForcedScreenRatio() : 1.0;
+                            this.bingMap.addConfig(conf);
                         }
                     }
                     this.bingMap.setConfig(this.bingMapConfigId);
@@ -897,7 +885,7 @@ class MapInstrument extends ISvgMapRootElement {
             setBingConfig();
         }
     }
-    update() {
+    update(_deltaTime) {
         this.updateVisibility();
         this.updateSize(true);
         const WXBrightnessValue = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:" + this.potIndex, "number");
@@ -907,6 +895,7 @@ class MapInstrument extends ISvgMapRootElement {
         }
         if (this.selfManagedInstrument) {
             this.instrument.doUpdate();
+            this.flightPlanManager.update(_deltaTime);
         }
         if (this.wpt) {
             const wpId = SimVar.GetSimVarValue("GPS WP NEXT ID", "string");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/A32NX_BaseAirliners.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/A32NX_BaseAirliners.js
@@ -324,8 +324,8 @@ var Airliners;
             super.Init();
             console.log("ATC Init");
         }
-        Update() {
-            super.Update();
+        onUpdate(_deltaTime) {
+            super.onUpdate(_deltaTime);
 
             const lightsTest = SimVar.GetSimVarValue("L:XMLVAR_LTS_Test", "Bool");
             const lightsTestChanged = lightsTest !== this.lightsTest;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.js
@@ -14,8 +14,8 @@ var A320_Neo_BAT;
             this.batTexts[0] = this.querySelector("#BAT1");
             this.batTexts[1] = this.querySelector("#BAT2");
         }
-        Update() {
-            super.Update();
+        onUpdate(_deltaTime) {
+            super.onUpdate(_deltaTime);
 
             const lightsTest = SimVar.GetSimVarValue("L:XMLVAR_LTS_Test", "Bool");
             this.lightsTest = lightsTest;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BRK/A320_Neo_BRK.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BRK/A320_Neo_BRK.js
@@ -68,8 +68,8 @@ var A320_Neo_BRK;
             this.rightGauge.addMarker(3, false);
             this.electricity = this.querySelector("#Electricity");
         }
-        Update() {
-            super.Update();
+        onUpdate(_deltaTime) {
+            super.onUpdate(_deltaTime);
             const currentPKGBrakeState = SimVar.GetSimVarValue("BRAKE PARKING POSITION", "Bool");
             const powerAvailable = SimVar.GetSimVarValue("L:DCPowerAvailable","Bool");
             if (this.topGauge != null) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IdentPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IdentPage.js
@@ -1,14 +1,15 @@
 class CDUIdentPage {
     static ShowPage(mcdu) {
+        const date = mcdu.getNavDataDateRange();
         mcdu.clearDisplay();
         mcdu.setTemplate([
             ["A320"],
             ["ENG"],
             ["LEAP A-1[color]green"],
             ["", "", "ACTIVE NAV DATA BASE"],
-            ["4MAY-4JUL[color]blue", "TC11103001[color]green"],
+            [date + "[color]blue", "AIRAC"],
             ["", "", "SECOND NAV DATA BASE"],
-            ["{4MAY-4JUL[color]blue"],
+            ["{" + date + "4MAY-4JUL[color]blue"],
             [""],
             [""],
             ["CHG CODE"],

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -182,8 +182,8 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this.taxiFuelWeight = 0.2;
         CDUInitPage.updateTowIfNeeded(this);
     }
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
 
         this.A32NXCore.update();
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Clock/A320_Neo_Clock.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Clock/A320_Neo_Clock.js
@@ -26,82 +26,76 @@ class A320_Neo_Clock extends BaseAirliners {
     }
     onInteractionEvent(_args) {
     }
-    Update() {
-        super.Update();
-        if (this.CanUpdate()) {
-            const absTime = SimVar.GetGlobalVarValue("ABSOLUTE TIME", "Seconds");
-            const lightsTest = SimVar.GetSimVarValue("L:XMLVAR_LTS_Test", "Bool");
-            const lightsTestChanged = lightsTest !== this.lightsTest;
-            this.lightsTest = lightsTest;
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
 
-            const chronoState = SimVar.GetSimVarValue("L:PUSH_CHRONO_CHR", "Bool");
-            if (chronoState !== this.lastChronoState) {
-                this.lastChronoState = chronoState;
-                if (chronoState === 1) {
-                    this.chronoStart = absTime;
-                } else {
-                    this.chronoAcc = this.chronoSeconds;
-                    this.chronoStart = 0;
+        const absTime = SimVar.GetGlobalVarValue("ABSOLUTE TIME", "Seconds");
+        const lightsTest = SimVar.GetSimVarValue("L:XMLVAR_LTS_Test", "Bool");
+        const lightsTestChanged = lightsTest !== this.lightsTest;
+        this.lightsTest = lightsTest;
+        const chronoState = SimVar.GetSimVarValue("L:PUSH_CHRONO_CHR", "Bool");
+        if (chronoState !== this.lastChronoState) {
+            this.lastChronoState = chronoState;
+            if (chronoState === 1) {
+                this.chronoStart = absTime;
+            } else {
+                this.chronoAcc = this.chronoSeconds;
+                this.chronoStart = 0;
+            }
+        }
+        const currentResetVal = SimVar.GetSimVarValue("L:PUSH_CHRONO_RST", "Bool");
+        if (currentResetVal !== this.lastResetVal) {
+            this.lastResetVal = currentResetVal;
+            // Intentionally performed on every press.
+            if (chronoState === 0) {
+                this.chronoStart = 0;
+                this.chronoAcc = 0;
+            }
+        }
+        if (this.topSelectorElem) {
+            if (lightsTest) {
+                this.topSelectorElem.textContent = "88:88";
+            } else {
+                const chronoTime = this.getChronoTime();
+                if (chronoTime !== this.lastChronoTime || lightsTestChanged) {
+                    this.lastChronoTime = chronoTime;
+                    this.topSelectorElem.textContent = chronoTime;
                 }
             }
-
-            const currentResetVal = SimVar.GetSimVarValue("L:PUSH_CHRONO_RST", "Bool");
-            if (currentResetVal !== this.lastResetVal) {
-                this.lastResetVal = currentResetVal;
-                // Intentionally performed on every press.
-                if (chronoState === 0) {
-                    this.chronoStart = 0;
-                    this.chronoAcc = 0;
+        }
+        if (this.middleSelectorElem) {
+            if (lightsTest) {
+                this.middleSelectorElem.textContent = "88:88";
+                this.middleSelectorElem2.textContent = "88";
+            } else {
+                let currentDisplayTime = "";
+                let currentDisplayTime2 = "";
+                if (SimVar.GetSimVarValue("L:PUSH_CHRONO_SET", "Bool") === 1) {
+                    currentDisplayTime = this.getUTCDate();
+                    currentDisplayTime2 = this.getUTCYear();
+                } else {
+                    const UTCTime = this.getUTCTime();
+                    currentDisplayTime = UTCTime.substr(0,5);
+                    currentDisplayTime2 = UTCTime.substr(6,2);
+                }
+                if (currentDisplayTime !== this.lastDisplayTime || lightsTestChanged) {
+                    this.lastDisplayTime = currentDisplayTime;
+                    this.middleSelectorElem.textContent = currentDisplayTime;
+                }
+                if (currentDisplayTime2 !== this.lastDisplayTime2 || lightsTestChanged) {
+                    this.lastDisplayTime2 = currentDisplayTime2;
+                    this.middleSelectorElem2.textContent = currentDisplayTime2;
                 }
             }
-
-            if (this.topSelectorElem) {
-                if (lightsTest) {
-                    this.topSelectorElem.textContent = "88:88";
-                } else {
-                    const chronoTime = this.getChronoTime();
-                    if (chronoTime !== this.lastChronoTime || lightsTestChanged) {
-                        this.lastChronoTime = chronoTime;
-                        this.topSelectorElem.textContent = chronoTime;
-                    }
-                }
-            }
-
-            if (this.middleSelectorElem) {
-                if (lightsTest) {
-                    this.middleSelectorElem.textContent = "88:88";
-                    this.middleSelectorElem2.textContent = "88";
-                } else {
-                    let currentDisplayTime = "";
-                    let currentDisplayTime2 = "";
-                    if (SimVar.GetSimVarValue("L:PUSH_CHRONO_SET", "Bool") === 1) {
-                        currentDisplayTime = this.getUTCDate();
-                        currentDisplayTime2 = this.getUTCYear();
-                    } else {
-                        const UTCTime = this.getUTCTime();
-                        currentDisplayTime = UTCTime.substr(0,5);
-                        currentDisplayTime2 = UTCTime.substr(6,2);
-                    }
-                    if (currentDisplayTime !== this.lastDisplayTime || lightsTestChanged) {
-                        this.lastDisplayTime = currentDisplayTime;
-                        this.middleSelectorElem.textContent = currentDisplayTime;
-                    }
-                    if (currentDisplayTime2 !== this.lastDisplayTime2 || lightsTestChanged) {
-                        this.lastDisplayTime2 = currentDisplayTime2;
-                        this.middleSelectorElem2.textContent = currentDisplayTime2;
-                    }
-                }
-            }
-
-            if (this.bottomSelectorElem) {
-                if (lightsTest) {
-                    this.bottomSelectorElem.textContent = "88:88";
-                } else {
-                    const currentFlightTime = this.getFlightTime();
-                    if (currentFlightTime !== this.lastFlightTime || lightsTestChanged) {
-                        this.lastFlightTime = currentFlightTime;
-                        this.bottomSelectorElem.textContent = currentFlightTime;
-                    }
+        }
+        if (this.bottomSelectorElem) {
+            if (lightsTest) {
+                this.bottomSelectorElem.textContent = "88:88";
+            } else {
+                const currentFlightTime = this.getFlightTime();
+                if (currentFlightTime !== this.lastFlightTime || lightsTestChanged) {
+                    this.lastFlightTime = currentFlightTime;
+                    this.bottomSelectorElem.textContent = currentFlightTime;
                 }
             }
         }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Com/A320_Neo_Com.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Com/A320_Neo_Com.js
@@ -63,8 +63,8 @@ class A320_Neo_Com extends BaseAirliners {
         }
     }
 
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
 
         this.updatePowerState();
         this.updateScreenState();

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.js
@@ -26,8 +26,8 @@ class A320_Neo_FCU extends BaseAirliners {
         super.reboot();
         this.mainPage.reboot();
     }
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
         this.updateMachTransition();
     }
     onEvent(_event) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FDW/A320_Neo_FDW.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FDW/A320_Neo_FDW.js
@@ -311,8 +311,8 @@ class A320_Neo_FDW extends BaseAirliners {
     disconnectedCallback() {
         super.disconnectedCallback();
     }
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
         const isOn = SimVar.GetSimVarValue(this.onVarName, "Boolean");
         if (isOn && (this.currentFrequencyType == A320_Neo_RadioManagement.FREQUENCY_TYPE.NONE)) {
             this.switchOn();

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -271,6 +271,9 @@ class FMCMainDisplay extends BaseAirliners {
         }
         SimVar.SetSimVarValue("L:AIRLINER_MCDU_CURRENT_FPLN_WAYPOINT", "number", this.currentFlightPlanWaypointIndex);
     }
+    getNavDataDateRange() {
+        return SimVar.GetGameVarValue("FLIGHT NAVDATA DATE RANGE", "string");
+    }
     get cruiseFlightLevel() {
         return this._cruiseFlightLevel;
     }
@@ -426,6 +429,7 @@ class FMCMainDisplay extends BaseAirliners {
                                     this.flightPlanManager.setDestination(airportTo.icao, () => {
                                         this.tmpOrigin = airportTo.ident;
                                         callback(true);
+                                        this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_TAKEOFF;
                                     });
                                 });
                             });
@@ -999,7 +1003,7 @@ class FMCMainDisplay extends BaseAirliners {
             return this.getFlapSpeed();
         }
         let speed = 220 * (1 - dCI) + 280 * dCI;
-        if (SimVar.GetSimVarValue("PLANE ALTITUDE", "feets") < 10000) {
+        if (SimVar.GetSimVarValue("PLANE ALTITUDE", "feet") < 10000) {
             speed = Math.min(speed, 250);
         }
         return speed;
@@ -1012,7 +1016,7 @@ class FMCMainDisplay extends BaseAirliners {
             return this.getFlapSpeed();
         }
         let speed = 290 * (1 - dCI) + 310 * dCI;
-        if (SimVar.GetSimVarValue("PLANE ALTITUDE", "feets") < 10000) {
+        if (SimVar.GetSimVarValue("PLANE ALTITUDE", "feet") < 10000) {
             speed = Math.min(speed, 250);
         }
         return speed;
@@ -1024,7 +1028,7 @@ class FMCMainDisplay extends BaseAirliners {
             return this.getFlapSpeed();
         }
         let speed = 288 * (1 - dCI) + 260 * dCI;
-        if (SimVar.GetSimVarValue("PLANE ALTITUDE", "feets") < 10000) {
+        if (SimVar.GetSimVarValue("PLANE ALTITUDE", "feet") < 10000) {
             speed = Math.min(speed, 250);
         }
         return speed;
@@ -1641,7 +1645,7 @@ class FMCMainDisplay extends BaseAirliners {
                 }
             }
             if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_CLIMB) {
-                const altitude = SimVar.GetSimVarValue("PLANE ALTITUDE", "feets");
+                const altitude = SimVar.GetSimVarValue("PLANE ALTITUDE", "feet");
                 const cruiseFlightLevel = this.cruiseFlightLevel * 100;
                 if (isFinite(cruiseFlightLevel)) {
                     if (altitude >= 0.96 * cruiseFlightLevel) {
@@ -1651,7 +1655,7 @@ class FMCMainDisplay extends BaseAirliners {
                 }
             }
             if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_CRUISE) {
-                const altitude = SimVar.GetSimVarValue("PLANE ALTITUDE", "feets");
+                const altitude = SimVar.GetSimVarValue("PLANE ALTITUDE", "feet");
                 const cruiseFlightLevel = this.cruiseFlightLevel;
                 if (isFinite(cruiseFlightLevel)) {
                     if (altitude < 0.94 * cruiseFlightLevel) {
@@ -2054,7 +2058,7 @@ class FMCMainDisplay extends BaseAirliners {
                 this.inOut = this.inOut.slice(0, -1);
             }
         };
-        this.cruiseFlightLevel = SimVar.GetGameVarValue("AIRCRAFT CRUISE ALTITUDE", "feets");
+        this.cruiseFlightLevel = SimVar.GetGameVarValue("AIRCRAFT CRUISE ALTITUDE", "feet");
         this.cruiseFlightLevel /= 100;
         if (!this.flightPlanManager) {
             this.flightPlanManager = new FlightPlanManager(this);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
@@ -31,8 +31,8 @@ class A320_Neo_MFD extends BaseAirliners {
                 break;
         }
     }
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
     }
 }
 class A320_Neo_MFD_MainElement extends NavSystemElement {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
@@ -22,8 +22,8 @@ class A320_Neo_PFD extends BaseAirliners {
         window.console.log("A320 Neo PFD - destroyed");
         super.disconnectedCallback();
     }
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
     }
 }
 class A320_Neo_PFD_MainElement extends NavSystemElement {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
@@ -1098,7 +1098,7 @@ var Airbus_FMA;
         }
         static IsActive_OPCLB() {
             if ((Simplane.getAutoPilotAltitudeSelected() || Simplane.getAutoPilotAltitudeArmed()) && Airbus_FMA.CurrentPlaneState.thisFlightDirectorActive && Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive) {
-                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feets");
+                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feet");
                 const altitude = Simplane.getAltitude();
                 if (altitude < targetAltitude - 100) {
                     return true;
@@ -1107,7 +1107,7 @@ var Airbus_FMA;
         }
         static IsActive_OPDES() {
             if ((Simplane.getAutoPilotAltitudeSelected() || Simplane.getAutoPilotAltitudeArmed()) && Airbus_FMA.CurrentPlaneState.thisFlightDirectorActive && Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive) {
-                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feets");
+                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feet");
                 const altitude = Simplane.getAltitude();
                 if (altitude > targetAltitude + 100) {
                     return true;
@@ -1121,7 +1121,7 @@ var Airbus_FMA;
                 } else if (Airbus_FMA.CurrentPlaneState.radioAltitude <= 1.5) {
                     return Airbus_FMA.MODE_STATE.NONE;
                 }
-                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feets");
+                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feet");
                 const altitude = Simplane.getAltitude();
                 if (altitude < targetAltitude - 100) {
                     if (Airbus_FMA.CurrentPlaneState.radioAltitude > 1.5) {
@@ -1132,7 +1132,7 @@ var Airbus_FMA;
                 }
             }
             if (Simplane.getAutoPilotFLCActive() && Airbus_FMA.CurrentPlaneState.thisFlightDirectorActive) {
-                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feets");
+                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feet");
                 const altitude = Simplane.getAltitude();
                 if (altitude < targetAltitude - 100) {
                     if (Airbus_FMA.CurrentPlaneState.radioAltitude <= 1.5) {
@@ -1151,7 +1151,7 @@ var Airbus_FMA;
                 }
             }
             if (Simplane.getAutoPilotFLCActive() && Airbus_FMA.CurrentPlaneState.thisFlightDirectorActive) {
-                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feets");
+                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feet");
                 const altitude = Simplane.getAltitude();
                 if (altitude > targetAltitude + 100) {
                     return true;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/RTPI/A320_Neo_RTPI.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/RTPI/A320_Neo_RTPI.js
@@ -14,8 +14,8 @@ class A320_Neo_RTPI extends BaseAirliners {
     disconnectedCallback() {
         super.disconnectedCallback();
     }
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
         this.refreshValue(SimVar.GetSimVarValue("RUDDER TRIM", "degrees"));
     }
     refreshValue(_value, _force = false) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/SAI/A320_Neo_SAI.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/SAI/A320_Neo_SAI.js
@@ -13,8 +13,8 @@ class A320_Neo_SAI extends BaseAirliners {
         this.addIndependentElementContainer(new NavSystemElementContainer("Bugs", "Bugs", new A320_Neo_SAI_Bugs()));
         this.addIndependentElementContainer(new NavSystemElementContainer("Pressure", "Pressure", new A320_Neo_SAI_Pressure()));
     }
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
     }
     onEvent(_event) {
     }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/FlightElements/Waypoint.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/FlightElements/Waypoint.js
@@ -274,27 +274,27 @@ class AirportInfo extends WayPointInfo {
     GetSymbolFileName() {
         var logo = "";
         if (this.airportClass == 2 || this.airportClass == 3) {
-            logo = "GPS/Airport_Soft.bmp";
+            logo = "GPS/Airport_Soft.png";
         } else if (this.airportClass == 1) {
             switch (Math.round((this.longestRunwayDirection % 180) / 45.0)) {
                 case 0:
                 case 4:
-                    logo = "GPS/Airport_Hard_NS.bmp";
+                    logo = "GPS/Airport_Hard_NS.png";
                     break;
                 case 1:
-                    logo = "GPS/Airport_Hard_NE_SW.bmp";
+                    logo = "GPS/Airport_Hard_NE_SW.png";
                     break;
                 case 2:
-                    logo = "GPS/Airport_Hard_EW.bmp";
+                    logo = "GPS/Airport_Hard_EW.png";
                     break;
                 case 3:
-                    logo = "GPS/Airport_Hard_NW_SE.bmp";
+                    logo = "GPS/Airport_Hard_NW_SE.png";
                     break;
             }
         } else if (this.airportClass == 4) {
-            logo = "GPS/Helipad.bmp";
+            logo = "GPS/Helipad.png";
         } else if (this.airportClass == 5) {
-            logo = "GPS/Private_Airfield.bmp";
+            logo = "GPS/Private_Airfield.png";
         }
         return logo;
     }
@@ -581,22 +581,22 @@ class VORInfo extends WayPointInfo {
         var image = "";
         switch (this.type) {
             case 1:
-                image = "GPS/Vor.bmp";
+                image = "GPS/Vor.png";
                 break;
             case 2:
-                image = "GPS/Vor_DME.bmp";
+                image = "GPS/Vor_DME.png";
                 break;
             case 3:
-                image = "GPS/DME.bmp";
+                image = "GPS/DME.png";
                 break;
             case 4:
-                image = "GPS/Tacan.bmp";
+                image = "GPS/Tacan.png";
                 break;
             case 5:
-                image = "GPS/Vor_Tac.bmp";
+                image = "GPS/Vor_Tac.png";
                 break;
             case 6:
-                image = "GPS/Localizer.bmp";
+                image = "GPS/Localizer.png";
                 break;
         }
         return image;
@@ -689,7 +689,7 @@ class NDBInfo extends WayPointInfo {
         return "N";
     }
     GetSymbol() {
-        return (this.type == 1 ? "GPS/Marker.bmp" : "GPS/Ndb.bmp");
+        return (this.type == 1 ? "GPS/Marker.png" : "GPS/Ndb.png");
     }
     imageFileName() {
         let fName = "";
@@ -764,7 +764,7 @@ class IntersectionInfo extends WayPointInfo {
         return this.loaded;
     }
     GetSymbol() {
-        return "GPS/Intersection.bmp";
+        return "GPS/Intersection.png";
     }
     imageFileName() {
         if (BaseInstrument.useSvgImages) {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Adresses #1603, Fixes #1600, Fixes #1599, Fixes #1601

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* Partially port Asobo 1.10.7 update changes
   * Not integrated yet: changes to AttitudeIndicator.js, ILSIndicator.js, NDCompass.js (some of it may be related to HUD stuff, don't know if we should inegrated that)
   * Some changes to FMCMainDisplay.js aren't integrated yet, not sure if that is wanted
   * Changes to A320_Neo_CDU_AvailableArrivalsPage.js not integrated, same as above
   * XML changes, fuelsystem changes not integrated yet
   * None of the CSS changes integrated yet, also not sure if we want to integrate those
* Also includes an Asobo update to the CDU, current AIRAC cycle from the internal MSFS database is now displayed on the MCDU
* Please check if I missed something


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build.py will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, slick on the **Artifacts** drop down and click the **A32NX** link
