### PR TITLE
Fix pressure page javascript error

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_PRESS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_PRESS.js
@@ -207,7 +207,7 @@ var A320_Neo_LowerECAM_PRESS;
             return indicatorRot;
         }
 
-        update() {
+        update(_deltaTime) {
             if (!this.isInitialised || !A320_Neo_EICAS.isOnBottomScreen()) {
                 return;
             }


### PR DESCRIPTION
## Summary of Changes
Fix pressure page javascript error

## Screenshots (if necessary)
n/a

## References
n/a

## Testing instructions
Enable msfs dev util, go to lower ECAM pressure page, ensure no javascript errors.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
