### PR TITLE
build: fixed build metadata when run on github action

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,10 +41,17 @@ build_metadata() {
     if [ -z "${GITHUB_EVENT_NAME}" ]; then
         GITHUB_EVENT_NAME="manual"
     fi
+    if [ -z "${GITHUB_REF}" ]; then
+        GITHUB_REF="$(git show-ref HEAD)"
+    fi
+    if [ -z "${GITHUB_SHA}" ]; then
+        GITHUB_SHA="$(git show-ref -s HEAD)"
+    fi
+    GITHUB_BUILT="$(date -u -Iseconds)"
     jq -n \
-        --arg built "$(date -u -Iseconds)" \
-        --arg ref "$(git show-ref HEAD | awk '{print $2}')" \
-        --arg sha "$(git show-ref -s HEAD)" \
+        --arg built "${GITHUB_BUILT}" \
+        --arg ref "${GITHUB_REF##*/}" \
+        --arg sha "${GITHUB_SHA}" \
         --arg actor "${GITHUB_ACTOR}" \
         --arg event_name "${GITHUB_EVENT_NAME}" \
         '{ built: $built, ref: $ref, sha: $sha, actor: $actor, event_name: $event_name }' \

--- a/scripts/dev-env/run.sh
+++ b/scripts/dev-env/run.sh
@@ -12,4 +12,11 @@ fi
 # Disable git-bash path conversion on windows
 export MSYS_NO_PATHCONV=1
 
-docker run --rm $TTY_PARAM -v "$(pwd)":/external ghcr.io/flybywiresim/dev-env "$@"
+docker run \
+    --rm $TTY_PARAM \
+    -e GITHUB_ACTOR="${GITHUB_ACTOR}" \
+    -e GITHUB_REF="${GITHUB_REF}" \
+    -e GITHUB_SHA="${GITHUB_SHA}" \
+    -v "$(pwd)":/external \
+    ghcr.io/flybywiresim/dev-env \
+    "$@"


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes the build metadata in the delivery. It will then correctly contain the sha, ref and actor.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
