### PR TITLE
[CDU] Add MCDU formatting helpers

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU.css
@@ -173,12 +173,6 @@ fmc-main-display::before {
   right: 6% !important;
 }
 
-.irs-text {
-  font-weight: lighter;
-  font-size: 6.3vw;
-  letter-spacing: 0.5vw;
-}
-
 .label {
   height: 5%;
   margin: 0;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
@@ -27,7 +27,6 @@ class A320_Neo_CDU_AirwaysFromWaypointPage {
                 subRows[idx] = ["VIA", "TO"];
             }
         });
-        mcdu._titleElement.innerHTML = `<span><span>AIRWAYS</span> <span class='s-text'>FROM </span><span class='green'>${waypoint.ident}</span></span>`;
         let showInput = false;
         const departureWaypoints = mcdu.flightPlanManager.getDepartureWaypoints();
         const routeWaypoints = mcdu.flightPlanManager.getEnRouteWaypoints();
@@ -89,7 +88,7 @@ class A320_Neo_CDU_AirwaysFromWaypointPage {
             }
         }
         mcdu.setTemplate([
-            undefined,
+            ["AIRWAYS {small}FROM {end}{green}" + waypoint.ident + "{end}"],
             subRows[0],
             rows[0],
             subRows[1],

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IRSInit.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IRSInit.js
@@ -46,19 +46,19 @@ class CDUIRSInit {
             GPSPosTitle = ["LAT", "LONG", "GPS POSITION"];
             originAirportTitle = ["LAT" + larrowupdwn , rarrowupdwn + "LONG", "REFERENCE"];
             GPSPosAlign = ["--°--.--", "--°--.--", " "];
-            originAirportString = ['{IrsInitFont}' + originAirportLat['deg'] + '°{IrsInitFontEnd}' + originAirportLat['min'] + '.' + originAirportLat['sec'] + '[s-text]{IrsInitFont}' + originAirportLat['dir'] + "{IrsInitFontEnd} [color]blue", '{IrsInitFont}' + originAirportLon['deg'] + '°{IrsInitFontEnd}' + originAirportLon['min'] + '.' + originAirportLon['sec'] + '[s-text]{IrsInitFont}' + originAirportLon['dir'] + "{IrsInitFontEnd} [color]blue", referenceName];
+            originAirportString = [originAirportLat['deg'] + "°{small}" + originAirportLat['min'] + "." + originAirportLat['sec'] + "{end}" + originAirportLat['dir'] + "[color]blue", originAirportLon['deg'] + "°{small}" + originAirportLon['min'] + "." + originAirportLon['sec'] + "{end}" + originAirportLon['dir'] + "[color]blue", referenceName];
             if (SimVar.GetSimVarValue("L:A32NX_ADIRS_KNOB_1", "Enum") || SimVar.GetSimVarValue("L:A32NX_ADIRS_KNOB_2", "Enum") || SimVar.GetSimVarValue("L:A32NX_ADIRS_KNOB_3", "Enum")) {
-                GPSPosAlign = ['{IrsInitFont}' + currentGPSLat['deg'] + '°{IrsInitFontEnd}' + currentGPSLat['min'] + '.' + Math.ceil(Number(currentGPSLat['sec'] / 100)) + '[s-text]{IrsInitFont}' + currentGPSLat['dir'] + "{IrsInitFontEnd} [color]green", '{IrsInitFont}' + currentGPSLon['deg'] + '°{IrsInitFontEnd}' + currentGPSLon['min'] + '.' + Math.ceil(Number(currentGPSLon['sec'] / 100)) + '[s-text]{IrsInitFont}' + currentGPSLon['dir'] + "{IrsInitFontEnd} [color]green", ""];
+                GPSPosAlign = [currentGPSLat['deg'] + "°{small}" + currentGPSLat['min'] + "." + Math.ceil(Number(currentGPSLat['sec'] / 100)) + "{end}" + currentGPSLat['dir'] + '[color]green', currentGPSLon['deg'] + "°{small}" + currentGPSLon['min'] + "." + Math.ceil(Number(currentGPSLon['sec'] / 100)) + "{end}" + currentGPSLon['dir'] + "[color]green", ""];
                 alignType = "GPS";
             }
         }
 
-        let IRSAlignOnPos = "{IrsInitFont}" + currentGPSLat['deg'] + '°{IrsInitFontEnd}' + currentGPSLat['min'] + '.' + Math.ceil(Number(currentGPSLat['sec'] / 100)) + '[s-text]{IrsInitFont}' + currentGPSLat['dir'] + '/{IrsInitFontEnd}{IrsInitFont}' + currentGPSLon['deg'] + '°{IrsInitFontEnd}' + currentGPSLon['min'] + '.' + Math.ceil(Number(currentGPSLon['sec'] / 100)) + '{IrsInitFont}' + currentGPSLon['dir'] + '{IrsInitFontEnd}';
+        let IRSAlignOnPos = currentGPSLat['deg'] + "°{small}" + currentGPSLat['min'] + "." + Math.ceil(Number(currentGPSLat['sec'] / 100)) + "{end}" + currentGPSLat['dir'] + "/" + currentGPSLon['deg'] + "°{small}" + currentGPSLon['min'] + "." + Math.ceil(Number(currentGPSLon['sec'] / 100)) + "{end}" + currentGPSLon['dir'];
         if (SimVar.GetSimVarValue("L:A32XN_Neo_ADIRS_ALIGN_TYPE_REF", "Enum") === 1) {
             alignMsg = "";
             alignType = "REF";
             if (checkAligned !== 2) {
-                IRSAlignOnPos = "{IrsInitFont}" + originAirportLat['deg'] + '°{IrsInitFontEnd}' + originAirportLat['min'] + '.' + originAirportLat['sec'] + '[s-text]{IrsInitFont}' + originAirportLat['dir'] + '/{IrsInitFontEnd}{IrsInitFont}' + originAirportLon['deg'] + '°{IrsInitFontEnd}' + originAirportLon['min'] + '.' + originAirportLon['sec'] + '{IrsInitFont}' + originAirportLon['dir'] + '{IrsInitFontEnd}';
+                IRSAlignOnPos = originAirportLat['deg'] + "°{small}" + originAirportLat['min'] + "." + originAirportLat['sec'] + "{end}" + originAirportLat['dir'] + "/" + originAirportLon['deg'] + "°{small}" + originAirportLon['min'] + "." + originAirportLon['sec'] + "{end}" + originAirportLon['dir'];
             }
         }
 
@@ -118,20 +118,6 @@ class CDUIRSInit {
             [],
             ["<RETURN", alignMsg]
         ]);
-
-        // IRS Font is different we loop over keywords to set correct font since at the moment we cannot adapt FMCMainDisplay.js to allow for extra keywords
-        mcdu._lineElements.forEach(function (ele) {
-            ele.forEach(function (el) {
-                if (el != null) {
-                    let newHtml = el;
-                    if (newHtml != null) {
-                        newHtml = newHtml.innerHTML.replace(/{IrsInitFont}/g, '<span class=\'irs-text\'>');
-                        newHtml = newHtml.replace(/{IrsInitFontEnd}/g, '</span>');
-                        el.innerHTML = newHtml;
-                    }
-                }
-            });
-        });
 
         mcdu.onLeftInput[0] = () => {
             lon = false;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -165,10 +165,8 @@ class CDUInitPage {
             ["COST INDEX"],
             [costIndex, "WIND>"],
             ["CRZ FL/TEMP", "TROPO"],
-            [cruiseFlTemp, "{smallFront}36090{smallEnd}[color]blue"],
+            [cruiseFlTemp, "{small}36090{end}[color]blue"],
         ]);
-
-        mcdu.insertSmallFontSpan();
 
         mcdu.onPrevPage = () => {
             if (mcdu.isAnEngineOn()) {
@@ -259,12 +257,12 @@ class CDUInitPage {
         let lwCell = "---.-";
         let towLwColor = "[color]white";
 
-        let taxiFuelCell = "{smallFront}0.4{smallEnd}";
+        let taxiFuelCell = "{small}0.4{end}";
         if (isFinite(mcdu.taxiFuelWeight)) {
             if (mcdu._taxiEntered) {
                 taxiFuelCell = mcdu.taxiFuelWeight.toFixed(1);
             } else {
-                taxiFuelCell = "{smallFront}" + mcdu.taxiFuelWeight.toFixed(1) + "{smallEnd}";
+                taxiFuelCell = "{small}" + mcdu.taxiFuelWeight.toFixed(1) + "{end}";
             }
         }
         mcdu.onLeftInput[0] = async () => {
@@ -281,7 +279,7 @@ class CDUInitPage {
         let tripColor = "[color]white";
 
         let rteRsvWeightCell = "---.-";
-        let rteRsvPercentCell = "{blueFront}5.0{blueEnd}";
+        let rteRsvPercentCell = "{blue}5.0{end}";
         let rteRsvColor = "[color]white";
 
         let altnWeightCell = "---.-";
@@ -289,7 +287,7 @@ class CDUInitPage {
         const altnColor = "[color]white";
 
         let finalWeightCell = "---.-";
-        let finalTimeCell = "{blueFront}0045{blueEnd}";
+        let finalTimeCell = "{blue}0045{end}";
         let finalColor = "[color]white";
 
         mcdu.onLeftInput[4] = async () => {
@@ -332,13 +330,13 @@ class CDUInitPage {
             }
 
             if (isFinite(mcdu.getTotalTripFuelCons()) && isFinite(mcdu.getTotalTripTime())) {
-                tripWeightCell = "__{smallFront}" + mcdu.getTotalTripFuelCons().toFixed(1);
-                tripTimeCell = FMCMainDisplay.secondsTohhmm(mcdu.getTotalTripTime()) + "{smallEnd}";
+                tripWeightCell = "{sp}{sp}{small}" + mcdu.getTotalTripFuelCons().toFixed(1);
+                tripTimeCell = FMCMainDisplay.secondsTohhmm(mcdu.getTotalTripTime()) + "{end}";
                 tripColor = "[color]green";
             }
 
             if (isFinite(mcdu.getRouteReservedWeight()) && isFinite(mcdu.getRouteReservedPercent())) {
-                rteRsvWeightCell = "__{smallFront}" + mcdu.getRouteReservedWeight().toFixed(1) + "{smallEnd}";
+                rteRsvWeightCell = "{sp}{sp}{small}" + mcdu.getRouteReservedWeight().toFixed(1) + "{end}";
                 rteRsvPercentCell = mcdu.getRouteReservedPercent().toFixed(1);
                 rteRsvColor = "[color]blue";
             }
@@ -351,16 +349,16 @@ class CDUInitPage {
             };
 
             //TODO Compute  ALTN WEIGHT & TIME, this is a placeholder value
-            altnWeightCell = "__{smallFront}{greenFront}0.0{greenEnd}{smallEnd}";
+            altnWeightCell = "{sp}{sp}{small}{green}0.0{end}{end}";
 
             if (isFinite(mcdu.getRouteFinalFuelWeight()) && isFinite(mcdu.getRouteFinalFuelTime())) {
-                finalWeightCell = "{smallFront}" + mcdu.getRouteFinalFuelWeight().toFixed(1) + "{smallEnd}";
+                finalWeightCell = "{small}" + mcdu.getRouteFinalFuelWeight().toFixed(1) + "{end}";
                 finalTimeCell = FMCMainDisplay.secondsTohhmm(mcdu.getRouteFinalFuelTime());
                 finalColor = "[color]blue";
             }
 
             // TODO compute final weight and time, this is a place holder value
-            finalWeightCell = "__{smallFront}" + "0.0" + "{smallEnd}";
+            finalWeightCell = "{sp}{sp}{small}" + "0.0" + "{end}";
             finalColor = "[color]blue";
 
             mcdu.takeOffWeight = mcdu.zeroFuelWeight + mcdu.blockFuel - mcdu.taxiFuelWeight;
@@ -369,13 +367,13 @@ class CDUInitPage {
                 towLwColor = "[color]green";
             }
 
-            towCell = "{smallFront}" + towCell;
-            lwCell = "000.0" + "{smallEnd}"; //TODO compute landing weight, this is a place holder value
+            towCell = "{small}" + towCell;
+            lwCell = "000.0" + "{end}"; //TODO compute landing weight, this is a place holder value
 
-            tripWindCell = "{smallFront}" + mcdu._windDir + "000" + "{smallEnd}";
+            tripWindCell = "{small}" + mcdu._windDir + "000" + "{end}";
             tripWindColor = "[color]blue";
             if (isFinite(mcdu.averageWind)) {
-                tripWindCell = "{smallFront}" + mcdu._windDir + mcdu.averageWind.toFixed(0).padStart(3, "0") + "{smallEnd}";
+                tripWindCell = "{small}" + mcdu._windDir + mcdu.averageWind.toFixed(0).padStart(3, "0") + "{end}";
 
             }
             mcdu.onRightInput[4] = async () => {
@@ -387,14 +385,14 @@ class CDUInitPage {
             };
 
             // TODO calculate minDestFob, this is a placeholder value
-            minDestFob = "__{smallFront}0.0{smallEnd}";
+            minDestFob = "{sp}{sp}{small}0.0{end}";
             minDestFobColor = "[color]blue";
 
             // TODO calculate extra weight and time, this is a plceholder value
             // extraWeightCell = parseFloat(blockFuel) - (parseFloat(taxiFuelCell) + parseFloat(taxiFuelCell) + parseFloat(rteRsvWeightCell) + parseFloat(minDestFob));
             extraColor = "[color]green";
-            extraWeightCell = "{smallFront}0.0";
-            extraTimeCell = "0000{smallEnd}";
+            extraWeightCell = "{small}0.0";
+            extraTimeCell = "0000{end}";
         }
 
         mcdu.setTemplate([
@@ -405,35 +403,13 @@ class CDUInitPage {
             [tripWeightCell + "/" + tripTimeCell + tripColor, blockFuel + blockFuelColor],
             ["RTE RSV/%", fuelPlanTopTitle + fuelPlanColor],
             [rteRsvWeightCell + "/" + rteRsvPercentCell + rteRsvColor, fuelPlanBottomTitle + fuelPlanColor],
-            ["ALTN  /TIME", "TOW/___LW"],
+            ["ALTN  /TIME", "TOW/{sp}{sp}{sp}LW"],
             [altnWeightCell + "/" + altnTimeCell + altnColor, towCell + "/" + lwCell + towLwColor],
             ["FINAL/TIME", "TRIP WIND"],
-            [finalWeightCell + "/" + finalTimeCell + finalColor, "{smallFront}" + tripWindCell + "{smallEnd}" + tripWindColor],
+            [finalWeightCell + "/" + finalTimeCell + finalColor, "{small}" + tripWindCell + "{end}" + tripWindColor],
             ["MIN DEST FOB", "EXTRA/TIME"],
             [minDestFob + minDestFobColor, extraWeightCell + "/" + extraTimeCell + extraColor],
         ]);
-
-        mcdu.insertSmallFontSpan();
-
-        // Set initial RTE RSV % to blue
-        mcdu._lineElements[2][0].innerHTML = mcdu._lineElements[2][0].innerHTML.replace(/{blueFront}/g, "<span class='blue'>");
-        mcdu._lineElements[2][0].innerHTML = mcdu._lineElements[2][0].innerHTML.replace(/{blueEnd}/g, "</span>");
-
-        //Set ALTN time to green
-        mcdu._lineElements[3][0].innerHTML = mcdu._lineElements[3][0].innerHTML.replace(/{greenFront}/g, "<span class='green'>");
-        mcdu._lineElements[3][0].innerHTML = mcdu._lineElements[3][0].innerHTML.replace(/{greenEnd}/g, "</span>");
-
-        // Set initial final time to blue
-        mcdu._lineElements[4][0].innerHTML = mcdu._lineElements[4][0].innerHTML.replace(/{blueFront}/g, "<span class='blue'>");
-        mcdu._lineElements[4][0].innerHTML = mcdu._lineElements[4][0].innerHTML.replace(/{blueEnd}/g, "</span>");
-
-        // Add required spacing to line elements
-        for (let i = 1; i <= 5; i++) {
-            mcdu._lineElements[i][0].innerHTML = mcdu._lineElements[i][0].innerHTML.replace(/_/g, "&nbsp;");
-        }
-
-        // Add required spacing to TOW/LW title element
-        mcdu._labelElements[3][1].innerHTML = mcdu._labelElements[3][1].innerHTML.replace(/_/g, "&nbsp;");
 
         // It infact does not work
         mcdu.onPlusMinus = () => {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -123,12 +123,36 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         }, 30000);
     }
 
-    insertSmallFontSpan() {
+    _formatCell(str) {
+        return str
+            .replace(/{small}/g, "<span class='s-text'>")
+            .replace(/{red}/g, "<span class='red'>")
+            .replace(/{green}/g, "<span class='green'>")
+            .replace(/{blue}/g, "<span class='blue'>")
+            .replace(/{white}/g, "<span class='white'>")
+            .replace(/{magenta}/g, "<span class='magenta'>")
+            .replace(/{inop}/g, "<span class='inop'>")
+            .replace(/{sp}/g, "&nbsp;")
+            .replace(/{end}/g, "</span>");
+    }
+
+    setTemplate(_template) {
+        super.setTemplate(_template);
+        // Apply formatting helper to title page, lines and labels
+        if (this._titleElement !== null) {
+            this._titleElement.innerHTML = this._formatCell(this._titleElement.innerHTML);
+        }
         this._lineElements.forEach((row) => {
             row.forEach((column) => {
-                if (column != null) {
-                    column.innerHTML = column.innerHTML.replace(/{smallFront}/g, "<span class='s-text'>");
-                    column.innerHTML = column.innerHTML.replace(/{smallEnd}/g, "</span>");
+                if (column !== null) {
+                    column.innerHTML = this._formatCell(column.innerHTML);
+                }
+            });
+        });
+        this._labelElements.forEach((row) => {
+            row.forEach((column) => {
+                if (column !== null) {
+                    column.innerHTML = this._formatCell(column.innerHTML);
                 }
             });
         });


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
In some cases, the MCDU requires multiple colors per cell. A good example is the INIT B page, where the user may edit the fuel, but not the number of minutes (which are computed). Hence the cell is split in blue and green, which is not supported out of the box by the MCDU template. There are other in-cell formatting changes

To fix this in the past pages, various pages use a little marker in their template (e.g. ` {smallFront}` and `{smallEnd}`) together with script that replaces these markers in the innerHTML with `<span>`s using the corresponding CSS classes. This is a bit ugly, especially as multiple pages need this.

As part of #1342, @tyler58546 built a little helper for the CDU code that generalized the markers and applies them everywhere by default. Unfortunately #1342 is pretty sizeable and it's not clear when this PR will land. Therefore, after a [conversation with @Lucky38i in Discord](https://discord.com/channels/738864299392630914/747622836381810739/775306984680587274) I'm pulling this into a standalone, separate PR that does nothing but introduce the formatting helper where it's possible.

This PR adjusts the pages that are already in the repository to use this new methods. I've tried searching the code base for all I could find. Please let me know if you find any others. Once this PR lands I'm happy to help out with any open PRs that want to rebase onto this (although it should be very straightforward).

All in all there are no expected user facing changes, so I do not think a CHANGELOG entry is necessary. This for developers and should simplify code in a few places and make it easier and faster to implement cells with special formatting in future.

### Notes for QA (once tagged with 'Ready to Test')

QA should verify that all MCDU pages are formatted as usual (and as expected), especially the ones touched as part of this PR:
- AIRWAYS (FPLN => LAT REV => AIRWAYS)
- IRS INIT (INIT => IRS INIT)
- INIT

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

While nearly all changes are invisible, I cleaned up the IRS INIT page that was using a font that was manually defined and did not match the normal font sizes, especially after #1243. Replacing this caused the font sizes to be corrected again, and this is the only change that should be visible to players (left old, right new):

![IRS INIT](https://user-images.githubusercontent.com/929769/98578397-97732080-22bd-11eb-9ad2-1f92b2964967.png)

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

## Additional context
<!-- Add any other context about the pull request here. -->

PRs that roll their own templating or are forgoing dual formatting and would benefit from this:
- #1524
- #1597
- #1823
- #1845

PR #1342 (where this is from) would also have to be adjusted. These PRs could be rebased once this PR lands to use the new templates.

Pages we know that use split colors and would benefit from this:
- INIT B (various fuel entries)
- FUEL PRED (same)
- AIRWAYS TO (title)
- PERF page (O=/S=/F=)
- DUPLICATE NAMES (waypoint)
- VERT REV (title)
- LAT REV (title)
- HOLD AT (title)
- FPLN (split colors in right column)

Credit for the original work goes to @tyler58546. Also thanks to @Lucky38i for some help on this.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BehEh#1234

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
