### PR TITLE
[CDU] Fix IRS coordinates always showing N/E

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -65,6 +65,7 @@
 1. [GPWS] Completely redone GPWS logic, and improve Retard call logic, prevent multiple calls playing at once - lukecologne (luke)
 1. [ECAM] Improve flaps/slats panel design on upper ECAM, improve flaps/slats transition logic - @paul92ilm (Lussion)
 1. [CDU] Allow inserting landing QNH in inHg - @pessip (Pessi Päivärinne)
+1. [CDU] Fix IRS coordinates always showing N/E - @beheh (Benedict Etzel)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -429,9 +429,9 @@ class CDUInitPage {
         const M = 0 | (deg % 1) * 60e7;
         let degree;
         if (lng) {
-            degree = (0 | (deg < 0 ? deg = -deg : deg)).toString().padStart(3, "0");
+            degree = (0 | (deg < 0 ? -deg : deg)).toString().padStart(3, "0");
         } else {
-            degree = 0 | (deg < 0 ? deg = -deg : deg);
+            degree = 0 | (deg < 0 ? -deg : deg);
         }
         return {
             dir : deg < 0 ? lng ? 'W' : 'S' : lng ? 'E' : 'N',


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes a tiny logical issue in some init page math that resulted in coordinates always showing N and E, instead of N or S and W or E respectively.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![IRS INIT](https://user-images.githubusercontent.com/929769/98868522-8dddea00-2470-11eb-9413-c97ebd7197db.png)

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

![grafik](https://user-images.githubusercontent.com/929769/98868611-b36af380-2470-11eb-90f2-d1e641df4fcc.png)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
To test this (small) fix:
1. Spawn at an airport that is in the southern hemisphere and/or west of Greenwhich, e.g. SBGL, cold and dark
2. Turn on external power
3. Set all 3 ADRIS knobs to NAV
4. On the MCDU, open the INIT page and enter an arbitrary FROM/TO
5. Click the `IRS INIT>` LSK
6. Check that the coordinates show the expected hemisphere (N/S) and the expected side of Greenwich (W/E), e.g. S/W in SBGL

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BehEh#1234

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
