### PR TITLE
fix: BG Opacity on Clock, Rudder Trim & Transponder

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -24,6 +24,7 @@
 1. [CHECKLISTS] Fixed typo in Descent preparation checklist - @ronson1909 (Ronson1909)
 1. [TCAS] Fixed TCAS traffic mode switch not turning - @Saschl (saschl#9432)
 1. [FLIGHTMODEL] Fixed spoiiler auto-retract after landing - @donstim - (donbikes#4084)
+1. [DISPLAYS] Fixed background opacity on Clock, Rudder Trim & Transponder - @nathaninnes (Nathan Innes)
 
 ## 0.5.1
 1. [CDU] Allow SimBrief user IDs as well as usernames - @pareil6 (pareil6)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/ATC/A320_Neo_ATC.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/ATC/A320_Neo_ATC.css
@@ -1,50 +1,65 @@
 ﻿:root {
-  --bodyHeightScale: 1; }
+  --bodyHeightScale: 1;
+}
 
 @keyframes TemporaryShow {
-  0%, 100% {
-    visibility: visible; } }
+  0%,
+  100% {
+    visibility: visible;
+  }
+}
 
 @keyframes TemporaryHide {
-  0%, 100% {
-    visibility: hidden; } }
+  0%,
+  100% {
+    visibility: hidden;
+  }
+}
 
 #highlight {
   position: absolute;
   height: 100%;
   width: 100%;
-  z-index: 10; }
+  z-index: 10;
+}
 
 #Electricity {
   width: 100%;
-  height: 100%; }
-  #Electricity[state=off] {
-    display: none; 
-background-color: black;}
+  height: 100%;
+}
+#Electricity[state="off"] {
+  display: none;
+  background-color: black;
+}
 
 @font-face {
   font-family: "Roboto";
   src: url("/Fonts/RobotoMono-Medium.ttf") format("truetype");
   font-weight: normal;
-  font-style: normal; }
+  font-style: normal;
+}
 
 @font-face {
   font-family: "Roboto-Light";
   src: url("/Fonts/RobotoMono-Light.ttf") format("truetype");
   font-weight: normal;
-  font-style: normal; }
+  font-style: normal;
+}
 
 @font-face {
   font-family: "Roboto-Bold";
   src: url("/Fonts/RobotoMono-Bold.ttf") format("truetype");
   font-weight: normal;
-  font-style: normal; }
+  font-style: normal;
+}
 
 @font-face {
   font-family: "Digital";
-  src: url("/Pages/VCockpit/Instruments/Shared/Fonts/digital.ttf") format("truetype");
+  src: url("/Pages/VCockpit/Instruments/Shared/Fonts/digital.ttf")
+    format("truetype");
   font-weight: 900;
-  font-style: normal; }
+  font-style: normal;
+}
 
 a320-neo-atc {
   width: 100%;
@@ -53,22 +68,25 @@ a320-neo-atc {
   overflow: hidden;
   border: 10px solid rgba(25, 40, 58, 0.219);
   padding: 18px;
-  background-clip:content-box; }
-  a320-neo-atc svg {
-    width: 100%;
-    height: 100%; }
-  a320-neo-atc text {
-    font-family: Digital;
-    font-size: 80px;
-    text-anchor: end;
-    fill: #5f482e;
-    letter-spacing: 22px;
-    alignment-baseline: central; }
-  a320-neo-atc #Content {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    left: 0%;
-    top: 0%;
-    background-color: rgba(39, 10, 43, 0.548); }
-
+  background-clip: content-box;
+}
+a320-neo-atc svg {
+  width: 100%;
+  height: 100%;
+}
+a320-neo-atc text {
+  font-family: Digital;
+  font-size: 80px;
+  text-anchor: end;
+  fill: #5f482e;
+  letter-spacing: 22px;
+  alignment-baseline: central;
+}
+a320-neo-atc #Content {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0%;
+  top: 0%;
+  background-color: rgb(37, 10, 40);
+}

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Clock/A320_Neo_Clock.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/Clock/A320_Neo_Clock.css
@@ -1,112 +1,134 @@
 :root {
-  --bodyHeightScale: 1; }
+  --bodyHeightScale: 1;
+}
 
 @keyframes TemporaryShow {
-  0%, 100% {
-    visibility: visible; } }
+  0%,
+  100% {
+    visibility: visible;
+  }
+}
 
 @keyframes TemporaryHide {
-  0%, 100% {
-    visibility: hidden; } }
+  0%,
+  100% {
+    visibility: hidden;
+  }
+}
 
 #highlight {
   position: absolute;
   height: 100%;
   width: 100%;
-  z-index: 10; }
+  z-index: 10;
+}
 
 #Electricity {
   width: 100%;
-  height: 100%; }
-  #Electricity[state=off] {
-    display: none; }
+  height: 100%;
+}
+#Electricity[state="off"] {
+  display: none;
+}
 
 @font-face {
   font-family: "Roboto";
   src: url("/Fonts/RobotoMono-Medium.ttf") format("truetype");
   font-weight: normal;
-  font-style: normal; }
+  font-style: normal;
+}
 
 @font-face {
   font-family: "Roboto-Light";
   src: url("/Fonts/RobotoMono-Light.ttf") format("truetype");
   font-weight: normal;
-  font-style: normal; }
+  font-style: normal;
+}
 
 @font-face {
   font-family: "Roboto-Bold";
   src: url("/Fonts/RobotoMono-Bold.ttf") format("truetype");
   font-weight: normal;
-  font-style: normal; }
+  font-style: normal;
+}
 
 @font-face {
   font-family: "Alarm-Clock";
-  src: url("/Pages/VCockpit/Instruments/Shared/Fonts/digital.ttf") format("truetype");
+  src: url("/Pages/VCockpit/Instruments/Shared/Fonts/digital.ttf")
+    format("truetype");
   font-weight: normal;
-  font-style: normal; }
+  font-style: normal;
+}
 
 a320-neo-clock-element {
   width: 100%;
   height: 100%;
-  overflow: hidden; }
-  a320-neo-clock-element #Mainframe {
-    position: absolute;
-    top: -4%;
-    bottom: 0;
-    left: 2%;
-    right: 0; 
-    background-color: rgba(5, 40, 80, 0.623);
-    color: rgba(155, 148, 148, 0.911);}
-    a320-neo-clock-element #Mainframe #TopSelector {
-      margin-top: 0%;
-      width: 100%;
-      height: 35%;
-      display: flex;
-      align-items: center;
-      justify-content: center; }
-      a320-neo-clock-element #Mainframe #TopSelector #TopSelectorValue {
-        font-family: Alarm-Clock;
-        font-size: 81px;
-        text-align: center;
-        color: rgba(155, 148, 148, 0.911); }
-    a320-neo-clock-element #Mainframe #MiddleSelector {
-      margin-top: 0%;
-      margin-left: 0%;
-      width: 80%;
-      height: 35%;
-      display: flex; 
-      align-items: center;
-      justify-content: center; 
-      }
-      a320-neo-clock-element #Mainframe #MiddleSelector #MiddleSelectorValue {
-        font-family: Alarm-Clock;
-        font-size: 81px;
-        margin-left: 2%;
-        margin-right: 5%;
-        width: 95%;
-        text-align: right;
-        /* font-kerning: none; Note: this one is in stdby for a new font */
-        color: rgba(155, 148, 148, 0.911); }
-      a320-neo-clock-element #Mainframe #MiddleSelector #MiddleSelectorValue2 {
-          font-family: Alarm-Clock;
-          font-size: 65px;
-          margin-left: 0%;
-          margin-right: 0%;
-          width: 5%;
-          text-align: right;
-          vertical-align: middle;
-          color: rgba(155, 148, 148, 0.911); }
+  overflow: hidden;
+}
+a320-neo-clock-element #Mainframe {
+  position: absolute;
+  top: -4%;
+  bottom: 0;
+  left: 2%;
+  right: 0;
+  background-color: rgb(5, 29, 59);
+  color: rgba(155, 148, 148, 0.911);
+}
+a320-neo-clock-element #Mainframe #TopSelector {
+  margin-top: 0%;
+  width: 100%;
+  height: 35%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+a320-neo-clock-element #Mainframe #TopSelector #TopSelectorValue {
+  font-family: Alarm-Clock;
+  font-size: 81px;
+  text-align: center;
+  color: rgba(155, 148, 148, 0.911);
+}
+a320-neo-clock-element #Mainframe #MiddleSelector {
+  margin-top: 0%;
+  margin-left: 0%;
+  width: 80%;
+  height: 35%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+a320-neo-clock-element #Mainframe #MiddleSelector #MiddleSelectorValue {
+  font-family: Alarm-Clock;
+  font-size: 81px;
+  margin-left: 2%;
+  margin-right: 5%;
+  width: 95%;
+  text-align: right;
+  /* font-kerning: none; Note: this one is in stdby for a new font */
+  color: rgba(155, 148, 148, 0.911);
+}
+a320-neo-clock-element #Mainframe #MiddleSelector #MiddleSelectorValue2 {
+  font-family: Alarm-Clock;
+  font-size: 65px;
+  margin-left: 0%;
+  margin-right: 0%;
+  width: 5%;
+  text-align: right;
+  vertical-align: middle;
+  color: rgba(155, 148, 148, 0.911);
+}
 
-    a320-neo-clock-element #Mainframe #BottomSelector {
-      margin-top: 1%;
-      width: 100%;
-      height: 35%;
-      display: flex;
-      align-items: center;
-      justify-content: center; }
-      a320-neo-clock-element #Mainframe #BottomSelector #BottomSelectorValue {
-        font-family: Alarm-Clock;
-        font-size: 81px;
-        text-align: center;
-        color: rgba(155, 148, 148, 0.911); }
-
+a320-neo-clock-element #Mainframe #BottomSelector {
+  margin-top: 1%;
+  width: 100%;
+  height: 35%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+a320-neo-clock-element #Mainframe #BottomSelector #BottomSelectorValue {
+  font-family: Alarm-Clock;
+  font-size: 81px;
+  text-align: center;
+  color: rgba(155, 148, 148, 0.911);
+}

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/RTPI/A320_Neo_RTPI.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/RTPI/A320_Neo_RTPI.css
@@ -1,78 +1,97 @@
 ﻿:root {
-  --bodyHeightScale: 1; }
+  --bodyHeightScale: 1;
+}
 
 @keyframes TemporaryShow {
-  0%, 100% {
-    visibility: visible; } }
+  0%,
+  100% {
+    visibility: visible;
+  }
+}
 
 @keyframes TemporaryHide {
-  0%, 100% {
-    visibility: hidden; } }
+  0%,
+  100% {
+    visibility: hidden;
+  }
+}
 
 #highlight {
   position: absolute;
   height: 100%;
   width: 100%;
-  z-index: 10; }
+  z-index: 10;
+}
 
 #Electricity {
   width: 100%;
-  height: 100%; }
-  #Electricity[state=off] {
-    display: none; 
-    background-color: black;}
+  height: 100%;
+}
+#Electricity[state="off"] {
+  display: none;
+  background-color: black;
+}
 
 @font-face {
   font-family: "Roboto";
   src: url("/Fonts/RobotoMono-Medium.ttf") format("truetype");
   font-weight: normal;
-  font-style: normal; }
+  font-style: normal;
+}
 
 @font-face {
   font-family: "Roboto-Light";
   src: url("/Fonts/RobotoMono-Light.ttf") format("truetype");
   font-weight: normal;
-  font-style: normal; }
+  font-style: normal;
+}
 
 @font-face {
   font-family: "Roboto-Bold";
   src: url("/Fonts/RobotoMono-Bold.ttf") format("truetype");
   font-weight: normal;
-  font-style: normal; }
+  font-style: normal;
+}
 
 @font-face {
   font-family: "Digital";
-  src: url("/Pages/VCockpit/Instruments/Shared/Fonts/digital.ttf") format("truetype");
+  src: url("/Pages/VCockpit/Instruments/Shared/Fonts/digital.ttf")
+    format("truetype");
   font-weight: 900;
-  font-style: normal; }
+  font-style: normal;
+}
 
 a320-neo-rtpi {
   width: 110%;
   height: 100%;
   position: relative;
   overflow: hidden;
-  }
-  a320-neo-rtpi svg {
-    width: 105%;
-    height: 100%; }
-  a320-neo-rtpi text {
-    font-family: Digital;
-    font-size: 150px;
-    fill: #5f482e;
-    /* fill: #985d1c; */
-    letter-spacing: -5px;
-    alignment-baseline: central; }
-  a320-neo-rtpi #Content {
-    position: absolute;
-    width: 105%;
-    height: 100%;
-    left: -5%;
-    top: -6%;
-    background-color: rgba(32, 19, 2, 0.884);}
-  a320-neo-rtpi #Content #Direction {
-      text-anchor: start; 
-      left: -10%;}
-    a320-neo-rtpi #Content #Value {
-      text-anchor: end; 
-      right: -8%;}
-
+}
+a320-neo-rtpi svg {
+  width: 105%;
+  height: 100%;
+}
+a320-neo-rtpi text {
+  font-family: Digital;
+  font-size: 150px;
+  fill: #5f482e;
+  /* fill: #985d1c; */
+  letter-spacing: -5px;
+  alignment-baseline: central;
+}
+a320-neo-rtpi #Content {
+  position: absolute;
+  width: 105%;
+  height: 100%;
+  left: -5%;
+  top: -6%;
+  background-color: rgb(32, 19, 2);
+}
+a320-neo-rtpi #Content #Direction {
+  text-anchor: start;
+  left: -10%;
+}
+a320-neo-rtpi #Content #Value {
+  text-anchor: end;
+  right: -8%;
+}


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes N/A

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixed background opacity of the Clock, Transponder and rudder trim backlighting to not be transparent.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before: 
![image](https://user-images.githubusercontent.com/18389085/103710220-686ee780-4fac-11eb-87eb-57a9d34b60bf.png)

After:
![image](https://user-images.githubusercontent.com/18389085/103710094-13cb6c80-4fac-11eb-8bce-9e42f0751ea6.png)

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
N/A

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
N/A
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
Sabes#8668
## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
You can spawn C&D and turn on electricity and check for any errors or unexpected behaviour with the mentioned displays. The only thing changed is the opacity so you should not really notice anything unless you have msfs-webui-devkit.



<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
