### PR TITLE
fix(docs): Change CFBW download link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This has the latest features, but is much more unstable, use at your own risk.
 
 This version is the same as the regular master/development version, but with the WIP custom fly-by-wire system. Expect issues with flight directors/autopilot if you intend to use this version. No support will be provided via Discord.
 
-[Download custom FBW development build here.](https://flybywiresim-packages.nyc3.cdn.digitaloceanspaces.com/vmaster-cfbw/A32NX-master-cfbw.zip)
+[Download custom FBW development build here.](https://api.flybywiresim.com/api/v1/download?url=https://flybywiresim-packages.b-cdn.net/vmaster-cfbw/A32NX-master-cfbw.zip)
 
 [**IMPORTANT:** view warnings and info for the custom FBW build here.](https://github.com/flybywiresim/a32nx/tree/fbw/docs)
 


### PR DESCRIPTION

## Summary of Changes
Changed CFBW download link in Readme, so it does not point to the old CDN


## Additional context
CDN was changed and old is disabled now

Discord username (if different from GitHub):
Foxtrot Sierra#6420

## Testing instructions
None