### PR TITLE
fix: EFB Dispatch page fuel quantity, cargo capacity, MRW, MTOW, MZFW

### DIFF
--- a/src/instruments/src/EFB/Dispatch/Pages/OverviewPage.tsx
+++ b/src/instruments/src/EFB/Dispatch/Pages/OverviewPage.tsx
@@ -92,10 +92,10 @@ const OverviewPage = (props: OverviewPageProps) => {
                             <span className="mt-2 text-lg">3400 [nm]</span>
 
                             <h3 className="text-xl font-medium flex items-center mt-6"><IconBox className="mr-2" size={23} stroke={1.5} strokeLinejoin="miter" /> MRW</h3>
-                            <span className="mt-2 text-lg">175,000 [lb]</span>
+                            <span className="mt-2 text-lg">79,400 [kg]</span>
 
                             <h3 className="text-xl font-medium flex items-center mt-6"><IconBox className="mr-2" size={23} stroke={1.5} strokeLinejoin="miter" /> MZFW</h3>
-                            <span className="mt-2 text-lg">141,800 [lb]</span>
+                            <span className="mt-2 text-lg">64,300 [kg]</span>
 
                             <h3 className="text-xl font-medium flex items-center mt-6"><IconUsers className="mr-2" size={23} stroke={1.5} strokeLinejoin="miter" /> Max PAX</h3>
                             <span className="mt-2 text-lg">180</span>
@@ -108,13 +108,13 @@ const OverviewPage = (props: OverviewPageProps) => {
                             <span className="mt-2 text-lg">0.82</span>
 
                             <h3 className="text-xl font-medium flex items-center mt-6"><IconBox className="mr-2" size={23} stroke={1.5} strokeLinejoin="miter" /> MTOW</h3>
-                            <span className="mt-2 text-lg">174,200 [lb]</span>
+                            <span className="mt-2 text-lg">79,000 [kg]</span>
 
                             <h3 className="text-xl font-medium flex items-center mt-6"><IconBox className="mr-2" size={23} stroke={1.5} strokeLinejoin="miter" /> Max Fuel Capacity</h3>
-                            <span className="mt-2 text-lg">21,005 [kg]</span>
+                            <span className="mt-2 text-lg">23,721 [l]</span>
 
                             <h3 className="text-xl font-medium flex items-center mt-6"><IconBox className="mr-2" size={23} stroke={1.5} strokeLinejoin="miter" /> Max Cargo</h3>
-                            <span className="mt-2 text-lg">44,000 [kg]</span>
+                            <span className="mt-2 text-lg">9,435 [kg]</span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Fix fuel capacity and cargo capacity values, change MRW, MTOW, MZFW to use metric units for consistency with fuel capacity and cargo capacity. Also changes the units for fuel capacity from kg, which is incorrect, to l.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes https://github.com/flybywiresim/a32nx/issues/3307
Partially addresses https://github.com/flybywiresim/a32nx/issues/3299

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
From Airport Planning Document:
![Screenshot (617)_LI](https://user-images.githubusercontent.com/70166617/106867667-bbf35480-6682-11eb-93ba-7529a150b0c3.jpg)

From FAA Type Certification Data Sheet:
![Screenshot (619)](https://user-images.githubusercontent.com/70166617/106868037-21dfdc00-6683-11eb-9e36-0b3a853839eb.png)

MSFS Fuel Quantity in Liters (Add them up):
![Screenshot (621)](https://user-images.githubusercontent.com/70166617/106868416-9c106080-6683-11eb-880f-3e74ff7f72c4.png)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
It might be nice to be able to have this page show the values in U.S. units when the user has U.S. units selected in the MSFS options menu. Should probably also add max landing weight.

Actual fuel capacity in liters is 23,724.  MSFS uses gallons as the base value, and the fuel quantity of each tank in gallons is specified in the flight_model.cfg file. The fuel capacity in gallons is 6267 (See https://github.com/flybywiresim/a32nx/pull/2286). Due to the conversion that MSFS uses between gallons and liters, MSFS converts 6267 gallons into 23,720.57 liters, which has been rounded off to 23,721.
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):donbikes#4084

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Turn on EFB and go to the Dispatch Overview page. Check that the various weight and fuel capacity values on that page are:
MRW: 79,400 kg
MTOW: 79,000 kg
MZFW: 64,300 kg
Max Fuel Capacity: 23,721 l
Max Cargo: 9,435 kg 
and that these numbers match the reference documentation provided above.

Check to make sure that nothing else about the EFB was affected.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
