### PR TITLE
fix: disable tiller plate emissive

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -44,6 +44,7 @@
 1. [SOUND] Reworked touchdown sounds - @hotshotp (Boris)
 1. [MISC] Added printer - @tyler58546 (tyler58546), @DarkOfNova (DarkOfNova)
 1. [ECAM] Added CONF/FLAPS 3 memos when GPWS LDG FLAPS 3 enabled - @tracernz (Mike)
+1. [MISC] Disabled left tiller deflection emissive - @ImenesFBW (Imenes)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -744,6 +744,11 @@
                 <!--<POTENTIOMETER>85</POTENTIOMETER>-->
                 <EMISSIVE_CODE>0</EMISSIVE_CODE>
             </UseTemplate>
+            <!-- This disables tiller deflection emissive -->
+            <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
+                <NODE_ID>YOKE_DECAL</NODE_ID>
+                <EMISSIVE_CODE>0</EMISSIVE_CODE>
+            </UseTemplate>
 
             <!-- NYI
         <UseTemplate Name="FBW_AIRBUS_Push_Transfer_Template">


### PR DESCRIPTION
## Summary of Changes

- Disables left steering tiller emissive since the tiller deflection plate should not be illuminated.

## Screenshots (if necessary)
BEFORE:
![image](https://user-images.githubusercontent.com/71195324/105771145-68855600-5f60-11eb-89f5-342b8d7e4265.png)

AFTER:
![afterpudhe](https://user-images.githubusercontent.com/71195324/105771313-aaae9780-5f60-11eb-92bf-ccfa3c0d1ca5.PNG)


## References
The Tiller plate is not backlit as confirmed by IRL A320 pilots.

## Additional context

Discord username: Imenes#8739

## Testing instructions

Tier 1. Make sure that the left steering tiller deflection plate is not illuminated. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
