### PR TITLE
refactor: move DH LVar init into FMC

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -211,6 +211,8 @@ class FMCMainDisplay extends BaseAirliners {
 
         SimVar.SetSimVarValue("L:FLIGHTPLAN_USE_DECEL_WAYPOINT", "number", 1);
 
+        SimVar.SetSimVarValue("L:AIRLINER_DECISION_HEIGHT", "feet", -1);
+
         this.flightPlanManager.onCurrentGameFlightLoaded(() => {
             this.flightPlanManager.updateFlightPlan(() => {
                 this.flightPlanManager.updateCurrentApproach(() => {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
@@ -117,7 +117,6 @@ var Airbus_FMA;
 
     class CurrentPlaneState {
         static init() {
-            SimVar.SetSimVarValue("L:AIRLINER_DECISION_HEIGHT", "feet", -1);
         }
 
         static refresh() {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* The AIRLINER_DECISION_HEIGHT simvar was previously initialized in the PFD. This PR changes that, now it is initialized in the FMC/MCDU.
* This is also a bugfix for the custom PFD, because without the old PFD this would be initialized as 0 instead of -1, which actually means 0 DH, so the PFD would show that, even if nothing was entered in the MCDU.
 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
* Make sure that when loading the plane, the DH is correctly initialized (i.e. nothing is shown on the FMA). Since the DH can only be shown on the FMA in approach and descent, I would recommend spawning in approach.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
