### PR TITLE
feat: WASM implementation of flight warning computer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@
 .DS_Store
 node_modules
 /src/sound/.cache
+/src/fwc/target
+/**/*.wasm
+/**/Cargo.lock
+/target

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/panel/panel.cfg
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/panel/panel.cfg
@@ -124,6 +124,14 @@ texture=$MFD2
 
 htmlgauge00=Airliners/A320_Neo/MFD/A320_Neo_MFD.html?Index=2, 0,0,1280,1280
 
+[VCockpit17]
+size_mm=0,0
+pixel_size=0,0
+texture=$PFD
+background_color=0,0,0
+
+htmlgauge00=WasmInstrument/WasmInstrument.html?wasm_module=nvg_demo.wasm&wasm_gauge=fwc, 0,0,0,0
+
 [VPainting01]
 size_mm				= 2048,512
 texture				= $RegistrationNumber

--- a/src/fwc/.cargo/config.toml
+++ b/src/fwc/.cargo/config.toml
@@ -1,0 +1,9 @@
+[net]
+git-fetch-with-cli = true
+
+[target.wasm32-wasi]
+rustflags = [
+  "-Clink-arg=--export-table",
+  "-Clink-arg=--export=malloc",
+  "-Clink-arg=--export=free",
+]

--- a/src/fwc/Cargo.toml
+++ b/src/fwc/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "nvg_demo"
+version = "0.1.0"
+authors = ["Gus Caplan <me@gus.host>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+msfs = "0.0.1-alpha.2"
+

--- a/src/fwc/build.sh
+++ b/src/fwc/build.sh
@@ -1,0 +1,21 @@
+#
+# A32NX
+# Copyright (C) 2020 FlyByWire Simulations and its contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+cd src/fwc
+
+cargo build --target wasm32-wasi

--- a/src/fwc/src/lib.rs
+++ b/src/fwc/src/lib.rs
@@ -1,0 +1,33 @@
+/*
+ * A32NX
+ * Copyright (C) 2020 FlyByWire Simulations and its contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use msfs::MSFSEvent;
+
+#[msfs::gauge(name=fwc)]
+async fn demo(mut gauge: msfs::Gauge) -> Result<(), Box<dyn std::error::Error>> {
+    while let Some(event) = gauge.next_event().await {
+        match event {
+            MSFSEvent::PostUpdate => {
+                println!("update");
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}

--- a/src/fwc/src/lib.rs
+++ b/src/fwc/src/lib.rs
@@ -17,17 +17,66 @@
  */
 
 use msfs::MSFSEvent;
+use msfs::legacy::{NamedVariable, execute_calculator_code};
 
 #[msfs::gauge(name=fwc)]
 async fn demo(mut gauge: msfs::Gauge) -> Result<(), Box<dyn std::error::Error>> {
+    let mut fwc = Fwc {
+        inputs: FwcInputs {
+            flight_phase: 7f64
+        },
+        outputs: FwcOutput {
+            ecam_message: "Hello".to_string()
+        }
+    };
+
     while let Some(event) = gauge.next_event().await {
         match event {
             MSFSEvent::PostUpdate => {
-                println!("update");
+                fwc.update();
+
+                let ecam_message = NamedVariable::from("A32NX_FWC_OUT_MESSAGE");
+                ecam_message.set_value(fwc.inputs.flight_phase);
+
+                execute_calculator_code::<()>("(>H:A32NX_DCDU_FWC)");
             }
             _ => {}
         }
     }
 
     Ok(())
+}
+
+
+struct FwcInputs {
+    flight_phase: f64
+}
+
+struct FwcOutput {
+    ecam_message: String
+}
+
+struct Fwc {
+    inputs: FwcInputs,
+    outputs: FwcOutput
+}
+
+impl Fwc {
+    fn update(&mut self) {
+        self.acquire();
+        self.concentrate();
+        self.output();
+    }
+
+    fn acquire(&self) {
+
+    }
+
+    fn concentrate(&self) {
+
+    }
+
+    fn output(&mut self) {
+        self.outputs.ecam_message = self.inputs.flight_phase.to_string();
+    }
 }


### PR DESCRIPTION
## Summary of Changes

This PR re-implements the FWC (flight warning computer) using Rust and WASM.

* [ ] Basic module
* [ ] Data acquisition
* [ ] Data display on ECAM

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): someperson#4953

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
