### PR TITLE
feat(cdu): Rework PERF page

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -148,6 +148,8 @@
 1. [FLIGHTMODEL] Updated legacy flight model parameters for consistency with modern flight model - @donstim - (donbikes#4084)
 1. [ECAM] Adjusted flaps panel - @MisterChocker (Leon)
 1. [CDU] F-PLN page visual rework - @Lollo999 (Lorenzo Pinna)
+1. [CDU] Fix PERF page order - @beheh (Benedict Etzel)
+1. [CDU] Improve PERF pages look and behaviour - @beheh (Benedict Etzel)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -277,6 +277,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this.showErrorMessage("INVALID ENTRY");
         return false;
     }
+
     onPowerOn() {
         super.onPowerOn();
         if (Simplane.getAutoPilotAirspeedManaged()) {
@@ -1023,20 +1024,22 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
     }
 
     getThrustTakeOffLimit() {
-        if (this.perfTOTemp <= 10) {
-            return 92.8;
-        }
-        if (this.perfTOTemp <= 40) {
-            return 92.8;
-        }
-        if (this.perfTOTemp <= 45) {
-            return 92.2;
-        }
-        if (this.perfTOTemp <= 50) {
-            return 90.5;
-        }
-        if (this.perfTOTemp <= 55) {
-            return 88.8;
+        if (isFinite(this.perfApprTransAlt)) {
+            if (this.perfTOTemp <= 10) {
+                return 92.8;
+            }
+            if (this.perfTOTemp <= 40) {
+                return 92.8;
+            }
+            if (this.perfTOTemp <= 45) {
+                return 92.2;
+            }
+            if (this.perfTOTemp <= 50) {
+                return 90.5;
+            }
+            if (this.perfTOTemp <= 55) {
+                return 88.8;
+            }
         }
         return 88.4;
     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #1823
Fixes #2096
Fixes #3121

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

This PR started out fixing a minor typo, but turned into a fully fledged makeover for the PERF page.

**Notice: I'm pulling this apart into smaller PRs to make it more manageable.**

It cleans up basic things the default aircraft gets wrong (order of pages, previous pages not accessible) and formats the pages to look much more like the Honeywell original. Note that this PR barely touches the actual functionality of fields, and doesn't touch performance calculations at all. It also does not fix the flight phase transitions (especially around CRZ => CLB => DES) being a bit wonky. This PR is really only about the look and feel of the PERF pages.

Functional changes:
- ~~Fix page order go around (GO AROUND <=> APPR rather than APPR <=> GO AROUND)~~ => #2940
- ~~Disable pages from previous flight phase (e.g. TAKEOFF is no longer accessible during CLB/CRZ/DES etc.)~~ => #2940
- [ ] Fix allowed entries for most fields according to documentation (e.g. -270C° is now rejected)
- [ ] Remember which fields are pilot-entered and which are not (large font/small font)
- [x] Make CI non-editable if no origin/destination is set
- ~~Disable TO SHIFT with dashes if no runway is set~~ => 3082
- ~~Disable various fields during TAKE OFF phase (V speeds, FLAPS, TO SHIFT, THR RED/ACC, ENG OUT ACC, FLX TO)~~ => #3082
- ~~Stop defaulting to flex temp 20C°~~ => #3082
- [ ] Update F/S/O speed calculation (once #2291 lands)

Cosmetic changes:
- [x] Fix typo on APPR and GO AROUND page (letter O instead of zero)
- [x] Fix split text colors for speeds on TAKE OFF, APPR and GO AROUND
- [x] Fix ENG OUT ACC field on GO AROUND
- [x] Fix FLAPS CONF3/FULL text color
- ~~Fix PREV PHASE / NEXT PHASE alignment~~ => #2940
- ~~Fix various label alignments~~ => #2940
- ~~Move take off RWY to header~~ => #3082
- [x] Make QNH amber if within 180nm of destination
- [x] Show amber boxes if CI is not set
- [x] Fix extraneous space in APPR FINAL
- [x] Fix various text colors
- [x] Fix various text sizes
- [x] Color unsupported items inop gray

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![image](https://user-images.githubusercontent.com/929769/101185748-8e723680-3652-11eb-9944-05a9d0691adf.png)

### Before
![grafik](https://user-images.githubusercontent.com/929769/98529985-a090cd00-227e-11eb-94a7-b5394b356151.png)

### After
![image](https://user-images.githubusercontent.com/929769/100291317-bd671900-2f7d-11eb-8a65-b2c4074adecc.png)
![image](https://user-images.githubusercontent.com/929769/100291332-c952db00-2f7d-11eb-82c0-2c6fc9a8ff2a.png)


## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![grafik](https://user-images.githubusercontent.com/929769/98523984-e2b61080-2276-11eb-8493-685dce2d9573.png)
![grafik](https://user-images.githubusercontent.com/929769/98524726-dc746400-2277-11eb-89f0-6ee169fb3d0e.png)
![grafik](https://user-images.githubusercontent.com/929769/98524738-de3e2780-2277-11eb-87de-98b12e870364.png)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BehEh#1234

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
