### PR TITLE
fix: upper ECAM showing engineering mode overlay

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -30,8 +30,8 @@
 1. [ADIRS] Added "ON BAT" light to ADIRS panel - @tyler58546 (tyler58546)
 1. [MCDU] Fixed INIT-A CRZ Temp insert - @MisterChocker (Leon)
 1. [MCDU] Fixed APPR/GO AROUND page order - @beheh (Benedict Etzel)
-1. [ECAM] Fixed engineering mode overlay displaying on upper ECAM in some cases - @davidwalschots (David Walschots)
 1. [OPTIONS] Changed unit option changes only effective after aircraft reload - @MisterChocker (Leon)
+1. [ECAM] Fixed engineering mode overlay displaying on upper ECAM in some cases - @davidwalschots (David Walschots)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -28,6 +28,7 @@
 1. [CHECKLISTS] Removed various outdated INOPs from the checklist - @Venorcis (Venorcis)
 1. [MCDU] Improved scratchpad handling on - @MisterChocker (Leon)
 1. [ADIRS] Added "ON BAT" light to ADIRS panel - @tyler58546 (tyler58546)
+1. [ECAM] Fixed engineering mode overlay displaying on upper ECAM in some cases - @davidwalschots (David Walschots)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.html
@@ -106,23 +106,8 @@
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/NavSystems/A320_Neo/A32NX_NavSystem.js"></script>
 
-<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/EICAS_Common.html"></script> <!-- MODIFIED -->
-
-<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.html"></script> <!-- MODIFIED -->
-<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.html"></script>
-<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_COND.html"></script> <!-- MODIFIED -->
-<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.html"></script>
-<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Elec.html"></script>
-<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.html"></script> <!-- MODIFIED -->
-<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_PRESS.html"></script> <!-- MODIFIED -->
-<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.html"></script> <!-- MODIFIED -->
-<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.html"></script> <!-- MODIFIED -->
-<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Status.html"></script> <!-- MODIFIED -->
-<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_CRZ.html"></script> <!-- MODIFIED -->
-<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_WHEEL.html"></script>
-<script type="text/html" import-template="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.html"></script>
-
-<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/A32NX_BaseAirliners.js"></script>
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/A32NX_BaseAirliners.js" 
+    import-after="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/EICAS_Common.html,/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Engine.html,/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.html,/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_COND.html,/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Fuel.html,/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Elec.html,/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.html,/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_PRESS.html,/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.html,/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_FTCL.html,/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Status.html,/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_CRZ.html,/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_WHEEL.html,/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.html"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_ECAMGauge.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js"></script>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.html
@@ -20,7 +20,6 @@
 </script>
 
 <script type="text/html" import-script="/JS/dataStorage.js"></script>
-<script type="text/html" import-script="/Pages/A32NX_Utils/NXDataStore.js"></script>
 <script type="text/html" import-script="/Pages/A32NX_Utils/NXLogic.js"></script>
 
 <!-- LOCAL SCRIPTS -->

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,7 +1,7 @@
 # Development Resources
 
 ## Tools:
-- [WebUI-DevKit](https://github.com/dga711/msfs-webui-devkit) - In-game development overlay for html-ui content. Provides fast reload, console output, and more! Note that after setting up WebUI-DevKit sometimes panels don't load correctly. Reloading the panels one or more times using <kbd>ALT</kbd> + <kbd>R</kbd> usually "fixes" these problems.
+- [WebUI-DevKit](https://github.com/dga711/msfs-webui-devkit) - In-game development overlay for html-ui content. Provides fast reload, console output, and more!
 - [devtools-backend-refurb](https://github.com/dga711/devtools-backend-refurb) - Chrome devtools server targeting Coherent GT. Gives you devtools for html-ui content. WARNING: This is still a work in progress, and tends to be very finnicky.
 
 

--- a/typings/fs-base-ui/html_ui/JS/common.d.ts
+++ b/typings/fs-base-ui/html_ui/JS/common.d.ts
@@ -912,6 +912,35 @@ declare global {
         addImport(): void;
     }
 
+    /**
+     * The component manager among other things handles the importing of scripts and templates.
+     * 
+     * The first two examples are for basic usage scenarios. These examples are insufficient for
+     * situations where a script or template depends on another script, e.g. when it depends on a
+     * class defined in that script. The following attributes are available to handle these cases:
+     * 
+     * `import-async`: when set to false, **all** scripts imported from that moment onward are loaded
+     * synchronously. I.e. they are loaded in the order they are listed. As this impact loading
+     * times using this attribute is **not recommended**.
+     * 
+     * `import-after`: any resource listed in this attribute will be imported after the script
+     * declared in the `import-script` attribute was imported. `import-after` supports
+     * declaring multiple values by using a `,` separator. Note that `import-after` is not supported
+     * for `import-template`.
+     * 
+     * Note that a template imported with `import-template` might itself contain references to
+     * other resources. Managing the import sequence of resources across multiple templates is
+     * unsupported. Thus, if you need to manage the import order of resources within a template,
+     * move the resources referenced by these templates to the importer of said template.
+     * 
+     * @example
+     * <script type="text/html" import-script="path/to/script.js"></script>
+     * @example
+     * <script type="text/html" import-template="path/to/template.html"></script>
+     * @example
+     * <script type="text/html" import-script="path/to/script.js" 
+     *   import-after="path/to/template.html,path/to/template.html"></script>
+     */
     class ComponentMgr {
         onNodeInserted(event: Event): void;
         checkAllComponents(): void;


### PR DESCRIPTION
## Summary of Changes
When developing the a32nx in combination with WebUI-DevKit for debugging purposes, the upper ECAM often showed the engineering mode overlay instead of the normal view. Whenever this happened, there were many errors in the console stating an `update` function couldn't be found on the `eicas-common-display`.

I traced this issue to the loading of scripts using the `import-script` attribute. Scripts by default are loaded asynchronously, meaning the declaration order isn't the loading order. In practice, usually this doesn't lead to problems because the file system and browser cache provides files at a quick enough rate for the order to be respected in most cases. However, as WebUI-DevKit has cache-busting code which removes caching altogether, the issue was more likely visible with it. The issue did also affect regular users of the a32nx, albeit odds of running into the issue were much smaller.

The various ECAM templates and scripts depend on the `EICASTemplateElement` class, which is declared in `A32NX_BaseAirliners.js`. I've now configured the loading such that it will always load that file first, before loading the ECAM templates.

Loading the `NXDataStore.js` twice also caused errors, which I resolved by removing one of the imports.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Test the ECAM displays function as expected.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
