### PR TITLE
Fix Issue #2586: AUTOBREAK MAX turn off while taxing/breaking before T/O

### DIFF
--- a/src/behavior/src/A32NX_Interior_Misc.xml
+++ b/src/behavior/src/A32NX_Interior_Misc.xml
@@ -183,6 +183,7 @@
                             alias onGroundWaitCounter = (L:A32NX_ON_GROUND_WAIT_COUNTER, number);
                             alias disarmAutobrakesOnLgRetract = (L:A32NX_DISARM_AUTOBRAKES_ON_LG_RETRACT, bool);
                             alias autobrakesActivated = (L:A32NX_AUTOBRAKES_ACTIVATED, bool);
+                            alias autobrakesActive = (A:AUTOBRAKES ACTIVE, bool);
 
                             if onGround and (A:AUTO BRAKE SWITCH CB, number) == 4 {
                                 autobrakesLevel = 3;
@@ -204,7 +205,9 @@
                                     if onGroundWaitCounter == 30 {
                                         if (A:AUTOBRAKES ACTIVE, bool) {
                                             autobrakesActivated = true;
-                                        } else {
+                                        }
+                                        
+                                        if autobrakesActivated and !autobrakesActive {
                                             autobrakesLevel = 0;
                                             autobrakesActivated = false;
                                             onGroundWaitCounter = 0;


### PR DESCRIPTION
Change #2510 which was converting RPN to infix was applied incorrectly to the autobrake code.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #2586

## Summary of Changes
One of the if conditions in the autobrake code was ported incorrectly when it was converted from RPN to infix.

## Screenshots (if necessary)


## References


## Additional context

geoffda

## Testing instructions
Autobrake switch behavior should work as follows:
1) When starting on the runway, max should be automatically set.
2) Once set to max, the settings should stay on max while taxiing and braking.
3) After takeoff with autobrakes set to max, autobrake setting should be turned off within 10 seconds of retracting the landing gear.
4) In flight, setting autobrakes max should not work. If autobrakes were set to either low or medium before attempting to select max, those settings should be preserved.
5) Upon landing, autobrakes should engage as per setting. Once manual brakes are applied, the autobrake setting should turn off.
6) At that point (with the aircraft on the ground) any autobrakes setting should be allowed.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
