### PR TITLE
fix: FCU baro knob overlapping text and emissive removed

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -38,6 +38,7 @@
 1. [DISPLAYS] Optimize performance by throttling instrument updates - @XSJoJo (Jorim Jaggi)
 1. [ECAM] Added F/CTL FLAP/MCDU DISAGREE check - @MisterChocker (Leon)
 1. [MISC] Changed AIRCOND knobs starting position to 12 o'clock - @ImenesFBW (Imenes)
+1. [FCU] Fixed baro knob overlapping text and emissive removed - @DarkOfNova (DarkOfNova), @ImenesFBW (Imenes)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/src/behavior/src/A32NX_Interior_FCU.xml
+++ b/src/behavior/src/A32NX_Interior_FCU.xml
@@ -96,6 +96,9 @@
                 <WWISE_EVENT_1>autopilot_knob_push_button_on</WWISE_EVENT_1>
                 <WWISE_EVENT_2>autopilot_knob_push_button_off</WWISE_EVENT_2>
             </UseTemplate>
+            <!--Disables baro knob emissive-->
+            <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
+            </UseTemplate>
         </Component>
     </Template>
 

--- a/src/behavior/src/A32NX_Interior_FCU.xml
+++ b/src/behavior/src/A32NX_Interior_FCU.xml
@@ -96,7 +96,7 @@
                 <WWISE_EVENT_1>autopilot_knob_push_button_on</WWISE_EVENT_1>
                 <WWISE_EVENT_2>autopilot_knob_push_button_off</WWISE_EVENT_2>
             </UseTemplate>
-            <!--Disables baro knob emissive-->
+            <!--Disables FCU baro knob emissive-->
             <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
             </UseTemplate>
         </Component>


### PR DESCRIPTION

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #2687

## Summary of Changes
- Removes overlapping text on the FCU Baro knob ( credit to @DarkOfNova for the texture fix)
- Adds additional template to prevent the FCU Baro knob emissive to load since the Baro knob is not backlit. 
## Screenshots (if necessary)

BEFORE:
![image](https://user-images.githubusercontent.com/71195324/105400027-aca4ed80-5c24-11eb-80ae-9afdbe64dfdd.png)


![before](https://user-images.githubusercontent.com/71195324/105397928-fb04bd00-5c21-11eb-98ee-b30d21829a92.PNG)

AFTER:
![knob](https://user-images.githubusercontent.com/71195324/105399954-9434d300-5c24-11eb-9973-76e82ad0cb7b.PNG)
![after](https://user-images.githubusercontent.com/71195324/105399963-972fc380-5c24-11eb-9d35-bea5830420a4.PNG)

## References

Baro knob should not be backlit. Confirmed by multiple real-world pilots.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
DarkOfNova#2688
Imenes#8739


## Testing instructions

Tier 1 test required. Make sure the FCU baro knob does not light up at any point and test the functionality of the knob.
Check the text on the knob to make sure the overlapping text issue is fixed. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
