### PR TITLE
[ND] Add missing altitude constraint symbol

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -92,6 +92,7 @@
 1. [CDU] Fixed autothrust targeting F or S speed on climb - @MisterChocker (Leon)
 1. [ND] Added altitude constraints in flight level based on the transition altitude provided in MCDU Take Off Performace @ilyeshammadi (Ilyes Hammadi)
 1. [ECAM] Fix cabin vertical speed unit - @MrMinimal (Tom Langwaldt)
+1. [ND] Add altitue constraint symbol and fix constraint circle color @ilyeshammadi (Ilyes Hammadi)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.css
@@ -73,3 +73,7 @@ map-instrument {
     width: 100%;
     height: 100%; }
 
+/* Set the CSTR circle stroke color */
+#path819 {
+  stroke: #ff94ff !important;
+}

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.css
@@ -72,3 +72,4 @@ map-instrument {
     left: 0%;
     width: 100%;
     height: 100%; }
+

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/A32NX_MapInstrument.css
@@ -72,8 +72,3 @@ map-instrument {
     left: 0%;
     width: 100%;
     height: 100%; }
-
-/* Set the CSTR circle stroke color */
-#path819 {
-  stroke: #ff94ff !important;
-}

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/Svg/A32NX_SvgConstraintElement.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/A320_Neo/Map/Svg/A32NX_SvgConstraintElement.js
@@ -40,16 +40,32 @@ class SvgConstraintElement extends SvgMapElement {
         return "ICON_CSTR_MAGENTA.svg";
     }
 
+    _getAltitudeDescriptionSymbol() {
+        if (this.source.legAltitudeDescription == 2) {
+            return '+';
+        } else if (this.source.legAltitudeDescription == 3) {
+            return '-';
+        } else {
+            return '';
+        }
+    }
+
     createDraw(map) {
         const fontSize = map.config.waypointLabelFontSize;
         let text = "CSTR";
         let speedText = "";
+        const altitudeDescriptionSymbol = this._getAltitudeDescriptionSymbol();
+
         if (this.source) {
             if (this.source.legAltitude1 > this.transitionAltitude) {
                 text = "FL" + (this.source.legAltitude1 / 100).toFixed(0);
             } else {
                 text = (this.source.legAltitude1 / 10).toFixed(0) + "0";
             }
+        }
+
+        if (altitudeDescriptionSymbol) {
+            text = altitudeDescriptionSymbol + text;
         }
 
         if (this.source.speedConstraint > 10) {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Add missing constraint symbol in the navigation display when CSTR is selected.


## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

### Before
![Screenshot (39)](https://user-images.githubusercontent.com/11317522/99309642-11754d80-285a-11eb-845e-b9c2bbb527ab.png)

### After
![Screenshot 2020-11-17 231908](https://user-images.githubusercontent.com/11317522/99457481-574e1680-292b-11eb-8fdf-4ad374ddff83.png)




## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![Screenshot 2020-11-16 222252](https://user-images.githubusercontent.com/11317522/99309812-4d101780-285a-11eb-98e1-a77482cf4aa2.png)

Video: https://youtu.be/TEi-WX08ov8?t=243
<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Union Araken#4083

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
