### PR TITLE
fix(ecam): temporary fix for self test font size

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.html
@@ -20,8 +20,10 @@
                 <div class="SelfTestWrapper" id="TopSelfTest">
                     <svg class="SelfTest" viewBox="0 0 600 600">
                         <rect fill="url(#ECAMBacklight)" x="0" y="0" width="100%" height="100%"></rect>
-                        <text class="self_test_text valueText" text-anchor="middle" x="50%" y="50%" font-size="24px">SELF TEST IN PROGRESS</text>
-                        <text class="self_test_text2 valueText" text-anchor="middle" x="50%" y="56%" font-size="24px">(MAX 40 SECONDS)</text>
+
+                        <!-- Disgusting hack, but we are rewriting this anyway :') -->
+                        <text style="font-size: 24px !important;" class="self_test_text valueText" text-anchor="middle" x="50%" y="50%" font-size="24px">SELF TEST IN PROGRESS</text>
+                        <text style="font-size: 24px !important;" class="self_test_text2 valueText" text-anchor="middle" x="50%" y="56%" font-size="24px">(MAX 40 SECONDS)</text>
                     </svg>
                 </div>
 
@@ -74,8 +76,10 @@
                 <div class="SelfTestWrapper" id="BottomSelfTest">
                     <svg class="SelfTest" viewBox="0 0 600 600">
                         <rect fill="url(#ECAMBacklight)" x="0" y="0" width="100%" height="100%"></rect>
-                        <text class="self_test_text valueText" text-anchor="middle" x="50%" y="50%" font-size="24px">SELF TEST IN PROGRESS</text>
-                        <text class="self_test_text2 valueText" text-anchor="middle" x="50%" y="56%" font-size="24px">(MAX 40 SECONDS)</text>
+
+                        <!-- Disgusting hack, but we are rewriting this anyway :') -->
+                        <text style="font-size: 24px !important;" class="self_test_text valueText" text-anchor="middle" x="50%" y="50%" font-size="24px">SELF TEST IN PROGRESS</text>
+                        <text style="font-size: 24px !important;" class="self_test_text2 valueText" text-anchor="middle" x="50%" y="56%" font-size="24px">(MAX 40 SECONDS)</text>
                     </svg>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #1964

## Summary of Changes

- Provide a temporary fix for self-test text being borked, since I could not find a culprit in the jungle of CSS and templates.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): someperson#4953

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
