### PR TITLE
[FIX] Wrong GPWS warnings

### DIFF
--- a/A32NX/html_ui/Pages/A32NX_Core/A32NX_GPWS.js
+++ b/A32NX/html_ui/Pages/A32NX_Core/A32NX_GPWS.js
@@ -71,12 +71,12 @@ class A32NX_GPWS {
             const Airspeed = SimVar.GetSimVarValue("AIRSPEED INDICATED", "Knots");
             const gearExtended = SimVar.GetSimVarValue("GEAR TOTAL PCT EXTENDED", "Percent") > 0.9;
 
-            this.update_maxRA(radioAlt, onGround);
+            this.update_maxRA(radioAlt, onGround, phase);
 
             this.GPWSMode1(radioAlt, vSpeed);
             //Mode 2 is disabled because of an issue with the terrain height simvar which causes false warnings very frequently. See PR#1742 for more info
             //this.GPWSMode2(radioAlt, Airspeed, FlapsInLandingConfig, gearExtended);
-            this.GPWSMode3(radioAlt, phase, FlapsInLandingConfig, gearExtended);
+            this.GPWSMode3(radioAlt, phase, FlapsInLandingConfig);
             this.GPWSMode4(radioAlt, Airspeed, FlapsInLandingConfig, gearExtended, phase);
             this.GPWSMode5(radioAlt);
 
@@ -86,6 +86,8 @@ class A32NX_GPWS {
             this.Mode3Code = 0;
             this.Mode4Code = 0;
             this.Mode5Code = 0;
+
+            this.Mode3MaxBaroAlt = NaN;
 
             SimVar.SetSimVarValue("L:A32NX_GPWS_GS_Warning_Active", "Bool", 0);
             SimVar.SetSimVarValue("L:A32NX_GPWS_Warning_Active", "Bool", 0);
@@ -126,9 +128,9 @@ class A32NX_GPWS {
         }
     }
 
-    update_maxRA(radioAlt, onGround) {
+    update_maxRA(radioAlt, onGround, phase) {
         // on ground check is to get around the fact that radio alt is set to around 300 while loading
-        if (onGround) {
+        if (onGround || phase === FlightPhase.FLIGHT_PHASE_GOAROUND) {
             this.Mode4MaxRAAlt = NaN;
         } else if (this.Mode4MaxRAAlt < radioAlt || isNaN(this.Mode4MaxRAAlt)) {
             this.Mode4MaxRAAlt = radioAlt;
@@ -316,8 +318,8 @@ class A32NX_GPWS {
      * @param FlapsInLandingConfig - If flaps is in landing config
      * @constructor
      */
-    GPWSMode3(radioAlt, phase, FlapsInLandingConfig, gearExtended) {
-        if (!(phase === FlightPhase.FLIGHT_PHASE_TAKEOFF || (phase === FlightPhase.FLIGHT_PHASE_GOAROUND && !(gearExtended && FlapsInLandingConfig))) || radioAlt > 1500 || radioAlt < 10) {
+    GPWSMode3(radioAlt, phase, FlapsInLandingConfig) {
+        if (!(phase === FlightPhase.FLIGHT_PHASE_TAKEOFF || phase === FlightPhase.FLIGHT_PHASE_GOAROUND) || radioAlt > 1500 || radioAlt < 10) {
             this.Mode3MaxBaroAlt = NaN;
             this.Mode3Code = 0;
             return;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->


## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* After the changes from #1715 by @antikythera288, go around flight phase is now implemented, so now, the "Too low terrain" warning on go-around should be no longer playing.
* "Don't sink" warnings on takeoff on some airports should also be fixed.


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
