### PR TITLE
feat: ask for online services consent on first use

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -80,6 +80,13 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this.climbTransitionGroundAltitude = null;
         this.initB = false;
 
+        // If the consent is not set, show telex page
+        const onlineFeaturesStatus = NXDataStore.get("CONFIG_TELEX_STATUS", "UNKNOWN");
+
+        if (onlineFeaturesStatus === "UNKNOWN") {
+            CDU_OPTIONS_TELEX.ShowPage(this);
+        }
+
         // Set up the AC type for the API
         NXDataStore.set("AC_TYPE", "A32NX");
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_TELEX.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_TELEX.js
@@ -2,35 +2,47 @@ class CDU_OPTIONS_TELEX {
     static ShowPage(mcdu) {
         mcdu.clearDisplay();
 
-        const storedTelexStatus = NXDataStore.get("CONFIG_TELEX_STATUS", "DISABLED");
+        const storedTelexStatus = NXDataStore.get("CONFIG_TELEX_STATUS", "UNKNOWN");
+        let firstTime = false;
 
         let telexToggleText;
+
         switch (storedTelexStatus) {
             case "ENABLED":
                 telexToggleText = "DISABLE*[color]blue";
                 break;
-            default:
+            case "UNKNOWN":
+                telexToggleText = "ENABLE*[color]blue";
+                firstTime = true;
+                break;
+            case "DISABLED":
                 telexToggleText = "ENABLE*[color]blue";
         }
 
         mcdu.setTemplate([
             ["A32NX OPTIONS"],
-            ["", "", "AOC FREE TEXT"],
+            ["", "", "ONLINE FEATURES"],
             ["WARNING:[color]red"],
-            ["[b-text]ALL MSGS ARE PUBLICLY"],
-            ["[s-text]READABLE. IF ENABLED,"],
+            ["[b-text]ENABLES FREE TEXT AND LIVE"],
+            ["[s-text]MAP. IF ENABLED,"],
             ["[b-text]AIRCRAFT POSITION DATA WILL"],
-            ["[s-text]ALSO BE PUBLISHED FOR THE"],
-            ["[b-text]DURATION OF THE FLIGHT,"],
-            ["[s-text]WHILE CONNECTED."],
-            ["[b-text]MSGS ARE NOT MODERATED."],
+            ["[s-text]BE PUBLISHED FOR THE"],
+            ["[b-text]DURATION OF THE FLIGHT."],
+            ["[s-text]MSGS ARE PUBLIC, NOT MODERATED."],
+            [""],
             ["[s-text]USE AT YOUR OWN RISK.[color]red"],
             ["", "CONFIRM[color]blue"],
-            ["<RETURN[color]blue", telexToggleText]
+            firstTime ? ["<LATER[color]blue", telexToggleText] : ["<RETURN[color]blue", telexToggleText]
         ]);
 
         mcdu.onLeftInput[5] = () => {
-            CDU_OPTIONS_MainMenu.ShowPage(mcdu);
+            if (firstTime) {
+                CDUMenuPage.ShowPage(mcdu);
+                // Take "LATER" as disabling it
+                NXDataStore.set("CONFIG_TELEX_STATUS", "DISABLED");
+            } else {
+                CDU_OPTIONS_MainMenu.ShowPage(mcdu);
+            }
         };
         mcdu.onRightInput[5] = () => {
             switch (storedTelexStatus) {
@@ -56,7 +68,11 @@ class CDU_OPTIONS_TELEX {
                             }
                         });
             }
-            CDU_OPTIONS_TELEX.ShowPage(mcdu);
+            if (firstTime) {
+                CDUMenuPage.ShowPage(mcdu);
+            } else {
+                CDU_OPTIONS_TELEX.ShowPage(mcdu);
+            }
         };
     }
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #[issue_no]

## Summary of Changes
* Shows TELEX options page on first use of the plane to ask for consent regarding plane position uplink.

Discord username (if different from GitHub): someperson#4953

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
