### PR TITLE
Fix compass spinning wildly

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/A32NX_BaseNDCompass.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/A32NX_BaseNDCompass.js
@@ -229,6 +229,10 @@ class Jet_NDCompass extends HTMLElement {
             const delta = ((desiredRotationHeading - this._delayedCompass + 540) % 360) - 180;
             if (Math.abs(delta) > 0.01) {
                 this._delayedCompass += delta * Math.min(1, 4 * (_deltaTime / 1000));
+
+                // Keep heading values within [0,360] range
+                this._delayedCompass %= 360;
+
                 compass = this._delayedCompass;
             }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #2032

## Summary of Changes
Change heading calculations to stay within 0-360 degree range.
Bug was caused by the compass rotating to 720/1080/1440/etc. degrees after multiple rotations.

To test, spin your Airbus 1080 degrees left or right and monitor the compass when it rotates over 0 degrees.
It shouldn't wildly spin in the opposite direction doing so.

## Screenshots (if necessary)
Previous behaviour (also works on ground if you spawn on runway): https://youtu.be/xRalxEtV7wc

![grafik](https://user-images.githubusercontent.com/8739690/100495934-5fd6f600-3150-11eb-96a3-33c68b04e17b.png)


## References
The compass shouldn't spin wildly after the 2-3rd full rotation.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): MrMinimal#8489

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
