### PR TITLE
feat: display new messages immediately on message page

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -72,6 +72,7 @@
 1. [FLIGHTMODEL] Updated landing gear contact point values to closer match reality - @wpine215 (Iceman) and @donstim (donbikes#4084)
 1. [TEXTURE] Various cockpit decal texture fixes and updates - @ImenesFBW (Imenes)
 1. [MCDU] Rework PERF TAKE OFF page - @beheh (Benedict Etzel)
+1. [CDU] Display incoming AOC messages immediately when viewing message list - @pareil6 (pareil6)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_MessagesReceived.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_MessagesReceived.js
@@ -17,19 +17,26 @@
  */
 
 class CDUAocMessagesReceived {
-    static ShowPage(mcdu, messages = null, offset = 5) {
+    static ShowPage(mcdu, messages = null, offset = 0) {
         if (!messages) {
             messages = mcdu.getMessages();
         }
         mcdu.clearDisplay();
+        CDUAocMessagesReceived._timer = 0;
+        mcdu.pageUpdate = () => {
+            CDUAocMessagesReceived._timer++;
+            if (CDUAocMessagesReceived._timer >= 100) {
+                CDUAocMessagesReceived.ShowPage(mcdu, null, offset);
+            }
+        };
 
         const msgTimeHeaders = [];
-        msgTimeHeaders.length = 6;
-        for (let i = 5; i > 0; i--) {
+        msgTimeHeaders.length = 5;
+        for (let i = 0; i < 5; i++) {
             let header = "";
-            if (messages[offset - i]) {
-                header += messages[offset - i]["time"];
-                if (messages[offset - i]["opened"]) {
+            if (messages[offset + i]) {
+                header += messages[offset + i]["time"];
+                if (messages[offset + i]["opened"]) {
                     header += " - VIEWED[color]green";
                 } else {
                     header += " - NEW[color]green";
@@ -40,109 +47,51 @@ class CDUAocMessagesReceived {
 
         mcdu.setTemplate([
             ["AOC RCVD MSGS"],
-            [msgTimeHeaders[5]],
-            [`${messages[offset - 5] ? "<" + messages[offset - 5]["type"] : "NO MESSAGES"}`],
-            [msgTimeHeaders[4]],
-            [`${messages[offset - 4] ? "<" + messages[offset - 4]["type"] : ""}`],
-            [msgTimeHeaders[3]],
-            [`${messages[offset - 3] ? "<" + messages[offset - 3]["type"] : ""}`],
-            [msgTimeHeaders[2]],
-            [`${messages[offset - 2] ? "<" + messages[offset - 2]["type"] : ""}`],
+            [msgTimeHeaders[0]],
+            [`${messages[offset + 0] ? "<" + messages[offset + 0]["type"] : "NO MESSAGES"}`],
             [msgTimeHeaders[1]],
-            [`${messages[offset - 1] ? "<" + messages[offset - 1]["type"] : ""}`],
+            [`${messages[offset + 1] ? "<" + messages[offset + 1]["type"] : ""}`],
+            [msgTimeHeaders[2]],
+            [`${messages[offset + 2] ? "<" + messages[offset + 2]["type"] : ""}`],
+            [msgTimeHeaders[3]],
+            [`${messages[offset + 3] ? "<" + messages[offset + 3]["type"] : ""}`],
+            [msgTimeHeaders[4]],
+            [`${messages[offset + 4] ? "<" + messages[offset + 4]["type"] : ""}`],
             [""],
             ["<RETURN"]
         ]);
 
         if (messages.length > 4) {
             mcdu.onNextPage = () => {
-                if (messages[offset - 1]) {
-                    offset *= 2;
+                if (messages[offset + 5]) {
+                    offset += 5;
                 }
                 CDUAocMessagesReceived.ShowPage(mcdu, messages, offset);
             };
             mcdu.onPrevPage = () => {
-                if (messages[offset - 1]) {
-                    offset /= 2;
+                if (messages[offset - 5]) {
+                    offset -= 5;
                 }
                 CDUAocMessagesReceived.ShowPage(mcdu, messages, offset);
             };
         }
 
-        mcdu.leftInputDelay[0] = () => {
-            return mcdu.getDelaySwitchPage();
-        };
+        for (let i = 0; i < 5; i++) {
+            mcdu.leftInputDelay[i] = () => {
+                return mcdu.getDelaySwitchPage();
+            };
 
-        mcdu.onLeftInput[0] = (value) => {
-            if (messages[offset - 5]) {
-                if (value === FMCMainDisplay.clrValue) {
-                    mcdu.deleteMessage(offset - 5);
-                    CDUAocMessagesReceived.ShowPage(mcdu, messages, offset);
-                } else {
-                    CDUAocRequestsMessage.ShowPage(mcdu, messages[offset - 5]);
+            mcdu.onLeftInput[i] = (value) => {
+                if (messages[offset + i]) {
+                    if (value === FMCMainDisplay.clrValue) {
+                        mcdu.deleteMessage(offset + i);
+                        CDUAocMessagesReceived.ShowPage(mcdu, messages, offset + i);
+                    } else {
+                        CDUAocRequestsMessage.ShowPage(mcdu, messages[offset + i]);
+                    }
                 }
-            }
-        };
-
-        mcdu.leftInputDelay[1] = () => {
-            return mcdu.getDelaySwitchPage();
-        };
-
-        mcdu.onLeftInput[1] = (value) => {
-            if (messages[offset - 4]) {
-                if (value === FMCMainDisplay.clrValue) {
-                    mcdu.deleteMessage(offset - 4);
-                    CDUAocMessagesReceived.ShowPage(mcdu, messages, offset);
-                } else {
-                    CDUAocRequestsMessage.ShowPage(mcdu, messages[offset - 4]);
-                }
-            }
-        };
-
-        mcdu.leftInputDelay[2] = () => {
-            return mcdu.getDelaySwitchPage();
-        };
-
-        mcdu.onLeftInput[2] = (value) => {
-            if (messages[offset - 3]) {
-                if (value === FMCMainDisplay.clrValue) {
-                    mcdu.deleteMessage(offset - 3);
-                    CDUAocMessagesReceived.ShowPage(mcdu, messages, offset);
-                } else {
-                    CDUAocRequestsMessage.ShowPage(mcdu, messages[offset - 3]);
-                }
-            }
-        };
-
-        mcdu.leftInputDelay[3] = () => {
-            return mcdu.getDelaySwitchPage();
-        };
-
-        mcdu.onLeftInput[3] = (value) => {
-            if (messages[offset - 2]) {
-                if (value === FMCMainDisplay.clrValue) {
-                    mcdu.deleteMessage(offset - 2);
-                    CDUAocMessagesReceived.ShowPage(mcdu, messages, offset);
-                } else {
-                    CDUAocRequestsMessage.ShowPage(mcdu, messages[offset - 2]);
-                }
-            }
-        };
-
-        mcdu.leftInputDelay[4] = () => {
-            return mcdu.getDelaySwitchPage();
-        };
-
-        mcdu.onLeftInput[4] = (value) => {
-            if (messages[offset - 1]) {
-                if (value === FMCMainDisplay.clrValue) {
-                    mcdu.deleteMessage(offset - 1);
-                    CDUAocMessagesReceived.ShowPage(mcdu, messages, offset);
-                } else {
-                    CDUAocRequestsMessage.ShowPage(mcdu, messages[offset - 1]);
-                }
-            }
-        };
+            };
+        }
 
         mcdu.leftInputDelay[5] = () => {
             return mcdu.getDelaySwitchPage();

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_MessagesSent.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_MessagesSent.js
@@ -17,127 +17,69 @@
  */
 
 class CDUAocMessagesSent {
-    static ShowPage(mcdu, messages = null, offset = 5) {
+    static ShowPage(mcdu, messages = null, offset = 0) {
         if (!messages) {
             messages = mcdu.getSentMessages();
         }
         mcdu.clearDisplay();
 
         const msgTimeHeaders = [];
-        msgTimeHeaders.length = 6;
-        for (let i = 5; i > 0; i--) {
+        msgTimeHeaders.length = 5;
+        for (let i = 0; i < 5; i++) {
             let header = "";
-            if (messages[offset - i]) {
-                header += messages[offset - i]["time"] + " - SENT[color]green";
+            if (messages[offset + i]) {
+                header += messages[offset + i]["time"] + " - SENT[color]green";
             }
             msgTimeHeaders[i] = header;
         }
 
         mcdu.setTemplate([
             ["AOC SENT MSGS"],
-            [msgTimeHeaders[5]],
-            [`${messages[offset - 5] ? "<" + messages[offset - 5]["type"] : "NO MESSAGES"}`],
-            [msgTimeHeaders[4]],
-            [`${messages[offset - 4] ? "<" + messages[offset - 4]["type"] : ""}`],
-            [msgTimeHeaders[3]],
-            [`${messages[offset - 3] ? "<" + messages[offset - 3]["type"] : ""}`],
-            [msgTimeHeaders[2]],
-            [`${messages[offset - 2] ? "<" + messages[offset - 2]["type"] : ""}`],
+            [msgTimeHeaders[0]],
+            [`${messages[offset + 0] ? "<" + messages[offset + 0]["type"] : "NO MESSAGES"}`],
             [msgTimeHeaders[1]],
-            [`${messages[offset - 1] ? "<" + messages[offset - 1]["type"] : ""}`],
+            [`${messages[offset + 1] ? "<" + messages[offset + 1]["type"] : ""}`],
+            [msgTimeHeaders[2]],
+            [`${messages[offset + 2] ? "<" + messages[offset + 2]["type"] : ""}`],
+            [msgTimeHeaders[3]],
+            [`${messages[offset + 3] ? "<" + messages[offset + 3]["type"] : ""}`],
+            [msgTimeHeaders[4]],
+            [`${messages[offset + 4] ? "<" + messages[offset + 4]["type"] : ""}`],
             [""],
             ["<RETURN"]
         ]);
 
         if (messages.length > 4) {
             mcdu.onNextPage = () => {
-                if (messages[offset - 1]) {
-                    offset *= 2;
+                if (messages[offset + 5]) {
+                    offset += 5;
                 }
                 CDUAocMessagesSent.ShowPage(mcdu, messages, offset);
             };
             mcdu.onPrevPage = () => {
-                if (messages[offset - 1]) {
-                    offset /= 2;
+                if (messages[offset - 5]) {
+                    offset -= 5;
                 }
                 CDUAocMessagesSent.ShowPage(mcdu, messages, offset);
             };
         }
 
-        mcdu.leftInputDelay[0] = () => {
-            return mcdu.getDelaySwitchPage();
-        };
+        for (let i = 0; i < 5; i++) {
+            mcdu.leftInputDelay[i] = () => {
+                return mcdu.getDelaySwitchPage();
+            };
 
-        mcdu.onLeftInput[0] = (value) => {
-            if (messages[offset - 5]) {
-                if (value === FMCMainDisplay.clrValue) {
-                    mcdu.deleteSentMessage(offset - 5);
-                    CDUAocMessagesSent.ShowPage(mcdu, messages, offset);
-                } else {
-                    CDUAocMessageSentDetail.ShowPage(mcdu, messages[offset - 5]);
+            mcdu.onLeftInput[i] = (value) => {
+                if (messages[offset + i]) {
+                    if (value === FMCMainDisplay.clrValue) {
+                        mcdu.deleteSentMessage(offset + i);
+                        CDUAocMessagesSent.ShowPage(mcdu, messages, offset);
+                    } else {
+                        CDUAocMessageSentDetail.ShowPage(mcdu, messages[offset + i]);
+                    }
                 }
-            }
-        };
-
-        mcdu.leftInputDelay[1] = () => {
-            return mcdu.getDelaySwitchPage();
-        };
-
-        mcdu.onLeftInput[1] = (value) => {
-            if (messages[offset - 4]) {
-                if (value === FMCMainDisplay.clrValue) {
-                    mcdu.deleteSentMessage(offset - 4);
-                    CDUAocMessagesSent.ShowPage(mcdu, messages, offset);
-                } else {
-                    CDUAocMessageSentDetail.ShowPage(mcdu, messages[offset - 4]);
-                }
-            }
-        };
-
-        mcdu.leftInputDelay[2] = () => {
-            return mcdu.getDelaySwitchPage();
-        };
-
-        mcdu.onLeftInput[2] = (value) => {
-            if (messages[offset - 3]) {
-                if (value === FMCMainDisplay.clrValue) {
-                    mcdu.deleteSentMessage(offset - 3);
-                    CDUAocMessagesSent.ShowPage(mcdu, messages, offset);
-                } else {
-                    CDUAocMessageSentDetail.ShowPage(mcdu, messages[offset - 3]);
-                }
-            }
-        };
-
-        mcdu.leftInputDelay[3] = () => {
-            return mcdu.getDelaySwitchPage();
-        };
-
-        mcdu.onLeftInput[3] = (value) => {
-            if (messages[offset - 2]) {
-                if (value === FMCMainDisplay.clrValue) {
-                    mcdu.deleteSentMessage(offset - 2);
-                    CDUAocMessagesSent.ShowPage(mcdu, messages, offset);
-                } else {
-                    CDUAocMessageSentDetail.ShowPage(mcdu, messages[offset - 2]);
-                }
-            }
-        };
-
-        mcdu.leftInputDelay[4] = () => {
-            return mcdu.getDelaySwitchPage();
-        };
-
-        mcdu.onLeftInput[4] = (value) => {
-            if (messages[offset - 1]) {
-                if (value === FMCMainDisplay.clrValue) {
-                    mcdu.deleteSentMessage(offset - 1);
-                    CDUAocMessagesSent.ShowPage(mcdu, messages, offset);
-                } else {
-                    CDUAocMessageSentDetail.ShowPage(mcdu, messages[offset - 1]);
-                }
-            }
-        };
+            };
+        }
 
         mcdu.leftInputDelay[5] = () => {
             return mcdu.getDelaySwitchPage();


### PR DESCRIPTION
## Summary of Changes
Makes AOC received messages page automatically show new messages as they arrive, instead of needing to exit back to the previous menu and reopen it.

Also rewrites the page offset logic fix weird bugs with more than 2 pages, and to avoid some slightly counterintuitive offset handling (ie. instead of showing messages from (offset - 5) to (offset - 1), show from (offset) to (offset + 4), since newest message is at index 0 anyway).

## Screenshots (if necessary)
Before - page selection bugs:
![image](https://user-images.githubusercontent.com/73158172/107029504-08d04b80-67a7-11eb-9d80-00f509fc9f03.gif)

After - page handling:
![image](https://user-images.githubusercontent.com/73158172/107029528-0e2d9600-67a7-11eb-9620-c70f0dac9ab7.gif)

After - page automatically updating with incoming messages:
![image](https://user-images.githubusercontent.com/73158172/107029533-11288680-67a7-11eb-9fb7-876fba3c93d8.gif)

## References
I'm 99% sure I've seen pilots comment on this before on Discord - will update once I've got someone to confirm though.

## Additional context

Discord username (if different from GitHub): pareil6#0990

## Testing instructions
Check page scrolling on the received _and sent_ message pages still works, check the received message page always (eventually) shows new messages that arrive (compare with the COMPANY MSG ECAM message - there's a slight delay, I can reduce it if it looks particularly bad).

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
