### PR TITLE
V0.4.1 BUGS REPORTED FROM A320 INSTRUCTOR IN REAL LIFE

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.js
@@ -100,9 +100,6 @@ class MapInstrument extends ISvgMapRootElement {
         this.isBushTrip = false;
     }
     get flightPlanManager() {
-        if (this.gps) {
-            return this.gps.currFlightPlanManager;
-        }
         return this._flightPlanManager;
     }
     setNPCAirplaneManagerTCASMode(mode) {
@@ -318,9 +315,6 @@ class MapInstrument extends ISvgMapRootElement {
             if (arg instanceof BaseInstrument) {
                 this.instrument = arg;
                 this.selfManagedInstrument = false;
-                if (this.instrument instanceof NavSystem) {
-                    this.gps = this.instrument;
-                }
             } else {
                 this.instrument = document.createElement("base-instrument");
                 this.selfManagedInstrument = true;
@@ -330,21 +324,15 @@ class MapInstrument extends ISvgMapRootElement {
             }
         } else {
         }
-        if (this.gps) {
-            if (!this.gps.currFlightPlanManager) {
-                this.gps.currFlightPlanManager = new FlightPlanManager(this.instrument);
-                this.gps.currFlightPlanManager.registerListener();
-            }
-            this.gps.addEventListener("FlightStart", this.onFlightStart.bind(this));
+        this._flightPlanManager = this.instrument.flightPlanManager;
+        if (this._flightPlanManager) {
+            this.instrument.addEventListener("FlightStart", this.onFlightStart.bind(this));
         } else {
-            if (!this._flightPlanManager) {
-                this._flightPlanManager = new FlightPlanManager(this.instrument);
-                this._flightPlanManager.registerListener();
-            }
+            this._flightPlanManager = new FlightPlanManager(this.instrument);
         }
         let bingMapId = this.bingId;
-        if (this.gps && this.gps.urlConfig.index) {
-            bingMapId += "_GPS" + this.gps.urlConfig.index;
+        if (this.instrument.urlConfig.index) {
+            bingMapId += "_GPS" + this.instrument.urlConfig.index;
         }
         this.bingMap = this.getElementsByTagName("bing-map")[0];
         this.bingMap.setMode(this.eBingMode);
@@ -855,9 +843,9 @@ class MapInstrument extends ISvgMapRootElement {
             const setConfig = () => {
                 if (this.navMap.configLoaded) {
                     for (let i = 0; i < 3; i++) {
-                        const bingConfig = new BingMapsConfig();
-                        if (bingConfig.load(this.navMap.config, i)) {
-                            this.bingMap.addConfig(bingConfig);
+                        const conf = this.navMap.config.generateBing(i);
+                        if (conf) {
+                            this.bingMap.addConfig(conf);
                         }
                     }
                     this.bingMap.setConfig(this.bingMapConfigId);
@@ -881,12 +869,12 @@ class MapInstrument extends ISvgMapRootElement {
             };
             loadSVGConfig();
             const setBingConfig = () => {
-                if (svgConfigLoaded && (!this.gps || this.gps.isComputingAspectRatio())) {
+                if (svgConfigLoaded && this.instrument.isComputingAspectRatio()) {
                     for (let i = 0; i < 3; i++) {
-                        const bingConfig = new BingMapsConfig();
-                        if (bingConfig.load(svgConfig, i)) {
-                            bingConfig.aspectRatio = (this.gps && this.gps.isAspectRatioForced()) ? this.gps.getForcedScreenRatio() : 1.0;
-                            this.bingMap.addConfig(bingConfig);
+                        const conf = svgConfig.generateBing(i);
+                        if (conf) {
+                            conf.aspectRatio = (this.instrument.isAspectRatioForced()) ? this.instrument.getForcedScreenRatio() : 1.0;
+                            this.bingMap.addConfig(conf);
                         }
                     }
                     this.bingMap.setConfig(this.bingMapConfigId);
@@ -897,7 +885,7 @@ class MapInstrument extends ISvgMapRootElement {
             setBingConfig();
         }
     }
-    update() {
+    update(_deltaTime) {
         this.updateVisibility();
         this.updateSize(true);
         const WXBrightnessValue = SimVar.GetSimVarValue("LIGHT POTENTIOMETER:" + this.potIndex, "number");
@@ -907,6 +895,7 @@ class MapInstrument extends ISvgMapRootElement {
         }
         if (this.selfManagedInstrument) {
             this.instrument.doUpdate();
+            this.flightPlanManager.update(_deltaTime);
         }
         if (this.wpt) {
             const wpId = SimVar.GetSimVarValue("GPS WP NEXT ID", "string");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/A32NX_BaseAirliners.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/A32NX_BaseAirliners.js
@@ -324,8 +324,8 @@ var Airliners;
             super.Init();
             console.log("ATC Init");
         }
-        Update() {
-            super.Update();
+        onUpdate(_deltaTime) {
+            super.onUpdate(_deltaTime);
 
             const lightsTest = SimVar.GetSimVarValue("L:XMLVAR_LTS_Test", "Bool");
             const lightsTestChanged = lightsTest !== this.lightsTest;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BAT/A320_Neo_BAT.js
@@ -14,8 +14,8 @@ var A320_Neo_BAT;
             this.batTexts[0] = this.querySelector("#BAT1");
             this.batTexts[1] = this.querySelector("#BAT2");
         }
-        Update() {
-            super.Update();
+        onUpdate(_deltaTime) {
+            super.onUpdate(_deltaTime);
 
             const lightsTest = SimVar.GetSimVarValue("L:XMLVAR_LTS_Test", "Bool");
             this.lightsTest = lightsTest;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BRK/A320_Neo_BRK.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/BRK/A320_Neo_BRK.js
@@ -68,8 +68,8 @@ var A320_Neo_BRK;
             this.rightGauge.addMarker(3, false);
             this.electricity = this.querySelector("#Electricity");
         }
-        Update() {
-            super.Update();
+        onUpdate(_deltaTime) {
+            super.onUpdate(_deltaTime);
             const currentPKGBrakeState = SimVar.GetSimVarValue("BRAKE PARKING POSITION", "Bool");
             const powerAvailable = SimVar.GetSimVarValue("L:DCPowerAvailable","Bool");
             if (this.topGauge != null) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IdentPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IdentPage.js
@@ -1,14 +1,15 @@
 class CDUIdentPage {
     static ShowPage(mcdu) {
+        const date = mcdu.getNavDataDateRange();
         mcdu.clearDisplay();
         mcdu.setTemplate([
             ["A320"],
             ["ENG"],
             ["LEAP A-1[color]green"],
             ["", "", "ACTIVE NAV DATA BASE"],
-            ["4MAY-4JUL[color]blue", "TC11103001[color]green"],
+            [date + "[color]blue", "AIRAC"],
             ["", "", "SECOND NAV DATA BASE"],
-            ["{4MAY-4JUL[color]blue"],
+            ["{" + date + "4MAY-4JUL[color]blue"],
             [""],
             [""],
             ["CHG CODE"],

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -208,7 +208,7 @@ class CDUInitPage {
             if (value === "") {
                 mcdu.inOut =
                     (isFinite(mcdu.zeroFuelWeight) ? mcdu.zeroFuelWeight.toFixed(1) : "") +
-                    "|" +
+                    "/" +
                     (isFinite(mcdu.zeroFuelWeightMassCenter) ? mcdu.zeroFuelWeightMassCenter.toFixed(1) : "");
             } else if (await mcdu.trySetZeroFuelWeightZFWCG(value)) {
                 CDUInitPage.updateTowIfNeeded(mcdu);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -182,8 +182,8 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this.taxiFuelWeight = 0.2;
         CDUInitPage.updateTowIfNeeded(this);
     }
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
 
         this.A32NXCore.update();
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Clock/A320_Neo_Clock.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Clock/A320_Neo_Clock.js
@@ -26,82 +26,76 @@ class A320_Neo_Clock extends BaseAirliners {
     }
     onInteractionEvent(_args) {
     }
-    Update() {
-        super.Update();
-        if (this.CanUpdate()) {
-            const absTime = SimVar.GetGlobalVarValue("ABSOLUTE TIME", "Seconds");
-            const lightsTest = SimVar.GetSimVarValue("L:XMLVAR_LTS_Test", "Bool");
-            const lightsTestChanged = lightsTest !== this.lightsTest;
-            this.lightsTest = lightsTest;
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
 
-            const chronoState = SimVar.GetSimVarValue("L:PUSH_CHRONO_CHR", "Bool");
-            if (chronoState !== this.lastChronoState) {
-                this.lastChronoState = chronoState;
-                if (chronoState === 1) {
-                    this.chronoStart = absTime;
-                } else {
-                    this.chronoAcc = this.chronoSeconds;
-                    this.chronoStart = 0;
+        const absTime = SimVar.GetGlobalVarValue("ABSOLUTE TIME", "Seconds");
+        const lightsTest = SimVar.GetSimVarValue("L:XMLVAR_LTS_Test", "Bool");
+        const lightsTestChanged = lightsTest !== this.lightsTest;
+        this.lightsTest = lightsTest;
+        const chronoState = SimVar.GetSimVarValue("L:PUSH_CHRONO_CHR", "Bool");
+        if (chronoState !== this.lastChronoState) {
+            this.lastChronoState = chronoState;
+            if (chronoState === 1) {
+                this.chronoStart = absTime;
+            } else {
+                this.chronoAcc = this.chronoSeconds;
+                this.chronoStart = 0;
+            }
+        }
+        const currentResetVal = SimVar.GetSimVarValue("L:PUSH_CHRONO_RST", "Bool");
+        if (currentResetVal !== this.lastResetVal) {
+            this.lastResetVal = currentResetVal;
+            // Intentionally performed on every press.
+            if (chronoState === 0) {
+                this.chronoStart = 0;
+                this.chronoAcc = 0;
+            }
+        }
+        if (this.topSelectorElem) {
+            if (lightsTest) {
+                this.topSelectorElem.textContent = "88:88";
+            } else {
+                const chronoTime = this.getChronoTime();
+                if (chronoTime !== this.lastChronoTime || lightsTestChanged) {
+                    this.lastChronoTime = chronoTime;
+                    this.topSelectorElem.textContent = chronoTime;
                 }
             }
-
-            const currentResetVal = SimVar.GetSimVarValue("L:PUSH_CHRONO_RST", "Bool");
-            if (currentResetVal !== this.lastResetVal) {
-                this.lastResetVal = currentResetVal;
-                // Intentionally performed on every press.
-                if (chronoState === 0) {
-                    this.chronoStart = 0;
-                    this.chronoAcc = 0;
+        }
+        if (this.middleSelectorElem) {
+            if (lightsTest) {
+                this.middleSelectorElem.textContent = "88:88";
+                this.middleSelectorElem2.textContent = "88";
+            } else {
+                let currentDisplayTime = "";
+                let currentDisplayTime2 = "";
+                if (SimVar.GetSimVarValue("L:PUSH_CHRONO_SET", "Bool") === 1) {
+                    currentDisplayTime = this.getUTCDate();
+                    currentDisplayTime2 = this.getUTCYear();
+                } else {
+                    const UTCTime = this.getUTCTime();
+                    currentDisplayTime = UTCTime.substr(0,5);
+                    currentDisplayTime2 = UTCTime.substr(6,2);
+                }
+                if (currentDisplayTime !== this.lastDisplayTime || lightsTestChanged) {
+                    this.lastDisplayTime = currentDisplayTime;
+                    this.middleSelectorElem.textContent = currentDisplayTime;
+                }
+                if (currentDisplayTime2 !== this.lastDisplayTime2 || lightsTestChanged) {
+                    this.lastDisplayTime2 = currentDisplayTime2;
+                    this.middleSelectorElem2.textContent = currentDisplayTime2;
                 }
             }
-
-            if (this.topSelectorElem) {
-                if (lightsTest) {
-                    this.topSelectorElem.textContent = "88:88";
-                } else {
-                    const chronoTime = this.getChronoTime();
-                    if (chronoTime !== this.lastChronoTime || lightsTestChanged) {
-                        this.lastChronoTime = chronoTime;
-                        this.topSelectorElem.textContent = chronoTime;
-                    }
-                }
-            }
-
-            if (this.middleSelectorElem) {
-                if (lightsTest) {
-                    this.middleSelectorElem.textContent = "88:88";
-                    this.middleSelectorElem2.textContent = "88";
-                } else {
-                    let currentDisplayTime = "";
-                    let currentDisplayTime2 = "";
-                    if (SimVar.GetSimVarValue("L:PUSH_CHRONO_SET", "Bool") === 1) {
-                        currentDisplayTime = this.getUTCDate();
-                        currentDisplayTime2 = this.getUTCYear();
-                    } else {
-                        const UTCTime = this.getUTCTime();
-                        currentDisplayTime = UTCTime.substr(0,5);
-                        currentDisplayTime2 = UTCTime.substr(6,2);
-                    }
-                    if (currentDisplayTime !== this.lastDisplayTime || lightsTestChanged) {
-                        this.lastDisplayTime = currentDisplayTime;
-                        this.middleSelectorElem.textContent = currentDisplayTime;
-                    }
-                    if (currentDisplayTime2 !== this.lastDisplayTime2 || lightsTestChanged) {
-                        this.lastDisplayTime2 = currentDisplayTime2;
-                        this.middleSelectorElem2.textContent = currentDisplayTime2;
-                    }
-                }
-            }
-
-            if (this.bottomSelectorElem) {
-                if (lightsTest) {
-                    this.bottomSelectorElem.textContent = "88:88";
-                } else {
-                    const currentFlightTime = this.getFlightTime();
-                    if (currentFlightTime !== this.lastFlightTime || lightsTestChanged) {
-                        this.lastFlightTime = currentFlightTime;
-                        this.bottomSelectorElem.textContent = currentFlightTime;
-                    }
+        }
+        if (this.bottomSelectorElem) {
+            if (lightsTest) {
+                this.bottomSelectorElem.textContent = "88:88";
+            } else {
+                const currentFlightTime = this.getFlightTime();
+                if (currentFlightTime !== this.lastFlightTime || lightsTestChanged) {
+                    this.lastFlightTime = currentFlightTime;
+                    this.bottomSelectorElem.textContent = currentFlightTime;
                 }
             }
         }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Com/A320_Neo_Com.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Com/A320_Neo_Com.js
@@ -63,8 +63,8 @@ class A320_Neo_Com extends BaseAirliners {
         }
     }
 
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
 
         this.updatePowerState();
         this.updateScreenState();

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.js
@@ -26,8 +26,8 @@ class A320_Neo_FCU extends BaseAirliners {
         super.reboot();
         this.mainPage.reboot();
     }
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
         this.updateMachTransition();
     }
     onEvent(_event) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FDW/A320_Neo_FDW.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FDW/A320_Neo_FDW.js
@@ -311,8 +311,8 @@ class A320_Neo_FDW extends BaseAirliners {
     disconnectedCallback() {
         super.disconnectedCallback();
     }
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
         const isOn = SimVar.GetSimVarValue(this.onVarName, "Boolean");
         if (isOn && (this.currentFrequencyType == A320_Neo_RadioManagement.FREQUENCY_TYPE.NONE)) {
             this.switchOn();

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -1232,8 +1232,8 @@ class FMCMainDisplay extends BaseAirliners {
         let zfw = 0;
         let zfwcg = 0;
         if (s) {
-            if (s.includes("")) {
-                const sSplit = s.split("|");
+            if (s.includes("/")) {
+                const sSplit = s.split("/");
                 zfw = parseFloat(sSplit[0]);
                 zfwcg = parseFloat(sSplit[1]);
             } else {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
@@ -31,8 +31,8 @@ class A320_Neo_MFD extends BaseAirliners {
                 break;
         }
     }
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
     }
 }
 class A320_Neo_MFD_MainElement extends NavSystemElement {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
@@ -22,8 +22,8 @@ class A320_Neo_PFD extends BaseAirliners {
         window.console.log("A320 Neo PFD - destroyed");
         super.disconnectedCallback();
     }
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
     }
 }
 class A320_Neo_PFD_MainElement extends NavSystemElement {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
@@ -1098,7 +1098,7 @@ var Airbus_FMA;
         }
         static IsActive_OPCLB() {
             if ((Simplane.getAutoPilotAltitudeSelected() || Simplane.getAutoPilotAltitudeArmed()) && Airbus_FMA.CurrentPlaneState.thisFlightDirectorActive && Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive) {
-                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feets");
+                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feet");
                 const altitude = Simplane.getAltitude();
                 if (altitude < targetAltitude - 100) {
                     return true;
@@ -1107,7 +1107,7 @@ var Airbus_FMA;
         }
         static IsActive_OPDES() {
             if ((Simplane.getAutoPilotAltitudeSelected() || Simplane.getAutoPilotAltitudeArmed()) && Airbus_FMA.CurrentPlaneState.thisFlightDirectorActive && Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive) {
-                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feets");
+                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feet");
                 const altitude = Simplane.getAltitude();
                 if (altitude > targetAltitude + 100) {
                     return true;
@@ -1121,7 +1121,7 @@ var Airbus_FMA;
                 } else if (Airbus_FMA.CurrentPlaneState.radioAltitude <= 1.5) {
                     return Airbus_FMA.MODE_STATE.NONE;
                 }
-                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feets");
+                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feet");
                 const altitude = Simplane.getAltitude();
                 if (altitude < targetAltitude - 100) {
                     if (Airbus_FMA.CurrentPlaneState.radioAltitude > 1.5) {
@@ -1132,7 +1132,7 @@ var Airbus_FMA;
                 }
             }
             if (Simplane.getAutoPilotFLCActive() && Airbus_FMA.CurrentPlaneState.thisFlightDirectorActive) {
-                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feets");
+                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feet");
                 const altitude = Simplane.getAltitude();
                 if (altitude < targetAltitude - 100) {
                     if (Airbus_FMA.CurrentPlaneState.radioAltitude <= 1.5) {
@@ -1151,7 +1151,7 @@ var Airbus_FMA;
                 }
             }
             if (Simplane.getAutoPilotFLCActive() && Airbus_FMA.CurrentPlaneState.thisFlightDirectorActive) {
-                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feets");
+                const targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feet");
                 const altitude = Simplane.getAltitude();
                 if (altitude > targetAltitude + 100) {
                     return true;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/RTPI/A320_Neo_RTPI.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/RTPI/A320_Neo_RTPI.js
@@ -14,8 +14,8 @@ class A320_Neo_RTPI extends BaseAirliners {
     disconnectedCallback() {
         super.disconnectedCallback();
     }
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
         this.refreshValue(SimVar.GetSimVarValue("RUDDER TRIM", "degrees"));
     }
     refreshValue(_value, _force = false) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/SAI/A320_Neo_SAI.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/SAI/A320_Neo_SAI.js
@@ -13,8 +13,8 @@ class A320_Neo_SAI extends BaseAirliners {
         this.addIndependentElementContainer(new NavSystemElementContainer("Bugs", "Bugs", new A320_Neo_SAI_Bugs()));
         this.addIndependentElementContainer(new NavSystemElementContainer("Pressure", "Pressure", new A320_Neo_SAI_Pressure()));
     }
-    Update() {
-        super.Update();
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
     }
     onEvent(_event) {
     }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/FlightElements/Waypoint.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/FlightElements/Waypoint.js
@@ -1,0 +1,913 @@
+class Airway {
+    constructor() {
+        this.icaos = [];
+    }
+    SetFromIAirwayData(data) {
+        this.name = data.name;
+        this.type = data.type;
+        this.icaos = data.icaos;
+    }
+}
+class WayPoint {
+    constructor(_instrument) {
+        this.ident = '';
+        this.icao = '';
+        this.altitudeinFP = 0;
+        this.bearingInFP = 0;
+        this.distanceInFP = 0;
+        this.estimatedTimeOfArrivalFP = 0;
+        this.estimatedTimeEnRouteFP = 0;
+        this.cumulativeEstimatedTimeEnRouteFP = 0;
+        this.cumulativeDistanceInFP = 0;
+        this.isInFlightPlan = false;
+        this.isActiveInFlightPlan = false;
+        this.legAltitudeDescription = 0;
+        this.legAltitude1 = 0;
+        this.legAltitude2 = 0;
+        this.speedConstraint = -1;
+        this.instrument = _instrument;
+        this.infos = new WayPointInfo(_instrument);
+        this.transitionLLas = [];
+    }
+    getSvgElement(index) {
+        if (this.infos) {
+            return this.infos.getSvgElement(index);
+        }
+    }
+    SetTypeFromEnum(_enum) {
+        switch (_enum) {
+            case 1:
+                this.type = 'A';
+                break;
+            case 2:
+                this.type = 'I';
+                break;
+            case 3:
+                this.type = 'V';
+                break;
+            case 4:
+                this.type = 'N';
+                break;
+            case 5:
+                this.type = 'U';
+                break;
+            case 6:
+                this.type = 'ATC';
+                break;
+        }
+    }
+    UpdateInfos(_CallBack = null, loadFacilitiesTransitively = true) {
+        this.instrument.facilityLoader.getFacilityDataCB(this.icao, (data) => {
+            this.SetFromIFacility(data, () => {}, loadFacilitiesTransitively);
+            if (_CallBack) {
+                _CallBack();
+            }
+        });
+    }
+    UpdateApproaches() {
+        if (this.type == 'A') {
+            this.infos.UpdateInfos(null, true);
+        }
+    }
+    GetInfos() {
+        switch (this.type) {
+            case 'A':
+                return this.infos;
+            case 'N':
+                return this.infos;
+            case 'V':
+                return this.infos;
+            case 'I':
+            case 'W':
+                return this.infos;
+            default:
+                return this.infos;
+        }
+    }
+    SetICAO(_ICAO, _endLoadCallback = null, _LoadApproaches = true) {
+        if (this.icao != _ICAO || this.infos.icao != _ICAO) {
+            this.icao = _ICAO;
+            this.infos.icao = _ICAO;
+            this.UpdateInfos(_endLoadCallback, _LoadApproaches);
+        }
+    }
+    SetIdent(_Ident) {
+        if (_Ident != "") {
+            this.ident = _Ident;
+            this.infos.ident = _Ident;
+        }
+    }
+    SetFromIFacility(data, callback = EmptyCallback.Void, loadFacilitiesTransitively = false) {
+        this.icao = data.icao;
+        if (!this.icao) {
+            console.warn("FacilityData without ICAO was used to Set a Waypoint, expect the unexpected.");
+            console.log(data);
+            return;
+        }
+        this.ident = this.icao.substring(7, 12).replace(new RegExp(" ", "g"), "");
+        this.type = this.icao[0];
+        if (this.type === "A") {
+            this.infos = new AirportInfo(this.instrument);
+            this.infos.SetFromIFacilityAirport(data, loadFacilitiesTransitively);
+            return callback();
+        } else if (this.type === "W") {
+            this.infos = new IntersectionInfo(this.instrument);
+            this.infos.SetFromIFacilityIntersection(data, callback, loadFacilitiesTransitively);
+        } else if (this.type === "V") {
+            this.infos = new VORInfo(this.instrument);
+            this.infos.SetFromIFacilityVOR(data, callback, loadFacilitiesTransitively);
+        } else if (this.type === "N") {
+            this.infos = new NDBInfo(this.instrument);
+            this.infos.SetFromIFacilityNDB(data, callback, loadFacilitiesTransitively);
+        }
+    }
+    imageFileName() {
+        let fileName = "ICON_MAP_INTERSECTION";
+        if (this.isInFlightPlan) {
+            fileName += "_FLIGHTPLAN";
+        }
+        if (this.isActiveInFlightPlan) {
+            fileName += "_ACTIVE";
+        }
+        if (BaseInstrument.useSvgImages) {
+            return fileName + ".svg";
+        }
+        return fileName + ".png";
+    }
+}
+class WayPointInfo {
+    constructor(_instrument) {
+        this.icao = '';
+        this.ident = '';
+        this.region = '';
+        this.name = '';
+        this.city = '';
+        this.routes = [];
+        this.timeInFP = 0;
+        this.totalTimeInFP = 0;
+        this.etaInFP = 0;
+        this.totalDistInFP = 0;
+        this.fuelConsInFP = 0;
+        this.totalFuelConsInFP = 0;
+        this.airwayIdentInFP = "";
+        this.coordinates = new LatLongAlt();
+        this.loaded = false;
+        this.airways = [];
+        this.airwayIn = undefined;
+        this.airwayOut = undefined;
+        this._svgElements = [];
+        this.instrument = _instrument;
+        this.loaded = true;
+    }
+    get lat() {
+        return this.coordinates.lat;
+    }
+    ;
+    set lat(l) {
+        this.coordinates.lat = l;
+    }
+    ;
+    get long() {
+        return this.coordinates.long;
+    }
+    ;
+    set long(l) {
+        this.coordinates.long = l;
+    }
+    ;
+    id() {
+        return "waypoint-" + this.icao;
+    }
+    getSvgElement(index) {
+        if (!this._svgElements[index]) {
+            this._svgElements[index] = new SvgNearestIntersectionElement(this);
+        }
+        return this._svgElements[index];
+    }
+    CopyBaseInfosFrom(_WP) {
+        this.icao = _WP.icao;
+        this.ident = _WP.ident;
+    }
+    UpdateInfos(_CallBack = null) {
+        this.loaded = false;
+        this.instrument.facilityLoader.getFacilityDataCB(this.icao, (data) => {
+            this.SetFromIFacilityWaypoint(data);
+            this.loaded = true;
+            if (_CallBack) {
+                _CallBack();
+            }
+        });
+    }
+    GetSymbol() {
+        return "";
+    }
+    imageFileName() {
+        return "";
+    }
+    getWaypointType() {
+        return "";
+    }
+    setEndCallbackIfUnset(_Callback) {
+        if (!this.endLoadCallback) {
+            this.endLoadCallback = _Callback;
+        }
+    }
+    SetFromIFacilityWaypoint(data) {
+        this.icao = data.icao;
+        this.ident = this.icao.substring(7, 12).replace(new RegExp(" ", "g"), "");
+        this.name = Utils.Translate(data.name);
+        this.region = Utils.Translate(data.region);
+        const separatedCity = data.city.split(", ");
+        this.city = separatedCity.length > 1 ? Utils.Translate(separatedCity[0]) + ", " + Utils.Translate(separatedCity[1]) : Utils.Translate(data.city);
+        this.lat = data.lat;
+        this.long = data.lon;
+    }
+    async UpdateAirway(name) {
+        if (this.airways.findIndex(airway => airway.name === name) === -1) {
+            const airways = await this.instrument.facilityLoader.getAllAirways(this, name);
+            if (airways.length === 1) {
+                this.airways.push(airways[0]);
+            }
+        }
+    }
+    async UpdateAirways() {
+        this.airways = await this.instrument.facilityLoader.getAllAirways(this);
+    }
+}
+class AirportInfo extends WayPointInfo {
+    constructor(_instrument) {
+        super(_instrument);
+        this.frequencies = [];
+        this.namedFrequencies = [];
+        this.departures = [];
+        this.approaches = [];
+        this.arrivals = [];
+        this.runways = [];
+        this.oneWayRunways = [];
+        this.airportClass = 0;
+        this.privateType = 0;
+        this.radarCoverage = 0;
+        this.needReload = false;
+        this.fuel = "";
+        this.bestApproach = "";
+        this.airspaceType = "";
+    }
+    getWaypointType() {
+        return "A";
+    }
+    getSvgElement(index) {
+        if (!this._svgElements[index]) {
+            this._svgElements[index] = new SvgNearestAirportElement(this);
+        }
+        return this._svgElements[index];
+    }
+    UpdateInfos(_CallBack = null, _LoadApproaches = true) {
+        this.loaded = false;
+        this.instrument.facilityLoader.getAirportDataCB(this.icao, (data) => {
+            this.SetFromIFacilityAirport(data, _LoadApproaches);
+            this.loaded = true;
+            if (_CallBack) {
+                _CallBack();
+            }
+        });
+    }
+    GetSymbolFileName() {
+        var logo = "";
+        if (this.airportClass == 2 || this.airportClass == 3) {
+            logo = "GPS/Airport_Soft.png";
+        } else if (this.airportClass == 1) {
+            switch (Math.round((this.longestRunwayDirection % 180) / 45.0)) {
+                case 0:
+                case 4:
+                    logo = "GPS/Airport_Hard_NS.png";
+                    break;
+                case 1:
+                    logo = "GPS/Airport_Hard_NE_SW.png";
+                    break;
+                case 2:
+                    logo = "GPS/Airport_Hard_EW.png";
+                    break;
+                case 3:
+                    logo = "GPS/Airport_Hard_NW_SE.png";
+                    break;
+            }
+        } else if (this.airportClass == 4) {
+            logo = "GPS/Helipad.png";
+        } else if (this.airportClass == 5) {
+            logo = "GPS/Private_Airfield.png";
+        }
+        return logo;
+    }
+    imageFileName() {
+        var fName = "";
+        if (this.airportClass === 0) {
+            fName = "ICON_MAP_AIRPORT_UNKNOWN_PINK.svg";
+        } else if (this.airportClass === 1) {
+            if (this.towered) {
+                if (this.fuel !== "") {
+                    fName = "ICON_MAP_AIRPORT_TOWERED_SERVICED_BLUE.svg";
+                } else {
+                    fName = "ICON_MAP_AIRPORT_TOWERED_NON_SERVICED_BLUE.svg";
+                }
+            } else {
+                if (this.fuel !== "") {
+                    fName = "ICON_MAP_AIRPORT_NON_TOWERED_SERVICED_PINK.svg";
+                } else {
+                    fName = "ICON_MAP_AIRPORT_NON_TOWERED_NON_SERVICED_PINK.svg";
+                }
+            }
+        } else if (this.airportClass === 2) {
+            if (this.fuel !== "") {
+                fName = "ICON_MAP_AIRPORT7.svg";
+            } else {
+                fName = "ICON_MAP_AIRPORT8.svg";
+            }
+        } else if (this.airportClass === 3) {
+            if (this.towered) {
+                fName = "ICON_MAP_AIRPORT_TOWERED_SEAPLANE_CIV_BLUE.svg";
+            } else {
+                fName = "ICON_MAP_AIRPORT_NON_TOWERED_SEAPLANE_CIV_PINK.svg";
+            }
+        } else if (this.airportClass === 4) {
+            fName = "ICON_MAP_AIRPORT_HELIPORT_PINK.svg";
+        } else if (this.airportClass === 5) {
+            fName = "ICON_MAP_AIRPORT_PRIVATE_PINK.svg";
+        }
+        if (fName === "") {
+        }
+        if (BaseInstrument.useSvgImages) {
+            return fName;
+        }
+        return fName.replace(".svg", ".png");
+    }
+    GetSize() {
+        var minX = 0;
+        var minY = 0;
+        var maxX = 0;
+        var maxY = 0;
+        var latCos = Math.cos((this.lat / 180) * Math.PI);
+        for (var i = 0; i < this.runways.length; i++) {
+            var centerY = (this.lat - this.runways[i].latitude) * 60;
+            var centerX = (this.runways[i].longitude - this.long) * latCos * 60;
+            var forwardY = -this.runways[i].cosDirection;
+            var forwardX = this.runways[i].sinDirection;
+            var beginX = centerX - (forwardX * ((this.runways[i].length / 2) * 0.000164579));
+            var beginY = centerY - (forwardY * ((this.runways[i].length / 2) * 0.000164579));
+            var endX = centerX + (forwardX * ((this.runways[i].length / 2) * 0.000164579));
+            var endY = centerY + (forwardY * ((this.runways[i].length / 2) * 0.000164579));
+            if (beginX < minX) {
+                minX = beginX;
+            }
+            if (endX < minX) {
+                minX = endX;
+            }
+            if (beginX > maxX) {
+                maxX = beginX;
+            }
+            if (endX > maxX) {
+                maxX = endX;
+            }
+            if (beginY < minY) {
+                minY = beginY;
+            }
+            if (endY < minY) {
+                minY = endY;
+            }
+            if (beginY > maxY) {
+                maxY = beginY;
+            }
+            if (endY > maxY) {
+                maxY = endY;
+            }
+        }
+        return new Vec2(2 * Math.max(-minX, maxX) + 0.1, 2 * Math.max(-minY, maxY) + 0.1);
+    }
+    getClassSize() {
+        if (!this.runways || !this.runways[0]) {
+            return AirportSize.Small;
+        }
+        if (this.runways[0].length < 5000 / 3.28) {
+            return AirportSize.Small;
+        }
+        if (this.runways[0].length > 8100 / 3.28) {
+            return AirportSize.Large;
+        }
+        if (this.towered) {
+            return AirportSize.Large;
+        }
+        return AirportSize.Medium;
+    }
+    IsUpToDate() {
+        return this.loaded;
+    }
+    SetFromIFacilityAirport(data, loadApproachesData = true) {
+        super.SetFromIFacilityWaypoint(data);
+        this.privateType = data.airportPrivateType;
+        this.fuel = data.fuel1 + " " + data.fuel2;
+        this.bestApproach = data.bestApproach;
+        this.radarCoverage = data.radarCoverage;
+        this.airspaceType = data.airspaceType + "";
+        this.airportClass = data.airportClass;
+        this.towered = data.towered;
+        this.name = Utils.Translate(data.name);
+        const separatedCity = data.city.split(", ");
+        this.city = separatedCity.length > 1 ? Utils.Translate(separatedCity[0]) + ", " + Utils.Translate(separatedCity[1]) : Utils.Translate(data.city);
+        this.region = Utils.Translate(data.region);
+        this.frequencies = [];
+        if (data.frequencies) {
+            for (let i = 0; i < data.frequencies.length; i++) {
+                this.frequencies.push(new Frequency(data.frequencies[i].name, data.frequencies[i].freqMHz, data.frequencies[i].freqBCD16));
+            }
+        }
+        this.runways = [];
+        if (data.runways) {
+            for (let i = 0; i < data.runways.length; i++) {
+                const runway = new Runway();
+                runway.latitude = data.runways[i].latitude;
+                runway.longitude = data.runways[i].longitude;
+                runway.elevation = data.runways[i].elevation;
+                runway.designation = data.runways[i].designation;
+                runway.length = data.runways[i].length;
+                runway.width = data.runways[i].width;
+                runway.surface = data.runways[i].surface;
+                runway.lighting = data.runways[i].lighting;
+                runway.direction = data.runways[i].direction;
+                runway.designatorCharPrimary = data.runways[i].designatorCharPrimary;
+                runway.designatorCharSecondary = data.runways[i].designatorCharSecondary;
+                this.runways.push(runway);
+                this.oneWayRunways.push(...runway.splitIfTwoWays());
+            }
+        }
+        if (this.oneWayRunways) {
+            this.oneWayRunways = this.oneWayRunways.sort((r1, r2) => {
+                if (parseInt(r1.designation) === parseInt(r2.designation)) {
+                    let v1 = 0;
+                    if (r1.designation.indexOf("L") != -1) {
+                        v1 = 1;
+                    } else if (r1.designation.indexOf("C") != -1) {
+                        v1 = 2;
+                    } else if (r1.designation.indexOf("R") != -1) {
+                        v1 = 3;
+                    }
+                    let v2 = 0;
+                    if (r2.designation.indexOf("L") != -1) {
+                        v2 = 1;
+                    } else if (r2.designation.indexOf("C") != -1) {
+                        v2 = 2;
+                    } else if (r2.designation.indexOf("R") != -1) {
+                        v2 = 3;
+                    }
+                    return v1 - v2;
+                }
+                return parseInt(r1.designation) - parseInt(r2.designation);
+            });
+        }
+        this.approaches = [];
+        if (data.approaches) {
+            for (let i = 0; i < data.approaches.length; i++) {
+                const approachData = data.approaches[i];
+                const approach = new Approach();
+                approach.name = approachData.name;
+                approach.runway = approachData.runway;
+
+                approach.transitions = [];
+                for (let i = 0; i < approachData.transitions.length; i++) {
+                    const transition = new Transition();
+                    transition.name = approachData.transitions[i].legs[0].fixIcao.substr(7, 5);
+                    transition.waypoints = [];
+                    for (let j = 0; j < approachData.transitions[i].legs.length; j++) {
+                        const wp = new WayPoint(this.instrument);
+                        wp.icao = approachData.transitions[i].legs[j].fixIcao;
+                        wp.ident = wp.icao.substr(7, 5);
+                        wp.bearingInFP = approachData.transitions[i].legs[j].course;
+                        wp.distanceInFP = approachData.transitions[i].legs[j].distance;
+                        transition.waypoints.push(wp);
+                        if (loadApproachesData) {
+                            this.instrument.facilityLoader.getFacility(approachData.transitions[i].legs[j].fixIcao).then(function (_legs, _index, _waypoint) {
+                                if (_waypoint) {
+                                    _legs[_index] = _waypoint;
+                                    _waypoint.bearingInFP = wp.bearingInFP;
+                                    _waypoint.distanceInFP = wp.distanceInFP;
+                                }
+                            }.bind(this, transition.waypoints, j));
+                        }
+                    }
+                    approach.transitions.push(transition);
+                }
+                approach.wayPoints = [];
+                for (let i = 0; i < approachData.finalLegs.length; i++) {
+                    const waypoint = new ApproachWayPoint(this.instrument);
+                    waypoint.icao = approachData.finalLegs[i].fixIcao;
+                    waypoint.ident = waypoint.icao.substr(7, 5);
+                    waypoint.bearingInFP = approachData.finalLegs[i].course;
+                    waypoint.distanceInFP = approachData.finalLegs[i].distance / 1852;
+                    approach.wayPoints.push(waypoint);
+                    if (loadApproachesData) {
+                        this.instrument.facilityLoader.getFacilityDataCB(waypoint.icao, (data) => {
+                            if (data) {
+                                waypoint.SetFromIFacility(data, () => { }, loadApproachesData);
+                            }
+                        });
+                    }
+                }
+                this.approaches.push(approach);
+            }
+        }
+        this.departures = data.departures;
+        for (let i = 0; i < this.departures.length; i++) {
+            for (let j = 0; j < this.departures[i].runwayTransitions.length; j++) {
+                this.departures[i].runwayTransitions[j].name = "RW" + this.departures[i].runwayTransitions[j].runwayNumber.toString();
+                switch (this.departures[i].runwayTransitions[j].runwayDesignation) {
+                    case 1:
+                        this.departures[i].runwayTransitions[j].name += "L";
+                        break;
+                    case 2:
+                        this.departures[i].runwayTransitions[j].name += "R";
+                        break;
+                    case 3:
+                        this.departures[i].runwayTransitions[j].name += "C";
+                        break;
+                }
+            }
+            for (let j = 0; j < this.departures[i].enRouteTransitions.length; j++) {
+                const legsCount = this.departures[i].enRouteTransitions[j].legs.length;
+                this.departures[i].enRouteTransitions[j].name = this.departures[i].enRouteTransitions[j].legs[legsCount - 1].fixIcao.substr(7, 5);
+            }
+        }
+        this.arrivals = data.arrivals;
+        for (let i = 0; i < this.arrivals.length; i++) {
+            for (let j = 0; j < this.arrivals[i].runwayTransitions.length; j++) {
+                this.arrivals[i].runwayTransitions[j].name = "RW" + this.arrivals[i].runwayTransitions[j].runwayNumber.toString();
+                switch (this.arrivals[i].runwayTransitions[j].runwayDesignation) {
+                    case 1:
+                        this.arrivals[i].runwayTransitions[j].name += "L";
+                        break;
+                    case 2:
+                        this.arrivals[i].runwayTransitions[j].name += "R";
+                        break;
+                    case 3:
+                        this.arrivals[i].runwayTransitions[j].name += "C";
+                        break;
+                }
+            }
+            for (let j = 0; j < this.arrivals[i].enRouteTransitions.length; j++) {
+                this.arrivals[i].enRouteTransitions[j].name = this.arrivals[i].enRouteTransitions[j].legs[0].fixIcao.substr(7, 5);
+            }
+        }
+    }
+    async UpdateNamedFrequencies() {
+        if (this.namedFrequencies.length === 0) {
+            this.namedFrequencies = await this.instrument.facilityLoader.GetAirportNamedFrequencies(this.icao);
+        }
+    }
+}
+class VORInfo extends WayPointInfo {
+    constructor(_instrument) {
+        super(_instrument);
+    }
+    getWaypointType() {
+        return "V";
+    }
+    getSvgElement(index) {
+        if (!this._svgElements[index]) {
+            this._svgElements[index] = new SvgNearestVORElement(this);
+        }
+        return this._svgElements[index];
+    }
+    IsUpToDate() {
+        return this.loaded;
+    }
+    GetSymbol() {
+        var image = "";
+        switch (this.type) {
+            case 1:
+                image = "GPS/Vor.png";
+                break;
+            case 2:
+                image = "GPS/Vor_DME.png";
+                break;
+            case 3:
+                image = "GPS/DME.png";
+                break;
+            case 4:
+                image = "GPS/Tacan.png";
+                break;
+            case 5:
+                image = "GPS/Vor_Tac.png";
+                break;
+            case 6:
+                image = "GPS/Localizer.png";
+                break;
+        }
+        return image;
+    }
+    imageFileName() {
+        let fName = "";
+        switch (this.type) {
+            case 1:
+                fName = "ICON_MAP_VOR.svg";
+            case 2:
+                fName = "ICON_MAP_VOR_DME.svg";
+            case 3:
+                fName = "ICON_MAP_VOR_DME.svg";
+            case 4:
+                fName = "ICON_MAP_VOR_TACAN.svg";
+            case 5:
+                fName = "ICON_MAP_VOR_VORTAC.svg";
+            case 6:
+                fName = "ICON_MAP_VOR.svg";
+        }
+        if (BaseInstrument.useSvgImages) {
+            return fName;
+        }
+        return fName.replace(".svg", ".png");
+    }
+    UpdateInfos(_CallBack = null, loadFacilitiesTransitively = true) {
+        this.loaded = false;
+        this.instrument.facilityLoader.getVorDataCB(this.icao, (data) => {
+            this.SetFromIFacilityVOR(data, () => {
+                this.loaded = true;
+                if (_CallBack) {
+                    _CallBack();
+                }
+            }, loadFacilitiesTransitively);
+        });
+    }
+    getClassName() {
+        switch (this.vorClass) {
+            case 1:
+                return "Terminal";
+            case 2:
+                return "Low_Alt";
+            case 3:
+                return "High_Alt";
+            case 4:
+                return "ILS";
+            case 5:
+                return "VOT";
+            case 0:
+            default:
+                return "Unknown";
+        }
+    }
+    SetFromIFacilityVOR(data, callback = EmptyCallback.Void, loadAirways = true) {
+        super.SetFromIFacilityWaypoint(data);
+        this.frequencyMHz = data.freqMHz;
+        this.frequencyBcd16 = data.freqBCD16;
+        this.weatherBroadcast = data.weatherBroadcast;
+        this.magneticVariation = data.magneticVariation;
+        this.type = data.type;
+        this.vorClass = data.vorClass;
+        this.instrument.facilityLoader.getVorWaypointDataCB(this.icao, (data) => {
+            if (!data) {
+                return callback();
+            }
+            this.routes = data.routes;
+            if (loadAirways) {
+                this.instrument.facilityLoader.getAllAirways(this).then(airways => {
+                    this.airways = airways;
+                    return callback();
+                });
+            } else {
+                return callback();
+            }
+        });
+    }
+}
+VORInfo.readManager = new InstrumentDataReadManager();
+class NDBInfo extends WayPointInfo {
+    constructor(_instrument) {
+        super(_instrument);
+    }
+    getSvgElement(index) {
+        if (!this._svgElements[index]) {
+            this._svgElements[index] = new SvgNearestNDBElement(this);
+        }
+        return this._svgElements[index];
+    }
+    getWaypointType() {
+        return "N";
+    }
+    GetSymbol() {
+        return (this.type == 1 ? "GPS/Marker.png" : "GPS/Ndb.png");
+    }
+    imageFileName() {
+        let fName = "";
+        if (this.type === 1) {
+            fName = "ICON_MAP_NDB_WAYPOINT.svg";
+        } else {
+            fName = "ICON_MAP_NDB_WAYPOINT.svg";
+        }
+        if (BaseInstrument.useSvgImages) {
+            return fName;
+        }
+        return fName.replace(".svg", ".png");
+    }
+    IsUpToDate() {
+        return this.loaded;
+    }
+    UpdateInfos(_CallBack = null, loadFacilitiesTransitively = true) {
+        this.loaded = false;
+        this.instrument.facilityLoader.getNdbDataCB(this.icao, (data) => {
+            this.SetFromIFacilityNDB(data, () => {
+                this.loaded = true;
+                if (_CallBack) {
+                    _CallBack();
+                }
+            }, loadFacilitiesTransitively);
+        });
+    }
+    getTypeString() {
+        switch (this.type) {
+            case 1:
+                return "Compass Point";
+            case 2:
+                return "MH";
+            case 3:
+                return "H";
+            case 4:
+                return "HH";
+            default:
+                return "Unknown";
+        }
+    }
+    SetFromIFacilityNDB(data, callback = EmptyCallback.Void, loadAirways = true) {
+        super.SetFromIFacilityWaypoint(data);
+        this.type = data.type;
+        this.weatherBroadcast = data.weatherBroadcast;
+        this.frequencyMHz = data.freqMHz;
+        this.instrument.facilityLoader.getNdbWaypointDataCB(this.icao, (data) => {
+            if (!data) {
+                return callback();
+            }
+            this.routes = data.routes;
+            if (loadAirways) {
+                this.instrument.facilityLoader.getAllAirways(this).then(airways => {
+                    this.airways = airways;
+                    return callback();
+                });
+            } else {
+                return callback();
+            }
+        });
+    }
+}
+NDBInfo.readManager = new InstrumentDataReadManager();
+class IntersectionInfo extends WayPointInfo {
+    constructor(_instrument) {
+        super(_instrument);
+    }
+    getWaypointType() {
+        return "W";
+    }
+    IsUpToDate() {
+        return this.loaded;
+    }
+    GetSymbol() {
+        return "GPS/Intersection.png";
+    }
+    imageFileName() {
+        if (BaseInstrument.useSvgImages) {
+            return "ICON_MAP_INTERSECTION.svg";
+        }
+        return "ICON_MAP_INTERSECTION.png";
+    }
+    vorImageFileNameSync() {
+        let fName = "";
+        switch (this.nearestVORType) {
+            case 1:
+                fName = "ICON_MAP_VOR.svg";
+            case 2:
+                fName = "ICON_MAP_VOR_DME.svg";
+            case 3:
+                fName = "ICON_MAP_VOR_DME.svg";
+            case 4:
+                fName = "ICON_MAP_VOR_TACAN.svg";
+            case 5:
+                fName = "ICON_MAP_VOR_VORTAC.svg";
+            case 6:
+                fName = "ICON_MAP_VOR.svg";
+        }
+        if (BaseInstrument.useSvgImages) {
+            return fName;
+        }
+        return fName.replace(".svg", ".png");
+    }
+    UpdateInfos(_CallBack = null, loadFacilitiesTransitively = true) {
+        this.loaded = false;
+        this.instrument.facilityLoader.getIntersectionDataCB(this.icao, (data) => {
+            this.SetFromIFacilityIntersection(data, () => {
+                this.loaded = true;
+                if (_CallBack) {
+                    _CallBack();
+                }
+            }, loadFacilitiesTransitively);
+        });
+    }
+    GetRouteToIdent(ident) {
+        ident = ident.trim();
+        for (let i = 0; i < this.routes.length; i++) {
+            const route = this.routes[i];
+            if (route.nextIcao.indexOf(ident) !== -1) {
+                return route;
+            } else if (route.prevIcao.indexOf(ident) !== -1) {
+                return route;
+            }
+        }
+    }
+    GetIcaoViaRouteByIdent(ident) {
+        ident = ident.trim();
+        for (let i = 0; i < this.routes.length; i++) {
+            const route = this.routes[i];
+            if (route.nextIcao.indexOf(ident) !== -1) {
+                return route.nextIcao;
+            } else if (route.prevIcao.indexOf(ident) !== -1) {
+                return route.prevIcao;
+            }
+        }
+    }
+    GetRouteToIcao(icao) {
+        icao = icao.trim();
+        for (let i = 0; i < this.routes.length; i++) {
+            const route = this.routes[i];
+            if (route.nextIcao.trim() === icao) {
+                return route;
+            } else if (route.prevIcao.trim() === icao) {
+                return route;
+            }
+        }
+    }
+    GetNextIcaoVia(routeName) {
+        for (let i = 0; i < this.routes.length; i++) {
+            const route = this.routes[i];
+            if (route.name.indexOf(routeName) !== -1) {
+                return route.nextIcao;
+            }
+        }
+    }
+    async GetNextWayPointVia(routeName) {
+        const nextIcao = this.GetNextIcaoVia(routeName);
+        if (nextIcao) {
+            return this.instrument.facilityLoader.getFacility(nextIcao);
+        }
+    }
+    SetFromIFacilityIntersection(data, callback = EmptyCallback.Void, loadAirways = true) {
+        super.SetFromIFacilityWaypoint(data);
+        this.routes = data.routes;
+        this.nearestVORType = data.nearestVorType;
+        this.nearestVORICAO = data.nearestVorICAO;
+        this.nearestVORFrequencyBCD16 = data.nearestVorFrequencyBCD16;
+        this.nearestVORFrequencyMHz = data.nearestVorFrequencyMHz;
+        this.nearestVORIdent = data.nearestVorICAO ? data.nearestVorICAO.substring(7, 12).replace(new RegExp(" ", "g"), "") : "";
+        this.nearestVORTrueRadial = data.nearestVorTrueRadial;
+        this.nearestVORMagneticRadial = data.nearestVorMagneticRadial;
+        this.nearestVORDistance = data.nearestVorDistance;
+        if (loadAirways) {
+            this.instrument.facilityLoader.getAllAirways(this).then(airways => {
+                this.airways = airways;
+                return callback();
+            });
+        } else {
+            return callback();
+        }
+    }
+    async UpdateAirways() {
+        this.airways = await this.instrument.facilityLoader.getAllAirways(this);
+    }
+    static GetCommonAirway(wp1, wp2) {
+        if (wp1 && wp2) {
+            if (wp1.infos instanceof IntersectionInfo) {
+                if (wp1.infos.airways && wp1.infos.airways.length > 0) {
+                    for (let i = 0; i < wp1.infos.airways.length; i++) {
+                        const wp1Airway = wp1.infos.airways[i];
+                        const wp2Index = wp1Airway.icaos.indexOf(wp2.icao);
+                        if (wp2Index !== -1) {
+                            return wp1Airway;
+                        }
+                    }
+                }
+            }
+            if (wp2.infos instanceof IntersectionInfo) {
+                if (wp2.infos.airways && wp2.infos.airways.length > 0) {
+                    for (let i = 0; i < wp2.infos.airways.length; i++) {
+                        const wp2Airway = wp2.infos.airways[i];
+                        const wp1Index = wp2Airway.icaos.indexOf(wp1.icao);
+                        if (wp1Index !== -1) {
+                            return wp2Airway;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+IntersectionInfo.readManager = new InstrumentDataReadManager();
+IntersectionInfo.longestAirway = 0;
+class Frequency {
+    constructor(_name, _mhValue, _bcd16Value) {
+        this.name = _name;
+        this.mhValue = _mhValue;
+        this.bcd16Value = _bcd16Value;
+    }
+}
+//# sourceMappingURL=Waypoint.js.map

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
@@ -10,38 +10,10 @@ class FlightPlanManager {
         this.decelPrevIndex = -1;
         this._lastDistanceToPreviousActiveWaypoint = 0;
         this._isGoingTowardPreviousActiveWaypoint = false;
-        this._update = () => {
-            const prevWaypoint = this.getPreviousActiveWaypoint();
-            if (prevWaypoint) {
-                const planeCoordinates = new LatLong(SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude"), SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude"));
-                if (isFinite(planeCoordinates.lat) && isFinite(planeCoordinates.long)) {
-                    const dist = Avionics.Utils.computeGreatCircleDistance(planeCoordinates, prevWaypoint.infos.coordinates);
-                    if (isFinite(dist)) {
-                        if (dist < this._lastDistanceToPreviousActiveWaypoint) {
-                            this._isGoingTowardPreviousActiveWaypoint = true;
-                        } else {
-                            this._isGoingTowardPreviousActiveWaypoint = false;
-                        }
-                        this._lastDistanceToPreviousActiveWaypoint = dist;
-                        if (this._activeWaypointIdentHasChanged || this._gpsActiveWaypointIndexHasChanged) {
-                            setTimeout(() => {
-                                this._activeWaypointIdentHasChanged = false;
-                                this._gpsActiveWaypointIndexHasChanged = false;
-                            }, 3000);
-                        }
-                        return;
-                    }
-                }
-            }
-            if (this._activeWaypointIdentHasChanged || this._gpsActiveWaypointIndexHasChanged) {
-                setTimeout(() => {
-                    this._activeWaypointIdentHasChanged = false;
-                    this._gpsActiveWaypointIndexHasChanged = false;
-                }, 3000);
-            }
-            this._isGoingTowardPreviousActiveWaypoint = false;
-        };
+        this._resetTimer = 0;
+        this._updateTimer = 0;
         this._isRegistered = false;
+        this._isRegisteredAndLoaded = false;
         this._currentFlightPlanIndex = 0;
         this._activeWaypointIdentHasChanged = false;
         this._timeLastSimVarCall = 0;
@@ -52,7 +24,7 @@ class FlightPlanManager {
         this._approachActivated = false;
         FlightPlanManager.DEBUG_INSTANCE = this;
         this.instrument = _instrument;
-        setInterval(this._update, 1000);
+        this.registerListener();
     }
     addHardCodedConstraints(wp) {
         return;
@@ -76,6 +48,50 @@ class FlightPlanManager {
             wp.legAltitude1 = 1900;
         }
     }
+    update(_deltaTime) {
+        if (this._resetTimer > 0) {
+            this._resetTimer -= _deltaTime;
+            if (this._resetTimer <= 0) {
+                this._resetTimer = 0;
+                this._activeWaypointIdentHasChanged = false;
+                this._gpsActiveWaypointIndexHasChanged = false;
+            }
+        }
+        this._updateTimer += _deltaTime;
+        if (this._updateTimer >= 1000) {
+            this._updateTimer = 0;
+            const prevWaypoint = this.getPreviousActiveWaypoint();
+            if (prevWaypoint) {
+                const planeCoordinates = new LatLong(SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude"), SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude"));
+                if (isFinite(planeCoordinates.lat) && isFinite(planeCoordinates.long)) {
+                    const dist = Avionics.Utils.computeGreatCircleDistance(planeCoordinates, prevWaypoint.infos.coordinates);
+                    if (isFinite(dist)) {
+                        if (dist < this._lastDistanceToPreviousActiveWaypoint) {
+                            this._isGoingTowardPreviousActiveWaypoint = true;
+                        } else {
+                            this._isGoingTowardPreviousActiveWaypoint = false;
+                        }
+                        this._lastDistanceToPreviousActiveWaypoint = dist;
+                        if ((this._activeWaypointIdentHasChanged || this._gpsActiveWaypointIndexHasChanged) && this._resetTimer <= 0) {
+                            this._resetTimer = 3000;
+                        }
+                        return;
+                    }
+                }
+            }
+            if ((this._activeWaypointIdentHasChanged || this._gpsActiveWaypointIndexHasChanged) && this._resetTimer <= 0) {
+                this._resetTimer = 3000;
+            }
+            this._isGoingTowardPreviousActiveWaypoint = false;
+        }
+    }
+    onCurrentGameFlightLoaded(_callback) {
+        if (this._isRegisteredAndLoaded) {
+            _callback();
+            return;
+        }
+        this._onCurrentGameFlightLoaded = _callback;
+    }
     registerListener() {
         if (this._isRegistered) {
             return;
@@ -85,11 +101,12 @@ class FlightPlanManager {
         setTimeout(() => {
             Coherent.call("LOAD_CURRENT_GAME_FLIGHT");
             Coherent.call("LOAD_CURRENT_ATC_FLIGHTPLAN");
-            if (this.onCurrentGameFlightLoaded) {
-                setTimeout(() => {
-                    this.onCurrentGameFlightLoaded();
-                }, 200);
-            }
+            setTimeout(() => {
+                this._isRegisteredAndLoaded = true;
+                if (this._onCurrentGameFlightLoaded) {
+                    this._onCurrentGameFlightLoaded();
+                }
+            }, 200);
         }, 200);
     }
     _loadWaypoints(data, currentWaypoints, callback) {

--- a/manifest-base.json
+++ b/manifest-base.json
@@ -6,7 +6,7 @@
       "OlderHistory": ""
     }
   },
-  "package_version": "0.4.0",
+  "package_version": "0.4.1",
   "title": "A32NX",
   "dependencies": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a32nx",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "scripts": {
     "lint": "eslint **/*.js",
     "lint-fix": "npm run lint -- --fix",


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- 1) When selecting TO FLEX in MCDU, the N1 corresponding to that TO FLEX does not appear in upper ECAM screen.
2) Once the aircraft has taken off (being in MAN FLX mode) when the aircraft reaches reduction altitude, you reduce thrust and it changes to SPEED mode, not to THRUST CLB mode as it should be
3) Clock in the cockpit shows local time not UTC time
4) Some symbols in ND do not look like real ones
5) In cruise altitude the aircraft goes at pitch of 5º attitude when it should be at 3,5º approximately.
6)Poor performance on the aircraft climbing (with low payload). It climbs at 800ft/min when has 8000ft remaining to reach optimum altitude shown in the FMC.
7) Climbing, in THURST CLB mode it goes at a faster N1 than the CLB limit shown in the upper ECAM screen
8)When disconnecting the PACK 1&2 for takeoff, if you do not connect them again once taken off, it does not appear any message in the ECAM or any advisory
9) Constraints appearing in Navigation Display do not make any sense
10)When disconnecting PACKS 1&2 the sound remains the same in the cockpit of the aircraft, when it should be considerably reduced due to no airflow flowing from the air conditioning system inside the aircraft.
11) When you put VOR 1&2 in the FCU on the captain´s side (also in the second first officer side) no VOR information appears in the Navigation Display. It should appear information in the Navigation Display (NM to VOR and direction TO/FROM the VOR) even though you have not selected any VOR in page RADNAV of the FMC, because the aircraft automatically detects the VOR´s with the strongest signal to appear in the ND when VOR/ADF is selected in the FCU. 
12) Cost index speed always remains the same. If you select cost index 6 for example it will show in PERF page 295kt managed speed. Later if you select a cost index of 200 the speed will show 295kt or 297kt maximum. The change in speeds in real life is larger than the aircraft shows
13) With MTOW and in cruise altitude (does not matter if at OPT ALTITUDE OR REC MAX) the PFD of the aircraft does not show the speed protection limit (yellow line), does not show the stall speed either (red line), does not show the green dot speed.-->
Fixes #[issue_no]
14) COND, PRESS, HYD,ELEC pages do not appear in ECAM
15) TOD nor TOC missing
16) EGT limits exceeded climbing in THRUST CLB mode.
17) STD altimeter mode in Integrated Standby Flight Display not appearing

## References
<!-- A320 instructor in real life. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
