### PR TITLE
[CDU] Fix incorrect block time display on INIT/REVIEW

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## 0.6.0
 1. [CDU] Allow SimBrief user IDs as well as usernames - @pareil6 - (pareil6)
+1. [CDU] Fix incorrect block time display on INIT/REVIEW - @pareil6 - (pareil6)
 
 ## 0.5.0
 1. [FLIGHTMODEL] Reworked AOA table - @donstim - (donbikes#4084)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_Init.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_Init.js
@@ -6,11 +6,6 @@ function formatWeight(value) {
     return (+value).toFixed(1);
 }
 
-function formatTime(timestamp) {
-    var date = new Date(+timestamp * 1000);
-    return `${date.getUTCHours().toString().padStart(2, "0")}${date.getUTCMinutes().toString().padEnd(2, "0")}`;
-}
-
 class CDUAocInit {
     static ShowPage(mcdu) {
         mcdu.clearDisplay();
@@ -52,7 +47,7 @@ class CDUAocInit {
             fltNbr = `{small}${mcdu.simbrief.icao_airline}${mcdu.simbrief.flight_number}{end}[color]green`;
         }
         if (mcdu.simbrief.ete) {
-            ete = `${formatTime(mcdu.simbrief.ete)}[color]cyan`;
+            ete = `${FMCMainDisplay.secondsTohhmm(mcdu.simbrief.ete)}[color]cyan`;
         }
 
         const currentFob = formatWeight(mcdu.getFOB() * mcdu._conversionWeight);
@@ -163,7 +158,7 @@ class CDUAocInit {
             inTime = `${FMCMainDisplay.secondsTohhmm(mcdu.aocTimes.in)}[color]green`;
         }
         if (mcdu.simbrief["blockTime"]) {
-            blockTime = `${formatTime(mcdu.simbrief.blockTime)}[color]green`;
+            blockTime = `${FMCMainDisplay.secondsTohhmm(mcdu.simbrief.blockTime)}[color]green`;
         }
 
         function updateView() {


### PR DESCRIPTION
Fixes #2560.

## Summary of Changes
Reuses existing seconds -> hh:mm function to fix formatting bug in function used in two places in the INIT/REVIEW B page, causing minutes values below 10 to be zero padded on the right instead of the left.

## Screenshots (if necessary)

SimBrief OFP:
![image](https://user-images.githubusercontent.com/73158172/102716962-202aa680-42d7-11eb-837f-dd7ada8b2847.png)

Before:
![Capture](https://user-images.githubusercontent.com/73158172/102716965-23be2d80-42d7-11eb-8e2c-2ba5e8b4c13a.PNG)

After:
![Capture1](https://user-images.githubusercontent.com/73158172/102716968-2a4ca500-42d7-11eb-90c0-9bf58f7ea687.PNG)

## References
N/A

## Additional context
N/A

Discord username (if different from GitHub): pareil6#0990

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link