### PR TITLE
[FIX] "too low terrain" warning on takeoff

### DIFF
--- a/A32NX/html_ui/Pages/A32NX_Core/A32NX_GPWS.js
+++ b/A32NX/html_ui/Pages/A32NX_Core/A32NX_GPWS.js
@@ -54,6 +54,7 @@ class A32NX_GPWS {
     }
     gpws(deltaTime) {
         const radioAlt = SimVar.GetSimVarValue("PLANE ALT ABOVE GROUND MINUS CG", "Feet");
+        const onGround = SimVar.GetSimVarValue("SIM ON GROUND", "Bool");
 
         this.UpdateAltState(radioAlt);
         this.differentiate_radioalt(radioAlt, deltaTime);
@@ -70,7 +71,7 @@ class A32NX_GPWS {
             const Airspeed = SimVar.GetSimVarValue("AIRSPEED INDICATED", "Knots");
             const gearExtended = SimVar.GetSimVarValue("GEAR TOTAL PCT EXTENDED", "Percent") > 0.9;
 
-            this.update_maxRA(radioAlt);
+            this.update_maxRA(radioAlt, onGround);
 
             this.GPWSMode1(radioAlt, vSpeed);
             //Mode 2 is disabled because of an issue with the terrain height simvar which causes false warnings very frequently. See PR#1742 for more info
@@ -125,8 +126,11 @@ class A32NX_GPWS {
         }
     }
 
-    update_maxRA(radioAlt) {
-        if (this.Mode4MaxRAAlt < radioAlt || isNaN(this.Mode4MaxRAAlt)) {
+    update_maxRA(radioAlt, onGround) {
+        // on ground check is to get around the fact that radio alt is set to around 300 while loading
+        if (onGround) {
+            this.Mode4MaxRAAlt = NaN;
+        } else if (this.Mode4MaxRAAlt < radioAlt || isNaN(this.Mode4MaxRAAlt)) {
             this.Mode4MaxRAAlt = radioAlt;
         }
     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->


## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* This change fixes the wrong "Too low, Terrain" warning on takeoff
* It was caused by the fact that the radio alt is set to a non zero value while loading (in my testing around 300ft), which caused problems.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
