### PR TITLE
build: use fragmenter for optimised distribution

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,6 +14,7 @@ jobs:
       MASTER_PRE_RELEASE_TAG: vmaster
       MASTER_ZIP_NAME: A32NX-master.zip
       BUILD_DIR_NAME: vmaster
+      CDN_DIR: /flybywiresim/addons/a32nx/vmaster/
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -23,8 +24,10 @@ jobs:
         run: |
           ./scripts/dev-env/run.sh ./scripts/setup.sh
           ./scripts/dev-env/run.sh ./scripts/build.sh
-      - name: Build ZIP file
+      - name: Build ZIP files
         run: |
+          ./scripts/dev-env/run.sh node ./scripts/fragment.js
+
           mkdir ./${{ env.BUILD_DIR_NAME }}
           zip -r ./${{ env.BUILD_DIR_NAME }}/${{ env.MASTER_ZIP_NAME }} ./A32NX/
       - name: Get and delete master pre-release zip asset
@@ -62,7 +65,16 @@ jobs:
             --data-raw '{
               "body": "This pre-release has its ${{ env.MASTER_ZIP_NAME }} asset updated on every commit to the master branch\nDo not use the source code assets, they are never updated\nLast updated on ${{ env.BUILT_DATE_TIME }} from commit ${{ github.sha }}\nThis link will always point to the latest master build: https://github.com/${{ github.repository }}/releases/download/${{ env.MASTER_PRE_RELEASE_TAG }}/${{ env.MASTER_ZIP_NAME }}"
             }'
-      - name: Upload to CDN
+      - name: Upload to Bunny CDN
+        uses: sebastianpopp/ftp-action@releases/v2
+        with:
+          host: ${{ secrets.BUNNY_BUCKET_HOST }}
+          user: ${{ secrets.BUNNY_BUCKET_USERNAME }}
+          password: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
+          localDir: ./build-modules/
+          remoteDir: ${{ env.CDN_DIR }}
+          options: "--delete --asci --transfer-all --verbose"
+      - name: Upload to DigitalOcean CDN
         uses: LibreTexts/do-space-sync-action@master
         with:
           args: --acl public-read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,17 +49,16 @@ jobs:
           mkdir tmp_A32NX
           mv A32NX tmp_A32NX/
           mv tmp_A32NX A32NX
+      - name: Upload to Bunny CDN
+        uses: sebastianpopp/ftp-action@releases/v2
+        with:
+          host: ${{ secrets.BUNNY_BUCKET_HOST }}
+          user: ${{ secrets.BUNNY_BUCKET_USERNAME }}
+          password: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
+          localDir: ./build-modules/
+          remoteDir: ${{ env.CDN_DIR }}
+          options: "--delete --asci --transfer-all --verbose"
       - uses: actions/upload-artifact@v2
         with:
           name: A32NX
           path: A32NX
-      - name: Upload to Bunny CDN
-        uses: SamKirkland/FTP-Deploy-Action@2.0.0
-        with:
-          FTP_SERVER: ${{ secrets.BUNNY_BUCKET_HOST }}
-          PORT: ${{ secrets.BUNNY_BUCKET_PORT }}
-          FTP_USERNAME: ${{ secrets.BUNNY_BUCKET_USERNAME }}
-          FTP_PASSWORD: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
-          LOCAL_DIR: ./build-modules/
-          REMOTE_DIR: ${{ env.CDN_DIR }}
-          ARGS: --delete

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,8 +33,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    env:
-      CDN_DIR: /flybywiresim/addons/a32nx/vmaster/
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -42,22 +40,11 @@ jobs:
         run: |
           ./scripts/dev-env/run.sh ./scripts/setup.sh
           ./scripts/dev-env/run.sh ./scripts/build.sh
-      - name: Generate zip files
+      - name: Generate ZIP files
         run: |
-          ./scripts/dev-env/run.sh node ./scripts/fragment.js
-
           mkdir tmp_A32NX
           mv A32NX tmp_A32NX/
           mv tmp_A32NX A32NX
-      - name: Upload to Bunny CDN
-        uses: sebastianpopp/ftp-action@releases/v2
-        with:
-          host: ${{ secrets.BUNNY_BUCKET_HOST }}
-          user: ${{ secrets.BUNNY_BUCKET_USERNAME }}
-          password: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
-          localDir: ./build-modules/
-          remoteDir: ${{ env.CDN_DIR }}
-          options: "--delete --asci --transfer-all --verbose"
       - uses: actions/upload-artifact@v2
         with:
           name: A32NX

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,13 +33,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    env:
+      CDN_DIR: /flybywiresim/addons/a32nx/vmaster/
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
-      - name: Generate layout.json and update manifest.json
+      - name: Build A32NX
         run: |
           ./scripts/dev-env/run.sh ./scripts/setup.sh
           ./scripts/dev-env/run.sh ./scripts/build.sh
+      - name: Generate zip files
+        run: |
+          ./scripts/dev-env/run.sh node ./scripts/fragment.js
 
           mkdir tmp_A32NX
           mv A32NX tmp_A32NX/
@@ -48,3 +53,13 @@ jobs:
         with:
           name: A32NX
           path: A32NX
+      - name: Upload to Bunny CDN
+        uses: SamKirkland/FTP-Deploy-Action@2.0.0
+        with:
+          FTP_SERVER: ${{ secrets.BUNNY_BUCKET_HOST }}
+          PORT: ${{ secrets.BUNNY_BUCKET_PORT }}
+          FTP_USERNAME: ${{ secrets.BUNNY_BUCKET_USERNAME }}
+          FTP_PASSWORD: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
+          LOCAL_DIR: ./build-modules/
+          REMOTE_DIR: ${{ env.CDN_DIR }}
+          ARGS: --delete

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     env:
       RELEASE_ZIP_NAME: A32NX-stable.zip
       BUILD_DIR_NAME: stable
+      CDN_DIR: /flybywiresim/addons/a32nx/stable/
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -31,7 +32,16 @@ jobs:
           asset_path: ./${{ env.BUILD_DIR_NAME }}/${{ env.RELEASE_ZIP_NAME }}
           asset_name: ${{ env.RELEASE_ZIP_NAME }}
           asset_content_type: application/zip
-      - name: Upload to CDN
+      - name: Upload to Bunny CDN
+        uses: sebastianpopp/ftp-action@releases/v2
+        with:
+          host: ${{ secrets.BUNNY_BUCKET_HOST }}
+          user: ${{ secrets.BUNNY_BUCKET_USERNAME }}
+          password: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
+          localDir: ./build-modules/
+          remoteDir: ${{ env.CDN_DIR }}
+          options: "--delete --asci --transfer-all --verbose"
+      - name: Upload to DigitalOcean CDN
         uses: LibreTexts/do-space-sync-action@master
         with:
           args: --acl public-read

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",
     "@babel/preset-typescript": "~7.12.7",
-    "@flybywiresim/fragmenter": "^0.1.4",
+    "@flybywiresim/fragmenter": "^0.1.5",
     "@flybywiresim/rnp": "^2.1.0",
     "@flybywiresim/rollup-plugin-msfs": "~0.1.3",
     "@rollup/plugin-babel": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",
     "@babel/preset-typescript": "~7.12.7",
+    "@flybywiresim/fragmenter": "^0.1.4",
     "@flybywiresim/rnp": "^2.1.0",
     "@flybywiresim/rollup-plugin-msfs": "~0.1.3",
     "@rollup/plugin-babel": "^5.2.1",

--- a/scripts/fragment.js
+++ b/scripts/fragment.js
@@ -1,4 +1,5 @@
 const fragmenter = require('@flybywiresim/fragmenter');
+const fs = require('fs');
 
 const execute = async () => {
     try {
@@ -32,8 +33,10 @@ const execute = async () => {
             }]
         });
         console.log(result);
+        console.log(fs.readFileSync('./build-modules/modules.json').toString());
     } catch (e) {
         console.error(e);
+        process.exit(1);
     }
 };
 

--- a/scripts/fragment.js
+++ b/scripts/fragment.js
@@ -1,0 +1,40 @@
+const fragmenter = require('@flybywiresim/fragmenter');
+
+const execute = async () => {
+    try {
+        const result = await fragmenter.pack({
+            baseDir: './A32NX',
+            outDir: './build-modules',
+            modules: [{
+                name: 'effects',
+                sourceDir: './effects'
+            }, {
+                name: 'html_ui',
+                sourceDir: './html_ui'
+            }, {
+                name: 'CUSTOMIZE',
+                sourceDir: './CUSTOMIZE'
+            }, {
+                name: 'ModelBehaviorDefs',
+                sourceDir: './ModelBehaviorDefs'
+            }, {
+                name: 'Textures',
+                sourceDir: './SimObjects/AirPlanes/Asobo_A320_NEO/TEXTURE'
+            }, {
+                name: 'Livery',
+                sourceDir: './SimObjects/AirPlanes/Asobo_A320_NEO-LIVERY'
+            }, {
+                name: 'Sound',
+                sourceDir: './SimObjects/AirPlanes/Asobo_A320_NEO/sound'
+            }, {
+                name: 'Model',
+                sourceDir: './SimObjects/AirPlanes/Asobo_A320_NEO/model'
+            }]
+        });
+        console.log(result);
+    } catch (e) {
+        console.error(e);
+    }
+};
+
+execute();


### PR DESCRIPTION
## Summary of Changes
After the normal build process, the artifact gets split up into multiple, smaller zip files and uploaded to a new CDN.

## Screenshots (if necessary)
N/A

## References
N/A

## Additional context

Discord username (if different from GitHub): nistei#1362

## Testing instructions

* Make sure the aircraft loads and functions (download the artiffact)

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
