### PR TITLE
Enhance ECAM COND Page

### DIFF
--- a/A32NX/html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js
+++ b/A32NX/html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js
@@ -17,22 +17,40 @@ class A32NX_LocalVarUpdater {
                 selector: this._noSmokingMemoSelector,
             },
             {
-                varName: "L:A32NX_CKPT_TEMP",
+                varName: "L:A32NX_CKPT_TRIM_TEMP",
                 type: "celsius",
                 selector: this._condTempSelector,
-                index: 1
+                identifier: 1
+            },
+            {
+                varName: "L:A32NX_FWD_TRIM_TEMP",
+                type: "celsius",
+                selector: this._condTempSelector,
+                identifier : 2
+            },
+            {
+                varName: "L:A32NX_AFT_TRIM_TEMP",
+                type: "celsius",
+                selector: this._condTempSelector,
+                identifier: 3
+            },
+            {
+                varName: "L:A32NX_CKPT_TEMP",
+                type: "celsius",
+                selector: this._condTrimOutletSelector,
+                identifier: "CKPT"
             },
             {
                 varName: "L:A32NX_FWD_TEMP",
                 type: "celsius",
-                selector: this._condTempSelector,
-                index : 2
+                selector: this._condTrimOutletSelector,
+                identifier: "FWD"
             },
             {
                 varName: "L:A32NX_AFT_TEMP",
                 type: "celsius",
-                selector: this._condTempSelector,
-                index: 3
+                selector: this._condTrimOutletSelector,
+                identifier: "AFT"
             },
             {
                 varName: "L:A32NX_FLAPS_IN_MOTION",
@@ -47,8 +65,8 @@ class A32NX_LocalVarUpdater {
         this.updaters.forEach(this._runUpdater);
     }
 
-    _runUpdater({varName, type, selector, index = null}) {
-        const newValue = selector(index);
+    _runUpdater({varName, type, selector, identifier = null}) {
+        const newValue = selector(identifier);
         const currentValue = SimVar.GetSimVarValue(varName, type);
         if (newValue !== currentValue) {
             SimVar.SetSimVarValue(varName, type, newValue);
@@ -72,11 +90,18 @@ class A32NX_LocalVarUpdater {
         return false;
     }
 
-    _condTempSelector(_index) {
+    _condTempSelector(_identifier) {
         // Temporary code until packs code is written and implemented
-        // Uses position of AIR COND knobs as a surrogate
-        const cabinKnobValue = SimVar.GetSimVarValue("L:A320_Neo_AIRCOND_LVL_" + _index, "Position(0-6)");
-        const cabinTemp = (18 + (0.12 * cabinKnobValue));
+        // Uses position of AIR COND knobs to generate the trim air temperature
+        const airconKnobValue = SimVar.GetSimVarValue("L:A320_Neo_AIRCOND_LVL_" + _identifier, "Position(0-100)");
+        const trimTemp = (0.12 * airconKnobValue) + 18; // Map from knob range 0-100 to 18-30 degrees C
+        return trimTemp;
+    }
+
+    _condTrimOutletSelector(_compartment) {
+        // Uses outlet temperature of trim air valves to generate the cabin temperature
+        const cabinTemp = SimVar.GetSimVarValue("L:A32NX_" + _compartment + "_TRIM_TEMP", "celsius");
+        // Dämpfung
         return cabinTemp;
     }
 

--- a/A32NX/html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js
+++ b/A32NX/html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js
@@ -113,7 +113,7 @@ class A32NX_LocalVarUpdater {
         const deltaTemp = trimTemp - currentCabinTemp;
 
         // variation depends on packflow
-        const cabinTempVariationSpeed = 0.0001 * (SimVar.GetSimVarValue("L:A32NX_KNOB_OVHD_AIRCOND_PACKFLOW_Position", "Position(0-2)") + 1);
+        const cabinTempVariationSpeed = 0.0005 * (SimVar.GetSimVarValue("L:A32NX_KNOB_OVHD_AIRCOND_PACKFLOW_Position", "Position(0-2)") + 1);
 
         const cabinTemp = currentCabinTemp + deltaTemp * cabinTempVariationSpeed;
 

--- a/A32NX/html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js
+++ b/A32NX/html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js
@@ -93,8 +93,15 @@ class A32NX_LocalVarUpdater {
     _condTempSelector(_identifier) {
         // Temporary code until packs code is written and implemented
         // Uses position of AIR COND knobs to generate the trim air temperature
-        const airconKnobValue = SimVar.GetSimVarValue("L:A320_Neo_AIRCOND_LVL_" + _identifier, "Position(0-100)");
-        const trimTemp = (0.12 * airconKnobValue) + 18; // Map from knob range 0-100 to 18-30 degrees C
+        let trimTemp = null;
+
+        if (SimVar.GetSimVarValue("L:A32NX_AIRCOND_HOTAIR_TOGGLE", "Bool")) {
+            const airconKnobValue = SimVar.GetSimVarValue("L:A320_Neo_AIRCOND_LVL_" + _identifier, "Position(0-100)");
+            trimTemp = (0.12 * airconKnobValue) + 18; // Map from knob range 0-100 to 18-30 degrees C
+        } else {
+            trimTemp = 18; // TODO replace placeholder with pack out temperature
+        }
+
         return trimTemp;
     }
 

--- a/A32NX/html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js
+++ b/A32NX/html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js
@@ -107,10 +107,20 @@ class A32NX_LocalVarUpdater {
 
     _condTrimOutletSelector(_compartment) {
         // Uses outlet temperature of trim air valves to generate the cabin temperature
-        const cabinTemp = SimVar.GetSimVarValue("L:A32NX_" + _compartment + "_TRIM_TEMP", "celsius");
-        // Dämpfung
+        const currentCabinTemp = SimVar.GetSimVarValue("L:A32NX_" + _compartment + "_TEMP", "celsius");
+        const trimTemp = SimVar.GetSimVarValue("L:A32NX_" + _compartment + "_TRIM_TEMP", "celsius");
+
+        const deltaTemp = trimTemp - currentCabinTemp;
+
+        // variation depends on packflow
+        const cabinTempVariationSpeed = 0.0001 * (SimVar.GetSimVarValue("L:A32NX_KNOB_OVHD_AIRCOND_PACKFLOW_Position", "Position(0-2)") + 1);
+
+        const cabinTemp = currentCabinTemp + deltaTemp * cabinTempVariationSpeed;
+
         return cabinTemp;
     }
+
+    // P: let currentPackFlow = ;
 
     _flapsInMotionSelector() {
         const currentFlapsPosition = SimVar.GetSimVarValue("TRAILING EDGE FLAPS LEFT PERCENT", "percent");

--- a/A32NX/html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js
+++ b/A32NX/html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js
@@ -120,8 +120,6 @@ class A32NX_LocalVarUpdater {
         return cabinTemp;
     }
 
-    // P: let currentPackFlow = ;
-
     _flapsInMotionSelector() {
         const currentFlapsPosition = SimVar.GetSimVarValue("TRAILING EDGE FLAPS LEFT PERCENT", "percent");
         const lastFlapsPosition = this.lastFlapsPosition;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_COND.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_COND.html
@@ -17,11 +17,11 @@
       
       <!-- Cockpit -->
       <text class="CondZone AlignCenter" x="153" y="120">CKPT</text>
-      <text id="CkptTemp" class="CondValue AlignCenter" x="153" y="152">21</text>
-      <text id="CkptTrimTemp" class="CondValue Smaller AlignCenter" x="153" y="198">21</text>
+      <text id="CkptCabinTemp" class="CondValue AlignCenter" x="153" y="152">-99</text>
+      <text id="CkptTrimTemp" class="CondValue Smaller AlignCenter" x="153" y="198">-99</text>
       <text class="DuctStatus" x="119" y="235">C</text>
       <text class="DuctStatus" x="187" y="235">H</text>
-      <g id="CkptGauge" transform="rotate(-45,155,250)">
+      <g id="CkptGauge" transform="rotate(-50,155,250)">
          <polygon class="st5" points="155,225  159,232 151,232" />
          <line class="st5" x1="155" y1="232" x2="155" y2="250" />  
       </g>
@@ -33,11 +33,11 @@
       
       <!-- Fwd -->
       <text class="CondZone AlignCenter" x="280" y="120">FWD</text>
-      <text id="FwdTemp" class="CondValue AlignCenter" x="280" y="152">21</text>
-      <text id="FwdTrimTemp" class="CondValue Smaller AlignCenter" x="280" y="198">23</text>
+      <text id="FwdCabinTemp" class="CondValue AlignCenter" x="280" y="152">-99</text>
+      <text id="FwdTrimTemp" class="CondValue Smaller AlignCenter" x="280" y="198">-99</text>
       <text class="DuctStatus" x="245" y="235">C</text>
       <text class="DuctStatus" x="315" y="235">H</text>
-      <g id="FwdGauge" transform="rotate(35,280,250)">
+      <g id="FwdGauge" transform="rotate(-50,280,250)">
          <polygon class="st5" points="276,232 280,225 284,232 " />
          <line class="st5" x1="280" y1="232" x2="280" y2="250" />
       </g>
@@ -49,11 +49,11 @@
       
       <!-- Aft -->
       <text class="CondZone AlignCenter" x="420" y="120">AFT</text>
-      <text id="AftTemp" class="CondValue AlignCenter" x="420" y="152">22</text>
-      <text id="AftTrimTemp" class="CondValue Smaller AlignCenter" x="420" y="198">23</text>
+      <text id="AftCabinTemp" class="CondValue AlignCenter" x="420" y="152">-99</text>
+      <text id="AftTrimTemp" class="CondValue Smaller AlignCenter" x="420" y="198">-99</text>
       <text class="DuctStatus" x="385" y="235">C</text>
       <text class="DuctStatus" x="455" y="235">H</text>
-      <g id="AftGauge" transform="rotate(-15,420,250)">
+      <g id="AftGauge" transform="rotate(-50,420,250)">
          <polygon class="st5" points="416,232 420,225 424,232"/>
          <line class="st5" x1="420" y1="232" x2="420" y2="250"/>
       </g>  
@@ -65,7 +65,7 @@
       
       <!-- Valve and tubes -->
       <text class="DuctStatus" x="565" y="296"><tspan x="565" y="295">HOT</tspan><tspan x="565" y="320">AIR</tspan></text>
-      <g id="HotAirValve" class="valve-moving">
+      <g id="HotAirValve">
          <circle class="st5" cx="506" cy="300" r="16"/>
          <line class="st5" x1="490" y1="300" x2="522" y2="300" id="HotAirValveOpen" />
          <line class="st5" x1="506" y1="284" x2="506" y2="316" id="HotAirValveClosed" />

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_COND.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_COND.js
@@ -25,6 +25,15 @@ var A320_Neo_LowerECAM_COND;
             this.isInitialised = true;
             // finding all html element for the display, first element of array is always the open on, the second is the closed one
             this.hotAirValveIndication = [this.querySelector("#HotAirValveOpen"), this.querySelector("#HotAirValveClosed")];
+            this.trimAirValveIndicator = [this.querySelector("#CkptGauge"), this.querySelector("#FwdGauge"), this.querySelector("#AftGauge")];
+
+            this.cockpitTrimTemp = this.querySelector("#CkptTrimTemp");
+            this.fwdTrimTemp = this.querySelector("#FwdTrimTemp");
+            this.aftTrimTemp = this.querySelector("#AftTrimTemp");
+
+            this.cockpitCabinTemp = this.querySelector("#CkptCabinTemp");
+            this.fwdCabinTemp = this.querySelector("#FwdCabinTemp");
+            this.aftCabinTemp = this.querySelector("#AftCabinTemp");
 
             // fan warnings, hidden on initialisation
             this.fanWarningIndication = [this.querySelector("#LeftFanWarning"), this.querySelector("#RightFanWarning")];
@@ -38,23 +47,28 @@ var A320_Neo_LowerECAM_COND;
                 return;
             }
 
-            // display zone and trim temperature for each zone
-            var zoneTemp = SimVar.GetSimVarValue("L:A32NX_CKPT_TEMP", "celsius");
-            this.querySelector("#CkptTemp").textContent = parseInt(zoneTemp);
-            var trimTemp = SimVar.GetSimVarValue("L:CKPT_DUCT_TEMP", "celsius");
-            this.querySelector("#CkptTrimTemp").textContent = parseInt(trimTemp);
+            // Disaply trim valve position for each zone
+            const gaugeOffset = -50; //Gauges range is from -50 degree to +50 degree, AC-selectort value is 0-100 - added an offset for this
 
-            zoneTemp = SimVar.GetSimVarValue("L:A32NX_FWD_TEMP", "celsius");
-            this.querySelector("#FwdTemp").textContent = parseInt(zoneTemp);
-            trimTemp = SimVar.GetSimVarValue("L:FWD_DUCT_TEMP", "celsius");
-            this.querySelector("#FwdTrimTemp").textContent = parseInt(trimTemp);
+            var airconSelectedTempCockpit = SimVar.GetSimVarValue("L:A320_Neo_AIRCOND_LVL_1", "Position(0-100)");
+            var airconSelectedTempFWD = SimVar.GetSimVarValue("L:A320_Neo_AIRCOND_LVL_2", "Position(0-100)");
+            var airconSelectedTempAFT = SimVar.GetSimVarValue("L:A320_Neo_AIRCOND_LVL_3", "Position(0-100)");
 
-            zoneTemp = SimVar.GetSimVarValue("L:A32NX_AFT_TEMP", "celsius");
-            this.querySelector("#AftTemp").textContent = parseInt(zoneTemp);
-            trimTemp = SimVar.GetSimVarValue("L:AFT_DUCT_TEMP", "celsius");
-            this.querySelector("#AftTrimTemp").textContent = parseInt(trimTemp);
+            this.trimAirValveIndicator[0].setAttribute("style", "transform-origin: 155px 250px; transform: rotate(" + (gaugeOffset + airconSelectedTempCockpit) + "deg); stroke-width: 4.5px; stroke-linecap: round;");
+            this.trimAirValveIndicator[1].setAttribute("style", "transform-origin: 280px 250px; transform: rotate(" + (gaugeOffset + airconSelectedTempFWD) + "deg); stroke-width: 4.5px; stroke-linecap: round;");
+            this.trimAirValveIndicator[2].setAttribute("style", "transform-origin: 420px 250px; transform: rotate(" + (gaugeOffset + airconSelectedTempAFT) + "deg); stroke-width: 4.5px; stroke-linecap: round;");
 
-            // TODO: disaply trim valve position for each zone
+            // Generate trim outlet values
+            this.cockpitTrimTemp.textContent = parseInt(SimVar.GetSimVarValue("L:A32NX_CKPT_TRIM_TEMP", "celsius"));
+            this.fwdTrimTemp.textContent = parseInt(SimVar.GetSimVarValue("L:A32NX_FWD_TRIM_TEMP", "celsius"));
+            this.aftTrimTemp.textContent = parseInt(SimVar.GetSimVarValue("L:A32NX_AFT_TRIM_TEMP", "celsius"));
+
+            // Display cabin temp
+            this.cockpitCabinTemp.textContent = parseInt(SimVar.GetSimVarValue("L:A32NX_CKPT_TEMP", "celsius"));
+            this.fwdCabinTemp.textContent = parseInt(SimVar.GetSimVarValue("L:A32NX_FWD_TEMP", "celsius"));
+            this.aftCabinTemp.textContent = parseInt(SimVar.GetSimVarValue("L:A32NX_AFT_TEMP", "celsius"));
+
+            console.log(SimVar.GetSimVarValue("L:A32NX_AFT_TEMP", "celsius"));
 
             // find if the hot air valve is open or not
             var currentHotAirSate = SimVar.GetSimVarValue("L:A32NX_AIRCOND_HOTAIR_TOGGLE", "Bool");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_COND.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_COND.js
@@ -23,6 +23,7 @@ var A320_Neo_LowerECAM_COND;
             }
 
             this.isInitialised = true;
+
             // finding all html element for the display, first element of array is always the open on, the second is the closed one
             this.hotAirValveIndication = [this.querySelector("#HotAirValveOpen"), this.querySelector("#HotAirValveClosed")];
             this.trimAirValveIndicator = [this.querySelector("#CkptGauge"), this.querySelector("#FwdGauge"), this.querySelector("#AftGauge")];
@@ -41,6 +42,20 @@ var A320_Neo_LowerECAM_COND;
             this.fanWarningIndication[1].setAttribute("visibility", "hidden");
 
             this.querySelector("#AltnMode").setAttribute("visibility", "hidden");
+
+            // Init Cabin Temp
+            if (Simplane.getIsGrounded()) {
+                SimVar.SetSimVarValue("L:A32NX_CKPT_TEMP", "celsius", Simplane.getAmbientTemperature());
+                SimVar.SetSimVarValue("L:A32NX_FWD_TEMP", "celsius", Simplane.getAmbientTemperature());
+                SimVar.SetSimVarValue("L:A32NX_AFT_TEMP", "celsius", Simplane.getAmbientTemperature());
+            } else {
+                // TODO FIX - not a function error
+                const defaultCabinTemp = 18; // Initial airborne cabin temperature
+                //Simvar.SetSimVarValue("L:A32NX_CKPT_TEMP", "celsius", defaultCabinTemp);
+                //Simvar.SetSimVarValue("L:A32NX_FWD_TEMP", "celsius", defaultCabinTemp);
+                //Simvar.SetSimVarValue("L:A32NX_AFT_TEMP", "celsius", defaultCabinTemp);
+            }
+
         }
         update(_deltaTime) {
             if (!this.isInitialised) {
@@ -48,7 +63,7 @@ var A320_Neo_LowerECAM_COND;
             }
 
             // Disaply trim valve position for each zone
-            const gaugeOffset = -50; //Gauges range is from -50 degree to +50 degree, AC-selectort value is 0-100 - added an offset for this
+            const gaugeOffset = -50; //Gauges range is from -50 degree to +50 degree, AC-selector value is 0-100 - added an offset for this
 
             var airconSelectedTempCockpit = SimVar.GetSimVarValue("L:A320_Neo_AIRCOND_LVL_1", "Position(0-100)");
             var airconSelectedTempFWD = SimVar.GetSimVarValue("L:A320_Neo_AIRCOND_LVL_2", "Position(0-100)");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_COND.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_COND.js
@@ -68,8 +68,6 @@ var A320_Neo_LowerECAM_COND;
             this.fwdCabinTemp.textContent = parseInt(SimVar.GetSimVarValue("L:A32NX_FWD_TEMP", "celsius"));
             this.aftCabinTemp.textContent = parseInt(SimVar.GetSimVarValue("L:A32NX_AFT_TEMP", "celsius"));
 
-            console.log(SimVar.GetSimVarValue("L:A32NX_AFT_TEMP", "celsius"));
-
             // find if the hot air valve is open or not
             var currentHotAirSate = SimVar.GetSimVarValue("L:A32NX_AIRCOND_HOTAIR_TOGGLE", "Bool");
             this.hotAirValveIndication[0].setAttribute("visibility", currentHotAirSate ? 'visible' : 'hidden');

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_CRZ.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_CRZ.html
@@ -79,11 +79,11 @@
             <!-- Cabin Temps -->
             <path class="PlaneSym" d="M 300 410 a 70 70 0 0 0 -30 -5 l -180 0 m 30 0 l 0 50 l 85 0 l 0 -10 m 0 10 l 85 0 l 0 -48 m -170 48 l -30 0 c -60 0 -60 -20 -45 -25"></path>
             <text class="Description SmallText" x="75" y="420">CKPT</text>
-            <text id="CockpitTemp" class="CRZValue SmallText AlignRight" x="90" y="440">24</text>
+            <text id="CockpitTemp" class="CRZValue SmallText AlignRight" x="90" y="440">-99</text>
             <text class="Description SmallText" x="165" y="420">FWD</text>
-            <text id="ForwardTemp" class="CRZValue SmallText AlignCenter" x="165" y="440">24</text>
+            <text id="ForwardTemp" class="CRZValue SmallText AlignCenter" x="165" y="440">-99</text>
             <text class="Description SmallText" x="250" y="420">AFT</text>
-            <text id="AftTemp" class="CRZValue SmallText AlignCenter" x="250" y="440">24</text>
+            <text id="AftTemp" class="CRZValue SmallText AlignCenter" x="250" y="440">-99</text>
             <text class="Unit" x="320" y="450">°C</text> 
 
     </svg>


### PR DESCRIPTION
Fixes #1995

## Summary of Changes
ECAM COND-Page:
- Enabled rotation of trim air valves
- Fixed color of hot air valve (always displayed in amber)
- Implemented trim air outlet temperature
- Added gradual cabin temperature adjustment
- Current pack flow influences temperature adjustment rate
- Cabin temperatur now gets calculated by trim air outlet 
- By closing the hot air valve cabin temperature will sink to pack outlet temp

## Screenshots (if necessary)
![grafik](https://user-images.githubusercontent.com/25608553/99461675-84ea8e00-2932-11eb-9879-306ef8a4b050.png)
![grafik](https://user-images.githubusercontent.com/25608553/99461715-959b0400-2932-11eb-9cca-b1444d46cc1c.png)


## References
![grafik](https://user-images.githubusercontent.com/25608553/99461346-f37b1c00-2931-11eb-937e-5f124035b007.png)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
Tim#0335
MrMinimal#8489

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
