### PR TITLE
[FIX] Retard callout bugs

### DIFF
--- a/A32NX/html_ui/Pages/A32NX_Core/A32NX_GPWS.js
+++ b/A32NX/html_ui/Pages/A32NX_Core/A32NX_GPWS.js
@@ -578,7 +578,7 @@ class A32NX_GPWS {
                 }
                 break;
             case "retardPlaying":
-                if (SimVar.GetSimVarValue("GENERAL ENG THROTTLE LEVER POSITION:1", "Percent over 100") === 0 || SimVar.GetSimVarValue("GENERAL ENG THROTTLE LEVER POSITION:2", "Percent over 100") === 0) {
+                if (SimVar.GetSimVarValue("GENERAL ENG THROTTLE LEVER POSITION:1", "Percent over 100") <= 0.05 || SimVar.GetSimVarValue("GENERAL ENG THROTTLE LEVER POSITION:2", "Percent over 100") <= 0.05) {
                     this.RetardState.action("land");
                     this.core.soundManager.removePeriodicSound(soundList.retard);
                 } else if (SimVar.GetSimVarValue("L:AIRLINER_FLIGHT_PHASE", "Enum") === FlightPhase.FLIGHT_PHASE_GOAROUND || radioAlt > 20) {
@@ -606,7 +606,7 @@ const RetardStateMachine = {
     retardPlaying: {
         transitions: {
             land: {
-                target: "retardStopped"
+                target: "landed"
             },
             go_around: {
                 target: "overRetard"


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #2336, Fixes  #2185

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* Fixes a bug where the retard callout would not play
* The retard callout now stops when the thrust levers are below 5%, instead of excatly at idle. This should fix the issues with it playing in a loop.

This logic is still not what it is in RL, and will need to be implemented in the FWC at some point.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
