### PR TITLE
[CDU] Added constraints symbols logic to flight plan

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -107,6 +107,7 @@
 1. [ND] Add heading line to ARC and NAV map mode @ilyeshammadi (Ilyes Hammadi)
 1. [PFD] Add QNH flashing when reach transition altitude - @Kimbyeoungjang (김병장#7165)
 1. [ECAM] Added flight phase inhibit override to recall button - @beheh (Benedict Etzel)
+1. [CDU] Added constraints symbols logic to flight plan @ilyeshammadi (Ilyes Hammadi)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
@@ -75,13 +75,13 @@ class CDUVerticalRevisionPage {
                     });
                 }
 
-                const PLUS_REGEX = /\+\d+/g
-                const MINUS_REGEX = /\-\d+/g
+                const PLUS_REGEX = /\+\d+/g;
+                const MINUS_REGEX = /\-\d+/g;
 
                 let altitude;
                 let code;
 
-                if ( value.match(MINUS_REGEX)) {
+                if (value.match(MINUS_REGEX)) {
                     code = 3;
                     altitude = value.split('-')[1];
                 } else if ((value.match(PLUS_REGEX))) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
@@ -79,17 +79,14 @@ class CDUVerticalRevisionPage {
                 const MINUS_REGEX = /\-\d+/g
 
                 let altitude;
-                let symbol;
                 let code;
 
                 if ( value.match(MINUS_REGEX)) {
-                    symbol = '-';
                     code = 3;
-                    altitude = value.split(symbol)[1];
+                    altitude = value.split('-')[1];
                 } else if ((value.match(PLUS_REGEX))) {
-                    symbol = '+';
                     code = 2;
-                    altitude = value.split(symbol)[1];
+                    altitude = value.split('+')[1];
                 } else {
                     code = 1;
                     altitude = value;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
@@ -74,10 +74,31 @@ class CDUVerticalRevisionPage {
                         CDUFlightPlanPage.ShowPage(mcdu, offset);
                     });
                 }
-                value = parseInt(value);
-                if (isFinite(value)) {
-                    if (value >= 0) {
-                        mcdu.flightPlanManager.setWaypointAltitude((value < 1000 ? value * 100 : value) / 3.28084, mcdu.flightPlanManager.indexOfWaypoint(waypoint), () => {
+
+                const PLUS_REGEX = /\+\d+/g
+                const MINUS_REGEX = /\-\d+/g
+
+                let altitude;
+                let symbol;
+                let code;
+
+                if ( value.match(MINUS_REGEX)) {
+                    symbol = '-';
+                    code = 3;
+                    altitude = value.split(symbol)[1];
+                } else if ((value.match(PLUS_REGEX))) {
+                    symbol = '+';
+                    code = 2;
+                    altitude = value.split(symbol)[1];
+                } else {
+                    code = 1;
+                    altitude = value;
+                }
+                altitude = parseInt(altitude);
+                if (isFinite(altitude)) {
+                    if (altitude >= 0) {
+                        mcdu.flightPlanManager.setLegAltitudeDescription(waypoint, code);
+                        mcdu.flightPlanManager.setWaypointAltitude((altitude < 1000 ? altitude * 100 : altitude) / 3.28084, mcdu.flightPlanManager.indexOfWaypoint(waypoint), () => {
                             mcdu.tryUpdateAltitudeConstraint(true);
                             this.ShowPage(mcdu, waypoint);
                         });

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
@@ -118,18 +118,6 @@ class FlightPlanManager {
         return `${waypoint.ident}_${this.indexOfWaypoint(waypoint)}`;
     }
     
-    _getWaypointAdditionalDataFromLocalStorage(waypoint) {
-        return localStorage.getItem('waypoints')[this._getWaypointLocalStorageKey(waypoint)]
-    }
-
-    _setWaypointAdditionalDataFromLocalStorage(waypoint, key, value) {
-        // Initialize with an empty object if not existing
-        if (!this._getWaypointAdditionalDataFromLocalStorage(waypoint)) {
-            localStorage.setItem('waypoints')[this._getWaypointLocalStorageKey(waypoint)] = {}
-        }
-        localStorage.setItem('waypoints')[this._getWaypointLocalStorageKey(waypoint)][key] = value;
-    }
-
     setOrGetLegAltitudeDescription(waypoint, newValue){
         // Create a unique key for the current waypoint
         const key = this._getWaypointLocalStorageKey(waypoint);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
@@ -132,9 +132,9 @@ class FlightPlanManager {
 
     setOrGetLegAltitudeDescription(waypoint, newValue){
         // Create a unique key for the current waypoint
-        const key = _getWaypointLocalStorageKey(waypoint);
+        const key = this._getWaypointLocalStorageKey(waypoint);
         // Save if not saved otherwise use the saved one
-        if (!localStorage.getItem('waypoints')[key]) {
+        if (!localStorage.getItem(key)) {
             localStorage.setItem(key, newValue);
             waypoint.legAltitudeDescription = newValue;
         }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
@@ -1,7 +1,6 @@
 class FlightPlanManager {
     constructor(_instrument) {
         this._waypoints = [[], []];
-        this._legAltitudesDescription = {};
         this._approachWaypoints = [];
         this._departureWaypointSize = 0;
         this._arrivalWaypointSize = 0;
@@ -115,21 +114,37 @@ class FlightPlanManager {
         }, 200);
     }
     
+    _getWaypointLocalStorageKey(waypoint) {
+        return `${waypoint.ident}_${this.indexOfWaypoint(waypoint)}`;
+    }
+    
+    _getWaypointAdditionalDataFromLocalStorage(waypoint) {
+        return localStorage.getItem('waypoints')[this._getWaypointLocalStorageKey(waypoint)]
+    }
+
+    _setWaypointAdditionalDataFromLocalStorage(waypoint, key, value) {
+        // Initialize with an empty object if not existing
+        if (!this._getWaypointAdditionalDataFromLocalStorage(waypoint)) {
+            localStorage.setItem('waypoints')[this._getWaypointLocalStorageKey(waypoint)] = {}
+        }
+        localStorage.setItem('waypoints')[this._getWaypointLocalStorageKey(waypoint)][key] = value;
+    }
+
     setOrGetLegAltitudeDescription(waypoint, newValue){
-        if (!this._legAltitudesDescription.hasOwnProperty(waypoint.ident)) {
-            this._legAltitudesDescription[waypoint.ident] = newValue;
-            this.setWaypointAdditionalData(1, 'legAltitudeDescription', newValue, () => {})
+        // Create a unique key for the current waypoint
+        const key = _getWaypointLocalStorageKey(waypoint);
+        // Save if not saved otherwise use the saved one
+        if (!localStorage.getItem('waypoints')[key]) {
+            localStorage.setItem(key, newValue);
             waypoint.legAltitudeDescription = newValue;
         }
-        this.getWaypointAdditionalData(1, 'legAltitudeDescription', (val) => {
-            console.log(val);
-        })
-        waypoint.legAltitudeDescription =  this._legAltitudesDescription[waypoint.ident]
-        return this._legAltitudesDescription[waypoint.ident]
+        const val = localStorage.getItem(key)
+        waypoint.legAltitudeDescription = parseInt(val);
     }
 
     setLegAltitudeDescription(waypoint, newValue){
-        this._legAltitudesDescription[waypoint.ident] = newValue;
+        const key = _getWaypointLocalStorageKey(waypoint);
+        localStorage.setItem(key, newValue);
         waypoint.legAltitudeDescription = newValue;
     }
 
@@ -219,15 +234,12 @@ class FlightPlanManager {
                     wp.speedConstraint = -1;
                 }
                 if ((ii > 0 && ii <= this.getDepartureWaypointsCount()) && (wp.altitudeinFP >= 500)) {
-                    // wp.legAltitudeDescription = 2;
                     this.setOrGetLegAltitudeDescription(wp, 2);
                     wp.legAltitude1 = wp.altitudeinFP;
                 } else if ((ii < (data.length - 1) && ii >= (data.length - 1 - this.getArrivalWaypointsCount())) && (wp.altitudeinFP >= 500)) {
-                    // wp.legAltitudeDescription = 2;
                     this.setOrGetLegAltitudeDescription(wp, 2);
                     wp.legAltitude1 = wp.altitudeinFP;
                 } else if (ii > 0 && ii < data.length - 1) {
-                    // wp.legAltitudeDescription = 1;
                     this.setOrGetLegAltitudeDescription(wp, 2);
                     wp.legAltitude1 = wp.altitudeinFP;
                 }
@@ -263,15 +275,12 @@ class FlightPlanManager {
                         v.speedConstraint = -1;
                     }
                     if ((ii > 0 && ii <= this.getDepartureWaypointsCount()) && (v.altitudeinFP >= 500)) {
-                        // v.legAltitudeDescription = 2;
                         this.setOrGetLegAltitudeDescription(v, 2);
                         v.legAltitude1 = v.altitudeinFP;
                     } else if ((ii < (data.length - 1) && ii >= (data.length - 1 - this.getArrivalWaypointsCount())) && (v.altitudeinFP >= 500)) {
-                        // v.legAltitudeDescription = 3;
                         this.setOrGetLegAltitudeDescription(v, 3);
                         v.legAltitude1 = v.altitudeinFP;
                     } else if (ii > 0 && ii < data.length - 1) {
-                        // v.legAltitudeDescription = 1;
                         this.setOrGetLegAltitudeDescription(v, 1);
                         v.legAltitude1 = v.altitudeinFP;
                     }
@@ -314,15 +323,12 @@ class FlightPlanManager {
                                 v.speedConstraint = -1;
                             }
                             if ((ii > 0 && ii <= this.getDepartureWaypointsCount()) && (v.altitudeinFP >= 500)) {
-                                // v.legAltitudeDescription = 2;
                                 this.setOrGetLegAltitudeDescription(v, 2);
                                 v.legAltitude1 = v.altitudeinFP;
                             } else if ((ii < (data.length - 1) && ii >= (data.length - 1 - this.getArrivalWaypointsCount())) && (v.altitudeinFP >= 500)) {
-                                // v.legAltitudeDescription = 3;
                                 this.setOrGetLegAltitudeDescription(v, 3);
                                 v.legAltitude1 = v.altitudeinFP;
                             } else if (ii > 0 && ii < data.length - 1) {
-                                // v.legAltitudeDescription = 1;
                                 this.setOrGetLegAltitudeDescription(v, 1);
                                 v.legAltitude1 = v.altitudeinFP;
                             }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
@@ -1,6 +1,7 @@
 class FlightPlanManager {
     constructor(_instrument) {
         this._waypoints = [[], []];
+        this._legAltitudesDescription = {};
         this._approachWaypoints = [];
         this._departureWaypointSize = 0;
         this._arrivalWaypointSize = 0;
@@ -113,6 +114,25 @@ class FlightPlanManager {
             }, 200);
         }, 200);
     }
+    
+    setOrGetLegAltitudeDescription(waypoint, newValue){
+        if (!this._legAltitudesDescription.hasOwnProperty(waypoint.ident)) {
+            this._legAltitudesDescription[waypoint.ident] = newValue;
+            this.setWaypointAdditionalData(1, 'legAltitudeDescription', newValue, () => {})
+            waypoint.legAltitudeDescription = newValue;
+        }
+        this.getWaypointAdditionalData(1, 'legAltitudeDescription', (val) => {
+            console.log(val);
+        })
+        waypoint.legAltitudeDescription =  this._legAltitudesDescription[waypoint.ident]
+        return this._legAltitudesDescription[waypoint.ident]
+    }
+
+    setLegAltitudeDescription(waypoint, newValue){
+        this._legAltitudesDescription[waypoint.ident] = newValue;
+        waypoint.legAltitudeDescription = newValue;
+    }
+
     _loadWaypoints(data, currentWaypoints, approach, callback) {
         const waypoints = [];
         const todo = data.length;
@@ -199,13 +219,16 @@ class FlightPlanManager {
                     wp.speedConstraint = -1;
                 }
                 if ((ii > 0 && ii <= this.getDepartureWaypointsCount()) && (wp.altitudeinFP >= 500)) {
-                    wp.legAltitudeDescription = 2;
+                    // wp.legAltitudeDescription = 2;
+                    this.setOrGetLegAltitudeDescription(wp, 2);
                     wp.legAltitude1 = wp.altitudeinFP;
                 } else if ((ii < (data.length - 1) && ii >= (data.length - 1 - this.getArrivalWaypointsCount())) && (wp.altitudeinFP >= 500)) {
-                    wp.legAltitudeDescription = 2;
+                    // wp.legAltitudeDescription = 2;
+                    this.setOrGetLegAltitudeDescription(wp, 2);
                     wp.legAltitude1 = wp.altitudeinFP;
                 } else if (ii > 0 && ii < data.length - 1) {
-                    wp.legAltitudeDescription = 1;
+                    // wp.legAltitudeDescription = 1;
+                    this.setOrGetLegAltitudeDescription(wp, 2);
                     wp.legAltitude1 = wp.altitudeinFP;
                 }
                 this.addHardCodedConstraints(wp);
@@ -240,13 +263,16 @@ class FlightPlanManager {
                         v.speedConstraint = -1;
                     }
                     if ((ii > 0 && ii <= this.getDepartureWaypointsCount()) && (v.altitudeinFP >= 500)) {
-                        v.legAltitudeDescription = 2;
+                        // v.legAltitudeDescription = 2;
+                        this.setOrGetLegAltitudeDescription(v, 2);
                         v.legAltitude1 = v.altitudeinFP;
                     } else if ((ii < (data.length - 1) && ii >= (data.length - 1 - this.getArrivalWaypointsCount())) && (v.altitudeinFP >= 500)) {
-                        v.legAltitudeDescription = 3;
+                        // v.legAltitudeDescription = 3;
+                        this.setOrGetLegAltitudeDescription(v, 3);
                         v.legAltitude1 = v.altitudeinFP;
                     } else if (ii > 0 && ii < data.length - 1) {
-                        v.legAltitudeDescription = 1;
+                        // v.legAltitudeDescription = 1;
+                        this.setOrGetLegAltitudeDescription(v, 1);
                         v.legAltitude1 = v.altitudeinFP;
                     }
                     this.addHardCodedConstraints(v);
@@ -288,13 +314,16 @@ class FlightPlanManager {
                                 v.speedConstraint = -1;
                             }
                             if ((ii > 0 && ii <= this.getDepartureWaypointsCount()) && (v.altitudeinFP >= 500)) {
-                                v.legAltitudeDescription = 2;
+                                // v.legAltitudeDescription = 2;
+                                this.setOrGetLegAltitudeDescription(v, 2);
                                 v.legAltitude1 = v.altitudeinFP;
                             } else if ((ii < (data.length - 1) && ii >= (data.length - 1 - this.getArrivalWaypointsCount())) && (v.altitudeinFP >= 500)) {
-                                v.legAltitudeDescription = 3;
+                                // v.legAltitudeDescription = 3;
+                                this.setOrGetLegAltitudeDescription(v, 3);
                                 v.legAltitude1 = v.altitudeinFP;
                             } else if (ii > 0 && ii < data.length - 1) {
-                                v.legAltitudeDescription = 1;
+                                // v.legAltitudeDescription = 1;
+                                this.setOrGetLegAltitudeDescription(v, 1);
                                 v.legAltitude1 = v.altitudeinFP;
                             }
                             this.addHardCodedConstraints(v);
@@ -468,7 +497,8 @@ class FlightPlanManager {
                     waypoint.transitionLLas = waypointData.transitionLLas;
                     const altitudeConstraintInFeet = waypoint.altitudeinFP;
                     if (altitudeConstraintInFeet >= 500) {
-                        waypoint.legAltitudeDescription = 1;
+                        // waypoint.legAltitudeDescription = 1;
+                        this.setOrGetLegAltitudeDescription(waypoint, 1);
                         waypoint.legAltitude1 = altitudeConstraintInFeet;
                     }
                     waypoint.speedConstraint = waypointData.speedConstraint;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
@@ -113,12 +113,12 @@ class FlightPlanManager {
             }, 200);
         }, 200);
     }
-    
+
     _getWaypointLocalStorageKey(waypoint) {
         return `${waypoint.ident}_${this.indexOfWaypoint(waypoint)}`;
     }
-    
-    setOrGetLegAltitudeDescription(waypoint, newValue){
+
+    setOrGetLegAltitudeDescription(waypoint, newValue) {
         // Create a unique key for the current waypoint
         const key = this._getWaypointLocalStorageKey(waypoint);
         // Save if not saved otherwise use the saved one
@@ -126,11 +126,11 @@ class FlightPlanManager {
             localStorage.setItem(key, newValue);
             waypoint.legAltitudeDescription = newValue;
         }
-        const val = localStorage.getItem(key)
+        const val = localStorage.getItem(key);
         waypoint.legAltitudeDescription = parseInt(val);
     }
 
-    setLegAltitudeDescription(waypoint, newValue){
+    setLegAltitudeDescription(waypoint, newValue) {
         const key = this._getWaypointLocalStorageKey(waypoint);
         localStorage.setItem(key, newValue);
         waypoint.legAltitudeDescription = newValue;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
@@ -491,7 +491,6 @@ class FlightPlanManager {
                     waypoint.transitionLLas = waypointData.transitionLLas;
                     const altitudeConstraintInFeet = waypoint.altitudeinFP;
                     if (altitudeConstraintInFeet >= 500) {
-                        // waypoint.legAltitudeDescription = 1;
                         this.setOrGetLegAltitudeDescription(waypoint, 1);
                         waypoint.legAltitude1 = altitudeConstraintInFeet;
                     }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
@@ -143,7 +143,7 @@ class FlightPlanManager {
     }
 
     setLegAltitudeDescription(waypoint, newValue){
-        const key = _getWaypointLocalStorageKey(waypoint);
+        const key = this._getWaypointLocalStorageKey(waypoint);
         localStorage.setItem(key, newValue);
         waypoint.legAltitudeDescription = newValue;
     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #499

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The goal of this PR is to be able to insert the constraints symbols that were always hardcoded before. The goal of this PR is not to update the AP behavior in order to follow those constraints but only to be able to insert and persist that data.

#### Note:
In order to see the new constraints and the symbols, you need to toggle the CSTR button until you see them, that issue if it's one in real life is not related to changes of this PR.

#### What has been done
- Update flight plan page to accepts `+`,  `-`  and non-symbols values.
- Persist the waypoint constraints symbols.
- Kept the already implemented asobo feature that sets the constraints symbols if not already set by the user.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![Screenshot 2020-11-24 015254](https://user-images.githubusercontent.com/11317522/100032223-cd54f080-2df7-11eb-86af-17173b829821.png)

**Please watch the demo video in order to get more context about this PR.**
https://www.youtube.com/watch?v=Qoz-j4g87S8
## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
Thanks to @MisterChocker for all the work he did on the constraints already 💯 
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Union Araken#4083

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
