### PR TITLE
[CDU] Allow SimBrief user IDs instead of usernames

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,7 +5,7 @@
 <!--  1. [Changed Area] Title of changes - @github username (Name)  -->
 
 ## 0.6.0
-1. [CDU] Allow SimBrief user IDs as well as usernames
+1. [CDU] Allow SimBrief user IDs as well as usernames - @pareil6 - (@pareil6#0990)
 
 ## 0.5.0
 1. [FLIGHTMODEL] Reworked AOA table - @donstim - (donbikes#4084)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,7 +5,7 @@
 <!--  1. [Changed Area] Title of changes - @github username (Name)  -->
 
 ## 0.6.0
-1. [CDU] Allow SimBrief user IDs as well as usernames - @pareil6 - (@pareil6#0990)
+1. [CDU] Allow SimBrief user IDs as well as usernames - @pareil6 - (pareil6#0990)
 
 ## 0.5.0
 1. [FLIGHTMODEL] Reworked AOA table - @donstim - (donbikes#4084)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,7 +5,7 @@
 <!--  1. [Changed Area] Title of changes - @github username (Name)  -->
 
 ## 0.6.0
-1.
+1. [CDU] Allow Simbrief usernames with underscores
 
 ## 0.5.0
 1. [FLIGHTMODEL] Reworked AOA table - @donstim - (donbikes#4084)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,7 +5,7 @@
 <!--  1. [Changed Area] Title of changes - @github username (Name)  -->
 
 ## 0.6.0
-1. [CDU] Allow Simbrief usernames with underscores
+1. [CDU] Allow SimBrief user IDs as well as usernames
 
 ## 0.5.0
 1. [FLIGHTMODEL] Reworked AOA table - @donstim - (donbikes#4084)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,7 +5,7 @@
 <!--  1. [Changed Area] Title of changes - @github username (Name)  -->
 
 ## 0.6.0
-1. [CDU] Allow SimBrief user IDs as well as usernames - @pareil6 - (pareil6#0990)
+1. [CDU] Allow SimBrief user IDs as well as usernames - @pareil6 - (pareil6)
 
 ## 0.5.0
 1. [FLIGHTMODEL] Reworked AOA table - @donstim - (donbikes#4084)

--- a/A32NX/html_ui/Pages/A32NX_Core/A32NX_ATSU.js
+++ b/A32NX/html_ui/Pages/A32NX_Core/A32NX_ATSU.js
@@ -135,16 +135,17 @@ const lbsToKg = (value) => {
  */
 const getSimBriefOfp = (mcdu, updateView) => {
     const simBriefUsername = NXDataStore.get("CONFIG_SIMBRIEF_USERNAME", "");
+    const simBriefUserId = NXDataStore.get("CONFIG_SIMBRIEF_USERID", "");
 
-    if (!simBriefUsername) {
+    if (!simBriefUsername && !simBriefUserId) {
         mcdu.showErrorMessage("NO SIMBRIEF USER");
-        throw ("No simbrief username provided");
+        throw ("No simbrief username/user ID provided");
     }
 
     mcdu.simbrief["sendStatus"] = "REQUESTING";
     updateView();
 
-    return SimBriefApi.getSimBriefOfp(simBriefUsername)
+    return SimBriefApi.getSimBriefOfp(simBriefUsername, simBriefUserId)
         .then(data => {
             mcdu.simbrief["units"] = data.params.units;
             mcdu.simbrief["route"] = data.general.route;

--- a/A32NX/html_ui/Pages/A32NX_Utils/SimBriefApi.js
+++ b/A32NX/html_ui/Pages/A32NX_Utils/SimBriefApi.js
@@ -4,7 +4,7 @@ class SimBriefApi {
         if (username) {
             apiUrl = `${SimBriefApi.url}&username=${username}`;
         } else if (userId) {
-            apiUrl = `${SimBriefApi.url}&userid=${username}`;
+            apiUrl = `${SimBriefApi.url}&userid=${userId}`;
         } else {
             throw ("No SimBrief username/user ID provided");
         }

--- a/A32NX/html_ui/Pages/A32NX_Utils/SimBriefApi.js
+++ b/A32NX/html_ui/Pages/A32NX_Utils/SimBriefApi.js
@@ -1,10 +1,15 @@
 class SimBriefApi {
-    static getSimBriefOfp(username) {
-        if (!username) {
-            throw ("No SimBrief username provided");
+    static getSimBriefOfp(username, userId) {
+        var apiUrl;
+        if (username) {
+            apiUrl = `${SimBriefApi.url}&username=${username}`;
+        } else if (userId) {
+            apiUrl = `${SimBriefApi.url}&userid=${username}`;
+        } else {
+            throw ("No SimBrief username/user ID provided");
         }
 
-        return fetch(`${SimBriefApi.url}&username=${username}`)
+        return fetch(apiUrl)
             .then((response) => {
                 if (!response.ok) {
                     throw (response);

--- a/A32NX/html_ui/Pages/A32NX_Utils/SimBriefApi.js
+++ b/A32NX/html_ui/Pages/A32NX_Utils/SimBriefApi.js
@@ -1,6 +1,6 @@
 class SimBriefApi {
     static getSimBriefOfp(username, userId) {
-        var apiUrl;
+        let apiUrl;
         if (username) {
             apiUrl = `${SimBriefApi.url}&username=${username}`;
         } else if (userId) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_SIMBRIEF.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_SIMBRIEF.js
@@ -2,9 +2,13 @@ class CDU_OPTIONS_SIMBRIEF {
     static ShowPage(mcdu) {
         mcdu.clearDisplay();
 
-        const simbriefUsername = NXDataStore.get("CONFIG_SIMBRIEF_USERNAME", "").replace('_', ' ');
+        const simbriefUsername = NXDataStore.get("CONFIG_SIMBRIEF_USERNAME", "").replace(/_/g, ' ');
 
-        const simbriefUsernameString = simbriefUsername != "" ? simbriefUsername : "[ ]";
+        const simbriefUsernameString = simbriefUsername ? simbriefUsername : "[ ]";
+
+        const simbriefUserId = NXDataStore.get("CONFIG_SIMBRIEF_USERID", "");
+
+        const simbriefUserIdString = simbriefUserId ? simbriefUserId : "[ ]";
 
         mcdu.setTemplate([
             ["A32NX OPTIONS"],
@@ -12,8 +16,8 @@ class CDU_OPTIONS_SIMBRIEF {
             [""],
             ["USERNAME"],
             [`${simbriefUsernameString}[color]blue`],
-            [""],
-            [""],
+            ["USER ID"],
+            [`${simbriefUserIdString}[color]blue`],
             [""],
             [""],
             [""],
@@ -29,7 +33,20 @@ class CDU_OPTIONS_SIMBRIEF {
             if (value === FMCMainDisplay.clrValue) {
                 NXDataStore.set("CONFIG_SIMBRIEF_USERNAME", "");
             } else {
-                NXDataStore.set("CONFIG_SIMBRIEF_USERNAME", value.replace(' ', '_'));
+                NXDataStore.set("CONFIG_SIMBRIEF_USERNAME", value.replace(/ /g, '_'));
+                NXDataStore.set("CONFIG_SIMBRIEF_USERID", "");
+            }
+            CDU_OPTIONS_SIMBRIEF.ShowPage(mcdu);
+        };
+
+        mcdu.onLeftInput[2] = (value) => {
+            if (value === FMCMainDisplay.clrValue) {
+                NXDataStore.set("CONFIG_SIMBRIEF_USERID", "");
+            } else if (!/^\d$/.test(value)) {
+                mcdu.showErrorMessage("NOT ALLOWED");
+            } else {
+                NXDataStore.set("CONFIG_SIMBRIEF_USERID", value);
+                NXDataStore.set("CONFIG_SIMBRIEF_USERNAME", "");
             }
             CDU_OPTIONS_SIMBRIEF.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_SIMBRIEF.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_SIMBRIEF.js
@@ -42,7 +42,7 @@ class CDU_OPTIONS_SIMBRIEF {
         mcdu.onLeftInput[2] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 NXDataStore.set("CONFIG_SIMBRIEF_USERID", "");
-            } else if (!/^\d$/.test(value)) {
+            } else if (!/^\d+$/.test(value)) {
                 mcdu.showErrorMessage("NOT ALLOWED");
             } else {
                 NXDataStore.set("CONFIG_SIMBRIEF_USERID", value);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_SIMBRIEF.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_SIMBRIEF.js
@@ -2,7 +2,7 @@ class CDU_OPTIONS_SIMBRIEF {
     static ShowPage(mcdu) {
         mcdu.clearDisplay();
 
-        const simbriefUsername = NXDataStore.get("CONFIG_SIMBRIEF_USERNAME", "");
+        const simbriefUsername = NXDataStore.get("CONFIG_SIMBRIEF_USERNAME", "").replace('_', ' ');
 
         const simbriefUsernameString = simbriefUsername != "" ? simbriefUsername : "[ ]";
 
@@ -29,7 +29,7 @@ class CDU_OPTIONS_SIMBRIEF {
             if (value === FMCMainDisplay.clrValue) {
                 NXDataStore.set("CONFIG_SIMBRIEF_USERNAME", "");
             } else {
-                NXDataStore.set("CONFIG_SIMBRIEF_USERNAME", value);
+                NXDataStore.set("CONFIG_SIMBRIEF_USERNAME", value.replace(' ', '_'));
             }
             CDU_OPTIONS_SIMBRIEF.ShowPage(mcdu);
         };


### PR DESCRIPTION
## Summary of Changes
Allows user to insert a SimBrief user ID instead of username.

## Screenshots (if necessary)
![20201218205117_1](https://user-images.githubusercontent.com/73158172/102661093-12a8db80-4174-11eb-8fbf-568df0718010.jpg)
![20201218205121_1](https://user-images.githubusercontent.com/73158172/102661098-15a3cc00-4174-11eb-89f1-747e726f2ef3.jpg)

## References
N/A

## Additional context
N/A

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): pareil6#0990

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
