### PR TITLE
build: workflow in container instead of spawning new ones

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    container: ghcr.io/flybywiresim/dev-env:latest
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout source
@@ -17,17 +18,18 @@ jobs:
       - name: install
         run: npm install --no-optional
       - name: lint
-        run: ./scripts/dev-env/run.sh npm run lint
+        run: npm run lint
   build:
     runs-on: ubuntu-latest
+    container: ghcr.io/flybywiresim/dev-env:latest
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
-      - name: Generate layout.json and update manifest.json
+      - name: build
         run: |
-          ./scripts/dev-env/run.sh ./scripts/setup.sh
-          ./scripts/dev-env/run.sh ./scripts/build.sh
+          ./scripts/setup.sh
+          ./scripts/build.sh
 
           mkdir tmp_A32NX
           mv A32NX tmp_A32NX/


### PR DESCRIPTION
## Summary of Changes
Workflow jobs run inside of the dev-env instead of spawning new containers.

## Screenshots (if necessary)

## References

## Additional context

Discord username (if different from GitHub): nistei#1362

## Testing instructions
No aircraft changes


## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
