### PR TITLE
Add auto-close notice to PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@
 <!-- Pull requests that do not follow this template are likely to be ignored. -->
 
 <!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
+<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
 Fixes #[issue_no]
 
 ## Summary of Changes


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

This PR is a GitHub-only change. It adds a notice to the pull request template to educate contributors about using GitHub's feature of automatically closing issues correctly when multiple issues are referenced.

