### PR TITLE
[CDU] Improve LAT REV page layout

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -69,6 +69,7 @@
 1. [General] Added location reporting for the live map - @nistei (Nistei)
 1. [ECAM] Fix cabin vertical speed display to show feet/min - @MattPaxtonBel, @RichardPilbery
 1. [FCU] Fix altitude change when the increment is 1000 - @lars-reimann (Lars Reimann)
+1. [CDU] Improve LAT REV page layout - @beheh (Benedict Etzel)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
@@ -4,57 +4,137 @@ class CDULateralRevisionPage {
         console.log(waypoint);
         mcdu.clearDisplay();
         mcdu.page.Current = mcdu.page.LateralRevisionPage;
+
+        let coordinates = "";
+        if (waypoint && waypoint.infos && waypoint.infos.coordinates) {
+            const lat = CDUInitPage.ConvertDDToDMS(waypoint.infos.coordinates['lat'], false);
+            const long = CDUInitPage.ConvertDDToDMS(waypoint.infos.coordinates['long'], true);
+            coordinates = `${lat.deg}°${lat.min}.${Math.ceil(Number(lat.sec / 100))}${lat.dir}/${long.deg}°${long.min}.${Math.ceil(Number(long.sec / 100))}${long.dir}[color]green`;
+        }
+        const isDeparture = waypoint === mcdu.flightPlanManager.getOrigin();
+        const isDestination = waypoint === mcdu.flightPlanManager.getDestination();
+        const isWaypoint = !isDeparture && !isDestination;
+
         let waypointIdent = "---";
         if (waypoint) {
             waypointIdent = waypoint.ident;
+            if (isDeparture) {
+                const departureRunway = mcdu.flightPlanManager.getDepartureRunway();
+                if (departureRunway) {
+                    waypointIdent += Avionics.Utils.formatRunway(departureRunway.designation);
+                }
+            } else if (isDestination) {
+                const approachRunway = mcdu.flightPlanManager.getApproachRunway();
+                if (approachRunway) {
+                    waypointIdent += Avionics.Utils.formatRunway(approachRunway.designation);
+                }
+            }
         }
-        let coordinates = "---";
-        console.log(waypoint);
-        if (waypoint && waypoint.infos && waypoint.infos.coordinates) {
-            coordinates = waypoint.infos.coordinates.toDegreeString();
-        }
-        let departureArrival = "";
-        if (waypoint === mcdu.flightPlanManager.getOrigin()) {
-            departureArrival = "<DEPARTURE";
+
+        let departureCell = "";
+        if (isDeparture) {
+            departureCell = "<DEPARTURE";
             mcdu.onLeftInput[0] = () => {
                 CDUAvailableDeparturesPage.ShowPage(mcdu, waypoint);
             };
-        } else if (waypoint === mcdu.flightPlanManager.getDestination()) {
-            departureArrival = "<ARRIVAL";
-            mcdu.onLeftInput[0] = () => {
+        }
+
+        let arrivalFixInfoCell = "";
+        if (isDestination) {
+            arrivalFixInfoCell = "ARRIVAL>";
+            mcdu.onRightInput[0] = () => {
                 CDUAvailableArrivalsPage.ShowPage(mcdu, waypoint);
             };
+        } else if (isDeparture) {
+            arrivalFixInfoCell = "FIX INFO>[color]inop";
         }
+
+        let crossingLabel = "";
+        let crossingCell = "";
+        if (!isDestination) {
+            crossingLabel = "LL XING/INCR/NO[color]inop";
+            crossingCell = "[{sp}{sp}]°/[{sp}]°/[][color]inop";
+        }
+
+        let offsetCell = "";
+        if (isDeparture || isWaypoint) {
+            offsetCell = "<OFFSET[color]inop";
+        }
+
+        let nextWptLabel = "";
+        let nextWpt = "";
+        const isPreflight = mcdu.currentFlightPhase === FlightPhase.FLIGHT_PHASE_PREFLIGHT;
+        if ((isDeparture && isPreflight) || isWaypoint || isDestination) {
+            if (isDestination) {
+                // TODO remove this once we support waypoints after the destination (otherwise sim crash)
+                nextWptLabel = "NEXT WPT[color]inop";
+                nextWpt = "[{sp}{sp}{sp}{sp}][color]inop";
+            } else {
+                nextWptLabel = "NEXT WPT";
+                nextWpt = "[{sp}{sp}{sp}{sp}][color]blue";
+                mcdu.onRightInput[2] = async () => {
+                    const value = mcdu.inOut;
+                    mcdu.clearUserInput();
+                    mcdu.insertWaypoint(value, waypointIndexFP + 1, (result) => {
+                        if (result) {
+                            CDUFlightPlanPage.ShowPage(mcdu);
+                        }
+                    });
+                };
+            }
+        }
+
+        let holdCell = "";
+        if (isWaypoint) {
+            holdCell = "<HOLD";
+            mcdu.onLeftInput[2] = () => {
+                CDUHoldAtPage.ShowPage(mcdu, waypoint, waypointIndexFP);
+            };
+        }
+
+        let enableAltnLabel = "";
+        let enableAltnCell = "";
+        if (!isDeparture && mcdu.altDestination) {
+            // TODO this should be hidden if we're already enroute to our alternate (see "Alternate Diversion" 11-5)
+            enableAltnLabel = "{sp}ENABLE[color]inop";
+            enableAltnCell = "{ALTN[color]inop";
+        }
+
+        let newDestLabel = "";
+        let newDestCell = "";
+        if (!isDestination) {
+            newDestLabel = "NEW DEST[color]inop";
+            newDestCell = "[{sp}{sp}][color]inop";
+        }
+
+        let airwaysCell = "";
+        if (isWaypoint) {
+            airwaysCell = "AIRWAYS>";
+            mcdu.onRightInput[4] = () => {
+                A320_Neo_CDU_AirwaysFromWaypointPage.ShowPage(mcdu, waypoint);
+            };
+        }
+
+        let altnCell = "";
+        if (isDestination) {
+            altnCell = "<ALTN[color]inop";
+        }
+
         mcdu.setTemplate([
-            ["LAT REV FROM " + waypointIdent],
+            [`LAT REV{small} FROM {end}{green}${waypointIdent}{end}`],
             ["", "", coordinates + "[color]green"],
-            [departureArrival, "FIX INFO>"],
-            ["", "LL WING/INCR/NO"],
-            ["[][color]blue", "[ ]°/[ ]°/[][color]blue"],
-            ["", "NEXT WPT"],
-            ["<HOLD[color]blue", "[ ][color]blue"],
-            ["ENABLE[color]blue", "NEW DEST"],
-            ["{ALTN[color]blue", "[ ][color]blue"],
+            [departureCell, arrivalFixInfoCell],
+            ["", crossingLabel],
+            [offsetCell, crossingCell],
+            ["", nextWptLabel],
+            [holdCell, nextWpt],
+            [enableAltnLabel, newDestLabel],
+            [enableAltnCell, newDestCell],
             [""],
-            ["", "AIRWAYS>"],
+            [altnCell, airwaysCell],
             [""],
             ["<RETURN"]
         ]);
-        mcdu.onRightInput[2] = async () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
-            mcdu.insertWaypoint(value, waypointIndexFP + 1, (result) => {
-                if (result) {
-                    CDUFlightPlanPage.ShowPage(mcdu);
-                }
-            });
-        };
-        mcdu.onLeftInput[2] = () => {
-            CDUHoldAtPage.ShowPage(mcdu, waypoint, waypointIndexFP);
-        };
-        mcdu.onRightInput[4] = () => {
-            A320_Neo_CDU_AirwaysFromWaypointPage.ShowPage(mcdu, waypoint);
-        };
         mcdu.onLeftInput[5] = () => {
             CDUFlightPlanPage.ShowPage(mcdu);
         };


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

This PR greatly improves the look of lateral revision page (LAT REV) in the MCDU, which right now is quite a bit away from the reference documentation.

Please note that this is mostly fixes visual issues on the LAT REV page only, not any behaviours and not any of the subpages, e.g. HOLD or AIRWAYS are out of scope for this PR. Items that were non-functional are also marked in gray now, but the behaviours were never there in the first place (nothing has been removed as part of this PR).

Here's a list of all the changes:
* [x] Fix page title according to reference (colors, text size, show runway if set)
* [x] Fix coordinate format (N12.123.1 E12.123.12 => 12.123.1N/012.123.123E)
* [x] Fix position of ARRIVAL (1L => 1R)
* [x] Fix typo (WING => XING)
* [x] Show or hide items based on type of waypoint and in some cases flight phase
  * Three primary versions: departure airport, enroute waypoint, destination airport
  * ENABLE ALTN is only visible if an alternate is set on the init page, and only on enroute waypoint and destination
* [x] Change text color for items missing implementation to inop gray
* [x] Disable NEXT WPT on destination airport for now as that crashes the sim

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![before/after](https://user-images.githubusercontent.com/929769/98873622-09dc3000-2479-11eb-88c3-e2240b62527d.png)

(note that the wrong N/E vs N/W coordinates were fixed after these screenshots were taken as part of #1867).

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

![grafik](https://user-images.githubusercontent.com/929769/98860633-46516100-2464-11eb-81c9-1a4cf28c6bbb.png)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

The visual layout of the page should be pretty obvious and changes depending on the type of waypoint you select (departure airport/enroute waypoint/destination waypoint). However:
- `NEXT WPT`: This will be hidden on the origin airport page as per the documentation after PREFLIGHT has ended, so you may not see it if you're in the takeoff phase.
- `NEXT WPT`: Is disabled on the destination airport for now as the sim can't handle that yet and crashes
- `HOLD`: While a hold page exists, it doesn't work really yet. I'm keeping it available for now.

The subpages (HOLD/ARRIVAL/DEPARTURE/AIRWAYS) don't cleanly return to this page yet on the return button, but I'll keep that out of scope for now as it's a bit tricky.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BehEh#1234

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
