### PR TITLE
fix(mcdu): correct alignment of PERF TAKE OFF page title

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -63,7 +63,7 @@ class CDUPerformancePage {
         if (hasOrigin) {
             const runwayObj = mcdu.flightPlanManager.getDepartureRunway();
             if (runwayObj) {
-                runway = `{green}${Avionics.Utils.formatRunway(runwayObj.designation)}{end}`;
+                runway = Avionics.Utils.formatRunway(runwayObj.designation);
                 hasRunway = true;
             }
         }
@@ -377,7 +377,7 @@ class CDUPerformancePage {
         }
 
         mcdu.setTemplate([
-            ["TAKE OFF RWY " + runway.padStart(3, "\xa0") + "[color]" + titleColor],
+            ["TAKE OFF RWY\xa0{green}" + runway.padStart(3, "\xa0") + "{end}[color]" + titleColor],
             ["\xa0V1\xa0\xa0FLP RETR", ""],
             [v1 + v1Check + "\xa0F=" + flpRetrCell, ""],
             ["\xa0VR\xa0\xa0SLT RETR", "TO SHIFT\xa0"],


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

This PR fixes the alignment of the PERF TAKE OFF page heading. For one, it ensures it's vertically aligned to the letters below, as in reality, and secondly it ensures the runway is left-padded to 3 characters with white space according to the reference below.

Not adding a change log as this new page layout was only introduced this release cycle.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![image](https://user-images.githubusercontent.com/929769/109315932-5b9f9f00-784b-11eb-834f-faed155ea161.png)


## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

![image](https://user-images.githubusercontent.com/929769/109316010-73772300-784b-11eb-8e0b-dabf38612de6.png)

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
