### PR TITLE
[CDU] Fix Performance page broken

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -1,4 +1,3 @@
-const QNH_REGEX = /[0-9]{2}.[0-9]{2}/;
 class CDUPerformancePage {
     static ShowPage(mcdu) {
         mcdu.activeSystem = 'FMGC';
@@ -510,6 +509,7 @@ class CDUPerformancePage {
             titleColor = "green";
         }
         let qnhCell = "[ ]";
+        const QNH_REGEX = /[0-9]{2}.[0-9]{2}/;
         if (isFinite(mcdu.perfApprQNH) || QNH_REGEX.test(mcdu.perfApprQNH)) {
             qnhCell = mcdu.perfApprQNH;
         }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -1,4 +1,3 @@
-const QNH_REGEX = /[0-9]{2}.[0-9]{2}/;
 class FMCMainDisplay extends BaseAirliners {
     constructor() {
         super(...arguments);
@@ -1748,6 +1747,7 @@ class FMCMainDisplay extends BaseAirliners {
 
     setPerfApprQNH(s) {
         const value = parseFloat(s);
+        const QNH_REGEX = /[0-9]{2}.[0-9]{2}/;
 
         if (QNH_REGEX.test(value)) {
             this.perfApprQNH = value;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->
Fix for the recently introduced bug in the performance page, I think that the structure of the code used by Asobo does not allow multiple declarations of entities in the same file. The issue was because a `const` was declared before the `class`

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #1841

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![Screenshot 2020-11-10 055319](https://user-images.githubusercontent.com/11317522/98635771-d9d04800-2325-11eb-9204-438bcf54e408.png)
## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
I believe the Issue was introduced  in this PR https://github.com/flybywiresim/a32nx/pull/1583
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Union Araken#4083



<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
