### PR TITLE
Fix altitude knob increment/decrement

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -67,6 +67,7 @@
 1. [CDU] Allow inserting landing QNH in inHg - @pessip (Pessi Päivärinne)
 1. [CDU] Fix IRS coordinates always showing N/E - @beheh (Benedict Etzel)
 1. [General] Added location reporting for the live map - @nistei (Nistei)
+1. [FCU] Fix altitude change when the increment is 1000 - @lars-reimann (Lars Reimann)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/ModelBehaviorDefs/A32NX/Interior/A32NX_Interior_FCU.xml
+++ b/A32NX/ModelBehaviorDefs/A32NX/Interior/A32NX_Interior_FCU.xml
@@ -124,29 +124,13 @@
             <UseTemplate Name="ASOBO_GT_Knob_Infinite_PushPull">
                 <!-- Calculates max(ALTITUDE_LOCK - INCREMENT + (INCREMENT - ALTITUDE_LOCK % INCREMENT) % INCREMENT, 100) -->
                 <ANTICLOCKWISE_CODE>
-                    3
-
-                                (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) #INCREMENT# -
-                                #INCREMENT# (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) #INCREMENT# % - #INCREMENT# %
-                            +
-                            100
-                        max
-                    (&gt;K:2:AP_ALT_VAR_SET_ENGLISH)
-
+                    3 (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) #INCREMENT# - #INCREMENT# (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) #INCREMENT# % - #INCREMENT# % + 100 max (&gt;K:2:AP_ALT_VAR_SET_ENGLISH)
                     (&gt;H:AP_KNOB_Down)
                     (&gt;H:A320_Neo_CDU_AP_DEC_ALT)
                 </ANTICLOCKWISE_CODE>
                 <!-- Calculates min(ALTITUDE_LOCK + INCREMENT - ALTITUDE_LOCK % INCREMENT, 49000) -->
                 <CLOCKWISE_CODE>
-                    3
-
-                                (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) #INCREMENT# +
-                                (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) #INCREMENT# %
-                            -
-                            49000
-                        min
-                    (&gt;K:2:AP_ALT_VAR_SET_ENGLISH)
-
+                    3 (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) #INCREMENT# + (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) #INCREMENT# % - 49000 min (&gt;K:2:AP_ALT_VAR_SET_ENGLISH)
                     (&gt;H:AP_KNOB_Up)
                     (&gt;H:A320_Neo_CDU_AP_INC_ALT)
                 </CLOCKWISE_CODE>

--- a/A32NX/ModelBehaviorDefs/A32NX/Interior/A32NX_Interior_FCU.xml
+++ b/A32NX/ModelBehaviorDefs/A32NX/Interior/A32NX_Interior_FCU.xml
@@ -35,7 +35,7 @@
             <MODE_BARO>0</MODE_BARO>
             <MODE_QNH>1</MODE_QNH>
             <MODE_STD_BARO>2</MODE_STD_BARO>
-            <MODE_STD_QNH>3</MODE_STD_QNH>      
+            <MODE_STD_QNH>3</MODE_STD_QNH>
             <NODE_ID>AUTOPILOT_Knob_Baro_#ID##SUFFIX_ID#</NODE_ID>
             <PART_ID>AUTOPILOT_Knob_Baro</PART_ID>
         </DefaultTemplateParameters>
@@ -61,14 +61,14 @@
                         }
                     }
                 </CLOCKWISE_CODE>
-                
+
                 <PULL_CODE>
-                    (L:XMLVAR_Baro#BARO_ID#_Mode) #MODE_BARO# == if{ 
-                        #MODE_STD_BARO# (&gt;L:XMLVAR_Baro#BARO_ID#_Mode) 
-                    } els{ 
-                        (L:XMLVAR_Baro#BARO_ID#_Mode) #MODE_QNH# == if{ 
-                            #MODE_STD_QNH# (&gt;L:XMLVAR_Baro#BARO_ID#_Mode) 
-                        } 
+                    (L:XMLVAR_Baro#BARO_ID#_Mode) #MODE_BARO# == if{
+                        #MODE_STD_BARO# (&gt;L:XMLVAR_Baro#BARO_ID#_Mode)
+                    } els{
+                        (L:XMLVAR_Baro#BARO_ID#_Mode) #MODE_QNH# == if{
+                            #MODE_STD_QNH# (&gt;L:XMLVAR_Baro#BARO_ID#_Mode)
+                        }
                     }
                 </PULL_CODE>
                 <PUSH_CODE>
@@ -86,10 +86,10 @@
                 <CENTER_RADIUS>0</CENTER_RADIUS>
                 <COUNT>36</COUNT>
                 <OVERRIDE_PUSH_ANIM_CODE>
-                    0 100 
-                        (L:XMLVAR_Baro#BARO_ID#_Mode) #MODE_STD_BARO# == 
+                    0 100
+                        (L:XMLVAR_Baro#BARO_ID#_Mode) #MODE_STD_BARO# ==
                         (L:XMLVAR_Baro#BARO_ID#_Mode) #MODE_STD_QNH# == or ?
-                    50 
+                    50
                         (O:_PushAnimVar) ?
                 </OVERRIDE_PUSH_ANIM_CODE>
                 <WWISE_EVENT>autopilot_selector_knob</WWISE_EVENT>
@@ -122,12 +122,32 @@
 
         <Component ID="#NODE_ID#" Node="#NODE_ID#">
             <UseTemplate Name="ASOBO_GT_Knob_Infinite_PushPull">
+                <!-- Calculates max(ALTITUDE_LOCK - INCREMENT + (INCREMENT - ALTITUDE_LOCK % INCREMENT) % INCREMENT, 100) -->
                 <ANTICLOCKWISE_CODE>
-                    3 (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) #INCREMENT# - 100 max (&gt;K:2:AP_ALT_VAR_SET_ENGLISH) (&gt;H:AP_KNOB_Down)
+                    3
+
+                                (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) #INCREMENT# -
+                                #INCREMENT# (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) #INCREMENT# % - #INCREMENT# %
+                            +
+                            100
+                        max
+                    (&gt;K:2:AP_ALT_VAR_SET_ENGLISH)
+
+                    (&gt;H:AP_KNOB_Down)
                     (&gt;H:A320_Neo_CDU_AP_DEC_ALT)
                 </ANTICLOCKWISE_CODE>
+                <!-- Calculates min(ALTITUDE_LOCK + INCREMENT - ALTITUDE_LOCK % INCREMENT, 49000) -->
                 <CLOCKWISE_CODE>
-                    3 (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) #INCREMENT# + 49000 min (&gt;K:2:AP_ALT_VAR_SET_ENGLISH) (&gt;H:AP_KNOB_Up)
+                    3
+
+                                (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) #INCREMENT# +
+                                (A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) #INCREMENT# %
+                            -
+                            49000
+                        min
+                    (&gt;K:2:AP_ALT_VAR_SET_ENGLISH)
+
+                    (&gt;H:AP_KNOB_Up)
                     (&gt;H:A320_Neo_CDU_AP_INC_ALT)
                 </CLOCKWISE_CODE>
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #1871

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Change the behavior of the altitude knob when the increment is 1000. It should first jump to the next number that is divisible by 1000 rather than just plainly adding 1000 to/subtracting 1000 from the previous altitude. The following table shows the changed behavior:

### Before

|original altitude  | -100  | +100  | -1000   | +1000   |
|---|---|---|---|---|
|   100| 100  |200   | 100  | **1100**  |
|  400 |  300 | 500  | 100  | **1400**  |
|  4000 | 3900  | 4100  | 3000  | 5000  |
|  4400 |  4300 |  4500 | **3400**  | **5400**  |
| 49000  |  48900 | 49000  | 48000  | 49000   |

### After

|original altitude  | -100  | +100  | -1000   | +1000   |
|---|---|---|---|---|
|   100| 100  |200   | 100  | **1000**  |
|  400 |  300 | 500  | 100  | **1000**  |
|  4000 | 3900  | 4100  | 3000  | 5000  |
|  4400 |  4300 |  4500 | **4000**  | **5000**  |
| 49000  |  48900 | 49000  | 48000  | 49000   |

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

Reported by St54Kevin (IRL A320 pilot).

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Ignavia#1987

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
