### PR TITLE
[MISC] Stop autobrake max disengaging on the ground

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,7 +12,6 @@
 1. [CDU] Improved ascent constraint algorithm - @MisterChocker (Leon)
 1. [CDU] Fixed FPLN airways showing as undefined - @pareil6 - (pareil6)
 1. [CDU] Allow SimBrief OFP to override previous flight plan - @pareil6 (pareil6)
-1. [MISC] Stop autobrake max disengaging on the ground - @pareil6 (pareil6)
 
 ## 0.5.0
 1. [FLIGHTMODEL] Reworked AOA table - @donstim - (donbikes#4084)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [CDU] Improved ascent constraint algorithm - @MisterChocker (Leon)
 1. [CDU] Fixed FPLN airways showing as undefined - @pareil6 - (pareil6)
 1. [CDU] Allow SimBrief OFP to override previous flight plan - @pareil6 (pareil6)
+1. [MISC] Stop autobrake max disengaging on the ground - @pareil6 (pareil6)
 
 ## 0.5.0
 1. [FLIGHTMODEL] Reworked AOA table - @donstim - (donbikes#4084)

--- a/src/behavior/src/A32NX_Interior_Misc.xml
+++ b/src/behavior/src/A32NX_Interior_Misc.xml
@@ -204,7 +204,8 @@
                                     if onGroundWaitCounter == 30 {
                                         if (A:AUTOBRAKES ACTIVE, bool) {
                                             autobrakesActivated = true;
-                                        } else {
+                                        }
+                                        if autobrakesActivated and !(A:AUTOBRAKES ACTIVE, bool) {
                                             autobrakesLevel = 0;
                                             autobrakesActivated = false;
                                             onGroundWaitCounter = 0;


### PR DESCRIPTION
Fixes #2586.

## Summary of Changes
Fixes autobrake max disengaging after a short period of time while on the ground, caused by a subtle logic error introduced in the RNP conversion.

## Screenshots (if necessary)
N/A

## References
N/A

## Additional context
N/A

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): pareil6#0990

## Testing instructions
Try setting autobrake max, try taxiing, using the foot brakes and checking that doesn't reset it, take off and check it clears after the landing gear comes up, check it can't be selected once in the air.

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
