### PR TITLE
fix(efb): handle 'useSimVar' usage in dev env

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@tailwindcss/postcss7-compat": "^2.0.2",
     "aewx-metar-parser": "~0.10.1",
     "byte-data": "^19.0.1",
+    "lodash": "^4.17.20",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-leaflet": "~3.0.5",

--- a/src/instruments/src/Common/index.tsx
+++ b/src/instruments/src/Common/index.tsx
@@ -6,6 +6,6 @@ import { SimVarProvider } from './simVars';
 /**
  * Use the given React element to render the instrument using React.
  */
-export const render = (Slot: React.ReactElement) => {
-    ReactDOM.render(<SimVarProvider>{Slot}</SimVarProvider>, Defaults.renderTarget);
+export const render = (Slot: React.ReactElement, container: Element | DocumentFragment | null = Defaults.renderTarget, dev?: boolean) => {
+    ReactDOM.render(<SimVarProvider dev={dev}>{Slot}</SimVarProvider>, container);
 }

--- a/src/instruments/src/EFB/index-web.tsx
+++ b/src/instruments/src/EFB/index-web.tsx
@@ -19,7 +19,7 @@
 import './Assets/Efb.scss';
 
 import React from "react";
-import ReactDOM from "react-dom";
 import Efb from "./Efb";
+import { render } from "../Common";
 
-ReactDOM.render(<Efb currentFlight="UAK049" />, document.getElementById('A32NX_REACT_MOUNT'));
+render(<Efb currentFlight="UAK049" />, document.getElementById('A32NX_REACT_MOUNT'), true)


### PR DESCRIPTION


## Summary of Changes
Mock simVar values in new useSimVar hook when using browser to work on it
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): arturkuma#6639

## Testing instructions
Check if EFB works as before. Run in browser and check if it works.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
