### PR TITLE
fix: invalid code in CAB PRESS page

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_PRESS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_PRESS.js
@@ -1,3 +1,21 @@
+/*
+ * A32NX
+ * Copyright (C) 2020 FlyByWire Simulations and its contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 /** @type A320_Neo_LowerECAM_PRESS */
 var A320_Neo_LowerECAM_PRESS;
 (function (A320_Neo_LowerECAM_PRESS) {
@@ -74,11 +92,11 @@ var A320_Neo_LowerECAM_PRESS;
             this.htmlSYS1text.setAttribute("visibility", "visible");
             this.htmlSYS2text.setAttribute("visibility", "hidden");
             this.htmlMANtext.setAttribute("visibility", "hidden");
-            this.htmlTextSafetyW.setAttribute("visibility", "hidden");
-            this.htmlCabinAltValueW.setAttribute("visibility", "hidden");
-            this.htmlCabinVSValueW.setAttribute("visibility", "hidden");
-            this.htmlPsiDecimalW.setAttribute("visibility", "hidden");
-            this.htmlPsiIntW.setAttribute("visibility", "hidden");
+            this.htmlTextSafety.setAttribute("visibility", "hidden");
+            this.htmlCabinAltValue.setAttribute("visibility", "hidden");
+            this.htmlCabinVSValue.setAttribute("visibility", "hidden");
+            this.htmlPsiDecimal.setAttribute("visibility", "hidden");
+            this.htmlPsiInt.setAttribute("visibility", "hidden");
 
         }
 


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

This fixes some references to non-existent class properties in the CAB PRESS SD page, which could (rarely) cause a race condition and make the instrument fail to update.

Discord username (if different from GitHub): someperson#4953

## Testing instructions

* Verify that the PRESS page still has the same functionality

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
