### PR TITLE
[CDU] Fix CLR position in scratchpad

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -135,6 +135,7 @@
 1. [MFD] Corrected icon for the Decel point on flightplan - @LoungeFlyZ (Chris Johnson)
 1. [ND] Update ND to only show Mode Changed when mode button is used - @ilyeshammadi (Ilyes Hammadi)
 1. [TCAS] Implement first iteration of TCAS - @lukecologne (luke)
+1. [CDU] Fix CLR position in scratchpad - @beheh (Benedict Etzel)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -286,11 +286,6 @@ class FMCMainDisplay extends BaseAirliners {
     setInOut(content) {
         this._inOut = content;
         this._inOutElement.textContent = this._inOut;
-        if (content === FMCMainDisplay.clrValue) {
-            this._inOutElement.style.paddingLeft = "8%";
-        } else {
-            this._inOutElement.style.paddingLeft = "";
-        }
     }
 
     setTemplate(template, large = false) {
@@ -3441,5 +3436,5 @@ FMCMainDisplay.approachTypes = [
     "MLS",
     "ILS"
 ];
-FMCMainDisplay.clrValue = " CLR ";
+FMCMainDisplay.clrValue = "\xa0\xa0\xa0\xa0\xa0CLR";
 FMCMainDisplay._AvailableKeys = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

This PR repositions the `CLR` five spaces into the scratchpad.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![image](https://user-images.githubusercontent.com/929769/101297827-39d5e380-382b-11eb-8707-35e6bad7e2d5.png)


## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

Honeywell CDU:

![image](https://user-images.githubusercontent.com/929769/101297794-16ab3400-382b-11eb-8e71-862f0f7524eb.png)
[(full video)](https://github.com/flybywiresim/a32nx/pull/1824#issuecomment-734339999)


FSLabs:

![image](https://user-images.githubusercontent.com/929769/101297816-288cd700-382b-11eb-873a-c4a785b85c92.png)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
