### PR TITLE
feat(apu): FLAP OPEN indication until fully closed

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/sound/sound.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/sound/sound.xml
@@ -41,12 +41,12 @@
         <Sound WwiseEvent="LEFT_WING_SCRAPE" ContinuousStopDelay="0.25" FadeOutType="2" FadeOutTime="0.25" WwiseData="true" NodeName="AILERON_RIGHT001"/>
         <Sound WwiseEvent="RIGHT_WING_SCRAPE" ContinuousStopDelay="0.25" FadeOutType="2" FadeOutTime="0.25" WwiseData="true" NodeName="AILERON_RIGHT" />
         <Sound WwiseEvent="FUSELAGE_SCRAPE" ContinuousStopDelay="0.5" FadeOutType="1" FadeOutTime="0.1" WwiseData="true" />
-        
+
           <Sound WwiseEvent="CENTER_TOUCHDOWN" ViewPoint="Outside" FadeOutType="2" FadeOutTime="0.5" WwiseData="true" >
 		<WwiseRTPC SimVar="WHEEL RPM" Units="RPM" Index="0" Derived="true" RTPCName="SIMVAR_WHEEL_RPM_DERIVED"/>
 		<WwiseRTPC SimVar="VERTICAL SPEED" Units="FEET PER MINUTE" Derived="true" Index="0" RTPCName="SIMVAR_VERTICAL_SPEED_DERIVED" />
-	</Sound> 
-	<Sound WwiseEvent="LEFT_TOUCHDOWN" ViewPoint="Outside" FadeOutType="2" FadeOutTime="0.5" WwiseData="true" >  
+	</Sound>
+	<Sound WwiseEvent="LEFT_TOUCHDOWN" ViewPoint="Outside" FadeOutType="2" FadeOutTime="0.5" WwiseData="true" >
 		<WwiseRTPC SimVar="WHEEL RPM" Units="RPM" Index="1" Derived="true" RTPCName="SIMVAR_WHEEL_RPM_DERIVED"/>
 		<WwiseRTPC SimVar="VERTICAL SPEED" Units="FEET PER MINUTE" Derived="true" Index="0" RTPCName="SIMVAR_VERTICAL_SPEED_DERIVED" />
 	</Sound>
@@ -54,7 +54,7 @@
 		<WwiseRTPC SimVar="WHEEL RPM" Units="RPM" Index="2" Derived="true" RTPCName="SIMVAR_WHEEL_RPM_DERIVED"/>
 		<WwiseRTPC SimVar="VERTICAL SPEED" Units="FEET PER MINUTE" Derived="true" Index="0" RTPCName="SIMVAR_VERTICAL_SPEED_DERIVED" />
 	</Sound>
-	
+
     </GroundSounds>
 
     <MiscellaneousSounds>
@@ -72,44 +72,44 @@
         </Sound>
 
         <!-- APU  =========================================================================  -->
-        
+
         <Sound WwiseData="true" WwiseEvent="apuwhine" ViewPoint="Inside" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="A32NX_APU_N" Units="PERCENT" Index="0">
             <WwiseRTPC LocalVar="A32NX_APU_N" Units="PERCENT" Index="0" RTPCName="SIMVAR_APU_PCT_RPM" />
             <WwiseRTPC LocalVar="A32NX_APU_N" Derived="true" Units="PERCENT" Index="0" RTPCName="SIMVAR_APU_PCT_RPM_DERIVED" />
             <Range LowerBound="1.0" />
         </Sound>
-        
+
         <Sound WwiseData="true" WwiseEvent="apuwhine2" ViewPoint="Inside" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="A32NX_APU_N" Units="PERCENT" Index="0">
             <WwiseRTPC LocalVar="A32NX_APU_N" Units="PERCENT" Index="0" RTPCName="SIMVAR_APU_PCT_RPM" />
             <WwiseRTPC LocalVar="A32NX_APU_N" Derived="true" Units="PERCENT" Index="0" RTPCName="SIMVAR_APU_PCT_RPM_DERIVED" />
             <Range LowerBound="1.0" />
         </Sound>
-        
+
         <Sound WwiseData="true" WwiseEvent="apubass" ViewPoint="Inside" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="A32NX_APU_N" Units="PERCENT" Index="0">
             <WwiseRTPC LocalVar="A32NX_APU_N" Units="PERCENT" Index="0" RTPCName="SIMVAR_APU_PCT_RPM" />
             <WwiseRTPC LocalVar="A32NX_APU_N" Derived="true" Units="PERCENT" Index="0" RTPCName="SIMVAR_APU_PCT_RPM_DERIVED" />
             <Range LowerBound="8.0" />
         </Sound>
-        
+
         <Sound WwiseData="true" WwiseEvent="apubass2" ViewPoint="Inside" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="A32NX_APU_N" Units="PERCENT" Index="0">
             <WwiseRTPC LocalVar="A32NX_APU_N" Units="PERCENT" Index="0" RTPCName="SIMVAR_APU_PCT_RPM" />
             <WwiseRTPC LocalVar="A32NX_APU_N" Derived="true" Units="PERCENT" Index="0" RTPCName="SIMVAR_APU_PCT_RPM_DERIVED" />
             <Range LowerBound="1.0" />
         </Sound>
-        
+
         <Sound WwiseData="true" WwiseEvent="apurun" ViewPoint="Inside" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="A32NX_APU_N" Units="PERCENT" Index="0">
             <WwiseRTPC LocalVar="A32NX_APU_N" Units="PERCENT" Index="0" RTPCName="SIMVAR_APU_PCT_RPM" />
             <WwiseRTPC LocalVar="A32NX_APU_N" Derived="true" Units="PERCENT" Index="0" RTPCName="SIMVAR_APU_PCT_RPM_DERIVED" />
             <WwiseRTPC SimVar="TURB ENG N1" Units="percent" Index="2" RTPCName="SIMVAR_TURB_ENG_N1" />
             <Range LowerBound="1.0" />
         </Sound>
-        
+
         <Sound WwiseData="true" WwiseEvent="apushut" Continuous="false" ViewPoint="Inside" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="A32NX_APU_N" Units="PERCENT" Index="0">
         <WwiseRTPC LocalVar="A32NX_APU_N" Units="PERCENT" Index="0" RTPCName="SIMVAR_APU_PCT_RPM" />
             <WwiseRTPC LocalVar="A32NX_APU_N" Derived="true" Units="PERCENT" Index="0" RTPCName="SIMVAR_APU_PCT_RPM_DERIVED" />
             <Range LowerBound="75" UpperBound="98" />
         </Sound>
-        
+
           <Sound WwiseData="true" WwiseEvent="apustartinit" Continuous="false" ViewPoint="Inside" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="A32NX_APU_N" Units="PERCENT" Index="0">
           <WwiseRTPC LocalVar="A32NX_APU_N" Derived="true" Units="PERCENT" Index="0" RTPCName="SIMVAR_APU_PCT_RPM_DERIVED" />
             <Range LowerBound="1.0" />
@@ -117,12 +117,12 @@
 
         <Sound WwiseData="true" WwiseEvent="apuflapopen" FadeOutType="2" FadeOutTime="1" Continuous="true" ViewPoint="Inside" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="A32NX_APU_MASTER_SW_ACTIVATED" Units="BOOLEAN">
             <Range LowerBound="1.0" />
-            <Requires LocalVar="APU_FLAP_OPEN" Units="PERCENT" Index="0">
+            <Requires LocalVar="A32NX_APU_FLAP_OPEN_PERCENTAGE" Units="PERCENT" Index="0">
                 <Range UpperBound="99" />
             </Requires>
         </Sound>
 
-        <Sound WwiseData="true" WwiseEvent="apuflapopenfull" Continuous="false" ViewPoint="Inside" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="APU_FLAP_OPEN" Units="PERCENT" Index="0">
+        <Sound WwiseData="true" WwiseEvent="apuflapopenfull" Continuous="false" ViewPoint="Inside" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="A32NX_APU_FLAP_OPEN_PERCENTAGE" Units="PERCENT" Index="0">
             <Range LowerBound="100" />
         </Sound>
 
@@ -169,12 +169,12 @@
 
         <Sound WwiseData="true" WwiseEvent="apuflapopenext" FadeOutType="2" FadeOutTime="1" Continuous="true" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="A32NX_APU_MASTER_SW_ACTIVATED" Units="BOOLEAN">
             <Range LowerBound="1.0" />
-            <Requires LocalVar="APU_FLAP_OPEN" Units="BOOLEAN" Index="0">
+            <Requires LocalVar="A32NX_APU_FLAP_OPEN_PERCENTAGE" Units="BOOLEAN" Index="0">
                 <Range UpperBound="99" />
             </Requires>
         </Sound>
 
-        <Sound WwiseData="true" WwiseEvent="apuflapopenfullext" Continuous="false" ViewPoint="Outside" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="APU_FLAP_OPEN" Units="BOOLEAN" Index="0">
+        <Sound WwiseData="true" WwiseEvent="apuflapopenfullext" Continuous="false" ViewPoint="Outside" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="A32NX_APU_FLAP_OPEN_PERCENTAGE" Units="BOOLEAN" Index="0">
             <Range LowerBound="100" />
         </Sound>
 
@@ -242,7 +242,7 @@
             <Range LowerBound="28" />
             </Requires >
         </Sound>
-         
+
         <Sound WwiseData="true" WwiseEvent="brakefan2" NodeName="BASE_RIGHT" FadeOutType="2" FadeOutTime="2" LocalVar="A32NX_BRAKE_FAN" Units="BOOL" Index="0">
             <Range LowerBound="1.0" />
             <WwiseRTPC SimVar="TURB ENG N1" Units="percent" Index="1" RTPCName="SIMVAR_TURB_ENG_N1" />
@@ -353,7 +353,7 @@
         </Sound>
 
         <!-- ENGINE SOUNDS (CFM LEAP-1A) ======================================================================================== -->
-        
+
         <Sound WwiseEvent="LSpool" WwiseData="true" NodeName="SOUND_ENGINE_LEFT" SimVar="TURB ENG N1" Units="percent" Index="1" ViewPoint="Inside" Continuous="true">
             <Range LowerBound="0" />
             <WwiseRTPC SimVar="TURB ENG N1" Units="percent" Index="1" RTPCName="SIMVAR_TURB_ENG_N1" />
@@ -490,7 +490,7 @@
             <Range LowerBound="1" />
             <WwiseRTPC SimVar="TURB ENG N1" Units="percent" Index="2" RTPCName="SIMVAR_TURB_ENG_N1" />
         </Sound>
-        
+
         <Sound WwiseEvent="FlyOverL" WwiseData="true" NodeName="SOUND_ENGINE_LEFT" ConeHeading="180.0" SimVar="TURB ENG N1" Units="percent" Index="1" ViewPoint="Outside" Continuous="true">
             <Range LowerBound="1" />
             <WwiseRTPC SimVar="TURB ENG N1" Units="percent" Index="1" RTPCName="SIMVAR_TURB_ENG_N1" />
@@ -570,7 +570,7 @@
             <WwiseRTPC SimVar="TURB ENG N1" Units="percent" Derived="true" Index="2" RTPCName="SIMVAR_TURB_ENG_N1_DERIVED" />
             <WwiseRTPC SimVar="AIRSPEED INDICATED" Units="knots" Index="1" RTPCName="SIMVAR_AIRSPEED_INDICATED" />
         </Sound>
-        
+
         <Sound WwiseEvent="StartVL" NodeName="SOUND_ENGINE_LEFT" FadeOutType="1" FadeOutTime="1" WwiseData="true" SimVar="TURB ENG N2" Units="percent" ViewPoint="Inside" Index="1" Continuous="true">
             <Range LowerBound="1" />
             <WwiseRTPC SimVar="TURB ENG N2" Units="percent" Index="1" RTPCName="SIMVAR_TURB_ENG_N2" />
@@ -863,7 +863,7 @@
             	</Requires>
             <WwiseRTPC SimVar="GROUND VELOCITY" Units="KNOTS" Index="0" RTPCName="SIMVAR_GROUND_VELOCITY" />
         </Sound>
-        
+
         <Sound WwiseData="true" WwiseEvent="groundrollnose" NodeName="PEDALS_LEFT" ViewPoint="Inside" FadeOutType="2" FadeOutTime="1" SimVar="GEAR ANIMATION POSITION" Units="PERCENT" Index="0">
             <Range LowerBound="55" />
             <Requires SimVar="GEAR TOTAL PCT EXTENDED" Units="PERCENT" Index="0">
@@ -1192,7 +1192,7 @@
         <Range UpperBound="0" />
             <WwiseRTPC SimVar="ELECTRICAL MAIN BUS VOLTAGE" Units="VOLTS" Index="1" RTPCName="SIMVAR_ELECTRICAL_MAIN_BUS_VOLTAGE" />
         </Sound>
-        
+
         <!-- Play sound whenever the no smoking ecam memo changes -->
         <Sound WwiseData="true" WwiseEvent="light_switch_seatbelt" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="A32NX_NO_SMOKING_MEMO" ViewPoint="Inside" Continuous="false">
             <Range UpperBound="0" />
@@ -1420,7 +1420,7 @@
         <Sound WwiseData="true" WwiseEvent="mcdubuttons" Continuous="false" ViewPoint="Inside"/>
         <Sound WwiseData="true" WwiseEvent="SpoilerARM" Continuous="false" ViewPoint="Inside"/>
         <Sound WwiseData="true" WwiseEvent="SpoilerDISARM" Continuous="false" ViewPoint="Inside"/>
-        
+
         <! PRINTER SOUNDS ====================================================================================  -->
         <Sound WwiseData="true" WwiseEvent="paperflip" Continuous="false" ViewPoint="Inside"/>
         <Sound WwiseData="true" WwiseEvent="papercrumble" Continuous="false" ViewPoint="Inside"/>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
@@ -110,8 +110,8 @@ var A320_Neo_LowerECAM_APU;
             const lowFuelPressure = SimVar.GetSimVarValue("L:A32NX_APU_LOW_FUEL_PRESSURE_FAULT", "Bool");
             toggleVisibility(this.FuelLoPr, lowFuelPressure);
 
-            const apuFlapOpenPercent = SimVar.GetSimVarValue("L:APU_FLAP_OPEN", "Percent");
-            toggleVisibility(this.APUFlapOpen, apuFlapOpenPercent === 100);
+            const apuFlapOpen = SimVar.GetSimVarValue("L:A32NX_APU_FLAP_ECAM_OPEN", "Bool");
+            toggleVisibility(this.APUFlapOpen, apuFlapOpen);
 
             this.apuInfo.update(_deltaTime);
         }
@@ -220,8 +220,11 @@ var A320_Neo_LowerECAM_APU;
     }
 
     function shouldShowApuData() {
+        // Once ELEC is implemented, this depends on the ECB being powered or not.
+        // The ECB will be powered when the MASTER SW is on and unpower when MASTER SW is off, N = 0, and the flap is closed.
+        const apuFlapOpen = SimVar.GetSimVarValue("L:A32NX_APU_FLAP_ECAM_OPEN", "Bool");
         const apuMasterSwitch = SimVar.GetSimVarValue("L:A32NX_APU_MASTER_SW_ACTIVATED", "Bool");
-        return apuMasterSwitch || getN() > 0;
+        return apuMasterSwitch || getN() > 0 || apuFlapOpen;
     }
 
     function getN() {

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -433,10 +433,18 @@
     - Bool
     - Indicates if the APU is inoperable
 
+- A32NX_APU_FLAP_OPEN_PERCENTAGE
+    - Percent
+    - Indicates the percentage the APU air intake flap is open
+
+- A32NX_APU_FLAP_ECAM_OPEN
+    - Bool
+    - Indicates if the APU air intake flap should be indicated as open on the APU ECAM
+
 - A32NX_FIRE_BUTTON_APU
     - Bool
     - Indicates if the APU fire button is released
- 
+
  - A32NX_RMP_L_TOGGLE_SWITCH
     - Boolean
     - Whether the left radio management panel toggle switch is on or off.

--- a/src/systems/a320/src/lib.rs
+++ b/src/systems/a320/src/lib.rs
@@ -40,7 +40,8 @@ pub struct A320SimulatorReadWriter {
     apu_egt_caution: NamedVariable,
     apu_egt_warning: NamedVariable,
     apu_fire_button_released: NamedVariable,
-    apu_flap_open: NamedVariable,
+    apu_air_intake_flap_is_ecam_open: NamedVariable,
+    apu_flap_open_percentage: NamedVariable,
     apu_gen_amperage: NamedVariable,
     apu_gen_frequency: NamedVariable,
     apu_gen_frequency_within_normal_range: NamedVariable,
@@ -75,7 +76,8 @@ impl A320SimulatorReadWriter {
             apu_egt_caution: NamedVariable::from("A32NX_APU_EGT_CAUTION"),
             apu_egt_warning: NamedVariable::from("A32NX_APU_EGT_WARNING"),
             apu_fire_button_released: NamedVariable::from("A32NX_FIRE_BUTTON_APU"),
-            apu_flap_open: NamedVariable::from("APU_FLAP_OPEN"),
+            apu_air_intake_flap_is_ecam_open: NamedVariable::from("A32NX_APU_FLAP_ECAM_OPEN"),
+            apu_flap_open_percentage: NamedVariable::from("A32NX_APU_FLAP_OPEN_PERCENTAGE"),
             apu_gen_amperage: NamedVariable::from("A32NX_APU_GEN_AMPERAGE"),
             apu_gen_frequency: NamedVariable::from("A32NX_APU_GEN_FREQ"),
             apu_gen_frequency_within_normal_range: NamedVariable::from("A32NX_APU_GEN_FREQ_NORMAL"),
@@ -146,7 +148,9 @@ impl SimulatorReadWriter for A320SimulatorReadWriter {
             .set_value(state.apu_caution_egt.get::<degree_celsius>());
         self.apu_egt_warning
             .set_value(state.apu_warning_egt.get::<degree_celsius>());
-        self.apu_flap_open
+        self.apu_air_intake_flap_is_ecam_open
+            .set_value(from_bool(state.apu_air_intake_flap_is_ecam_open));
+        self.apu_flap_open_percentage
             .set_value(state.apu_air_intake_flap_opened_for.get::<percent>());
         self.apu_gen_amperage
             .set_value(state.apu_gen_current.get::<ampere>());

--- a/src/systems/systems/src/simulator/mod.rs
+++ b/src/systems/systems/src/simulator/mod.rs
@@ -156,6 +156,8 @@ impl SimulatorReadState {
 /// into the the simulator.
 #[derive(Default)]
 pub struct SimulatorWriteState {
+    pub apu_air_intake_flap_is_ecam_open: bool,
+    pub apu_air_intake_flap_opened_for: Ratio,
     pub apu_bleed_air_valve_open: bool,
     pub apu_bleed_fault: bool,
     pub apu_caution_egt: ThermodynamicTemperature,
@@ -175,5 +177,4 @@ pub struct SimulatorWriteState {
     pub apu_start_sw_available: bool,
     pub apu_start_sw_on: bool,
     pub apu_warning_egt: ThermodynamicTemperature,
-    pub apu_air_intake_flap_opened_for: Ratio,
 }


### PR DESCRIPTION
## Summary of Changes
This further improves the FLAP OPEN indication on the APU ECAM page.

It is displayed when:
1. The flap is fully open
2. The flap was fully open and is closing, but not fully closed.
3. The flap was fully open, started closing, but started opening again before fully closing.

Additionally this PR ensures that while the FLAP OPEN indication is shown, the APU N and EGT are displayed (instead of amber XX); even when the APU N = 0 and MASTER SW is OFF.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
