### PR TITLE
refactor(mcdu): RADNAV (part 2)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -108,6 +108,8 @@
 1. [TEXTURE] Improved cockpit decal fonts and emissives, and remade various labels in the cockpit. @FoxinTale (Aubrey)
 1. [FWC] Add aural Altitude Alert (C Chord) - @Kimbyeongjang (김병장#7165)
 1. [TEXTURE] Improved cockpit decal fonts and emissives, and remade various labels in the cockpit. @FoxinTale (Aubrey)
+1. [CDU] RADNAV - A manual VOR/ADF ident input is now permament - @St54Kevin
+1. [CDU] RADNAV - ID/Frequency fields now format to correct font size depending on pilot input - @St54Kevin
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -110,6 +110,7 @@
 1. [TEXTURE] Improved cockpit decal fonts and emissives, and remade various labels in the cockpit. @FoxinTale (Aubrey)
 1. [CDU] RADNAV - A manual VOR/ADF ident input is now permament - @St54Kevin
 1. [CDU] RADNAV - ID/Frequency fields now format to correct font size depending on pilot input - @St54Kevin
+1. [CDU] RADNAV - All fields now have correct format display and input restricitons - @St54Kevin
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -18,6 +18,7 @@
 
 class CDUNavRadioPage {
     static ShowPage(mcdu) {
+        <script type="text/javascript" src="/JS/debug.js"></script>
         mcdu.clearDisplay();
         mcdu.page.Current = mcdu.page.NavRadioPage;
         mcdu.activeSystem = 'FMGC';

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -38,27 +38,33 @@ class CDUNavRadioPage {
         CDUNavRadioPage._timer = 0;
         mcdu.pageUpdate = () => {
             CDUNavRadioPage._timer++;
-            if (CDUNavRadioPage._timer >= 5) {
+            if (CDUNavRadioPage._timer >= 15) {
                 CDUNavRadioPage.ShowPage(mcdu);
             }
         };
         if (!radioOn) {
             vor1FrequencyCell = "[\xa0\xa0]/[\xa0\xa0.\xa0]";
             const vor1Ident = mcdu.radioNav.getVORBeacon(1);
-            if (mcdu.vor1Frequency > 0) {
-                vor1FrequencyCell = "{small}" + "\xa0" + vor1Ident.ident + "{end}" + "/" + mcdu.vor1Frequency.toFixed(2);
+            if (mcdu.vor1Frequency != 0 && !mcdu.vor1IdIsPilotEntered && mcdu.vor1FreqIsPilotEntered) {
+                vor1FrequencyCell = "{small}" + vor1Ident.ident + "{end}" + "/" + mcdu.vor1Frequency.toFixed(2);
+            } else if (mcdu.vor1Frequency != 0 && mcdu.vor1IdIsPilotEntered && !mcdu.vor1FreqIsPilotEntered) {
+                vor1FrequencyCell = vor1Ident.ident + "/" + "{small}" + mcdu.vor1Frequency.toFixed(2) + "{end}";
             }
-            if (vor1Ident.ident == "" && mcdu.vor1Frequency > 0) {
-                vor1FrequencyCell = "[\xa0\xa0]/" + mcdu.vor1Frequency.toFixed(2);
-            }
+            //if (vor1Ident.ident == "" && mcdu.vor1Frequency > 0) {
+            //    vor1FrequencyCell = "[\xa0\xa0]/" + mcdu.vor1Frequency.toFixed(2);
+            //}
             mcdu.onLeftInput[0] = (value) => {
                 const numValue = parseFloat(value);
                 if (value === FMCMainDisplay.clrValue) {
+                    mcdu.vor1FreqIsPilotEntered = false;
+                    mcdu.vor1IdIsPilotEntered = false;
                     mcdu.vor1Frequency = 0;
                     mcdu.vor1Course = 0;
                     mcdu.radioNav.setVORActiveFrequency(1, 0);
                     CDUNavRadioPage.ShowPage(mcdu);
                 } else if (!isFinite(numValue) && value.length == 3) {
+                    mcdu.vor1IdIsPilotEntered = true;
+                    mcdu.vor1FreqIsPilotEntered = false;
                     mcdu.getOrSelectVORsByIdent(value, (navaids) => {
                         mcdu.vor1Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setVORActiveFrequency(1, mcdu.vor1Frequency);
@@ -68,6 +74,8 @@ class CDUNavRadioPage {
                         });
                     });
                 } else if (isFinite(numValue) && numValue >= 108 && numValue <= 117.95 && RadioNav.isHz50Compliant(numValue)) {
+                    mcdu.vor1IdIsPilotEntered = false;
+                    mcdu.vor1FreqIsPilotEntered = true;
                     if (numValue != mcdu.vor1Frequency) {
                         mcdu.vor1Course = 0;
                     }
@@ -133,17 +141,19 @@ class CDUNavRadioPage {
             };
             adf1FrequencyCell = "[\xa0\xa0]/[\xa0\xa0\xa0.]";
             const adf1Ident = SimVar.GetSimVarValue(`ADF IDENT:1`, "string");
-            if (mcdu.adf1Frequency > 0) {
-                adf1FrequencyCell = "{small}" + "\xa0" + adf1Ident.padStart(3, "\xa0") + "{end}" + "/" + mcdu.adf1Frequency.toFixed(1);
+            if (mcdu.adf1Frequency != 0 && !mcdu.adf1IdIsPilotEntered && mcdu.adf1FreqIsPilotEntered) {
+                adf1FrequencyCell = "{small}" + adf1Ident.padStart(3, "\xa0") + "{end}" + "/" + mcdu.adf1Frequency.toFixed(1);
                 adf1BfoOption = "<ADF1 BFO";
-            }
-            if (adf1Ident == "" && mcdu.adf1Frequency > 0) {
-                adf1FrequencyCell = "[\xa0\xa0]/" + mcdu.adf1Frequency.toFixed(1);
+            } else if (mcdu.adf1Frequency != 0 && mcdu.adf1IdIsPilotEntered && !mcdu.adf1FreqIsPilotEntered) {
+                adf1FrequencyCell = adf1Ident.padStart(3, "\xa0")+ "/" + "{small}" +  + mcdu.adf1Frequency.toFixed(1) + "{end}";
+                adf1BfoOption = "<ADF1 BFO";
             }
             mcdu.onLeftInput[4] = (value) => {
                 const numValue = parseFloat(value);
                 if (!isFinite(numValue) && value.length >= 2 && value.length <= 3) {
                     mcdu.getOrSelectNDBsByIdent(value, (navaids) => {
+                        mcdu.adf1FreqIsPilotEntered = false;
+                        mcdu.adf1IdIsPilotEntered = true;
                         mcdu.adf1Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setADFActiveFrequency(1, mcdu.adf1Frequency);
                         mcdu.requestCall(() => {
@@ -152,12 +162,16 @@ class CDUNavRadioPage {
                     });
                 } else if (isFinite(numValue) && numValue >= 100 && numValue <= 1699.9) {
                     SimVar.SetSimVarValue("K:ADF_COMPLETE_SET", "Frequency ADF BCD32", Avionics.Utils.make_adf_bcd32(numValue * 1000)).then(() => {
+                        mcdu.adf1FreqIsPilotEntered = true;
+                        mcdu.adf1IdIsPilotEntered = false;
                         mcdu.adf1Frequency = numValue;
                         mcdu.requestCall(() => {
                             CDUNavRadioPage.ShowPage(mcdu);
                         });
                     });
                 } else if (value === FMCMainDisplay.clrValue) {
+                    mcdu.adf1FreqIsPilotEntered = false;
+                    mcdu.adf1IdIsPilotEntered = false;
                     mcdu.adf1Frequency = 0;
                     mcdu.radioNav.setADFActiveFrequency(1, 0);
                     CDUNavRadioPage.ShowPage(mcdu);
@@ -170,21 +184,24 @@ class CDUNavRadioPage {
         if (!radioOn) {
             vor2FrequencyCell = "[\xa0\xa0.\xa0]/[\xa0\xa0]";
             const vor2Ident = mcdu.radioNav.getVORBeacon(2);
-            if (mcdu.vor2Frequency > 0) {
-                vor2FrequencyCell = mcdu.vor2Frequency.toFixed(2) + "/" + "{small}" + vor2Ident.ident + "\xa0" + "{end}";
-            }
-            if (vor2Ident.ident == "" && mcdu.vor2Frequency > 0) {
-                vor2FrequencyCell = mcdu.vor2Frequency.toFixed(2) + "/[\xa0\xa0]";
+            if (mcdu.vor2Frequency != 0 && mcdu.vor2FreqIsPilotEntered && !mcdu.vor2IdIsPilotEntered) {
+                vor2FrequencyCell = mcdu.vor2Frequency.toFixed(2) + "/" + "{small}" + vor2Ident.ident + "{end}";
+            } else if (mcdu.vor2Frequency != 0 && !mcdu.vor2FreqIsPilotEntered && mcdu.vor2IdIsPilotEntered) {
+                vor2FrequencyCell = "{small}" + mcdu.vor2Frequency.toFixed(2) + "{end}" + "/" + vor2Ident.ident;
             }
             mcdu.onRightInput[0] = (value) => {
                 const numValue = parseFloat(value);
                 if (value === FMCMainDisplay.clrValue) {
+                    mcdu.vor2FreqIsPilotEntered = false;
+                    mcdu.vor2IdIsPilotEntered = false;
                     mcdu.vor2Frequency = 0;
                     mcdu.vor2Course = 0;
                     mcdu.radioNav.setVORActiveFrequency(2, 0);
                     CDUNavRadioPage.ShowPage(mcdu);
                 } else if (!isFinite(numValue) && value.length == 3) {
                     mcdu.getOrSelectVORsByIdent(value, (navaids) => {
+                        mcdu.vor2FreqIsPilotEntered = false;
+                        mcdu.vor2IdIsPilotEntered = true;
                         mcdu.vor2Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setVORActiveFrequency(2, mcdu.vor2Frequency);
                         mcdu.vor2Course = 0;
@@ -194,6 +211,8 @@ class CDUNavRadioPage {
                     });
                 } else if (isFinite(numValue) && numValue >= 108 && numValue <= 117.95 && RadioNav.isHz50Compliant(numValue)) {
                     if (numValue != mcdu.vor2Frequency) {
+                        mcdu.vor2FreqIsPilotEntered = true;
+                        mcdu.vor2IdIsPilotEntered = false;
                         mcdu.vor2Course = 0;
                     }
                     mcdu.vor2Frequency = numValue;
@@ -235,16 +254,18 @@ class CDUNavRadioPage {
             };
             adf2FrequencyCell = "[\xa0\xa0\xa0.]/[\xa0\xa0]";
             const adf2Ident = SimVar.GetSimVarValue(`ADF IDENT:2`, "string");
-            if (mcdu.adf2Frequency > 0) {
-                adf2FrequencyCell = mcdu.adf2Frequency.toFixed(1) + "/" + "{small}" + adf2Ident.padEnd(3, "\xa0") + "\xa0" + "{end}";
+            if (mcdu.adf2Frequency > 0 && mcdu.adf2FreqIsPilotEntered && !mcdu.adf2IdIsPilotEntered) {
+                adf2FrequencyCell = mcdu.adf2Frequency + "/" + "{small}" + adf2Ident.padEnd(3, "\xa0") + "{end}";
                 adf2BfoOption = "ADF2 BFO>";
-            }
-            if (adf2Ident == "" && mcdu.adf2Frequency > 0) {
-                adf2FrequencyCell = mcdu.adf2Frequency.toFixed(1) + "/[\xa0\xa0]";
+            } else if (mcdu.adf2Frequency > 0 && !mcdu.adf2FreqIsPilotEntered && mcdu.adf2IdIsPilotEntered) {
+                adf2FrequencyCell = "{small}" + mcdu.adf2Frequency + "{end}" + "/" + adf2Ident.padEnd(3, "\xa0");
+                adf2BfoOption = "ADF2 BFO>";
             }
             mcdu.onRightInput[4] = (value) => {
                 const numValue = parseFloat(value);
                 if (!isFinite(numValue) && value.length >= 2 && value.length <= 3) {
+                    mcdu.adf2FreqIsPilotEntered = false;
+                    mcdu.adf2IdIsPilotEntered = true;
                     mcdu.getOrSelectNDBsByIdent(value, (navaids) => {
                         mcdu.adf2Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setADFActiveFrequency(2, mcdu.adf2Frequency);
@@ -254,12 +275,16 @@ class CDUNavRadioPage {
                     });
                 } else if (isFinite(numValue) && numValue >= 100 && numValue <= 1699.9) {
                     SimVar.SetSimVarValue("K:ADF2_COMPLETE_SET", "Frequency ADF BCD32", Avionics.Utils.make_adf_bcd32(numValue * 1000)).then(() => {
+                        mcdu.adf2FreqIsPilotEntered = true;
+                        mcdu.adf2IdIsPilotEntered = false;
                         mcdu.adf2Frequency = numValue;
                         mcdu.requestCall(() => {
                             CDUNavRadioPage.ShowPage(mcdu);
                         });
                     });
                 } else if (value === FMCMainDisplay.clrValue) {
+                    mcdu.adf2FreqIsPilotEntered = false;
+                    mcdu.adf2IdIsPilotEntered = false;
                     mcdu.adf2Frequency = 0;
                     mcdu.radioNav.setADFActiveFrequency(2, 0);
                     adf2FrequencyCell = "[\xa0\xa0.]/[\xa0]";

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -38,14 +38,14 @@ class CDUNavRadioPage {
         CDUNavRadioPage._timer = 0;
         mcdu.pageUpdate = () => {
             CDUNavRadioPage._timer++;
-            if (CDUNavRadioPage._timer >= 15) {
+            if (CDUNavRadioPage._timer >= 5) {
                 CDUNavRadioPage.ShowPage(mcdu);
             }
         };
         if (!radioOn) {
             vor1FrequencyCell = "[\xa0]/[\xa0\xa0.\xa0]";
             const vor1Beacon = mcdu.radioNav.getVORBeacon(1);
-            const vor1Ident = vor1Beacon && vor1Beacon.ident.length === 3 ? vor1Beacon.ident : "";
+            const vor1Ident = vor1Beacon && vor1Beacon.ident.length >= 2 && vor1Beacon.ident.length <= 3 ? vor1Beacon.ident : "";
             if (mcdu.vor1Frequency != 0 && !mcdu.vor1IdIsPilotEntered && mcdu.vor1FreqIsPilotEntered) {
                 vor1FrequencyCell = "{small}" + vor1Ident.padStart(3, "\xa0") + "{end}" + "/" + mcdu.vor1Frequency.toFixed(2);
             } else if (mcdu.vor1Frequency != 0 && mcdu.vor1IdIsPilotEntered && !mcdu.vor1FreqIsPilotEntered) {
@@ -60,19 +60,19 @@ class CDUNavRadioPage {
                     mcdu.vor1Course = 0;
                     mcdu.radioNav.setVORActiveFrequency(1, 0);
                     CDUNavRadioPage.ShowPage(mcdu);
-                } else if (!isFinite(numValue) && value.length == 3) {
-                    mcdu.vor1IdIsPilotEntered = true;
-                    mcdu.vor1FreqIsPilotEntered = false;
-                    mcdu.vor1IdPilotValue = value;
+                } else if (!isFinite(numValue) && value.length >= 2 && value.length <= 3) {
                     mcdu.getOrSelectVORsByIdent(value, (navaids) => {
                         if (navaids) {
+                            mcdu.vor1IdIsPilotEntered = true;
+                            mcdu.vor1FreqIsPilotEntered = false;
+                            mcdu.vor1IdPilotValue = value;
                             mcdu.vor1Frequency = navaids.infos.frequencyMHz;
                             mcdu.radioNav.setVORActiveFrequency(1, mcdu.vor1Frequency);
                             mcdu.vor1Course = 0;
+                            mcdu.requestCall(() => {
+                                CDUNavRadioPage.ShowPage(mcdu);
+                            });
                         }
-                        mcdu.requestCall(() => {
-                            CDUNavRadioPage.ShowPage(mcdu);
-                        });
                     });
                 } else if (isFinite(numValue)) {
                     if (!/^\d{3}(\.\d{1,2})?$/.test(value) || !RadioNav.isHz50Compliant(numValue)) {
@@ -202,7 +202,7 @@ class CDUNavRadioPage {
         if (!radioOn) {
             vor2FrequencyCell = "[\xa0\xa0.\xa0]/[\xa0]";
             const vor2Beacon = mcdu.radioNav.getVORBeacon(2);
-            const vor2Ident = vor2Beacon && vor2Beacon.ident.length === 3 ? vor2Beacon.ident : "";
+            const vor2Ident = vor2Beacon && vor2Beacon.ident.length >= 2 && vor2Beacon.ident.length <= 3 ? vor2Beacon.ident : "";
             if (mcdu.vor2Frequency != 0 && mcdu.vor2FreqIsPilotEntered && !mcdu.vor2IdIsPilotEntered) {
                 vor2FrequencyCell = mcdu.vor2Frequency.toFixed(2) + "/" + "{small}" + vor2Ident.padEnd(3, "\xa0") + "{end}";
             } else if (mcdu.vor2Frequency != 0 && !mcdu.vor2FreqIsPilotEntered && mcdu.vor2IdIsPilotEntered) {
@@ -217,17 +217,19 @@ class CDUNavRadioPage {
                     mcdu.vor2Course = 0;
                     mcdu.radioNav.setVORActiveFrequency(2, 0);
                     CDUNavRadioPage.ShowPage(mcdu);
-                } else if (!isFinite(numValue) && value.length == 3) {
+                } else if (!isFinite(numValue)  && value.length >= 2 && value.length <= 3) {
                     mcdu.getOrSelectVORsByIdent(value, (navaids) => {
-                        mcdu.vor2FreqIsPilotEntered = false;
-                        mcdu.vor2IdIsPilotEntered = true;
-                        mcdu.vor2IdPilotValue = value;
-                        mcdu.vor2Frequency = navaids.infos.frequencyMHz;
-                        mcdu.radioNav.setVORActiveFrequency(2, mcdu.vor2Frequency);
-                        mcdu.vor2Course = 0;
-                        mcdu.requestCall(() => {
-                            CDUNavRadioPage.ShowPage(mcdu);
-                        });
+                        if (navaids) {
+                            mcdu.vor2IdIsPilotEntered = true;
+                            mcdu.vor2FreqIsPilotEntered = false;
+                            mcdu.vor2IdPilotValue = value;
+                            mcdu.vor2Frequency = navaids.infos.frequencyMHz;
+                            mcdu.radioNav.setVORActiveFrequency(2, mcdu.vor2Frequency);
+                            mcdu.vor2Course = 0;
+                            mcdu.requestCall(() => {
+                                CDUNavRadioPage.ShowPage(mcdu);
+                            });
+                        }
                     });
                 } else if (isFinite(numValue)) {
                     if (!/^\d{3}(\.\d{1,2})?$/.test(value) || !RadioNav.isHz50Compliant(numValue)) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -43,13 +43,16 @@ class CDUNavRadioPage {
             }
         };
         if (!radioOn) {
-            vor1FrequencyCell = "[\xa0]/[\xa0\xa0.\xa0]";
+            vor1FrequencyCell = "[\xa0\xa0]/[\xa0\xa0.\xa0]";
             const vor1Ident = mcdu.radioNav.getVORBeacon(1);
             if (mcdu.vor1Frequency != 0 && !mcdu.vor1IdIsPilotEntered && mcdu.vor1FreqIsPilotEntered) {
-                vor1FrequencyCell = "{small}" + vor1Ident.ident.padStart(3, "\xa0") + "{end}" + "/" + mcdu.vor1Frequency.toFixed(2);
+                vor1FrequencyCell = "{small}" + vor1Ident.ident + "{end}" + "/" + mcdu.vor1Frequency.toFixed(2);
             } else if (mcdu.vor1Frequency != 0 && mcdu.vor1IdIsPilotEntered && !mcdu.vor1FreqIsPilotEntered) {
-                vor1FrequencyCell = mcdu.vor1IdPilotValue.padStart(3, "\xa0") + "/" + "{small}" + mcdu.vor1Frequency.toFixed(2) + "{end}";
+                vor1FrequencyCell = vor1Ident.ident + "/" + "{small}" + mcdu.vor1Frequency.toFixed(2) + "{end}";
             }
+            //if (vor1Ident.ident == "" && mcdu.vor1Frequency > 0) {
+            //    vor1FrequencyCell = "[\xa0\xa0]/" + mcdu.vor1Frequency.toFixed(2);
+            //}
             mcdu.onLeftInput[0] = (value) => {
                 const numValue = parseFloat(value);
                 if (value === FMCMainDisplay.clrValue) {
@@ -62,7 +65,6 @@ class CDUNavRadioPage {
                 } else if (!isFinite(numValue) && value.length == 3) {
                     mcdu.vor1IdIsPilotEntered = true;
                     mcdu.vor1FreqIsPilotEntered = false;
-                    mcdu.vor1IdPilotValue = value;
                     mcdu.getOrSelectVORsByIdent(value, (navaids) => {
                         mcdu.vor1Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setVORActiveFrequency(1, mcdu.vor1Frequency);
@@ -137,13 +139,13 @@ class CDUNavRadioPage {
                     CDUNavRadioPage.ShowPage(mcdu);
                 }
             };
-            adf1FrequencyCell = "[\xa0]/[\xa0\xa0\xa0.]";
+            adf1FrequencyCell = "[\xa0\xa0]/[\xa0\xa0\xa0.]";
             const adf1Ident = SimVar.GetSimVarValue(`ADF IDENT:1`, "string");
             if (mcdu.adf1Frequency != 0 && !mcdu.adf1IdIsPilotEntered && mcdu.adf1FreqIsPilotEntered) {
                 adf1FrequencyCell = "{small}" + adf1Ident.padStart(3, "\xa0") + "{end}" + "/" + mcdu.adf1Frequency.toFixed(1);
                 adf1BfoOption = "<ADF1 BFO";
             } else if (mcdu.adf1Frequency != 0 && mcdu.adf1IdIsPilotEntered && !mcdu.adf1FreqIsPilotEntered) {
-                adf1FrequencyCell = mcdu.adf1IdPilotValue.padStart(3, "\xa0")+ "/" + "{small}" +  + mcdu.adf1Frequency.toFixed(1) + "{end}";
+                adf1FrequencyCell = adf1Ident.padStart(3, "\xa0")+ "/" + "{small}" +  + mcdu.adf1Frequency.toFixed(1) + "{end}";
                 adf1BfoOption = "<ADF1 BFO";
             }
             mcdu.onLeftInput[4] = (value) => {
@@ -152,7 +154,6 @@ class CDUNavRadioPage {
                     mcdu.getOrSelectNDBsByIdent(value, (navaids) => {
                         mcdu.adf1FreqIsPilotEntered = false;
                         mcdu.adf1IdIsPilotEntered = true;
-                        mcdu.adf1IdPilotValue = value;
                         mcdu.adf1Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setADFActiveFrequency(1, mcdu.adf1Frequency);
                         mcdu.requestCall(() => {
@@ -181,12 +182,12 @@ class CDUNavRadioPage {
         }
 
         if (!radioOn) {
-            vor2FrequencyCell = "[\xa0\xa0.\xa0]/[\xa0]";
+            vor2FrequencyCell = "[\xa0\xa0.\xa0]/[\xa0\xa0]";
             const vor2Ident = mcdu.radioNav.getVORBeacon(2);
             if (mcdu.vor2Frequency != 0 && mcdu.vor2FreqIsPilotEntered && !mcdu.vor2IdIsPilotEntered) {
-                vor2FrequencyCell = mcdu.vor2Frequency.toFixed(2) + "/" + "{small}" + vor2Ident.ident.padEnd(3, "\xa0") + "{end}";
+                vor2FrequencyCell = mcdu.vor2Frequency.toFixed(2) + "/" + "{small}" + vor2Ident.ident + "{end}";
             } else if (mcdu.vor2Frequency != 0 && !mcdu.vor2FreqIsPilotEntered && mcdu.vor2IdIsPilotEntered) {
-                vor2FrequencyCell = "{small}" + mcdu.vor2Frequency.toFixed(2) + "{end}" + "/" + mcdu.vor2IdPilotValue.padEnd(3, "\xa0");
+                vor2FrequencyCell = "{small}" + mcdu.vor2Frequency.toFixed(2) + "{end}" + "/" + vor2Ident.ident;
             }
             mcdu.onRightInput[0] = (value) => {
                 const numValue = parseFloat(value);
@@ -201,7 +202,6 @@ class CDUNavRadioPage {
                     mcdu.getOrSelectVORsByIdent(value, (navaids) => {
                         mcdu.vor2FreqIsPilotEntered = false;
                         mcdu.vor2IdIsPilotEntered = true;
-                        mcdu.vor2IdPilotValue = value;
                         mcdu.vor2Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setVORActiveFrequency(2, mcdu.vor2Frequency);
                         mcdu.vor2Course = 0;
@@ -252,13 +252,13 @@ class CDUNavRadioPage {
                     mcdu.addNewMessage(NXSystemMessages.entryOutOfRange);
                 }
             };
-            adf2FrequencyCell = "[\xa0\xa0\xa0.]/[\xa0]";
+            adf2FrequencyCell = "[\xa0\xa0\xa0.]/[\xa0\xa0]";
             const adf2Ident = SimVar.GetSimVarValue(`ADF IDENT:2`, "string");
             if (mcdu.adf2Frequency > 0 && mcdu.adf2FreqIsPilotEntered && !mcdu.adf2IdIsPilotEntered) {
-                adf2FrequencyCell = mcdu.adf2Frequency.toFixed(1) + "/" + "{small}" + adf2Ident.padEnd(3, "\xa0") + "{end}";
+                adf2FrequencyCell = mcdu.adf2Frequency + "/" + "{small}" + adf2Ident.padEnd(3, "\xa0") + "{end}";
                 adf2BfoOption = "ADF2 BFO>";
             } else if (mcdu.adf2Frequency > 0 && !mcdu.adf2FreqIsPilotEntered && mcdu.adf2IdIsPilotEntered) {
-                adf2FrequencyCell = "{small}" + mcdu.adf2Frequency.toFixed(1) + "{end}" + "/" + mcdu.adf2IdPilotValue.padEnd(3, "\xa0");
+                adf2FrequencyCell = "{small}" + mcdu.adf2Frequency + "{end}" + "/" + adf2Ident.padEnd(3, "\xa0");
                 adf2BfoOption = "ADF2 BFO>";
             }
             mcdu.onRightInput[4] = (value) => {
@@ -266,7 +266,6 @@ class CDUNavRadioPage {
                 if (!isFinite(numValue) && value.length >= 2 && value.length <= 3) {
                     mcdu.adf2FreqIsPilotEntered = false;
                     mcdu.adf2IdIsPilotEntered = true;
-                    mcdu.adf2IdPilotValue = value;
                     mcdu.getOrSelectNDBsByIdent(value, (navaids) => {
                         mcdu.adf2Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setADFActiveFrequency(2, mcdu.adf2Frequency);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -255,10 +255,10 @@ class CDUNavRadioPage {
             adf2FrequencyCell = "[\xa0\xa0\xa0.]/[\xa0]";
             const adf2Ident = SimVar.GetSimVarValue(`ADF IDENT:2`, "string");
             if (mcdu.adf2Frequency > 0 && mcdu.adf2FreqIsPilotEntered && !mcdu.adf2IdIsPilotEntered) {
-                adf2FrequencyCell = mcdu.adf2Frequency + "/" + "{small}" + adf2Ident.padEnd(3, "\xa0") + "{end}";
+                adf2FrequencyCell = mcdu.adf2Frequency.toFixed(1) + "/" + "{small}" + adf2Ident.padEnd(3, "\xa0") + "{end}";
                 adf2BfoOption = "ADF2 BFO>";
             } else if (mcdu.adf2Frequency > 0 && !mcdu.adf2FreqIsPilotEntered && mcdu.adf2IdIsPilotEntered) {
-                adf2FrequencyCell = "{small}" + mcdu.adf2Frequency + "{end}" + "/" + mcdu.adf2IdPilotValue.padEnd(3, "\xa0");
+                adf2FrequencyCell = "{small}" + mcdu.adf2Frequency.toFixed(1) + "{end}" + "/" + mcdu.adf2IdPilotValue.padEnd(3, "\xa0");
                 adf2BfoOption = "ADF2 BFO>";
             }
             mcdu.onRightInput[4] = (value) => {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -44,9 +44,10 @@ class CDUNavRadioPage {
         };
         if (!radioOn) {
             vor1FrequencyCell = "[\xa0]/[\xa0\xa0.\xa0]";
-            const vor1Ident = mcdu.radioNav.getVORBeacon(1);
+            const vor1Beacon = mcdu.radioNav.getVORBeacon(1);
+            const vor1Ident = vor1Beacon && vor1Beacon.ident.length === 3 ? vor1Beacon.ident : "";
             if (mcdu.vor1Frequency != 0 && !mcdu.vor1IdIsPilotEntered && mcdu.vor1FreqIsPilotEntered) {
-                vor1FrequencyCell = "{small}" + vor1Ident.ident.padStart(3, "\xa0") + "{end}" + "/" + mcdu.vor1Frequency.toFixed(2);
+                vor1FrequencyCell = "{small}" + vor1Ident.padStart(3, "\xa0") + "{end}" + "/" + mcdu.vor1Frequency.toFixed(2);
             } else if (mcdu.vor1Frequency != 0 && mcdu.vor1IdIsPilotEntered && !mcdu.vor1FreqIsPilotEntered) {
                 vor1FrequencyCell = mcdu.vor1IdPilotValue.padStart(3, "\xa0") + "/" + "{small}" + mcdu.vor1Frequency.toFixed(2) + "{end}";
             }
@@ -64,14 +65,24 @@ class CDUNavRadioPage {
                     mcdu.vor1FreqIsPilotEntered = false;
                     mcdu.vor1IdPilotValue = value;
                     mcdu.getOrSelectVORsByIdent(value, (navaids) => {
-                        mcdu.vor1Frequency = navaids.infos.frequencyMHz;
-                        mcdu.radioNav.setVORActiveFrequency(1, mcdu.vor1Frequency);
-                        mcdu.vor1Course = 0;
+                        if (navaids) {
+                            mcdu.vor1Frequency = navaids.infos.frequencyMHz;
+                            mcdu.radioNav.setVORActiveFrequency(1, mcdu.vor1Frequency);
+                            mcdu.vor1Course = 0;
+                        }
                         mcdu.requestCall(() => {
                             CDUNavRadioPage.ShowPage(mcdu);
                         });
                     });
-                } else if (isFinite(numValue) && numValue >= 108 && numValue <= 117.95 && RadioNav.isHz50Compliant(numValue)) {
+                } else if (isFinite(numValue)) {
+                    if (!/^\d{3}(\.\d{1,2})?$/.test(value) || !RadioNav.isHz50Compliant(numValue)) {
+                        mcdu.addNewMessage(NXSystemMessages.formatError);
+                        return false;
+                    }
+                    if (numValue < 108 || numValue > 117.95) {
+                        mcdu.addNewMessage(NXSystemMessages.entryOutOfRange);
+                        return false;
+                    }
                     mcdu.vor1IdIsPilotEntered = false;
                     mcdu.vor1FreqIsPilotEntered = true;
                     if (numValue != mcdu.vor1Frequency) {
@@ -159,7 +170,15 @@ class CDUNavRadioPage {
                             CDUNavRadioPage.ShowPage(mcdu);
                         });
                     });
-                } else if (isFinite(numValue) && numValue >= 100 && numValue <= 1699.9) {
+                } else if (isFinite(numValue)) {
+                    if (!/^\d{3,4}(\.\d{1})?$/.test(value)) {
+                        mcdu.addNewMessage(NXSystemMessages.formatError);
+                        return false;
+                    }
+                    if (numValue < 190 || numValue > 1750) {
+                        mcdu.addNewMessage(NXSystemMessages.entryOutOfRange);
+                        return false;
+                    }
                     SimVar.SetSimVarValue("K:ADF_COMPLETE_SET", "Frequency ADF BCD32", Avionics.Utils.make_adf_bcd32(numValue * 1000)).then(() => {
                         mcdu.adf1FreqIsPilotEntered = true;
                         mcdu.adf1IdIsPilotEntered = false;
@@ -182,9 +201,10 @@ class CDUNavRadioPage {
 
         if (!radioOn) {
             vor2FrequencyCell = "[\xa0\xa0.\xa0]/[\xa0]";
-            const vor2Ident = mcdu.radioNav.getVORBeacon(2);
+            const vor2Beacon = mcdu.radioNav.getVORBeacon(2);
+            const vor2Ident = vor2Beacon && vor2Beacon.ident.length === 3 ? vor2Beacon.ident : "";
             if (mcdu.vor2Frequency != 0 && mcdu.vor2FreqIsPilotEntered && !mcdu.vor2IdIsPilotEntered) {
-                vor2FrequencyCell = mcdu.vor2Frequency.toFixed(2) + "/" + "{small}" + vor2Ident.ident.padEnd(3, "\xa0") + "{end}";
+                vor2FrequencyCell = mcdu.vor2Frequency.toFixed(2) + "/" + "{small}" + vor2Ident.padEnd(3, "\xa0") + "{end}";
             } else if (mcdu.vor2Frequency != 0 && !mcdu.vor2FreqIsPilotEntered && mcdu.vor2IdIsPilotEntered) {
                 vor2FrequencyCell = "{small}" + mcdu.vor2Frequency.toFixed(2) + "{end}" + "/" + mcdu.vor2IdPilotValue.padEnd(3, "\xa0");
             }
@@ -209,10 +229,18 @@ class CDUNavRadioPage {
                             CDUNavRadioPage.ShowPage(mcdu);
                         });
                     });
-                } else if (isFinite(numValue) && numValue >= 108 && numValue <= 117.95 && RadioNav.isHz50Compliant(numValue)) {
+                } else if (isFinite(numValue)) {
+                    if (!/^\d{3}(\.\d{1,2})?$/.test(value) || !RadioNav.isHz50Compliant(numValue)) {
+                        mcdu.addNewMessage(NXSystemMessages.formatError);
+                        return false;
+                    }
+                    if (numValue < 108 || numValue > 117.95) {
+                        mcdu.addNewMessage(NXSystemMessages.entryOutOfRange);
+                        return false;
+                    }
+                    mcdu.vor2FreqIsPilotEntered = true;
+                    mcdu.vor2IdIsPilotEntered = false;
                     if (numValue != mcdu.vor2Frequency) {
-                        mcdu.vor2FreqIsPilotEntered = true;
-                        mcdu.vor2IdIsPilotEntered = false;
                         mcdu.vor2Course = 0;
                     }
                     mcdu.vor2Frequency = numValue;
@@ -274,7 +302,15 @@ class CDUNavRadioPage {
                             CDUNavRadioPage.ShowPage(mcdu);
                         });
                     });
-                } else if (isFinite(numValue) && numValue >= 100 && numValue <= 1699.9) {
+                } else if (isFinite(numValue)) {
+                    if (!/^\d{3,4}(\.\d{1})?$/.test(value)) {
+                        mcdu.addNewMessage(NXSystemMessages.formatError);
+                        return false;
+                    }
+                    if (numValue < 190 || numValue > 1750) {
+                        mcdu.addNewMessage(NXSystemMessages.entryOutOfRange);
+                        return false;
+                    }
                     SimVar.SetSimVarValue("K:ADF2_COMPLETE_SET", "Frequency ADF BCD32", Avionics.Utils.make_adf_bcd32(numValue * 1000)).then(() => {
                         mcdu.adf2FreqIsPilotEntered = true;
                         mcdu.adf2IdIsPilotEntered = false;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -43,12 +43,12 @@ class CDUNavRadioPage {
             }
         };
         if (!radioOn) {
-            vor1FrequencyCell = "[\xa0\xa0]/[\xa0\xa0.\xa0]";
+            vor1FrequencyCell = "[\xa0]/[\xa0\xa0.\xa0]";
             const vor1Ident = mcdu.radioNav.getVORBeacon(1);
             if (mcdu.vor1Frequency != 0 && !mcdu.vor1IdIsPilotEntered && mcdu.vor1FreqIsPilotEntered) {
-                vor1FrequencyCell = "{small}" + vor1Ident.ident + "{end}" + "/" + mcdu.vor1Frequency.toFixed(2);
+                vor1FrequencyCell = "{small}" + vor1Ident.ident.padStart(3, "\xa0") + "{end}" + "/" + mcdu.vor1Frequency.toFixed(2);
             } else if (mcdu.vor1Frequency != 0 && mcdu.vor1IdIsPilotEntered && !mcdu.vor1FreqIsPilotEntered) {
-                vor1FrequencyCell = vor1Ident.ident + "/" + "{small}" + mcdu.vor1Frequency.toFixed(2) + "{end}";
+                vor1FrequencyCell = mcdu.vor1IdPilotValue.padStart(3, "\xa0") + "/" + "{small}" + mcdu.vor1Frequency.toFixed(2) + "{end}";
             }
             mcdu.onLeftInput[0] = (value) => {
                 const numValue = parseFloat(value);
@@ -62,6 +62,7 @@ class CDUNavRadioPage {
                 } else if (!isFinite(numValue) && value.length == 3) {
                     mcdu.vor1IdIsPilotEntered = true;
                     mcdu.vor1FreqIsPilotEntered = false;
+                    mcdu.vor1IdPilotValue = value;
                     mcdu.getOrSelectVORsByIdent(value, (navaids) => {
                         mcdu.vor1Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setVORActiveFrequency(1, mcdu.vor1Frequency);
@@ -136,13 +137,13 @@ class CDUNavRadioPage {
                     CDUNavRadioPage.ShowPage(mcdu);
                 }
             };
-            adf1FrequencyCell = "[\xa0\xa0]/[\xa0\xa0\xa0.]";
+            adf1FrequencyCell = "[\xa0]/[\xa0\xa0\xa0.]";
             const adf1Ident = SimVar.GetSimVarValue(`ADF IDENT:1`, "string");
             if (mcdu.adf1Frequency != 0 && !mcdu.adf1IdIsPilotEntered && mcdu.adf1FreqIsPilotEntered) {
                 adf1FrequencyCell = "{small}" + adf1Ident.padStart(3, "\xa0") + "{end}" + "/" + mcdu.adf1Frequency.toFixed(1);
                 adf1BfoOption = "<ADF1 BFO";
             } else if (mcdu.adf1Frequency != 0 && mcdu.adf1IdIsPilotEntered && !mcdu.adf1FreqIsPilotEntered) {
-                adf1FrequencyCell = adf1Ident.padStart(3, "\xa0")+ "/" + "{small}" +  + mcdu.adf1Frequency.toFixed(1) + "{end}";
+                adf1FrequencyCell = mcdu.adf1IdPilotValue.padStart(3, "\xa0")+ "/" + "{small}" +  + mcdu.adf1Frequency.toFixed(1) + "{end}";
                 adf1BfoOption = "<ADF1 BFO";
             }
             mcdu.onLeftInput[4] = (value) => {
@@ -151,6 +152,7 @@ class CDUNavRadioPage {
                     mcdu.getOrSelectNDBsByIdent(value, (navaids) => {
                         mcdu.adf1FreqIsPilotEntered = false;
                         mcdu.adf1IdIsPilotEntered = true;
+                        mcdu.adf1IdPilotValue = value;
                         mcdu.adf1Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setADFActiveFrequency(1, mcdu.adf1Frequency);
                         mcdu.requestCall(() => {
@@ -179,12 +181,12 @@ class CDUNavRadioPage {
         }
 
         if (!radioOn) {
-            vor2FrequencyCell = "[\xa0\xa0.\xa0]/[\xa0\xa0]";
+            vor2FrequencyCell = "[\xa0\xa0.\xa0]/[\xa0]";
             const vor2Ident = mcdu.radioNav.getVORBeacon(2);
             if (mcdu.vor2Frequency != 0 && mcdu.vor2FreqIsPilotEntered && !mcdu.vor2IdIsPilotEntered) {
-                vor2FrequencyCell = mcdu.vor2Frequency.toFixed(2) + "/" + "{small}" + vor2Ident.ident + "{end}";
+                vor2FrequencyCell = mcdu.vor2Frequency.toFixed(2) + "/" + "{small}" + vor2Ident.ident.padEnd(3, "\xa0") + "{end}";
             } else if (mcdu.vor2Frequency != 0 && !mcdu.vor2FreqIsPilotEntered && mcdu.vor2IdIsPilotEntered) {
-                vor2FrequencyCell = "{small}" + mcdu.vor2Frequency.toFixed(2) + "{end}" + "/" + vor2Ident.ident;
+                vor2FrequencyCell = "{small}" + mcdu.vor2Frequency.toFixed(2) + "{end}" + "/" + mcdu.vor2IdPilotValue.padEnd(3, "\xa0");
             }
             mcdu.onRightInput[0] = (value) => {
                 const numValue = parseFloat(value);
@@ -199,6 +201,7 @@ class CDUNavRadioPage {
                     mcdu.getOrSelectVORsByIdent(value, (navaids) => {
                         mcdu.vor2FreqIsPilotEntered = false;
                         mcdu.vor2IdIsPilotEntered = true;
+                        mcdu.vor2IdPilotValue = value;
                         mcdu.vor2Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setVORActiveFrequency(2, mcdu.vor2Frequency);
                         mcdu.vor2Course = 0;
@@ -249,13 +252,13 @@ class CDUNavRadioPage {
                     mcdu.addNewMessage(NXSystemMessages.entryOutOfRange);
                 }
             };
-            adf2FrequencyCell = "[\xa0\xa0\xa0.]/[\xa0\xa0]";
+            adf2FrequencyCell = "[\xa0\xa0\xa0.]/[\xa0]";
             const adf2Ident = SimVar.GetSimVarValue(`ADF IDENT:2`, "string");
             if (mcdu.adf2Frequency > 0 && mcdu.adf2FreqIsPilotEntered && !mcdu.adf2IdIsPilotEntered) {
                 adf2FrequencyCell = mcdu.adf2Frequency + "/" + "{small}" + adf2Ident.padEnd(3, "\xa0") + "{end}";
                 adf2BfoOption = "ADF2 BFO>";
             } else if (mcdu.adf2Frequency > 0 && !mcdu.adf2FreqIsPilotEntered && mcdu.adf2IdIsPilotEntered) {
-                adf2FrequencyCell = "{small}" + mcdu.adf2Frequency + "{end}" + "/" + adf2Ident.padEnd(3, "\xa0");
+                adf2FrequencyCell = "{small}" + mcdu.adf2Frequency + "{end}" + "/" + mcdu.adf2IdPilotValue.padEnd(3, "\xa0");
                 adf2BfoOption = "ADF2 BFO>";
             }
             mcdu.onRightInput[4] = (value) => {
@@ -263,6 +266,7 @@ class CDUNavRadioPage {
                 if (!isFinite(numValue) && value.length >= 2 && value.length <= 3) {
                     mcdu.adf2FreqIsPilotEntered = false;
                     mcdu.adf2IdIsPilotEntered = true;
+                    mcdu.adf2IdPilotValue = value;
                     mcdu.getOrSelectNDBsByIdent(value, (navaids) => {
                         mcdu.adf2Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setADFActiveFrequency(2, mcdu.adf2Frequency);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -18,7 +18,6 @@
 
 class CDUNavRadioPage {
     static ShowPage(mcdu) {
-        <script type="text/javascript" src="/JS/debug.js"></script>
         mcdu.clearDisplay();
         mcdu.page.Current = mcdu.page.NavRadioPage;
         mcdu.activeSystem = 'FMGC';

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -43,13 +43,16 @@ class CDUNavRadioPage {
             }
         };
         if (!radioOn) {
-            vor1FrequencyCell = "[\xa0]/[\xa0\xa0.\xa0]";
+            vor1FrequencyCell = "[\xa0\xa0]/[\xa0\xa0.\xa0]";
             const vor1Ident = mcdu.radioNav.getVORBeacon(1);
             if (mcdu.vor1Frequency != 0 && !mcdu.vor1IdIsPilotEntered && mcdu.vor1FreqIsPilotEntered) {
-                vor1FrequencyCell = "{small}" + vor1Ident.ident.padStart(3, "\xa0") + "{end}" + "/" + mcdu.vor1Frequency.toFixed(2);
+                vor1FrequencyCell = "{small}" + vor1Ident.ident + "{end}" + "/" + mcdu.vor1Frequency.toFixed(2);
             } else if (mcdu.vor1Frequency != 0 && mcdu.vor1IdIsPilotEntered && !mcdu.vor1FreqIsPilotEntered) {
-                vor1FrequencyCell = mcdu.vor1IdPilotValue.padStart(3, "\xa0") + "/" + "{small}" + mcdu.vor1Frequency.toFixed(2) + "{end}";
+                vor1FrequencyCell = vor1Ident.ident + "/" + "{small}" + mcdu.vor1Frequency.toFixed(2) + "{end}";
             }
+            //if (vor1Ident.ident == "" && mcdu.vor1Frequency > 0) {
+            //    vor1FrequencyCell = "[\xa0\xa0]/" + mcdu.vor1Frequency.toFixed(2);
+            //}
             mcdu.onLeftInput[0] = (value) => {
                 const numValue = parseFloat(value);
                 if (value === FMCMainDisplay.clrValue) {
@@ -62,7 +65,6 @@ class CDUNavRadioPage {
                 } else if (!isFinite(numValue) && value.length == 3) {
                     mcdu.vor1IdIsPilotEntered = true;
                     mcdu.vor1FreqIsPilotEntered = false;
-                    mcdu.vor1IdPilotValue = value;
                     mcdu.getOrSelectVORsByIdent(value, (navaids) => {
                         mcdu.vor1Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setVORActiveFrequency(1, mcdu.vor1Frequency);
@@ -137,13 +139,13 @@ class CDUNavRadioPage {
                     CDUNavRadioPage.ShowPage(mcdu);
                 }
             };
-            adf1FrequencyCell = "[\xa0]/[\xa0\xa0\xa0.]";
+            adf1FrequencyCell = "[\xa0\xa0]/[\xa0\xa0\xa0.]";
             const adf1Ident = SimVar.GetSimVarValue(`ADF IDENT:1`, "string");
             if (mcdu.adf1Frequency != 0 && !mcdu.adf1IdIsPilotEntered && mcdu.adf1FreqIsPilotEntered) {
                 adf1FrequencyCell = "{small}" + adf1Ident.padStart(3, "\xa0") + "{end}" + "/" + mcdu.adf1Frequency.toFixed(1);
                 adf1BfoOption = "<ADF1 BFO";
             } else if (mcdu.adf1Frequency != 0 && mcdu.adf1IdIsPilotEntered && !mcdu.adf1FreqIsPilotEntered) {
-                adf1FrequencyCell = mcdu.adf1IdPilotValue.padStart(3, "\xa0")+ "/" + "{small}" +  + mcdu.adf1Frequency.toFixed(1) + "{end}";
+                adf1FrequencyCell = adf1Ident.padStart(3, "\xa0")+ "/" + "{small}" +  + mcdu.adf1Frequency.toFixed(1) + "{end}";
                 adf1BfoOption = "<ADF1 BFO";
             }
             mcdu.onLeftInput[4] = (value) => {
@@ -152,7 +154,6 @@ class CDUNavRadioPage {
                     mcdu.getOrSelectNDBsByIdent(value, (navaids) => {
                         mcdu.adf1FreqIsPilotEntered = false;
                         mcdu.adf1IdIsPilotEntered = true;
-                        mcdu.adf1IdPilotValue = value;
                         mcdu.adf1Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setADFActiveFrequency(1, mcdu.adf1Frequency);
                         mcdu.requestCall(() => {
@@ -181,12 +182,12 @@ class CDUNavRadioPage {
         }
 
         if (!radioOn) {
-            vor2FrequencyCell = "[\xa0\xa0.\xa0]/[\xa0]";
+            vor2FrequencyCell = "[\xa0\xa0.\xa0]/[\xa0\xa0]";
             const vor2Ident = mcdu.radioNav.getVORBeacon(2);
             if (mcdu.vor2Frequency != 0 && mcdu.vor2FreqIsPilotEntered && !mcdu.vor2IdIsPilotEntered) {
-                vor2FrequencyCell = mcdu.vor2Frequency.toFixed(2) + "/" + "{small}" + vor2Ident.ident.padEnd(3, "\xa0") + "{end}";
+                vor2FrequencyCell = mcdu.vor2Frequency.toFixed(2) + "/" + "{small}" + vor2Ident.ident + "{end}";
             } else if (mcdu.vor2Frequency != 0 && !mcdu.vor2FreqIsPilotEntered && mcdu.vor2IdIsPilotEntered) {
-                vor2FrequencyCell = "{small}" + mcdu.vor2Frequency.toFixed(2) + "{end}" + "/" + mcdu.vor2IdPilotValue.padEnd(3, "\xa0");
+                vor2FrequencyCell = "{small}" + mcdu.vor2Frequency.toFixed(2) + "{end}" + "/" + vor2Ident.ident;
             }
             mcdu.onRightInput[0] = (value) => {
                 const numValue = parseFloat(value);
@@ -201,7 +202,6 @@ class CDUNavRadioPage {
                     mcdu.getOrSelectVORsByIdent(value, (navaids) => {
                         mcdu.vor2FreqIsPilotEntered = false;
                         mcdu.vor2IdIsPilotEntered = true;
-                        mcdu.vor2IdPilotValue = value;
                         mcdu.vor2Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setVORActiveFrequency(2, mcdu.vor2Frequency);
                         mcdu.vor2Course = 0;
@@ -252,13 +252,13 @@ class CDUNavRadioPage {
                     mcdu.addNewMessage(NXSystemMessages.entryOutOfRange);
                 }
             };
-            adf2FrequencyCell = "[\xa0\xa0\xa0.]/[\xa0]";
+            adf2FrequencyCell = "[\xa0\xa0\xa0.]/[\xa0\xa0]";
             const adf2Ident = SimVar.GetSimVarValue(`ADF IDENT:2`, "string");
             if (mcdu.adf2Frequency > 0 && mcdu.adf2FreqIsPilotEntered && !mcdu.adf2IdIsPilotEntered) {
                 adf2FrequencyCell = mcdu.adf2Frequency + "/" + "{small}" + adf2Ident.padEnd(3, "\xa0") + "{end}";
                 adf2BfoOption = "ADF2 BFO>";
             } else if (mcdu.adf2Frequency > 0 && !mcdu.adf2FreqIsPilotEntered && mcdu.adf2IdIsPilotEntered) {
-                adf2FrequencyCell = "{small}" + mcdu.adf2Frequency + "{end}" + "/" + mcdu.adf2IdPilotValue.padEnd(3, "\xa0");
+                adf2FrequencyCell = "{small}" + mcdu.adf2Frequency + "{end}" + "/" + adf2Ident.padEnd(3, "\xa0");
                 adf2BfoOption = "ADF2 BFO>";
             }
             mcdu.onRightInput[4] = (value) => {
@@ -266,7 +266,6 @@ class CDUNavRadioPage {
                 if (!isFinite(numValue) && value.length >= 2 && value.length <= 3) {
                     mcdu.adf2FreqIsPilotEntered = false;
                     mcdu.adf2IdIsPilotEntered = true;
-                    mcdu.adf2IdPilotValue = value;
                     mcdu.getOrSelectNDBsByIdent(value, (navaids) => {
                         mcdu.adf2Frequency = navaids.infos.frequencyMHz;
                         mcdu.radioNav.setADFActiveFrequency(2, mcdu.adf2Frequency);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -217,7 +217,7 @@ class CDUNavRadioPage {
                     mcdu.vor2Course = 0;
                     mcdu.radioNav.setVORActiveFrequency(2, 0);
                     CDUNavRadioPage.ShowPage(mcdu);
-                } else if (!isFinite(numValue)  && value.length >= 2 && value.length <= 3) {
+                } else if (!isFinite(numValue) && value.length >= 2 && value.length <= 3) {
                     mcdu.getOrSelectVORsByIdent(value, (navaids) => {
                         if (navaids) {
                             mcdu.vor2IdIsPilotEntered = true;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -50,9 +50,6 @@ class CDUNavRadioPage {
             } else if (mcdu.vor1Frequency != 0 && mcdu.vor1IdIsPilotEntered && !mcdu.vor1FreqIsPilotEntered) {
                 vor1FrequencyCell = vor1Ident.ident + "/" + "{small}" + mcdu.vor1Frequency.toFixed(2) + "{end}";
             }
-            //if (vor1Ident.ident == "" && mcdu.vor1Frequency > 0) {
-            //    vor1FrequencyCell = "[\xa0\xa0]/" + mcdu.vor1Frequency.toFixed(2);
-            //}
             mcdu.onLeftInput[0] = (value) => {
                 const numValue = parseFloat(value);
                 if (value === FMCMainDisplay.clrValue) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -154,7 +154,7 @@ class CDUNavRadioPage {
                 adf1FrequencyCell = "{small}" + adf1Ident.padStart(3, "\xa0") + "{end}" + "/" + mcdu.adf1Frequency.toFixed(1);
                 adf1BfoOption = "<ADF1 BFO";
             } else if (mcdu.adf1Frequency != 0 && mcdu.adf1IdIsPilotEntered && !mcdu.adf1FreqIsPilotEntered) {
-                adf1FrequencyCell = mcdu.adf1IdPilotValue.padStart(3, "\xa0")+ "/" + "{small}" +  + mcdu.adf1Frequency.toFixed(1) + "{end}";
+                adf1FrequencyCell = mcdu.adf1IdPilotValue.padStart(3, "\xa0") + "/" + "{small}" + mcdu.adf1Frequency.toFixed(1) + "{end}";
                 adf1BfoOption = "<ADF1 BFO";
             }
             mcdu.onLeftInput[4] = (value) => {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The RADNAV page is finally fun to use :D

My second pass over the RADNAV page to improve quality as it lags behind other pages of the MCDU. Main goal is to get accurate display of everything you need. Navaids reception problems are not goal of this PR. The list below might extend while progressing.

- [x] Make manual navaid ID display "permament". When putting in an identifier, it now immediately will be filled in and will stay, while before its display was dependent on the navaids reception. 
- [x] Correct big/small font behavior depending on wether ID or Freq is put in manually. The manual input is always display big while the auto filled ID or Freq is small and vise versa. 
- [X] Fix ADF frequency decimal. Currently a manual input will show a decimal while the auto fill does not. Both should show the decimal in any case. 
- [X] Create an input check on the ADF fields. Currently you can put in any decimal numbers. It should be only one decimal. 
- [X] Make the ILS identifier NOT show when it is tuned in the VOR fields. 

**Attention! The RADNAV page is only to show what is set up, not how the reception is. That can be checked on the ND wether it shows any identifier. MSFS2020 is very limited in its navaid reception, eg. ILS only closer than around 25nm.**

**Allowed field input formats:**
**VOR1/2:** XX, XXX, 123, 123.4, 123.45 (Range 108-117.95)
**CRS:** 1, 12, 123 (Range 1-360) (limited due to system, IRL its 0-360)
**LS/FREQ:** 123, 123.4 (Range 108-111.95)
****ADF1/2**:** XX, XXX, 123.5, 1234, 1234.5 (Range 190-1750)

**Known Issues:**
1. When putting in an VOR/ADF frequency, the identifier will be fetched depending wether its receptable or not so the ID field will stay empty until you are in range. Thats why the ID can also flicker on the RADNAV page. This will be solved in a seperate PR, where I want to establish a Database search with frequency. I want to get this one out first because it improves RADNAV handling alot.
 ![image](https://user-images.githubusercontent.com/448627/108354050-324a9780-71e9-11eb-8763-1b06fbbaec35.png)

2. System error messages (OUT OF RANGE, WRONG FORMAT etc.) might not always be correct (in terms of which message is shown).
3. ILS CRS field has no function yet, so it is marked grey inop
4. There is NO autotuning yet
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/448627/108350661-cbc37a80-71e4-11eb-80ea-9be567d3fd65.png)

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
- Honeywell FMS Pilot Guide
- IRL experience

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): St54Kevin#3583

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Load up the plane however you want
2. Get information about what navaids are around you
3. Fiddle with the RADNAV MCDU page to confirm correct behavior and formats
4. Keep in mind the small reception range for navaids in MSFS2020

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
