### PR TITLE
feat(mcdu): Support CONF 3 Landing

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -44,6 +44,7 @@
 1. [SOUND] Reworked touchdown sounds - @hotshotp (Boris)
 1. [MISC] Added printer - @tyler58546 (tyler58546), @DarkOfNova (DarkOfNova)
 1. [ECAM] Added CONF/FLAPS 3 memos when GPWS LDG FLAPS 3 enabled - @tracernz (Mike)
+1. [CDU] Add landing config selection (CONF3 or FULL) on Perf Appr page - @tracernz (Mike)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/A32NX/html_ui/Pages/A32NX_Utils/NXSpeeds.js
+++ b/A32NX/html_ui/Pages/A32NX_Utils/NXSpeeds.js
@@ -510,6 +510,7 @@ class NXApprSpeeds {
         this.f = f[cm](m);
         this.s = s[cm](m);
         this.gd = _computeGD(m);
+        this.valid = true;
     }
 }
 

--- a/A32NX/html_ui/Pages/A32NX_Utils/NXSpeeds.js
+++ b/A32NX/html_ui/Pages/A32NX_Utils/NXSpeeds.js
@@ -492,6 +492,27 @@ class NXToSpeeds {
     }
 }
 
+class NXApprSpeeds {
+    /**
+     * Calculates VLS and Vapp for selected landing configuration
+     * @param {number} m Projected landing mass in t
+     * @param {boolean} isConf3 CONF3 if true, else FULL
+     * @param {number} [wind=live measured] tower headwind component
+     */
+    constructor(m, isConf3, wind = NaN) {
+        const cm = _correctMass(m);
+        this.vls = vls[isConf3 ? 3 : 4][cm](m, 1);
+        if (isFinite(wind)) {
+            this.vapp = this.vls + NXSpeedsUtils.addWindComponent(wind / 3);
+        } else {
+            this.vapp = this.vls + NXSpeedsUtils.addWindComponent();
+        }
+        this.f = f[cm](m);
+        this.s = s[cm](m);
+        this.gd = _computeGD(m);
+    }
+}
+
 class NXSpeedsUtils {
     /**
      * Calculates wind component for ground speed mini

--- a/A32NX/html_ui/Pages/A32NX_Utils/NXSpeeds.js
+++ b/A32NX/html_ui/Pages/A32NX_Utils/NXSpeeds.js
@@ -499,14 +499,10 @@ class NXApprSpeeds {
      * @param {boolean} isConf3 CONF3 if true, else FULL
      * @param {number} [wind=live measured] tower headwind component
      */
-    constructor(m, isConf3, wind = NaN) {
+    constructor(m, isConf3, wind = (SimVar.GetSimVarValue("AIRCRAFT WIND Z", "knots") * -1)) {
         const cm = _correctMass(m);
         this.vls = vls[isConf3 ? 3 : 4][cm](m, 1);
-        if (isFinite(wind)) {
-            this.vapp = this.vls + NXSpeedsUtils.addWindComponent(wind / 3);
-        } else {
-            this.vapp = this.vls + NXSpeedsUtils.addWindComponent();
-        }
+        this.vapp = this.vls + NXSpeedsUtils.addWindComponent(wind / 3);
         this.f = f[cm](m);
         this.s = s[cm](m);
         this.gd = _computeGD(m);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -85,6 +85,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             des: [],
             alternate: null
         };
+        this.approachSpeeds = undefined; // based on selected config, not current config
     }
     get templateID() {
         return "A320_Neo_CDU";
@@ -1033,6 +1034,21 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
     isAltitudeManaged() {
         return SimVar.GetSimVarValue("AUTOPILOT ALTITUDE SLOT INDEX", "number") === 2;
     }
+    updateApproachSpeeds() {
+        let weight = this.tryEstimateLandingWeight();
+        // Actual weight is used during approach phase (FCOM bulletin 46/2), and we also assume during go-around
+        // We also fall back to current weight when landing weight is unavailable
+        if (this.currentFlightPhase >= FlightPhase.FLIGHT_PHASE_APPROACH || !isFinite(weight)) {
+            weight = SimVar.GetSimVarValue("TOTAL WEIGHT", "kg") / 1000;
+        }
+        // if pilot has set approach wind in MCDU we use it, otherwise fall back to current measured wind
+        if (isFinite(this.perfApprWindSpeed) && isFinite(this.perfApprWindHeading)) {
+            this.approachSpeeds = new NXApprSpeeds(weight, this.perfApprFlaps3, this._towerHeadwind);
+        } else {
+            this.approachSpeeds = new NXApprSpeeds(weight, this.perfApprFlaps3);
+        }
+        this.approachSpeeds.valid = this.currentFlightPhase >= FlightPhase.FLIGHT_PHASE_APPROACH || isFinite(weight);
+    }
 
     updateAutopilot() {
         const now = performance.now();
@@ -1055,6 +1071,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             }
         }
         if (this.updateAutopilotCooldown < 0) {
+            this.updateApproachSpeeds();
             const currentApMasterStatus = SimVar.GetSimVarValue("AUTOPILOT MASTER", "boolean");
             if (currentApMasterStatus != this._apMasterStatus) {
                 this._apMasterStatus = currentApMasterStatus;
@@ -1296,6 +1313,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         switch (Simplane.getFlapsHandleIndex()) {
             case 0: return this.getPerfGreenDotSpeed();
             case 1: return this.getSlatApproachSpeed();
+            case 3: return this.perfApprFlaps3 ? this.getVApp() : this.getFlapApproachSpeed();
             case 4: return this.getVApp();
             default: return this.getFlapApproachSpeed();
         }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -558,6 +558,7 @@ class CDUPerformancePage {
         mcdu.onLeftInput[2] = (value) => {
             if (mcdu.setPerfApprWind(value)) {
                 mcdu.updateTowerHeadwind();
+                mcdu.updateApproachSpeeds();
                 CDUPerformancePage.ShowAPPRPage(mcdu);
             }
         };
@@ -570,21 +571,37 @@ class CDUPerformancePage {
                 CDUPerformancePage.ShowAPPRPage(mcdu);
             }
         };
+
         let vappCell = "---";
-        const vApp = mcdu.getVApp();
-        if (isFinite(vApp)) {
-            vappCell = vApp.toFixed(0);
+        let vlsCell = "---";
+        let flpRetrCell = "---";
+        let sltRetrCell = "---";
+        let cleanCell = "---";
+        if (mcdu.approachSpeeds && mcdu.approachSpeeds.valid) {
+            vappCell = mcdu.approachSpeeds.vapp.toFixed(0);
+            vlsCell = mcdu.approachSpeeds.vls.toFixed(0);
+            flpRetrCell = mcdu.approachSpeeds.f.toFixed(0) + "[color]green";
+            sltRetrCell = mcdu.approachSpeeds.s.toFixed(0) + "[color]green";
+            cleanCell = mcdu.approachSpeeds.gd.toFixed(0) + "[color]green";
+        }
+        if (isFinite(mcdu.vApp)) { // pilot override
+            vappCell = mcdu.vApp.toFixed(0);
         }
         mcdu.onLeftInput[4] = (value) => {
             if (mcdu.setPerfApprVApp(value)) {
                 CDUPerformancePage.ShowAPPRPage(mcdu);
             }
         };
-        let vlsCell = "---";
-        const vls = mcdu.getVLS();
-        if (isFinite(vls)) {
-            vlsCell = vls.toFixed(0);
-        }
+        mcdu.onRightInput[3] = () => {
+            mcdu.setPerfApprFlaps3(true);
+            mcdu.updateApproachSpeeds();
+            CDUPerformancePage.ShowAPPRPage(mcdu);
+        };
+        mcdu.onRightInput[4] = () => {
+            mcdu.setPerfApprFlaps3(false);
+            mcdu.updateApproachSpeeds();
+            CDUPerformancePage.ShowAPPRPage(mcdu);
+        };
         let finalCell = "-----";
         const approach = mcdu.flightPlanManager.getApproach();
         if (approach && approach.name) {
@@ -610,21 +627,6 @@ class CDUPerformancePage {
                 CDUPerformancePage.ShowAPPRPage(mcdu);
             }
         };
-        let flpRetrCell = "---";
-        const flapSpeed = mcdu.getFlapApproachSpeed();
-        if (isFinite(flapSpeed)) {
-            flpRetrCell = flapSpeed.toFixed(0) + "[color]green";
-        }
-        let sltRetrCell = "---";
-        const slatSpeed = mcdu.getSlatApproachSpeed();
-        if (isFinite(slatSpeed)) {
-            sltRetrCell = slatSpeed.toFixed(0) + "[color]green";
-        }
-        let cleanCell = "---";
-        const cleanSpeed = mcdu.getPerfGreenDotSpeed();
-        if (isFinite(cleanSpeed)) {
-            cleanCell = cleanSpeed.toFixed(0) + "[color]green";
-        }
 
         const bottomRowLabels = ["\xa0PREV", "NEXT\xa0"];
         const bottomRowCells = ["<PHASE", "PHASE>"];
@@ -659,6 +661,7 @@ class CDUPerformancePage {
                 CDUPerformancePage.ShowGOAROUNDPage(mcdu);
             };
         }
+
         mcdu.setTemplate([
             ["APPR[color]" + titleColor],
             ["QNH", "FINAL", "FLP RETR"],
@@ -668,9 +671,9 @@ class CDUPerformancePage {
             ["MAG WIND", "DH", "CLEAN"],
             [magWindHeadingCell + "°/" + magWindSpeedCell + "[color]cyan", dhCell + "[color]cyan", "0=" + cleanCell + "[color]green"],
             ["TRANS ALT", "LDG CONF"],
-            [transAltCell + "[color]cyan", "CONF3*[color]green"],
+            [transAltCell + "[color]cyan", mcdu.perfApprFlaps3 ? "CONF3[color]cyan" : "[s-text]CONF3*[color]cyan"],
             ["VAPP", "", "VLS"],
-            [vappCell + "[color]cyan", "FULL[color]green", vlsCell + "[color]green"],
+            [vappCell + "[color]cyan", mcdu.perfApprFlaps3 ? "[s-text]FULL*[color]cyan" : "FULL[color]cyan", vlsCell + "[color]green"],
             bottomRowLabels,
             bottomRowCells,
         ]);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -1336,30 +1336,8 @@ class FMCMainDisplay extends BaseAirliners {
         }
     }
 
-    getCleanApproachSpeed() {
-        let dWeight = (this.getWeight() - 42) / (75 - 42);
-        dWeight = Math.min(Math.max(dWeight, 0), 1);
-        const base = Math.max(172, this.getVLS() + 5);
-        return base + 40 * dWeight;
-    }
-
-    // Overridden by getManagedApproachSpeedMcdu in A320_Neo_CDU_MainDisplay
-    // Not sure what to do with this
-    getManagedApproachSpeed(flapsHandleIndex = NaN) {
-        switch (((isNaN(flapsHandleIndex)) ? Simplane.getFlapsHandleIndex() : flapsHandleIndex)) {
-            case 0:
-                return this.getCleanApproachSpeed();
-            case 1:
-                return this.getSlatApproachSpeed();
-            case 4:
-                return this.getVApp();
-            default:
-                return this.getFlapApproachSpeed();
-        }
-    }
-
     updateCleanApproachSpeed() {
-        const apprGreenDotSpeed = this.getCleanApproachSpeed();
+        const apprGreenDotSpeed = this.getPerfGreenDotSpeed();
         if (isFinite(apprGreenDotSpeed)) {
             SimVar.SetSimVarValue("L:AIRLINER_APPR_GREEN_DOT_SPD", "Number", apprGreenDotSpeed);
         }
@@ -2955,7 +2933,7 @@ class FMCMainDisplay extends BaseAirliners {
         }
         if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_APPROACH) {
             // Is this LVar used by anything? It doesn't look like it...
-            SimVar.SetSimVarValue("L:AIRLINER_MANAGED_APPROACH_SPEED", "number", this.getManagedApproachSpeed());
+            SimVar.SetSimVarValue("L:AIRLINER_MANAGED_APPROACH_SPEED", "number", this.getManagedApproachSpeedMcdu());
         }
         this.updateRadioNavState();
     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The MCDU PERF APPR page has a landing config selection, allowing either FULL or CONF 3. This selection alters the speeds displayed on the page, and the target approach speed V<sub>APP</sub>.

I have adjusted the formatting for the CONF 3 and FULL items on the APPR page to match the Honeywell manual. The latest rev. of the Honeywell FMS changes the format slightly but I have been unable to get a solid reference to date so I've elected to stick with step 1A for now (future PR to update if we decide to).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before:
(R4 and R5 INOP)
![image](https://user-images.githubusercontent.com/9995998/103679155-5e1f0e80-4fe9-11eb-9b40-ff629f364165.png)

After:
Full config selected (default):
![image](https://user-images.githubusercontent.com/9995998/103678787-dc2ee580-4fe8-11eb-9e66-11d197868144.png)
CONF3 selected:
![image](https://user-images.githubusercontent.com/9995998/103678818-eb159800-4fe8-11eb-9087-a75b515c8d34.png)



## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
Honeywell Step 1A MCDU:
![image](https://user-images.githubusercontent.com/9995998/103677119-c4566200-4fe6-11eb-8b18-9cc37160f325.png)
![image](https://user-images.githubusercontent.com/9995998/103677155-cfa98d80-4fe6-11eb-97ad-731283ea2569.png)
![image](https://user-images.githubusercontent.com/9995998/105576378-3d232f80-5dd7-11eb-8daa-13cf4eacadda.png)

FCOM (older unfortunately):
![image](https://user-images.githubusercontent.com/9995998/105576412-7b205380-5dd7-11eb-81f3-a2b3946d2acb.png)

FCOM bulletin 46/2:
![image](https://user-images.githubusercontent.com/9995998/105577464-ad817f00-5dde-11eb-819e-98ab7b181287.png)

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Prior to approach phase, the values shown on the PERF page are based on estimated landing weight, which in turn is based on ZFW and our EFOB at the destination. Upon activating the approach phase the current weight is used instead.

Many thanks to MisterChocker and BehEh for their advice and assistance on this.

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- VLS and Vapp, F, S and O speeds correct with both CONF 3 and FULL selected in MCDU.
- Magenta target on PFD speed tape is appropriate.
- Pilot override of Vapp affects PFD magenta target, and autopilot managed speed (see tooltip on speed knob during approach)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
