### PR TITLE
[ECAM] Stop updating the ECAM pages twice

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -13,6 +13,23 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         return this.urlConfig.index === 2;
     }
 
+    // The following two functions can be called from anywhere on the EICAS
+    static isOnTopScreen() {
+        const eicas = document.getElementsByTagName("a320-neo-eicas-element");
+        if (!eicas.length) {
+            return false;
+        }
+        return eicas[0].isTopScreen;
+    }
+
+    static isOnBottomScreen() {
+        const eicas = document.getElementsByTagName("a320-neo-eicas-element");
+        if (!eicas.length) {
+            return false;
+        }
+        return eicas[0].isBottomScreen;
+    }
+
     changePage(_pageName) {
         let pageName = _pageName.toUpperCase();
         for (let i = 0; i < this.lowerScreenPages.length; i++) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
@@ -56,7 +56,7 @@ var A320_Neo_LowerECAM_APU;
             this.isInitialised = true;
         }
         update(_deltaTime) {
-            if (!this.isInitialised) {
+            if (!this.isInitialised || !A320_Neo_EICAS.isOnBottomScreen()) {
                 return;
             }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.js
@@ -125,7 +125,7 @@ var A320_Neo_LowerECAM_BLEED;
         }
 
         update(_deltaTime) {
-            if (!this.isInitialised) {
+            if (!this.isInitialised || !A320_Neo_EICAS.isOnBottomScreen()) {
                 return;
             }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_COND.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_COND.js
@@ -34,7 +34,7 @@ var A320_Neo_LowerECAM_COND;
             this.querySelector("#AltnMode").setAttribute("visibility", "hidden");
         }
         update(_deltaTime) {
-            if (!this.isInitialised) {
+            if (!this.isInitialised || !A320_Neo_EICAS.isOnBottomScreen()) {
                 return;
             }
 
@@ -65,4 +65,3 @@ var A320_Neo_LowerECAM_COND;
     A320_Neo_LowerECAM_COND.Page = Page;
 })(A320_Neo_LowerECAM_COND || (A320_Neo_LowerECAM_COND = {}));
 customElements.define("a320-neo-lower-ecam-cond", A320_Neo_LowerECAM_COND.Page);
-//# sourceMappingURL=A320_Neo_LowerECAM_COND.js.map

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_CRZ.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_CRZ.js
@@ -84,7 +84,7 @@ var A320_Neo_LowerECAM_CRZ;
             this.isInitialised = true;
         }
         update(_deltaTime) {
-            if (!this.isInitialised) {
+            if (!this.isInitialised || !A320_Neo_EICAS.isOnBottomScreen()) {
                 return;
             }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.js
@@ -43,7 +43,7 @@ var A320_Neo_LowerECAM_DOOR;
             this.isInitialised = true;
         }
         update(_deltaTime) {
-            if (!this.isInitialised) {
+            if (!this.isInitialised || !A320_Neo_EICAS.isOnBottomScreen()) {
                 return;
             }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.js
@@ -40,7 +40,7 @@ var A320_Neo_LowerECAM_Engine;
             this.isInitialised = true;
         }
         update(_deltaTime) {
-            if (!this.isInitialised) {
+            if (!this.isInitialised || !A320_Neo_EICAS.isOnBottomScreen()) {
                 return;
             }
             if (this.engineLeft != null) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.js
@@ -73,7 +73,7 @@ let A320_Neo_LowerECAM_FTCL;
         }
 
         update(_deltaTime) {
-            if (!this.isInitialised) {
+            if (!this.isInitialised || !A320_Neo_EICAS.isOnBottomScreen()) {
                 return;
             }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.js
@@ -84,7 +84,7 @@ var A320_Neo_LowerECAM_Fuel;
             this.isInMetric = BaseAirliners.unitIsMetric(Aircraft.A320_NEO);
         }
         update(_deltaTime) {
-            if (!this.isInitialised) {
+            if (!this.isInitialised || !A320_Neo_EICAS.isOnBottomScreen()) {
                 return;
             }
             let factor = this.gallonToPounds;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_PRESS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_PRESS.js
@@ -189,7 +189,7 @@ var A320_Neo_LowerECAM_PRESS;
         }
 
         update() {
-            if (!this.isInitialised) {
+            if (!this.isInitialised || !A320_Neo_EICAS.isOnBottomScreen()) {
                 return;
             }
 
@@ -304,4 +304,3 @@ var A320_Neo_LowerECAM_PRESS;
     A320_Neo_LowerECAM_PRESS.Page = Page;
 })(A320_Neo_LowerECAM_PRESS || (A320_Neo_LowerECAM_PRESS = {}));
 customElements.define("a320-neo-lower-ecam-press", A320_Neo_LowerECAM_PRESS.Page);
-//# sourceMappingURL=A320_Neo_LowerECAM_PRESS.js.map

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Status.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Status.js
@@ -355,7 +355,7 @@ var A320_Neo_LowerECAM_Status;
             this.isInitialised = true;
         }
         update(_deltaTime) {
-            if (!this.isInitialised) {
+            if (!this.isInitialised || !A320_Neo_EICAS.isOnBottomScreen()) {
                 return;
             }
             this.frameCount++;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_WHEEL.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_WHEEL.js
@@ -240,7 +240,7 @@ var A320_Neo_LowerECAM_WHEEL;
         }
 
         update(_deltaTime) {
-            if (!this.isInitialised) {
+            if (!this.isInitialised || !A320_Neo_EICAS.isOnBottomScreen()) {
                 return;
             }
 
@@ -372,10 +372,6 @@ var A320_Neo_LowerECAM_WHEEL;
         }
 
         updateAutoBrake(_deltaTime) {
-            if (!this.isInitialised) {
-                return;
-            }
-
             const autoBrakeMode = SimVar.GetSimVarValue("L:XMLVAR_Autobrakes_Level", "Number");
 
             if (autoBrakeMode === 0) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -1223,14 +1223,15 @@ var A320_Neo_UpperECAM;
             this.isInitialised = true;
         }
         update(_deltaTime) {
+            if (!this.isInitialised || !A320_Neo_EICAS.isOnTopScreen()) {
+                return;
+            }
+
             const leftThrottleDetent = Simplane.getEngineThrottleMode(0);
             const rightThrottleDetent = Simplane.getEngineThrottleMode(1);
             const highestThrottleDetent = (leftThrottleDetent >= rightThrottleDetent) ? leftThrottleDetent : rightThrottleDetent;
             const numberPhase = SimVar.GetSimVarValue("L:AIRLINER_FLIGHT_PHASE", "number");
 
-            if (!this.isInitialised) {
-                return;
-            }
             for (let i = 0; i < this.allPanels.length; ++i) {
                 if (this.allPanels[i] != null) {
                     this.allPanels[i].update(_deltaTime);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Right now, the EICAS/ECAM code is shared between the lower and the upper DU. This is mostly fine, except for updating pages when it's not needed. Most critically, `getActiveFailures` calls a lot of simvars to check the active ECAM failures, and is run from the bottom screen. This is completely unnecessary. My upcoming PR on the FWC #1943 also runs twice without this.

Note that while testing, in some cases I've seen the new page briefly flash with old data. This issue existed previously, and the inactive pages were never updated previously. This change purely disabled:

- the top ECAM screen being silently refreshed the bottom screen
- the bottom page being silently refreshed the top screen

I'm not sure this is worth a CHANGELOG entry - it's hidden to users, but may have a slight performance improvement.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
