### PR TITLE
fix(apu): APU GEN title must be white when running

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.css
@@ -42,12 +42,9 @@ a320-neo-lower-ecam-apu text.Title {
   stroke-width: 2;
   fill: rgba(4, 4, 5, 1);
 }
-:root .APUGenTitleInactive {
-  fill: var(--displayWhite);
-  font-size: 18px;
-}
+:root .APUGenTitleInactive,
 :root .APUGenTitle {
-  fill: var(--displayGreen);
+  fill: var(--displayWhite);
   font-size: 18px;
 }
 :root .APUGenTitleWarn {


### PR DESCRIPTION
## Summary of Changes
APU GEN title must be white when running (load, V and Hz within operational conditions).

## Screenshots (if necessary)
Wrong:
![image](https://user-images.githubusercontent.com/1074786/108722510-89bb7100-7523-11eb-99ba-4c724f5193ab.png)

Right:
![image](https://user-images.githubusercontent.com/1074786/108722562-98a22380-7523-11eb-833d-0d15a8c79ad3.png)


## References
https://www.youtube.com/watch?v=Im0OFRxImYw

## Additional context
Discord username (if different from GitHub): SjotgunSjonnie#9623

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
