### PR TITLE
[API] Report AC type to API

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -102,6 +102,7 @@
 1. [ECAM] Implemented proper FWC flight phases - @beheh (Benedict Etzel)
 1. [ECAM] Updated ECAM messages - @beheh (Benedict Etzel)
 1. [CDU] New improved RADNAV page | Ability to tune navaids with identifier - @St54Kevin (Kevin Karas)
+1. [General] Added aircraft type reporting for the live map - @nistei (nistei)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -102,7 +102,6 @@
 1. [ECAM] Implemented proper FWC flight phases - @beheh (Benedict Etzel)
 1. [ECAM] Updated ECAM messages - @beheh (Benedict Etzel)
 1. [CDU] New improved RADNAV page | Ability to tune navaids with identifier - @St54Kevin (Kevin Karas)
-1. [General] Added aircraft type reporting for the live map - @nistei (nistei)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/A32NX_Utils/NXApi.js
+++ b/A32NX/html_ui/Pages/A32NX_Utils/NXApi.js
@@ -50,6 +50,10 @@ class NXApi {
             return Promise.reject(NXApi.disabledError);
         }
 
+        if (!flightNo) {
+            return Promise.reject(NXApi.disabledError);
+        }
+
         const connectBody = NXApi.buildTelexBody(flightNo);
         const headers = {"Content-Type": "application/json"};
 
@@ -212,3 +216,6 @@ NXApi.disconnectedError = "TELEX DISCONNECTED";
 NXApi.noRecipientError = "NO RECIPIENT";
 NXApi.accessToken = "";
 NXApi.updateRate = 15000;
+
+NXDataStore.set("PLAN_ORIGIN", "");
+NXDataStore.set("PLAN_DESTINATION", "");

--- a/A32NX/html_ui/Pages/A32NX_Utils/NXApi.js
+++ b/A32NX/html_ui/Pages/A32NX_Utils/NXApi.js
@@ -189,9 +189,9 @@ class NXApi {
         const long = SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude");
         const alt = SimVar.GetSimVarValue("PLANE ALTITUDE", "feet");
         const heading = SimVar.GetSimVarValue("PLANE HEADING DEGREES MAGNETIC", "degree");
+        const acType = SimVar.GetSimVarValue("TITLE", "string");
         const origin = NXDataStore.get("PLAN_ORIGIN", "");
         const destination = NXDataStore.get("PLAN_DESTINATION", "");
-        const acType = NXDataStore.get("AC_TYPE", "unknown");
         const freetext = NXDataStore.get("CONFIG_ONLINE_FEATURES_STATUS", "DISABLED") === "ENABLED";
 
         return {

--- a/A32NX/html_ui/Pages/A32NX_Utils/NXApi.js
+++ b/A32NX/html_ui/Pages/A32NX_Utils/NXApi.js
@@ -188,7 +188,7 @@ class NXApi {
         const lat = SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude");
         const long = SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude");
         const alt = SimVar.GetSimVarValue("PLANE ALTITUDE", "feet");
-        const heading = SimVar.GetSimVarValue("PLANE HEADING DEGREES MAGNETIC", "degree");
+        const heading = SimVar.GetSimVarValue("PLANE HEADING DEGREES TRUE", "degree");
         const acType = SimVar.GetSimVarValue("TITLE", "string");
         const origin = NXDataStore.get("PLAN_ORIGIN", "");
         const destination = NXDataStore.get("PLAN_DESTINATION", "");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -102,9 +102,6 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             CDU_OPTIONS_TELEX.ShowPage(this);
         }
 
-        // Set up the AC type for the API
-        NXDataStore.set("AC_TYPE", "A32NX");
-
         // Start the TELEX Ping. API functions check the connection status themself
         setInterval(() => {
             const toDelete = [];


### PR DESCRIPTION
## Summary of Changes
Use the `TITLE` SimVar to report the correct AC type to the API
Fix some minor bugs
- Destination and origin from the previous flight  were reported
- A connection with an empty flight number could be established

## Screenshots (if necessary)
Reported AC type in the API
![image](https://user-images.githubusercontent.com/1652722/99886618-49a3d400-2c3e-11eb-853d-c0b6ea39fd8b.png)

## References

## Additional context

Discord username (if different from GitHub): nistei#1362

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
