### PR TITLE
Fixed typo in Descent Preparation checklist

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -22,6 +22,7 @@
 1. [CDU] Fixed altitude button setting the speed on ATC request - @brookemckim (brookemckim)
 1. [CDU] Refactored CDU and FMS Main - @MisterChocker (Leon)
 1. [API] Fix connection issues when using default ATC and SimBrief - @nistei (nistei#1362)
+1. [CHECKLISTS] Fixed typo in Descent preparation checklist - @ronson1909 (Ronson1909)
 
 ## 0.5.1
 1. [CDU] Allow SimBrief user IDs as well as usernames - @pareil6 (pareil6)

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/Checklist/Library.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/Checklist/Library.xml
@@ -1257,7 +1257,7 @@
          <CheckpointDesc SubjectTT="TT:FMGS: PERF DES Page" ExpectationTT="TT:CHECK" />
       </Checkpoint>
       <Checkpoint Id="A320_DPREP_FMGS_PERF_APPR">
-         <CheckpointDesc SubjectTT="TT:FMGS: PEFR APPR Page" ExpectationTT="TT:CHECK" />
+         <CheckpointDesc SubjectTT="TT:FMGS: PERF APPR Page" ExpectationTT="TT:CHECK" />
       </Checkpoint>
       <Checkpoint Id="A320_DPREP_FMGS_GA">
          <CheckpointDesc SubjectTT="TT:FMGS: Go-Around Page" ExpectationTT="TT:CHECK" />


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #2843

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixed a typo in the Descent preparation checklist.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
none

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
none

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
none

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Open "Descent preparation" checklist.
1. Go to checkpoint after "PERF DES Page".

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
