### PR TITLE
fix(apu): MASTER SW reversed push state

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -1402,8 +1402,10 @@
                         }
                     </LEFT_SINGLE_CODE>
                     <DOWN_CODE>(L:A32NX_APU_MASTER_SW_ACTIVATED, Bool)</DOWN_CODE>
+
                     <SEQ1_CODE>(L:A32NX_APU_MASTER_FAULT, Bool)</SEQ1_CODE>
                     <SEQ2_CODE>(L:A32NX_APU_MASTER_SW_ACTIVATED, Bool)</SEQ2_CODE>
+                    
                     <TOOLTIPID>%((L:A32NX_APU_MASTER_SW_ACTIVATED, Bool))%{if}TT:COCKPIT.TOOLTIPS.APU_SWITCH_TURN_OFF%{else}TT:COCKPIT.TOOLTIPS.APU_SWITCH_TURN_ON%{end}</TOOLTIPID>
                 </UseTemplate>
 

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -1401,6 +1401,7 @@
                             }
                         }
                     </LEFT_SINGLE_CODE>
+                    <DOWN_CODE>(L:A32NX_APU_MASTER_SW_ACTIVATED, Bool)</DOWN_CODE>
                     <SEQ1_CODE>(L:A32NX_APU_MASTER_FAULT, Bool)</SEQ1_CODE>
                     <SEQ2_CODE>(L:A32NX_APU_MASTER_SW_ACTIVATED, Bool)</SEQ2_CODE>
                     <TOOLTIPID>%((L:A32NX_APU_MASTER_SW_ACTIVATED, Bool))%{if}TT:COCKPIT.TOOLTIPS.APU_SWITCH_TURN_OFF%{else}TT:COCKPIT.TOOLTIPS.APU_SWITCH_TURN_ON%{end}</TOOLTIPID>


### PR DESCRIPTION
## Summary of Changes
Recently the `FBW_Push_Toggle` XML template was added. It has many great features which simplify the way we define elements in the cockpit. However, not all buttons that use `LEFT_SINGLE_CODE` have the `DOWN_CODE` set; while they should. For the APU MASTER SW specifically this caused a bug where one could reverse the push state of the push button: the button was `in` when OFF and `out` when ON if you didn't turn on the batteries before pressing the MASTER SW.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

## Testing instructions
1. Start with a cold and dark cockpit.
2. Press the APU MASTER SW.
3. Turn both batteries ON.
4. Press the APU MASTER SW.

Expected: The APU MASTER SW is ON, with the button pushed in.
Actual: The APU MASTER SW is ON, with the button out.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
