### PR TITLE
[CDU] Fix athr targeting flap speed on climb

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -89,6 +89,7 @@
 1. [ECAM] Fixed ELEV limits display on the F/CTL page - @lousybyte (lousybyte)
 1. [CDU] Fix missing preflight flight phase - @beheh (Benedict Etzel)
 1. [CDU] Fix flight phase when spawning mid-air - @beheh (Benedict Etzel)
+1. [CDU] Fixed autothrust targeting F or S speed on climb - @MisterChocker (Leon)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -328,10 +328,6 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
                 maxSpeed = this.v2Speed + 50;
             }
         }
-        const flapsHandleIndex = Simplane.getFlapsHandleIndex();
-        if (flapsHandleIndex != 0) {
-            return Math.min(maxSpeed, this.getFlapSpeed());
-        }
         let dCI = this.costIndex / 999;
         dCI = dCI * dCI;
         let speed = 290 * (1 - dCI) + 330 * dCI;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -1392,10 +1392,6 @@ class FMCMainDisplay extends BaseAirliners {
     getCrzManagedSpeed() {
         let dCI = this.costIndex / 999;
         dCI = dCI * dCI;
-        const flapsHandleIndex = SimVar.GetSimVarValue("FLAPS HANDLE INDEX", "Number");
-        if (flapsHandleIndex != 0) {
-            return this.getFlapSpeed();
-        }
         let speed = 290 * (1 - dCI) + 310 * dCI;
         if (SimVar.GetSimVarValue("PLANE ALTITUDE", "feet") < 10000) {
             speed = Math.min(speed, 250);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #565
Fixes #782
Fixes some one part of #422
Fixes some one part of #760

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- ATHR now targets climb speed for managed speed mode instead of next flap retraction speed
_ATHR now accelerates past F and S speed marker as it should do_

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/1857322/99186505-fa970400-2750-11eb-968c-2aebd05597c1.png)
![image](https://user-images.githubusercontent.com/1857322/99186513-0387d580-2751-11eb-8611-08b725abb8b1.png)
![image](https://user-images.githubusercontent.com/1857322/99186517-0b477a00-2751-11eb-8a9a-840f9010ad3f.png)

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
https://www.youtube.com/watch?v=gLBlHOEQrIM&feature=youtu.be

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): DerL30N#3751

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
