### PR TITLE
fix(rmp): workaround for active freq being zero

### DIFF
--- a/src/instruments/src/RMP/Components/RootRadioPanels.tsx
+++ b/src/instruments/src/RMP/Components/RootRadioPanels.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+import { RootRadioPanel } from './BaseRadioPanels';
+import { useSimVar } from '../../Common/simVars';
+
+declare const SimVar; // this can also be replaced once /typings are available
+
+function initFrequencies() {
+    SimVar.SetSimVarValue('K:COM_RADIO_SET_HZ', 'Hz', 122800000); // Unicom
+    SimVar.SetSimVarValue('K:COM2_RADIO_SET_HZ', 'Hz', 121500000); // Guard
+    SimVar.SetSimVarValue('K:COM3_RADIO_SET_HZ', 'Hz', 131500000);
+    SimVar.SetSimVarValue('K:COM_STBY_RADIO_SET_HZ', 'Hz', 121950000);
+    SimVar.SetSimVarValue('K:COM2_STBY_RADIO_SET_HZ', 'Hz', 136975000);
+    SimVar.SetSimVarValue('K:COM3_STBY_RADIO_SET_HZ', 'Hz', 135475000);
+    SimVar.SetSimVarValue('A32NX_RMP_L_VHF2_STANDBY_FREQUENCY', 'Hz', 124275000);
+    SimVar.SetSimVarValue('A32NX_RMP_L_VHF3_STANDBY_FREQUENCY', 'Hz', 135475000);
+    SimVar.SetSimVarValue('A32NX_RMP_R_VHF1_STANDBY_FREQUENCY', 'Hz', 129675000);
+    SimVar.SetSimVarValue('A32NX_RMP_R_VHF3_STANDBY_FREQUENCY', 'Hz', 136975000);
+}
+
+export const RadioPanelsContainer = () => {
+    const [com1] = useSimVar('COM ACTIVE FREQUENCY:1', 'Hz', 1000);
+    const initFreqs = com1 === 0;
+
+    // Workaround for Asobo bug
+    // Frequency can be 0 when starting at the gate even when set in Apron.FLT
+    useEffect(() => {
+        initFrequencies();
+    }, [initFreqs]);
+
+    return (
+        <div className="rmp-wrapper">
+            <RootRadioPanel side="L" />
+            <RootRadioPanel side="R" />
+        </div>
+    );
+};

--- a/src/instruments/src/RMP/index.tsx
+++ b/src/instruments/src/RMP/index.tsx
@@ -1,11 +1,8 @@
 import './style.scss';
 import React from 'react';
 import { render } from '../Common';
-import { RootRadioPanel } from './Components/BaseRadioPanels';
+import { RadioPanelsContainer } from './Components/RootRadioPanels';
 
 render(
-    <div className="rmp-wrapper">
-        <RootRadioPanel side="L" />
-        <RootRadioPanel side="R" />
-    </div>,
+    <RadioPanelsContainer />,
 );


### PR DESCRIPTION
Fixes #3362 

## Summary of Changes
Add workaround for Simvars `COM ACTIVE FREQUENCY:1` and `COM ACTIVE FREQUENCY:2` being set to 0 when loading in at the gate.

## Screenshots (if necessary)
Before:
![image](https://user-images.githubusercontent.com/13190749/108050418-69a92080-6ffe-11eb-868e-cdfe87e78db9.png)
After:
![image](https://user-images.githubusercontent.com/13190749/108050577-a412bd80-6ffe-11eb-9381-bed4c6540ee2.png)

## Additional context
This issue appears to only occur when spawning in at the gate - I tried spawning in the air/approach/on the runway and they all worked fine. Other things I tried:
* I diffed the apron.FLT and runway.FLT files, and didn't find any obvious differences related to the RMP.
* Reading simvars from other instruments (ie the PFD), but `COM ACTIVE FREQUENCY` was still set to zero

I also compared the original code from before the React RMP PR was merged in, and there appears to be a [workaround for these values being set to 0](https://github.com/flybywiresim/a32nx/blob/d53d3f73245cddc50bbb82d2af1f27489188f466/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FDW/A320_Neo_FDW.js#L104-L115) from Asobo. This suggests that the issue is something deeper within the sim which can't be fixed through a FLT file (else they would've likely fixed it that way instead?)

## Testing instructions
1) Spawn at a gate
2) Enable ground power and check that the active frequency for VHF1, VHF2, and VHF3 are non zero
3) Spawn at runway
4) Check the active frequency for VHF1, VHF2, and VHF3

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
