### PR TITLE
feat(efb): make EFB have its own battery

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -42,7 +42,7 @@
                 <NODE_ID>SCREEN_EFB</NODE_ID>
             </DefaultTemplateParameters>
 
-            <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
+            <UseTemplate Name="ASOBO_GT_Material_Emissive_Code">
                 <EMISSIVE_CODE>0.7</EMISSIVE_CODE>
             </UseTemplate>
 

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -47,7 +47,13 @@
             </UseTemplate>
 
             <UseTemplate Name="ASOBO_GT_Interaction_LeftSingle_Code">
-                <LEFT_SINGLE_CODE>0</LEFT_SINGLE_CODE>
+                <LEFT_SINGLE_CODE>
+                    (L:A32NX_EFB_TURNED_ON) 0 == if{
+                        1 (&gt;L:A32NX_EFB_TURNED_ON)
+                    }
+                </LEFT_SINGLE_CODE>
+
+                <TOOLTIPID>%((L:A32NX_EFB_TURNED_ON) 0 ==)%{if}Turn on flyPad%{end}</TOOLTIPID>
             </UseTemplate>
         </Component>
 

--- a/src/instruments/src/EFB/StatusBar/StatusBar.tsx
+++ b/src/instruments/src/EFB/StatusBar/StatusBar.tsx
@@ -72,7 +72,8 @@ export default class StatusBar extends React.Component<TimeProps, any> {
                 <div className="flex items-center">
                     <IconWifi className="mr-2" size={22} stroke={1.5} strokeLinejoin="miter" />
                     100%
-                    <IconBatteryCharging className="ml-2" color="yellow" size={25} stroke={1.5} strokeLinejoin="miter" />
+                    {/* TODO find a way to use `setSimVar` here */}
+                    <IconBatteryCharging onClick={() => SimVar.SetSimVarValue('L:A32NX_EFB_TURNED_ON', 'number', 0)} className="ml-2" color="yellow" size={25} stroke={1.5} strokeLinejoin="miter" />
                 </div>
             </div>
         );

--- a/src/instruments/src/EFB/react-app-env.d.ts
+++ b/src/instruments/src/EFB/react-app-env.d.ts
@@ -18,7 +18,7 @@
  */
 
 declare module "util.mjs" {
-
+    function setSimVar(name: string, value: any, unit: string)
 }
 
 declare module "*.svg" {


### PR DESCRIPTION
## Summary of Changes

* Add very basic battery logic to EFB

Discord username (if different from GitHub): someperson#4953

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

* Click on the EFB to turn it on (no need for aircraft DC or AC power)
* Observe startup sequence
* Turn off EFB by clicking on the yellow indicator on the top right
* Observe shutdown
* Observe turned off state
* Click on the EFB to turn it on
* Observe startup sequence

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
