### PR TITLE
fix: disable EFB for testing

### DIFF
--- a/src/instruments/src/EFB/config.json
+++ b/src/instruments/src/EFB/config.json
@@ -1,4 +1,4 @@
 {
-  "index": "./index.jsx",
+  "index": "./temporary.jsx",
   "isInteractive": true
 }

--- a/src/instruments/src/EFB/temporary.jsx
+++ b/src/instruments/src/EFB/temporary.jsx
@@ -1,0 +1,24 @@
+/*
+ * A32NX
+ * Copyright (C) 2020-2021 FlyByWire Simulations and its contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import ReactDOM from 'react-dom';
+import { renderTarget } from '../util.mjs';
+
+import './temporary.scss';
+
+ReactDOM.render(<div id="efb-temp" />, renderTarget);

--- a/src/instruments/src/EFB/temporary.scss
+++ b/src/instruments/src/EFB/temporary.scss
@@ -1,0 +1,21 @@
+/*!
+ * A32NX
+ * Copyright (C) 2020-2021 FlyByWire Simulations and its contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#efb-temp {
+  background-color: black;
+}


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

# THIS IS NOT TO BE MERGED! ONLY USED FOR QA

* Disables the EFB so the source of the memory leak can be identified

Discord username (if different from GitHub): someperson#4953

## Testing instructions

* Perform a long (about 3 hours) flight to see if there is any performance degradation

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
