### PR TITLE
Add custom sidestick priority template

### DIFF
--- a/A32NX/ModelBehaviorDefs/A32NX/Interior/A32NX_Interior_Misc.xml
+++ b/A32NX/ModelBehaviorDefs/A32NX/Interior/A32NX_Interior_Misc.xml
@@ -357,7 +357,7 @@
             <Update Frequency="5">
 						(* This Update Ensures that the state of some simvars that are linked to the same button is consistent. *)
 						(A:FUELSYSTEM VALVE SWITCH:#VALVE_ID#, Bool) sp1
-						(A:GENERAL ENG STARTER:#ID#, Bool) l1 != if{ 
+						(A:GENERAL ENG STARTER:#ID#, Bool) l1 != if{
 							(&gt;K:TOGGLE_STARTER#ID#)
 						}
             </Update>
@@ -402,5 +402,30 @@
 
             <TOOLTIPID>Test GPWS / Stop G/S alert</TOOLTIPID>
         </UseTemplate>
+    </Template>
+
+    <Template Name="FBW_Airbus_Sidestick_Priority">
+        <DefaultTemplateParameters>
+            <WWISE_EVENT_1>yoke_push_button_on</WWISE_EVENT_1>
+            <WWISE_EVENT_2>yoke_push_button_off</WWISE_EVENT_2>
+            <ANIM_NAME>#NODE_ID#</ANIM_NAME>
+            <ID>1</ID>
+            <TOOLTIPID>%((A:AUTOPILOT MASTER, Bool))%{if}Disc. Autopilot%{else}Take priority%{end}</TOOLTIPID>
+        </DefaultTemplateParameters>
+
+        <Component ID="#NODE_ID#" Node="#NODE_ID#">
+            <UseTemplate Name="ASOBO_GT_Push_Button_Held">
+                <LEFT_SINGLE_CODE>
+                    (A:AUTOPILOT MASTER, Bool) if{
+                        (&gt;K:AP_MASTER)
+                    } els{
+                        1 (&gt;L:A32NX_PRIORITY_TAKEOVER:#ID#)
+                    }
+                </LEFT_SINGLE_CODE>
+                <LEFT_LEAVE_CODE>
+                    0 (&gt;L:A32NX_PRIORITY_TAKEOVER:#ID#)
+                </LEFT_LEAVE_CODE>
+            </UseTemplate>
+        </Component>
     </Template>
 </ModelBehaviors>

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -694,13 +694,15 @@
                 <ANIM_NAME_YOKE_Y>yoke_lever_stick_fore2_aft</ANIM_NAME_YOKE_Y>
             </UseTemplate>
 
-            <UseTemplate Name="ASOBO_HANDLING_Push_AP_Trim_Disc_Template">
+            <UseTemplate Name="FBW_Airbus_Sidestick_Priority">
                 <NODE_ID>PUSH_YOKE_LEFT</NODE_ID>
                 <ANIM_NAME>PUSH_YOKE_LEFT</ANIM_NAME>
+                <ID>1</ID>
             </UseTemplate>
-            <UseTemplate Name="ASOBO_HANDLING_Push_AP_Trim_Disc_Template">
+            <UseTemplate Name="FBW_Airbus_Sidestick_Priority">
                 <NODE_ID>PUSH_YOKE_RIGHT</NODE_ID>
                 <ANIM_NAME>PUSH_YOKE_RIGHT</ANIM_NAME>
+                <ID>2</ID>
             </UseTemplate>
 
             <UseTemplate Name="ASOBO_HANDLING_Steering_Tiller_Template">


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
* This changes the AP takeover pushbutton to our own template
* Now, when the AP is engaged, pressing the button will disconnect it.
* When it isn't engaged, as long as the button is held, the LVar "L:A32NX_PRIORITY_TAKEOVER:x" will be set to 1, where x corresponds to the side (1 is left, 2 is right)
* This is only for compatability with YourControls, and has no WWise events hooked up.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
