### PR TITLE
[CDU] Add location reporting and fix ATC issue

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -66,6 +66,7 @@
 1. [ECAM] Improve flaps/slats panel design on upper ECAM, improve flaps/slats transition logic - @paul92ilm (Lussion)
 1. [CDU] Allow inserting landing QNH in inHg - @pessip (Pessi Päivärinne)
 1. [CDU] Fix IRS coordinates always showing N/E - @beheh (Benedict Etzel)
+1. [General] Added location reporting for the live map - @nistei (Nistei)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -17,7 +17,6 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this._cruiseEntered = false;
         this._blockFuelEntered = false;
         this._gpsprimaryack = 0;
-        this.telexPingId = 0;
     }
     get templateID() {
         return "A320_Neo_CDU";
@@ -38,7 +37,13 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this.A32NXCore = new A32NX_Core();
         this.A32NXCore.init(this._lastTime);
 
-        SimVar.SetSimVarValue("ATC FLIGHT NUMBER", "string", "", "FMC");
+        const flightNo = SimVar.GetSimVarValue("ATC FLIGHT NUMBER", "string");
+        NXApi.connectTelex(flightNo)
+            .catch((err) => {
+                if (err !== NXApi.disconnectedError) {
+                    this.showErrorMessage("FLT NBR IN USE");
+                }
+            });
 
         this.defaultInputErrorMessage = "NOT ALLOWED";
         this.onDir = () => {
@@ -82,7 +87,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             // Update connection
             NXApi.updateTelex()
                 .catch((err) => {
-                    if (err !== NXApi.disabledError) {
+                    if (err !== NXApi.disconnectedError) {
                         console.log("TELEX PING FAILED");
                     }
                 });

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -721,25 +721,16 @@ class FMCMainDisplay extends BaseAirliners {
             return callback(false);
         }
 
-        const storedTelexStatus = NXDataStore.get("CONFIG_TELEX_STATUS", "DISABLED");
-
-        let connectSuccess = true;
         SimVar.SetSimVarValue("ATC FLIGHT NUMBER", "string", flightNo, "FMC").then(() => {
-            if (storedTelexStatus === "ENABLED") {
-                const initTelexServer = async () => {
-                    NXApi.connectTelex(flightNo)
-                        .catch((err) => {
-                            if (err !== NXApi.disconnectedError) {
-                                this.showErrorMessage("FLT NBR IN USE");
-                            }
+            NXApi.connectTelex(flightNo)
+                .then(() => {
+                    callback(true);
+                })
+                .catch(() => {
+                    this.showErrorMessage("FLT NBR IN USE");
 
-                            connectSuccess = false;
-                        });
-                };
-
-                initTelexServer();
-            }
-            return callback(connectSuccess);
+                    callback(false);
+                });
         });
     }
 


### PR DESCRIPTION
Fixes #1795 

## Summary of Changes
Permanent location reporting. Only FreeText is opt-in.
Do not persist accessTokens across sessions.
Fix the ATC issue by not resetting the FlightNumber SimVar.

## Screenshots (if necessary)

## References

## Additional context
Server is already updated to support the disabling of FreeText in the backend.


Discord username (if different from GitHub): nistei#1362


## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
