### PR TITLE
Fix typo for cabin vertical speed

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -91,6 +91,7 @@
 1. [CDU] Fix flight phase when spawning mid-air - @beheh (Benedict Etzel)
 1. [CDU] Fixed autothrust targeting F or S speed on climb - @MisterChocker (Leon)
 1. [ND] Added altitude constraints in flight level based on the transition altitude provided in MCDU Take Off Performace @ilyeshammadi (Ilyes Hammadi)
+1. [ECAM] Fix cabin vertical speed unit - @MrMinimal (Tom Langwaldt)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_CRZ.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_CRZ.html
@@ -70,7 +70,7 @@
 
             <text class="Description" x="515" y="380">CAB V/S</text>
             <text id="CabinVerticalSpeed" class="CRZValue AlignRight" x="510" y="400">0</text>
-            <text class="Unit" x="555" y="400">FT/S</text>
+            <text class="Unit" x="555" y="400">FT/MIN</text>
 
             <text class="Description" x="515" y="450">CAB ALT</text>
             <text id="CabinAltitude" class="CRZValue AlignRight" x="510" y="470">6850</text>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #1976 

## Summary of Changes
Unit of cabin pressure change is feet/minute in code but not in the display.
Fixed this typo.

## Screenshots
Before:
![grafik](https://user-images.githubusercontent.com/8739690/99299610-ba687c00-284b-11eb-9106-b2dd3291b13a.png)


After:
![grafik](https://user-images.githubusercontent.com/8739690/99299196-2ac2cd80-284b-11eb-906e-b0d73dcb5a41.png)


## References
https://www.youtube.com/watch?v=sRiEf-at0Bs&feature=youtu.be&t=896


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
