### PR TITLE
[CDU] Allow SimBrief OFP to override previous flight plan

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,11 +5,12 @@
 <!--  1. [Changed Area] Title of changes - @github username (Name)  -->
 
 ## 0.6.0
-1. [CDU] Allow SimBrief user IDs as well as usernames - @pareil6 - (pareil6)
-1. [CDU] Fix incorrect block time display on INIT/REVIEW - @pareil6 - (pareil6)
+1. [CDU] Allow SimBrief user IDs as well as usernames - @pareil6 (pareil6)
+1. [CDU] Fix incorrect block time display on INIT/REVIEW - @pareil6 (pareil6)
 1. [ECAM] Improved PACKS indication - @MisterChocker (Leon)
 1. [CDU] Improved visuals of CDU Pages - @MisterChocker (Leon)
 1. [CDU] Improved ascent constraint algorithm - @MisterChocker (Leon)
+1. [CDU] Allow SimBrief OFP to override previous flight plan - @pareil6 (pareil6)
 
 ## 0.5.0
 1. [FLIGHTMODEL] Reworked AOA table - @donstim - (donbikes#4084)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -33,9 +33,14 @@ class CDUInitPage {
                     flightNo = SimVar.GetSimVarValue("ATC FLIGHT NUMBER", "string", "FMC") + "[color]cyan";
                 }
 
-                requestEnable = false;
-                requestButtonLabel = "";
-                requestButton = "";
+                // If an active SimBrief OFP matches the FP, hide the request option
+                // This allows loading a new OFP via INIT/REVIEW loading a different orig/dest to the current one
+                if (mcdu.simbrief.sendStatus != "DONE" ||
+                    (mcdu.simbrief["originIcao"] === mcdu.flightPlanManager.getOrigin().ident && mcdu.simbrief["destinationIcao"] === mcdu.flightPlanManager.getDestination().ident)) {
+                    requestEnable = false;
+                    requestButtonLabel = "";
+                    requestButton = "";
+                }
 
                 if (resetFlightNo) {
                     flightNo = "________[color]amber";


### PR DESCRIPTION
## Summary of Changes
If the active SimBrief OFP has different origin/destination airports to the currently active flight plan, enable the INIT REQUEST option on the FP INIT A page. This allows a new SimBrief flight plan to be loaded after a flight, by loading the new OFP from the INIT/REVIEW screen, then returning to the FP INIT A screen and selecting INIT REQUEST to overwrite the existing flight plan.

## Screenshots (if necessary)
Loading initial flight plan:
![20201221230409_1](https://user-images.githubusercontent.com/73158172/102830784-088c1480-43e2-11eb-9e51-56f0af13fb69.jpg)
![20201221230431_1](https://user-images.githubusercontent.com/73158172/102830791-0a55d800-43e2-11eb-8ab8-bf387bf097df.jpg)
![20201221230508_1](https://user-images.githubusercontent.com/73158172/102830800-0c1f9b80-43e2-11eb-8e9b-1d3a90fe2ee1.jpg)

After loading new SimBrief OFP data from the INIT/REVIEW page:
![20201221230551_1](https://user-images.githubusercontent.com/73158172/102830825-1a6db780-43e2-11eb-8402-8055fe79519f.jpg)
![20201221230554_1](https://user-images.githubusercontent.com/73158172/102830829-1c377b00-43e2-11eb-8bc8-8f027403532d.jpg)
![20201221230602_1](https://user-images.githubusercontent.com/73158172/102830845-22c5f280-43e2-11eb-8743-7b5d6a0afd63.jpg)

Flight plan waypoints successfully cleared and replaced:
![20201221230608_1](https://user-images.githubusercontent.com/73158172/102830850-25c0e300-43e2-11eb-932e-1cbf5f4de265.jpg)

## References
N/A

## Additional context
I can't find any obvious reference for how this behaviour works in the real MCDU - if anyone has details, let me know and I can update this to match. Intuition says that the INIT REQUEST text on the INIT A page should maybe be cyan instead of amber if there's an active FP and it's still visible (based on the rest of the UI), and/or should potentially only be visible when on the ground - open to suggestions here though.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): pareil6#0990

## Testing instructions
INIT REQUEST should only become visible on the INIT A page in the case where you have made a SimBrief init request and the origin/destination airports in that request disagree with what is currently in the active FP (or if there is no active FP, as before). Loading from it should properly clear the previous flight plan as well, not leaving any waypoints/etc. behind when inserting the new one.

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link