### PR TITLE
[ECAM] Improve inhibit and recall behaviour

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -103,6 +103,7 @@
 1. [ECAM] Implemented proper FWC flight phases - @beheh (Benedict Etzel)
 1. [ECAM] Updated ECAM messages - @beheh (Benedict Etzel)
 1. [CDU] New improved RADNAV page | Ability to tune navaids with identifier - @St54Kevin (Kevin Karas)
+1. [ECAM] Added flight phase inhibit override to recall button - @beheh (Benedict Etzel)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/A32NX_Utils/NXLogic.js
+++ b/A32NX/html_ui/Pages/A32NX_Utils/NXLogic.js
@@ -92,6 +92,9 @@ class NXLogic_ConfirmNode {
         this._previousValue = value;
         return value;
     }
+    read() {
+        return this._previousValue;
+    }
 }
 
 /**

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -97,7 +97,6 @@ var A320_Neo_UpperECAM;
             this.simVarCache = {};
             this.frameCount = 0;
             this._aircraft = Aircraft.A320_NEO;
-            this.takeoffMemoTimer = new NXLogic_ConfirmNode(120);
             this.toInhibitTimer = new NXLogic_ConfirmNode(3);
             this.ldgInhibitTimer = new NXLogic_ConfirmNode(3);
         }
@@ -118,9 +117,9 @@ var A320_Neo_UpperECAM;
             return value;
         }
         getADIRSMins() {
-            const secs = SimVar.GetSimVarValue("L:A320_Neo_ADIRS_TIME", "seconds");
+            const secs = this.getCachedSimVar("L:A320_Neo_ADIRS_TIME", "seconds");
             const mins = Math.ceil(secs / 60);
-            if (secs > 0 && SimVar.GetSimVarValue("L:A320_Neo_ADIRS_IN_ALIGN", "Bool")) {
+            if (secs > 0 && this.getCachedSimVar("L:A320_Neo_ADIRS_IN_ALIGN", "Bool")) {
                 return mins;
             } else {
                 return -1;
@@ -134,6 +133,9 @@ var A320_Neo_UpperECAM;
         }
         engineShutdown(_engine) {
             return (this.getCachedSimVar("TURB ENG N1:" + _engine, "Percent") < 15 || this.getCachedSimVar("FUELSYSTEM VALVE SWITCH:" + (_engine), "Bool") == 0) && !Simplane.getIsGrounded();
+        }
+        isEngineRunning(_engine) {
+            return this.getCachedSimVar(`ENG N1 RPM:${_engine}`, "Percent") >= 15;
         }
         getEngineFailActions(_engine) {
             return [
@@ -214,7 +216,7 @@ var A320_Neo_UpperECAM;
                     action: "TA"
                 },
                 {
-                    style: "blue",
+                    style: "cyan",
                     message: "AVOID ICING CONDITIONS"
                 }
             ];
@@ -427,7 +429,7 @@ var A320_Neo_UpperECAM;
                                         }
                                     },
                                     {
-                                        style: "blue",
+                                        style: "cyan",
                                         message: "GLDG DIST: 2NM/1000FT"
                                     },
                                     {
@@ -446,7 +448,8 @@ var A320_Neo_UpperECAM;
                             {
                                 message: "",
                                 level: 3,
-                                isActive: () => this.isInFlightPhase(5, 6, 7) && Simplane.getIndicatedSpeed() > (A32NX_Selectors.VMAX() + 4),
+                                flightPhasesInhib: [2, 3, 4, 8, 9, 10],
+                                isActive: () => Simplane.getIndicatedSpeed() > (A32NX_Selectors.VMAX() + 4),
                             },
                         ]
                     },
@@ -563,6 +566,7 @@ var A320_Neo_UpperECAM;
                             {
                                 message: "",
                                 level: 3,
+                                flightPhasesInhib: [4, 5, 7, 8],
                                 isActive: () => {
                                     return this.getCachedSimVar("L:A32NX_FIRE_TEST_CARGO", "Bool");
                                 },
@@ -610,9 +614,8 @@ var A320_Neo_UpperECAM;
                                 id: "config_flaps",
                                 message: "",
                                 level: 3,
-                                isActive: () => {
-                                    return this.activeTakeoffConfigWarnings.includes("flaps") && Simplane.getIsGrounded();
-                                },
+                                flightPhasesInhib: [5, 6, 7, 8, 10], // TODO
+                                isActive: () => this.activeTakeoffConfigWarnings.includes("flaps"),
                                 alwaysShowCategory: true,
                                 actions: [
                                     {
@@ -625,9 +628,8 @@ var A320_Neo_UpperECAM;
                                 id: "config_spd_brk",
                                 message: "",
                                 level: 3,
-                                isActive: () => {
-                                    return this.activeTakeoffConfigWarnings.includes("spd_brk") && Simplane.getIsGrounded();
-                                },
+                                flightPhasesInhib: [5, 6, 7, 8], // TODO
+                                isActive: () => this.activeTakeoffConfigWarnings.includes("spd_brk"),
                                 alwaysShowCategory: true,
                                 actions: [
                                     {
@@ -640,6 +642,7 @@ var A320_Neo_UpperECAM;
                                 id: "config_park_brake",
                                 message: "",
                                 level: 3,
+                                flightPhasesInhib: [1, 4, 5, 6, 7, 8, 9, 10], // TODO
                                 isActive: () => {
                                     return this.activeTakeoffConfigWarnings.includes("park_brake") && Simplane.getIsGrounded();
                                 },
@@ -659,8 +662,9 @@ var A320_Neo_UpperECAM;
                             {
                                 message: "EXCESS CAB ALT",
                                 level: 3,
+                                flightPhasesInhib: [1, 2, 3, 4, 5, 7, 8, 9, 10],
                                 isActive: () => (
-                                    this.fwcFlightPhase === 6 &&
+                                    !Simplane.getIsGrounded() &&
                                     this.getCachedSimVar("PRESSURIZATION CABIN ALTITUDE", "feet") > 10000
                                 ),
                                 actions: [
@@ -802,10 +806,9 @@ var A320_Neo_UpperECAM;
                                 message: "HOT",
                                 id: "brakes_hot",
                                 level: 2,
-                                isActive: () => (
-                                    !this.isInFlightPhase(4, 8, 9, 10) &&
-                                    SimVar.GetSimVarValue("L:A32NX_BRAKES_HOT", "Bool")
-                                ),
+                                flightPhasesInhib: [4, 8, 9, 10],
+                                page: "WHEEL",
+                                isActive: () => SimVar.GetSimVarValue("L:A32NX_BRAKES_HOT", "Bool"),
                                 actions: [
                                     {
                                         style: "action",
@@ -813,17 +816,18 @@ var A320_Neo_UpperECAM;
                                         action: "PREFER CHOCKS"
                                     },
                                     {
-                                        style: "blue",
+                                        style: "cyan",
                                         message: "&nbsp;-DELAY T.O FOR COOL"
                                     }
                                 ]
                             },
                             {
                                 message: "PARK BRK ON",
-                                id: "brakes_hot",
+                                id: "brakes_park_brk_on",
                                 level: 2,
+                                flightPhasesInhib: [1, 2, 3, 4, 5, 8, 9, 10],
                                 isActive: () => (
-                                    this.isInFlightPhase(6, 7) && SimVar.GetSimVarValue("BRAKE PARKING INDICATOR", "Bool")
+                                    this.isInFlightPhase(8, 6, 7) && SimVar.GetSimVarValue("BRAKE PARKING INDICATOR", "Bool")
                                 ),
                                 actions: [
                                     {
@@ -836,7 +840,9 @@ var A320_Neo_UpperECAM;
                             },
                             {
                                 message: "A/SKID N/WS OFF",
+                                id: "brakes_askid_nws_off",
                                 level: 2,
+                                flightPhasesInhib: [4, 5],
                                 page: "WHEEL",
                                 inopSystems: [
                                     "CAT_3_DUAL",
@@ -847,13 +853,11 @@ var A320_Neo_UpperECAM;
                                     "ASKID_NWS" // only as trigger for STS messages
                                 ],
                                 isActive: () => (
-                                    this.fwcFlightPhase !== 4 &&
-                                    this.fwcFlightPhase !== 5 &&
-                                    SimVar.GetSimVarValue("ANTISKID BRAKES ACTIVE", "Bool") === 0
+                                    !SimVar.GetSimVarValue("ANTISKID BRAKES ACTIVE", "Bool")
                                 ),
                                 actions: [
                                     {
-                                        style: "blue",
+                                        style: "cyan",
                                         message: "&nbsp;MAX BRK PR......1000PSI"
                                     }
                                 ],
@@ -869,12 +873,8 @@ var A320_Neo_UpperECAM;
                                 inopSystems: [
                                     "TCAS"
                                 ],
-                                isActive: () => {
-                                    return (
-                                        !this.isInFlightPhase(3, 4, 5, 7, 8) &&
-                                        this.getCachedSimVar("L:A320_Neo_ADIRS_STATE", "Enum") == 0
-                                    );
-                                },
+                                flightPhasesInhib: [3, 4, 5, 7, 8],
+                                isActive: () => !this.isInFlightPhase(1, 10) && this.getCachedSimVar("L:A320_Neo_ADIRS_STATE", "Enum") !== 2,
                             }
                         ]
                     },
@@ -892,7 +892,7 @@ var A320_Neo_UpperECAM;
                                 ),
                                 actions: [
                                     {
-                                        style: "blue",
+                                        style: "cyan",
                                         message: "&nbsp;-TOW AND T.O DATA.CHECK"
                                     }
                                 ]
@@ -923,35 +923,38 @@ var A320_Neo_UpperECAM;
                 normal: [
                     {
                         message: "IR IN ALIGN > 7 MN",
+                        style: () => this.isEngineRunning(1) || this.isEngineRunning(2) ? "InfoCaution" : "InfoIndication",
                         isActive: () => this.isInFlightPhase(1, 2) && this.getADIRSMins() >= 7
                     },
                     {
                         message: "IR IN ALIGN 6 MN",
+                        style: () => this.isEngineRunning(1) || this.isEngineRunning(2) ? "InfoCaution" : "InfoIndication",
                         isActive: () => this.isInFlightPhase(1, 2) && this.getADIRSMins() === 6
                     },
                     {
                         message: "IR IN ALIGN 5 MN",
+                        style: () => this.isEngineRunning(1) || this.isEngineRunning(2) ? "InfoCaution" : "InfoIndication",
                         isActive: () => this.isInFlightPhase(1, 2) && this.getADIRSMins() === 5
                     },
                     {
                         message: "IR IN ALIGN 4 MN",
+                        style: () => this.isEngineRunning(1) || this.isEngineRunning(2) ? "InfoCaution" : "InfoIndication",
                         isActive: () => this.isInFlightPhase(1, 2) && this.getADIRSMins() === 4
                     },
                     {
                         message: "IR IN ALIGN 3 MN",
+                        style: () => this.isEngineRunning(1) || this.isEngineRunning(2) ? "InfoCaution" : "InfoIndication",
                         isActive: () => this.isInFlightPhase(1, 2) && this.getADIRSMins() === 3
                     },
                     {
                         message: "IR IN ALIGN 2 MN",
+                        style: () => this.isEngineRunning(1) || this.isEngineRunning(2) ? "InfoCaution" : "InfoIndication",
                         isActive: () => this.isInFlightPhase(1, 2) && this.getADIRSMins() === 2
                     },
                     {
                         message: "IR IN ALIGN 1 MN",
+                        style: () => this.isEngineRunning(1) || this.isEngineRunning(2) ? "InfoCaution" : "InfoIndication",
                         isActive: () => this.isInFlightPhase(1, 2) && (this.getADIRSMins() === 0 || this.getADIRSMins() === 1)
-                    },
-                    {
-                        message: "IRS ALIGNED",
-                        isActive: () => this.isInFlightPhase(1, 2) && this.getADIRSMins() === -1
                     },
                     {
                         message: "GND SPLRS ARMED",
@@ -965,6 +968,12 @@ var A320_Neo_UpperECAM;
                         message: "NO SMOKING",
                         isActive: () => this.getCachedSimVar("L:A32NX_NO_SMOKING_MEMO", "Bool")
                     },
+                    {
+                        message: "STROBE LT OFF",
+                        isActive: () => (
+                            this.isInFlightPhase(6, 7, 8) && !this.getCachedSimVar("LIGHT STROBE ON", "Bool")
+                        ),
+                    },
                 ]
             };
             this.secondaryEcamMessage = {
@@ -974,13 +983,13 @@ var A320_Neo_UpperECAM;
                         message: "LAND ASAP",
                         style: "fail-3",
                         important: true,
-                        isActive: () => this.leftEcamMessagePanel.landASAP === 3 && this.fwcFlightPhase !== 4 && this.fwcFlightPhase !== 8,
+                        isActive: () => this.leftEcamMessagePanel.landASAP === 3 && !Simplane.getIsGrounded()
                     },
                     {
                         message: "LAND ASAP",
                         style: "fail-2",
                         important: true,
-                        isActive: () => this.leftEcamMessagePanel.landASAP === 2 && this.fwcFlightPhase !== 4 && this.fwcFlightPhase !== 8,
+                        isActive: () => this.leftEcamMessagePanel.landASAP === 2 && !Simplane.getIsGrounded()
                     },
                     {
                         message: "T.O. INHIBIT",
@@ -1022,21 +1031,28 @@ var A320_Neo_UpperECAM;
                     },
                     {
                         message: "SPEED BRK",
-                        isActive: () => {
-                            return (
-                                !this.isInFlightPhase(1, 8, 9, 10) &&
-                                SimVar.GetSimVarValue("SPOILERS HANDLE POSITION", "position") > 0
-                            );
-                        }
+                        style: () => {
+                            if (this.isInFlightPhase(2, 3, 4, 5)) {
+                                return "InfoCaution";
+                            }
+                            // todo
+                            return "InfoIndication";
+                        },
+                        isActive: () => (
+                            !(
+                                this.fwcFlightPhase === 1 ||
+                                this.fwcFlightPhase === 8 ||
+                                this.fwcFlightPhase === 9 ||
+                                this.fwcFlightPhase === 10
+                            ) && SimVar.GetSimVarValue("SPOILERS HANDLE POSITION", "position") > 0
+                        ),
                     },
                     {
                         message: "AUTO BRK LO",
-                        isActive: () => {
-                            return (
-                                (this.fwcFlightPhase === 7 || this.fwcFlightPhase === 8) &&
-                                SimVar.GetSimVarValue("L:XMLVAR_Autobrakes_Level", "Enum") === 1
-                            );
-                        }
+                        isActive: () => (
+                            (this.fwcFlightPhase === 7 || this.fwcFlightPhase === 8) &&
+                            SimVar.GetSimVarValue("L:XMLVAR_Autobrakes_Level", "Enum") === 1
+                        )
                     },
                     {
                         message: "AUTO BRK MED",
@@ -1059,9 +1075,8 @@ var A320_Neo_UpperECAM;
                     {
                         message: "PARK BRK",
                         isActive: () => (
-                            this.isInFlightPhase(1, 2, 9, 10) &&
-                            this.getCachedSimVar("BRAKE PARKING INDICATOR", "Bool")
-                        )
+                            this.isInFlightPhase(1, 2, 9, 10) && this.getCachedSimVar("BRAKE PARKING INDICATOR", "Bool")
+                        ),
                     },
                     {
                         message: "HYD PTU",
@@ -1073,40 +1088,17 @@ var A320_Neo_UpperECAM;
                     },
                     {
                         message: "NW STRG DISC",
-                        style: "InfoIndication",
+                        style: () => this.isEngineRunning(1) || this.isEngineRunning(2) ? "InfoCaution" : "InfoIndication",
                         isActive: () => (
-                            this.getCachedSimVar("PUSHBACK STATE", "Enum") !== 3 &&
-                            this.getCachedSimVar("ENG N1 RPM:1", "Percent") < 15 &&
-                            this.getCachedSimVar("ENG N1 RPM:1", "Percent") < 15
-                        )
-                    },
-                    {
-                        message: "NW STRG DISC",
-                        style: "InfoCaution",
-                        isActive: () => (
-                            this.getCachedSimVar("PUSHBACK STATE", "Enum") !== 3 && (
-                                this.getCachedSimVar("ENG N1 RPM:1", "Percent") >= 15 ||
-                                this.getCachedSimVar("ENG N1 RPM:1", "Percent") >= 15
-                            )
+                            this.getCachedSimVar("PUSHBACK STATE", "Enum") !== 3
                         )
                     },
                     {
                         message: "PRED W/S OFF",
-                        style: "InfoIndication",
+                        style: () => this.isInFlightPhase(3, 4, 5, 7, 8, 9) ? "InfoCaution" : "InfoIndication", // todo also when pressing to config
                         isActive: () => {
                             return (
-                                !this.isInFlightPhase(3, 4, 5, 7, 8, 9) &&
-                                !this.getCachedSimVar("L:A32NX_SWITCH_RADAR_PWS_Position", "Bool")
-                            );
-                        }
-                    },
-                    {
-                        message: "PRED W/S OFF",
-                        style: "InfoCaution",
-                        isActive: () => {
-                            return (
-                                // TODO should turn amber in phase 2 once T.O. Config is pressed at least once
-                                this.isInFlightPhase(3, 4, 5, 7, 8, 9) &&
+                                !this.isInFlightPhase(1, 10) &&
                                 !this.getCachedSimVar("L:A32NX_SWITCH_RADAR_PWS_Position", "Bool")
                             );
                         }
@@ -1122,8 +1114,7 @@ var A320_Neo_UpperECAM;
                         message: "COMPANY MSG",
                         isActive: () => {
                             return this.isInFlightPhase(1, 2, 6, 9, 10) && (
-                                this.getCachedSimVar("L:A32NX_COMPANY_MSG_COUNT", "Number") > 0 ||
-                                SimVar.GetSimVarValue("L:A32NX_COMPANY_MSG_COUNT", "Number") > 0
+                                this.getCachedSimVar("L:A32NX_COMPANY_MSG_COUNT", "Number") > 0
                             );
                         }
                     },
@@ -1143,19 +1134,15 @@ var A320_Neo_UpperECAM;
                         message: "APU AVAIL",
                         isActive: () => (
                             !this.getCachedSimVar("BLEED AIR APU", "Bool") &&
-                            SimVar.GetSimVarValue("APU PCT RPM", "Percent") >= 95
+                            this.getCachedSimVar("APU PCT RPM", "Percent") >= 95
                         )
                     },
                     {
                         message: "APU BLEED",
                         isActive: () => (
                             this.getCachedSimVar("BLEED AIR APU", "Bool") &&
-                            SimVar.GetSimVarValue("APU PCT RPM", "Percent") >= 95
+                            this.getCachedSimVar("APU PCT RPM", "Percent") >= 95
                         )
-                    },
-                    {
-                        message: "IGNITION",
-                        isActive: () => this.getCachedSimVar("L:XMLVAR_ENG_MODE_SEL", "Enum") === 2
                     },
                     {
                         message: "LDG LT",
@@ -1286,10 +1273,6 @@ var A320_Neo_UpperECAM;
                 return;
             }
 
-            const leftThrottleDetent = Simplane.getEngineThrottleMode(0);
-            const rightThrottleDetent = Simplane.getEngineThrottleMode(1);
-            const highestThrottleDetent = (leftThrottleDetent >= rightThrottleDetent) ? leftThrottleDetent : rightThrottleDetent;
-
             for (let i = 0; i < this.allPanels.length; ++i) {
                 if (this.allPanels[i] != null) {
                     this.allPanels[i].update(_deltaTime);
@@ -1305,28 +1288,28 @@ var A320_Neo_UpperECAM;
 
             this.overflowArrow.setAttribute("opacity", (this.leftEcamMessagePanel.overflow || this.rightEcamMessagePanel.overflow) ? "1" : "0");
 
-            //Show takeoff memo 2 mins after second engine start
-            //Hides after takeoff thurst application
-            this.updateTOMemo(_deltaTime);
-            this.updateTOInhibit(_deltaTime);
+            this.updateInhibitMessages(_deltaTime);
 
-            //Show landing memo at 2000ft
-            //Hides after slowing down to 80kts
-            this.updateLDGMemo(_deltaTime);
-            this.updateLDGInhibit(_deltaTime);
+            const memosInhibited = this.leftEcamMessagePanel.hasWarnings || this.leftEcamMessagePanel.hasCautions;
+            const showTOMemo = SimVar.GetSimVarValue("L:A32NX_FWC_TOMEMO", "Bool") && !memosInhibited;
+            if (this.takeoffMemo != null) {
+                this.takeoffMemo.divMain.style.display = showTOMemo ? "block" : "none";
+            }
+
+            const showLdgMemo = SimVar.GetSimVarValue("L:A32NX_FWC_LDGMEMO", "Bool") && !memosInhibited;
+            if (this.landingMemo != null) {
+                this.landingMemo.divMain.style.display = showLdgMemo ? "block" : "none";
+            }
 
             //Hide left message panel when memo is diplayed
             if (this.leftEcamMessagePanel != null) {
-                this.leftEcamMessagePanel.divMain.style.display = (this.showTakeoffMemo || this.showLandingMemo) ? "none" : "block";
+                this.leftEcamMessagePanel.divMain.style.display = (showTOMemo || showLdgMemo) ? "none" : "block";
             }
 
-            if (SimVar.GetSimVarValue("L:A32NX_BTN_TOCONFIG", "Bool") == 1) {
-                SimVar.SetSimVarValue("L:A32NX_BTN_TOCONFIG", "Bool", 0);
+            if (SimVar.GetSimVarValue("L:A32NX_FWC_TOCONFIG", "Bool")) {
+                SimVar.SetSimVarValue("L:A32NX_FWC_TOCONFIG", "Bool", 0);
                 /// FWC ESLD 1.0.180
                 if (this.isInFlightPhase(2, 9)) {
-                    this._fwcMemoTOConfig = true;
-                }
-                if (this._fwcMemoTOConfig) {
                     this.updateTakeoffConfigWarnings(true);
                 }
             }
@@ -1345,8 +1328,8 @@ var A320_Neo_UpperECAM;
 
             }
 
-            if (SimVar.GetSimVarValue("L:A32NX_BTN_RCL", "Bool") == 1) {
-                SimVar.SetSimVarValue("L:A32NX_BTN_RCL", "Bool", 0);
+            if (SimVar.GetSimVarValue("L:A32NX_FWC_RECALL", "Bool")) {
+                SimVar.SetSimVarValue("L:A32NX_FWC_RECALL", "Bool", 0);
                 this.leftEcamMessagePanel.recall();
                 this.clearedSecondaryFailures = [];
             }
@@ -1379,11 +1362,11 @@ var A320_Neo_UpperECAM;
 
             this.statusReminder.setAttribute("visibility", (this.leftEcamMessagePanel.secondaryFailures.length > 0 && this.leftEcamMessagePanel.secondaryFailures.length == this.clearedSecondaryFailures.length) ? "visible" : "hidden");
 
-            if (highestThrottleDetent == ThrottleMode.TOGA || highestThrottleDetent == ThrottleMode.FLEX_MCT) {
+            if (this.fwcFlightPhase === 3) {
                 this.updateTakeoffConfigWarnings(false);
             }
 
-            if (Simplane.getCurrentFlightPhase() > 2) {
+            if (this.fwcFlightPhase === 5) {
                 this.activeTakeoffConfigWarnings = [];
             }
 
@@ -1421,17 +1404,17 @@ var A320_Neo_UpperECAM;
             if (speedBrake > 0) {
                 this.activeTakeoffConfigWarnings.push("spd_brk");
             }
-            if (parkBrake == 1 && !_test) {
+            if (parkBrake && !_test) {
                 this.activeTakeoffConfigWarnings.push("park_brake");
             }
-            if (brakesHot == 1) {
+            if (brakesHot) {
                 this.activeTakeoffConfigWarnings.push("brakes_hot");
             }
             if (!(v1Speed <= vrSpeed && vrSpeed <= v2Speed)) {
                 this.activeTakeoffConfigWarnings.push("to_speeds_disagree");
             }
 
-            if (_test && this.activeTakeoffConfigWarnings.length == 0) {
+            if (_test && this.activeTakeoffConfigWarnings.length === 0) {
                 SimVar.SetSimVarValue("L:A32NX_TO_CONFIG_NORMAL", "Bool", 1);
             } else {
                 SimVar.SetSimVarValue("L:A32NX_TO_CONFIG_NORMAL", "Bool", 0);
@@ -1443,60 +1426,10 @@ var A320_Neo_UpperECAM;
             }
         }
 
-        updateTOMemo(_deltaTime) {
-            /// FWC ESLD 1.0.180
-            const resetTakeoffMemo = this.isInFlightPhase(10, 3, 1, 6);
-            if (this._fwcMemoTOConfig && resetTakeoffMemo) {
-                this._fwcMemoTOConfig = false;
-            }
-
-            const eng1NotRunning = this.getCachedSimVar("ENG N1 RPM:1", "Percent") < 15;
-            const eng2NotRunning = this.getCachedSimVar("ENG N1 RPM:2", "Percent") < 15;
-            const toTimerElapsed = this.takeoffMemoTimer.write(!eng1NotRunning && !eng2NotRunning, _deltaTime);
-            this.showTakeoffMemo = this._fwcMemoTOConfig || (this.fwcFlightPhase === 2 && toTimerElapsed);
-
-            if (this.takeoffMemo != null) {
-                this.takeoffMemo.divMain.style.display = this.showTakeoffMemo ? "block" : "none";
-            }
-        }
-
-        updateTOInhibit(_deltaTime) {
-            this.showTakeoffInhibit = this.toInhibitTimer.write(this.isInFlightPhase(3, 4, 5), _deltaTime);
-        }
-
-        updateLDGMemo(_deltaTime) {
-            const radioHeight = this.getCachedSimVar("RADIO HEIGHT", "Feet");
-
-            // FWC ESLD 1.0.190
-            const setAbove2200ft = radioHeight > 2200;
-            const clearAbove2200ft = !this.isInFlightPhase(7, 8, 6);
-            if (!this._fwcMemoAbove2200Ft && setAbove2200ft && !clearAbove2200ft) {
-                this._fwcMemoAbove2200Ft = true;
-            } else if (this._fwcMemoAbove2200Ft && clearAbove2200ft) {
-                this._fwcMemoAbove2200Ft = false;
-            }
-
-            const setBelow2000ft = radioHeight < 2000;
-            const clearBelow2000ft = radioHeight > 2200;
-            if (!this._fwcMemoBelow2000Ft && setBelow2000ft) {
-                this._fwcMemoBelow2000Ft = true;
-            } else if (this._fwcMemoBelow2000Ft && clearBelow2000ft) {
-                this._fwcMemoBelow2000Ft = false;
-            }
-
-            this.showLandingMemo = (
-                (this._fwcMemoAbove2200Ft && this._fwcMemoBelow2000Ft && this.fwcFlightPhase === 6) ||
-                this.fwcFlightPhase === 7 ||
-                this.fwcFlightPhase === 8
-            );
-
-            if (this.landingMemo != null) {
-                this.landingMemo.divMain.style.display = this.showLandingMemo ? "block" : "none";
-            }
-        }
-
-        updateLDGInhibit(_deltaTime) {
-            this.showLandingInhibit = this.ldgInhibitTimer.write(this.isInFlightPhase(7, 8), _deltaTime);
+        updateInhibitMessages(_deltaTime) {
+            this.inhibitOverride = this.getCachedSimVar("L:A32NX_FWC_INHIBOVRD", "Bool");
+            this.showTakeoffInhibit = this.toInhibitTimer.write(this.isInFlightPhase(3, 4, 5) && !this.inhibOverride, _deltaTime);
+            this.showLandingInhibit = this.ldgInhibitTimer.write(this.isInFlightPhase(7, 8) && !this.inhibOverride, _deltaTime);
         }
 
         getInfoPanelManager() {
@@ -2423,6 +2356,7 @@ var A320_Neo_UpperECAM;
                 2: 0,
                 3: 0
             };
+            this.knownFailures = [];
             this.clearedMessages = [];
             this.inopSystems = {};
             this.landASAP = 0;
@@ -2455,13 +2389,13 @@ var A320_Neo_UpperECAM;
                     this.addLine("fail-" + failure.level, category.name, failure.message, failure.action, failure.alwaysShowCategory);
                     warningsCount[failure.level] = warningsCount[failure.level] + 1;
                     if (failure.actions != null) {
-                        let fisrtAction = true;
+                        let firstAction = true;
                         for (const action of failure.actions) {
                             if (action.isCompleted == null || !action.isCompleted()) {
-                                if ((action.style != "action-timer" || fisrtAction)) {
+                                if ((action.style != "action-timer" || firstAction)) {
                                     this.addLine(action.style, null, action.message, action.action, false, action.id, action.duration, action.timerMessage);
                                 }
-                                fisrtAction = false;
+                                firstAction = false;
                             }
                         }
                     }
@@ -2471,7 +2405,11 @@ var A320_Neo_UpperECAM;
                 const activeMessages = this.getActiveMessages();
                 for (const message of activeMessages) {
                     if (!this.failMode || message.important) {
-                        this.addLine(message.style || "InfoIndication", null, message.message, null);
+                        let style = message.style;
+                        if (typeof style === "function") {
+                            style = style();
+                        }
+                        this.addLine(style || "InfoIndication", null, message.message, null);
                     }
                 }
             }
@@ -2583,9 +2521,31 @@ var A320_Neo_UpperECAM;
                     if (message.id == null) {
                         message.id = `${i} ${n}`;
                     }
-                    const isActive = message.isActive();
 
+                    if (!this.knownFailures.includes(message.id)) {
+                        // only check for inhibition if the failure has not occured yet
+
+                        if (!this.parent.fwcFlightPhase) {
+                            // inhibition requires a valid flight phase
+                            continue;
+                        }
+
+                        const inhibitedPhases = Array.isArray(message.flightPhasesInhib) ? message.flightPhasesInhib : [];
+                        if (
+                            !this.parent.inhibitOverride &&
+                            inhibitedPhases.length &&
+                            this.parent.isInFlightPhase(...inhibitedPhases) &&
+                            !this.knownFailures.includes(message.id)
+                        ) {
+                            continue;
+                        }
+                    }
+
+                    const isActive = message.isActive();
                     if (isActive) {
+                        if (!this.knownFailures.includes(message.id) && this.parent.fwcFlightPhase) {
+                            this.knownFailures.push(message.id);
+                        }
                         if (!this.clearedMessages.includes(message.id)) {
                             this.hasActiveFailures = true;
                             if (message.level == 3) {
@@ -2594,9 +2554,10 @@ var A320_Neo_UpperECAM;
                             if (message.level == 2) {
                                 this.hasCautions = true;
                             }
-                            if (output[i] == null) {
-                                output[i] = this.messages.failures[i];
-                                output[i].messages = [];
+                            if (!output[i]) {
+                                // Load the failure into output if it was not seen before, but take special care not to
+                                // just copy the original messages.failures object, as you will mutate it.
+                                output[i] = Object.assign({}, this.messages.failures[i], {messages: []});
                             }
                             output[i].messages.push(message);
                             if (this.activePage == null && message.page != null) {
@@ -2620,9 +2581,14 @@ var A320_Neo_UpperECAM;
                                 }
                             }
                         }
+                    } else {
+                        if (this.knownFailures.includes(message.id)) {
+                            this.knownFailures = this.knownFailures.filter(id => id !== message.id);
+                        }
                     }
                 }
             }
+
             return output;
         }
 
@@ -2641,6 +2607,11 @@ var A320_Neo_UpperECAM;
                 const index = this.clearedMessages.indexOf(_failure);
                 if (index > -1) {
                     this.clearedMessages.splice(index, 1);
+                }
+                // By adding the message to the list of known failures it will bypass any flight phase inhibition.
+                // If it is not active it will be removed again from the list immediately by getActiveFailures().
+                if (!this.knownFailures.includes(_failure)) {
+                    this.knownFailures.push(_failure);
                 }
             } else {
                 this.clearedMessages = [];

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -286,3 +286,15 @@
 - A32NX_FWC_SKIP_STARTUP
     - Bool
     - Set to true in a non-cold and dark flight phase to skip the initial memorization step
+
+- A32NX_FWC_TOMEMO
+    - Bool
+    - True when the FWC decides that the takeoff memo should be shown
+
+- A32NX_FWC_LDGMEMO
+    - Bool
+    - True when the FWC decides that the landing memo should be shown
+
+- A32NX_FWC_INHIBOVRD
+    - Bool
+    - True when the FWC decides that flight phase inhibits should be overridden (and ignored)


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

This PR is a followup to #1943, incorporates some feedback from there and improves the ECAM inhibit and recall behavior to be more accurate. Where previously there was no distinction between inactive messages and inhibited message, this PR splits those two out so that the inhibit behavior can be implemented more accurately. This allows the flight phase inhibition to be correctly overridden using the recall button, and also ensures warnings stay visible during a flight phase change if they were visible previously.

The PR also provides some minor fixes to some ECAM messages themselves, by fixing colors and improving when and how some of the messages appear. See the full changelog below:

### User-facing Changes

- Active warnings persist through flight phase changes, even if they would be inhibited  
*For example, A/SKID N/WS OFF is inhibited above 80 knots until at 1500ft RA. If the A/SKID N/WS switch is turned off during this window, the associated warning won't appear until 1500ft RA. However, if A/SKID N/WS OFF appears before 80 knots it remains continuously visible.*
- The Recall button lifts flight phase inhibition for the current flight phase  
*For example, BRAKES HOT is inhibited between touchdown and last engine shutdown + 5 minutes. If the pilot presses the RCL button during this window, BRAKES HOT will appear immediately (as the pilot has lifted the flight phase inhibition), even if BRAKES HOT was not visible and cleared previously.*
- STROBE LT OFF has been added (in the air)
- IR IN ALIGN X MIN turns amber when at least one engine is running
- PRED W/S OFF now already turns amber when the T.O CONFIG is pressed before takeoff
- SPEED BRK turns amber after engines are started and before takeoff  
*Flashing and amber in the air during non-idle will come in a future PR*
- BRAKES HOT now calls up the WHEEL page
- CARGO SMOKE is inhibited during takeoff and landing while above 80 knots
- Make T.O CONFIG use more accurate flight phase logic
- IR(S) ALIGNED has been removed again  
*While this memo is described in the documentation, no pilot could recall having seen it. Upon further investigation the documentation contains logic that will never make this message appear (possibly only as a brief flash upon aligning completing). It may also just be a remnant of an old version.*
- IGNITION memo has been removed again  
*This memo is pretty complicated as it needs to appear only during continuous ignition and not during normal start. So we'll wait with this until we have a proper FADEC implementation.*
- TCAS FAULT is now hidden during flight phases 1 and 10 (as per FWC F8)  
*I know there's a lot of reference footage for Cold and Dark having TCAS FAULT out there, but after some discussion in [#pilot-feedback](https://discord.com/channels/738864299392630914/754851312306487326/779343095581638656) this appears to be fixed in more modern aircraft (probably most Neos).*
- Fixed a bug that could cause warnings to become permanently disabled for the rest of the flight
- Fixed warnings not overriding T.O/LDG Memo
- Fixed some ECAM actions being white instead of cyan

### Developer-facing Changes
- Button logic for Recall, Takeoff Memo, Takeoff Inhibit, Landing Memo and Landing Inhibit has moved to the FWC
- Generalized inhibit behaviour in the ECAM (using flightPhasesInhib)


## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

![image](https://user-images.githubusercontent.com/929769/99788774-e45ac080-2b21-11eb-940e-172db7409b20.png)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BehEh#1234

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
