### PR TITLE
Various fixes/additions to ECAM, FWC, and FMA

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -165,8 +165,8 @@
 1. [CDU] Added Soft GA Logic - @MisterChocker (Leon)
 1. [ECAM] Improved Thrust Rating update condition - @MisterChocker (Leon)
 1. [OPTIONS] Added options entry to enable NO PORTABLE DEVICES memo - @wpine215 (Iceman)
-1. [ECAM] Added REFUELG, OUTER TANK XFRD, CABIN READY, FUEL X FEED, and ADIRS SWTG memos - @wpine215 (Iceman)
-1. [ECAM] Added PACKS/NAI/WAI text indicator on upper ECAM - @wpine215 (Iceman)
+2. [ECAM] Added REFUELG, OUTR TK XFRD, CABIN READY, FUEL X FEED, and ADIRS SWTG memos - @wpine215 (Iceman)
+3. [ECAM] Added PACKS/NAI/WAI text indicator on upper ECAM - @wpine215 (Iceman)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -164,6 +164,9 @@
 1. [Sound] Replaced sounds for various switches, levers, and buttons - @hotshotp (Boris)
 1. [CDU] Added Soft GA Logic - @MisterChocker (Leon)
 1. [ECAM] Improved Thrust Rating update condition - @MisterChocker (Leon)
+1. [OPTIONS] Added options entry to enable NO PORTABLE DEVICES memo - @wpine215 (Iceman)
+1. [ECAM] Added REFUELG, OUTER TANK XFRD, CABIN READY, FUEL X FEED, and ADIRS SWTG memos - @wpine215 (Iceman)
+1. [ECAM] Added PACKS/NAI/WAI text indicator on upper ECAM - @wpine215 (Iceman)
 
 ## 0.4.0
 1. [General] Add CHANGELOG.md - @nathaninnes (Nathan Innes)

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -1995,6 +1995,7 @@
                         <ARROW_TYPE>Curved</ARROW_TYPE>
                         <WWISE_EVENT>turnknob</WWISE_EVENT>
                         <INIT_VALUE>1</INIT_VALUE>
+                        <SWITCH_POSITION_VAR>A32NX_KNOB_OVHD_AUDIOSWITCH_Position</SWITCH_POSITION_VAR>
                     </UseTemplate>
                 </Component>
 

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -1995,7 +1995,7 @@
                         <ARROW_TYPE>Curved</ARROW_TYPE>
                         <WWISE_EVENT>turnknob</WWISE_EVENT>
                         <INIT_VALUE>1</INIT_VALUE>
-                        <SWITCH_POSITION_VAR>A32NX_KNOB_OVHD_AUDIOSWITCH_Position</SWITCH_POSITION_VAR>
+                        <SWITCH_POSITION_VAR>KNOB_OVHD_AUDIOSWITCH_Position</SWITCH_POSITION_VAR>
                     </UseTemplate>
                 </Component>
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU.html
@@ -109,6 +109,7 @@
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_METAR.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_ATIS.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_TAF.js"></script>
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_CIDS.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_FMGC.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_REALISM.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_TELEX.js"></script>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_CIDS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_CIDS.js
@@ -1,0 +1,44 @@
+class CDU_OPTIONS_CIDS {
+    static ShowPage(mcdu) {
+        mcdu.clearDisplay();
+
+        const storedUsingNPD = parseInt(NXDataStore.get("CONFIG_USING_PORTABLE_DEVICES", "0"));
+        const displayCurrentOption = storedUsingNPD ? "NO PORT DEVC" : "NO SMOKING";
+
+        mcdu.setTemplate([
+            ["A32NX OPTIONS CIDS"],
+            ["\xa0PAX SIGNS"],
+            [`*${displayCurrentOption}[color]cyan`],
+            [""],
+            [""],
+            [""],
+            [""],
+            [""],
+            [""],
+            [""],
+            [""],
+            [""],
+            ["<RETURN"]
+        ]);
+
+        mcdu.onLeftInput[0] = (value) => {
+            if (value !== "") {
+                mcdu.showErrorMessage("NOT ALLOWED");
+            } else {
+                const newNPDOption = storedUsingNPD ? "0" : "1";
+                NXDataStore.set("CONFIG_USING_PORTABLE_DEVICES", newNPDOption);
+            }
+            CDU_OPTIONS_CIDS.ShowPage(mcdu);
+        };
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onLeftInput[5] = () => {
+            CDU_OPTIONS_MainMenu.ShowPage(mcdu);
+        };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+    }
+}

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_Menu.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_Menu.js
@@ -8,9 +8,9 @@ class CDU_OPTIONS_MainMenu {
             [""],
             ["<AOC", "REALISM>"],
             [""],
+            ["<CIDS"],
+            [""],
             ["<FMGC"],
-            [""],
-            [""],
             [""],
             [""],
             [""],
@@ -22,14 +22,21 @@ class CDU_OPTIONS_MainMenu {
         mcdu.onLeftInput[0] = () => {
             CDU_OPTIONS_AOC.ShowPage(mcdu);
         };
-        mcdu.onLeftInput[1] = () => {
-            CDU_OPTIONS_FMGC.ShowPage(mcdu);
-        };
-
         mcdu.leftInputDelay[0] = () => {
             return mcdu.getDelaySwitchPage();
         };
+
+        mcdu.onLeftInput[1] = () => {
+            CDU_OPTIONS_CIDS.ShowPage(mcdu);
+        };
         mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onLeftInput[2] = () => {
+            CDU_OPTIONS_FMGC.ShowPage(mcdu);
+        };
+        mcdu.leftInputDelay[2] = () => {
             return mcdu.getDelaySwitchPage();
         };
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_WHEEL.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_WHEEL.html
@@ -290,7 +290,7 @@
         <g id="autobrake-element" visibility="hidden">
             <text id="autobrake-title" class="big-text color-green">AUTO BRK </text>
 
-            <text id="autobrake-quantity-min" class="big-text color-green autobrake-mode" visibility="hidden">MIN</text>
+            <text id="autobrake-quantity-min" class="big-text color-green autobrake-mode" visibility="hidden">LO</text>
             <text id="autobrake-quantity-med" class="big-text color-green autobrake-mode" visibility="hidden">MED</text>
             <text id="autobrake-quantity-max" class="big-text color-green autobrake-mode" visibility="hidden">MAX</text>
         </g>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.html
@@ -4,6 +4,7 @@
 <script type="text/html" id="UpperECAMTemplate">
     <div id="Separators">
         <svg viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg">
+            <text id="packsIndicator" class="Value" style="font-size: 12pt;" x="295" y="20" text-anchor="middle" alignment-baseline="central"></text>
             <line class="Separator" x1="0" y1="402" x2="345" y2="402" stroke-linecap="round" />
             <line class="Separator" x1="405" y1="402" x2="600" y2="402" stroke-linecap="round" />
             <line class="Separator" x1="375" y1="415" x2="375" y2="575" stroke-linecap="round" />

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -1147,7 +1147,7 @@ var A320_Neo_UpperECAM;
                         message: "CABIN READY",
                         isActive: () => {
                             return (
-                                (this.getCachedSimVar("L:A32NX_CABIN_READY", "Bool")) && 
+                                (this.getCachedSimVar("L:A32NX_CABIN_READY", "Bool")) &&
                                 ((this.isInFlightPhase(2)) ||
                                 (this.isInFlightPhase(6, 7) && this.getCachedSimVar("GEAR CENTER POSITION", "Percent") > 80))
                             );
@@ -1224,7 +1224,7 @@ var A320_Neo_UpperECAM;
                                 (SimVar.GetSimVarValue("L:A32NX_KNOB_SWITCHING_3_Position", "Enum") != 1) ||
                                 (SimVar.GetSimVarValue("L:A32NX_KNOB_SWITCHING_4_Position", "Enum") != 1)
                             );
-                        }                        
+                        }
                     },
                     {
                         message: "GPWS FLAP 3",
@@ -1273,7 +1273,7 @@ var A320_Neo_UpperECAM;
                                 (SimVar.GetSimVarValue("L:A32NX_KNOB_SWITCHING_1_Position", "Enum") != 1) ||
                                 (SimVar.GetSimVarValue("L:A32NX_KNOB_SWITCHING_2_Position", "Enum") != 1)
                             );
-                        }                        
+                        }
                     },
                 ]
             };
@@ -1417,7 +1417,7 @@ var A320_Neo_UpperECAM;
                 const eng2NAIactive = this.getCachedSimVar("ENG ANTI ICE:2", "Bool");
                 const WAIactive = this.getCachedSimVar("STRUCTURAL DEICE SWITCH", "Bool");
 
-                let textList = [];
+                const textList = [];
                 if ((!ignStateActive || (ignStateActive && !this.isGrounded)) && ((apuActive && apuBleedActive) || (eng1active || eng2active))) {
                     textList.push("PACKS");
                 }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -1144,10 +1144,7 @@ var A320_Neo_UpperECAM;
                         )
                     },
                     {
-                        message: "PRED W/S OFF",
-                        style: () => (
-                            this.isInFlightPhase(3, 4, 5, 7, 8, 9) || this.predWsMemo.read()
-                        ) ? "InfoCaution" : "InfoIndication",
+                        message: "CABIN READY",
                         isActive: () => {
                             return (
                                 (this.getCachedSimVar("L:A32NX_CABIN_READY", "Bool")) && 
@@ -1407,8 +1404,10 @@ var A320_Neo_UpperECAM;
             this.packsText = this.querySelector("#packsIndicator");
             this.isTogaFlexMct1 = this.getCachedSimVar("GENERAL ENG THROTTLE MANAGED MODE:1", "number") > 4;
             this.isTogaFlexMct2 = this.getCachedSimVar("GENERAL ENG THROTTLE MANAGED MODE:2", "number") > 4;
+            this.isGrounded = this.getCachedSimVar("SIM ON GROUND", "bool");
+            this.flightPhaseBeforeClb = (Simplane.getCurrentFlightPhase() < FlightPhase.FLIGHT_PHASE_CLIMB);
 
-            if (this.isTogaFlexMct1 && this.isTogaFlexMct2) {
+            if (this.isGrounded || this.flightPhaseBeforeClb || (this.isTogaFlexMct1 && this.isTogaFlexMct2)) {
                 const ignStateActive = this.getCachedSimVar("L:XMLVAR_ENG_MODE_SEL", "Enum") == 2;
                 const apuBleedActive = this.getCachedSimVar("BLEED AIR APU", "Bool");
                 const apuActive = this.getCachedSimVar("APU PCT RPM", "Percent") >= 95;
@@ -1417,10 +1416,9 @@ var A320_Neo_UpperECAM;
                 const eng1NAIactive = this.getCachedSimVar("ENG ANTI ICE:1", "Bool");
                 const eng2NAIactive = this.getCachedSimVar("ENG ANTI ICE:2", "Bool");
                 const WAIactive = this.getCachedSimVar("STRUCTURAL DEICE SWITCH", "Bool");
-                const isOnGround = this.getCachedSimVar("SIM ON GROUND", "bool");
 
                 let textList = [];
-                if ((!ignStateActive || !isOnGround) && ((apuActive && apuBleedActive) || (eng1active || eng2active))) {
+                if ((!ignStateActive || (ignStateActive && !this.isGrounded)) && ((apuActive && apuBleedActive) || (eng1active || eng2active))) {
                     textList.push("PACKS");
                 }
                 if ((eng1active && eng1NAIactive) || (eng2active && eng2NAIactive)) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -1039,7 +1039,7 @@ var A320_Neo_UpperECAM;
                         ),
                     },
                     {
-                        message: "OUTER TK FUEL XFRD",
+                        message: "OUTR TK FUEL XFRD",
                         isActive: () => {
                             return (
                                 this.getCachedSimVar("A:FUELSYSTEM VALVE SWITCH:4", "Bool") ||

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -1221,14 +1221,6 @@ var A320_Neo_UpperECAM;
                         ),
                     },
                     {
-                        message: "AUDIO 3 XFRD",
-                        isActive: () => {
-                            return (
-                                (SimVar.GetSimVarValue("L:A32NX_KNOB_OVHD_AUDIOSWITCH_Position", "Enum") != 1)
-                            );
-                        }                        
-                    },
-                    {
                         message: "SWITCHG PNL",
                         isActive: () => {
                             return (
@@ -1409,6 +1401,37 @@ var A320_Neo_UpperECAM;
             this.frameCount++;
             if (this.frameCount % 16 == 0) {
                 this.simVarCache = {};
+            }
+
+            // Packs indicator
+            this.packsText = this.querySelector("#packsIndicator");
+            this.isTogaFlexMct1 = this.getCachedSimVar("GENERAL ENG THROTTLE MANAGED MODE:1", "number") > 4;
+            this.isTogaFlexMct2 = this.getCachedSimVar("GENERAL ENG THROTTLE MANAGED MODE:2", "number") > 4;
+
+            if (this.isTogaFlexMct1 && this.isTogaFlexMct2) {
+                const ignStateActive = this.getCachedSimVar("L:XMLVAR_ENG_MODE_SEL", "Enum") == 2;
+                const apuBleedActive = this.getCachedSimVar("BLEED AIR APU", "Bool");
+                const apuActive = this.getCachedSimVar("APU PCT RPM", "Percent") >= 95;
+                const eng1active = this.getCachedSimVar("ENG COMBUSTION:1", "Bool");
+                const eng2active = this.getCachedSimVar("ENG COMBUSTION:2", "Bool");
+                const eng1NAIactive = this.getCachedSimVar("ENG ANTI ICE:1", "Bool");
+                const eng2NAIactive = this.getCachedSimVar("ENG ANTI ICE:2", "Bool");
+                const WAIactive = this.getCachedSimVar("STRUCTURAL DEICE SWITCH", "Bool");
+                const isOnGround = this.getCachedSimVar("SIM ON GROUND", "bool");
+
+                let textList = [];
+                if ((!ignStateActive || !isOnGround) && ((apuActive && apuBleedActive) || (eng1active || eng2active))) {
+                    textList.push("PACKS");
+                }
+                if ((eng1active && eng1NAIactive) || (eng2active && eng2NAIactive)) {
+                    textList.push("NAI");
+                }
+                if ((eng1active || eng2active) && WAIactive) {
+                    textList.push("WAI");
+                }
+                this.packsText.textContent = textList.join("/");
+            } else {
+                this.packsText.textContent = "";
             }
 
             this.fwcFlightPhase = SimVar.GetSimVarValue("L:A32NX_FWC_FLIGHT_PHASE", "Enum");
@@ -1953,19 +1976,19 @@ var A320_Neo_UpperECAM;
             return "42%";
         }
         getValueTextX() {
-            return "11%";
+            return "14%";
         }
         getBoxX() {
             return "15";
         }
         getValueTextX2() {
-            return "17%";
+            return "20%";
         }
         getValueTextXpoint() {
-            return "14%";
+            return "17%";
         }
         getValueTextXFF() {
-            return "20%";
+            return "17%";
         }
     }
     A320_Neo_UpperECAM.LinesStyleComponent_Left = LinesStyleComponent_Left;
@@ -1989,7 +2012,7 @@ var A320_Neo_UpperECAM;
             return "82%";
         }
         getValueTextXFF() {
-            return "85%";
+            return "82%";
         }
     }
     A320_Neo_UpperECAM.LinesStyleComponent_Right = LinesStyleComponent_Right;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.css
@@ -230,7 +230,7 @@ a320-neo-pfd-element #Mainframe #InstrumentsContainer #FMA .Active {
 }
 a320-neo-pfd-element #Mainframe #InstrumentsContainer #FMA .ActiveBlink {
   color: var(--displayWhite);
-  animation: blinking 1s infinite;
+  animation: blinking 2s infinite;
 }
 a320-neo-pfd-element #Mainframe #InstrumentsContainer #FMA .Status {
   color: var(--displayWhite);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.css
@@ -230,7 +230,7 @@ a320-neo-pfd-element #Mainframe #InstrumentsContainer #FMA .Active {
 }
 a320-neo-pfd-element #Mainframe #InstrumentsContainer #FMA .ActiveBlink {
   color: var(--displayWhite);
-  animation: blinking 2s infinite;
+  animation: blinking 1.5s infinite;
 }
 a320-neo-pfd-element #Mainframe #InstrumentsContainer #FMA .Status {
   color: var(--displayWhite);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
@@ -1750,7 +1750,7 @@ var Airbus_FMA;
                     switch (targetState) {
                         case Column4.ROW_3_STATE.DH: {
                             var value = Airbus_FMA.CurrentPlaneState.decisionHeight;
-                            this.setRowMultiText(2, "DH", Airbus_FMA.MODE_STATE.STATUS, value.toFixed(0), Airbus_FMA.MODE_STATE.ARMED);
+                            this.setRowMultiText(2, "RADIO", Airbus_FMA.MODE_STATE.STATUS, value.toFixed(0), Airbus_FMA.MODE_STATE.ARMED);
                             break;
                         }
                         case Column4.ROW_3_STATE.NO_DH: {
@@ -1759,7 +1759,7 @@ var Airbus_FMA;
                         }
                         case Column4.ROW_3_STATE.MDA: {
                             var value = Airbus_FMA.CurrentPlaneState.minimumDescentAltitude;
-                            this.setRowMultiText(2, "MDA", Airbus_FMA.MODE_STATE.STATUS, value.toFixed(0), Airbus_FMA.MODE_STATE.ARMED);
+                            this.setRowMultiText(2, "BARO", Airbus_FMA.MODE_STATE.STATUS, value.toFixed(0), Airbus_FMA.MODE_STATE.ARMED);
                             break;
                         }
                         default: {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
@@ -1750,7 +1750,7 @@ var Airbus_FMA;
                     switch (targetState) {
                         case Column4.ROW_3_STATE.DH: {
                             var value = Airbus_FMA.CurrentPlaneState.decisionHeight;
-                            this.setRowMultiText(2, "RADIO", Airbus_FMA.MODE_STATE.STATUS, value.toFixed(0), Airbus_FMA.MODE_STATE.ARMED);
+                            this.setRowMultiText(2, "DH", Airbus_FMA.MODE_STATE.STATUS, value.toFixed(0), Airbus_FMA.MODE_STATE.ARMED);
                             break;
                         }
                         case Column4.ROW_3_STATE.NO_DH: {
@@ -1759,7 +1759,7 @@ var Airbus_FMA;
                         }
                         case Column4.ROW_3_STATE.MDA: {
                             var value = Airbus_FMA.CurrentPlaneState.minimumDescentAltitude;
-                            this.setRowMultiText(2, "BARO", Airbus_FMA.MODE_STATE.STATUS, value.toFixed(0), Airbus_FMA.MODE_STATE.ARMED);
+                            this.setRowMultiText(2, "MDA", Airbus_FMA.MODE_STATE.STATUS, value.toFixed(0), Airbus_FMA.MODE_STATE.ARMED);
                             break;
                         }
                         default: {


### PR DESCRIPTION
Fixes #2238

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Added new options menu (CIDS) with option to replace "NO SMOKING" memo with "NO PORTABLE DEVICES", which are commonly found on Neo aircraft
- Added PACKS/NAI/WAI text indicator on upper ECAM, which is visible when thrust mode targets TOGA, FLEX/MCT, or SOFT GA.
- Added REFUELG left memo when fuel truck connected
- Added OUTR TK XFRD left memo when fuel is actively being transferred from outer to inner tanks
- Added CABIN READY right memo according to documentation (flight phases 2, 6, and 7)
- Added FUEL X FEED right memo when fuel cross-feed is on
- Added ADIRS SWTG right memo when either Air Data or IRS switching knobs on the pedestal are in use
- Adjusted position of AUTO BRK right memos to reflect documentation
- Adjusted positioning of N2 and FF text on the EWD, as it was previously asymmetrical
- Increased blinking interval of "LVR CLB" on FMA from 1s to 1.5s as it was blinking too quickly
- Fixed typo in WHEEL ECAM page where "AUTO BRAKE LO" was mislabeled as "AUTO BRAKE MIN"

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![image](https://user-images.githubusercontent.com/28059870/102497973-5c47d800-4047-11eb-8cc2-442c305f7658.png)


## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
Available upon request.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Iceman#5540

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
