### PR TITLE
Don't run actions on Draft PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,12 +1,18 @@
 name: PR
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     branches:
       - master
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -16,6 +22,7 @@ jobs:
         run: npm run lint
   build:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout source
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #1827 

## Summary of Changes
Actions for PRs now only run when:
* Non-Draft PR has been created
* Non-Draft PR has been updated
* Draft has been converted to Non-Draft PR

## Screenshots (if necessary)


## References


## Additional context

Discord username (if different from GitHub): nistei#1362

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
