### PR TITLE
build: ignore legacy npm peer dependencies

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,4 +4,4 @@ set -ex
 
 rm -f package-lock.json
 rm -rf node_modules
-npm install --no-optional
+npm install --no-optional --legacy-peer-deps


### PR DESCRIPTION
Fixes #3562

## Summary of Changes

* This adds `--legacy-peer-deps` to the dev-env npm install call to temporarily fix a bad peer dependency declaration with `tabler-icons`.

Discord username (if different from GitHub): someperson#4953

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
