### PR TITLE
build: fragmenter fix & artifact size reduction

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -73,7 +73,7 @@ jobs:
           password: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
           localDir: ./build-modules/
           remoteDir: ${{ env.CDN_DIR }}
-          options: "--delete --asci --transfer-all --verbose"
+          options: "--delete --transfer-all --verbose"
       - name: Upload to DigitalOcean CDN
         uses: LibreTexts/do-space-sync-action@master
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      CDN_DIR: /flybywiresim/addons/a32nx/fragmenter-test/
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout source
@@ -42,9 +44,20 @@ jobs:
           ./scripts/dev-env/run.sh ./scripts/build.sh
       - name: Generate ZIP files
         run: |
+          ./scripts/dev-env/run.sh node ./scripts/fragment.js
+
           mkdir tmp_A32NX
           mv A32NX tmp_A32NX/
           mv tmp_A32NX A32NX
+      - name: Upload to Bunny CDN
+        uses: sebastianpopp/ftp-action@releases/v2
+        with:
+          host: ${{ secrets.BUNNY_BUCKET_HOST }}
+          user: ${{ secrets.BUNNY_BUCKET_USERNAME }}
+          password: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
+          localDir: ./build-modules/
+          remoteDir: ${{ env.CDN_DIR }}
+          options: "--delete --asci --transfer-all --verbose"
       - uses: actions/upload-artifact@v2
         with:
           name: A32NX

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,18 +51,5 @@ jobs:
           mv tmp_A32NX A32NX
       - uses: actions/upload-artifact@v2
         with:
-          name: Modules
-          path: ./build-modules/
-      - name: Upload to Bunny CDN
-        uses: sebastianpopp/ftp-action@releases/v2
-        with:
-          host: ${{ secrets.BUNNY_BUCKET_HOST }}
-          user: ${{ secrets.BUNNY_BUCKET_USERNAME }}
-          password: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
-          localDir: ./build-modules/
-          remoteDir: ${{ env.CDN_DIR }}
-          options: "--delete --transfer-all --verbose"
-      - uses: actions/upload-artifact@v2
-        with:
           name: A32NX
-          path: A32NX
+          path: ./build-modules/full.zip

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,10 @@ jobs:
           mkdir tmp_A32NX
           mv A32NX tmp_A32NX/
           mv tmp_A32NX A32NX
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Modules
+          path: ./build-modules/
       - name: Upload to Bunny CDN
         uses: sebastianpopp/ftp-action@releases/v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,8 +32,6 @@ jobs:
           docker run --rm -v "$(pwd)":/external ghcr.io/flybywiresim/dev-env@sha256:0bf0844b914cbd45a8a0a866a71c7a07fa09308f48cb961708be479f0d63aa0f scripts/test-rust.sh
   build:
     runs-on: ubuntu-latest
-    env:
-      CDN_DIR: /flybywiresim/addons/a32nx/fragmenter-test/
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout source
@@ -42,14 +40,12 @@ jobs:
         run: |
           ./scripts/dev-env/run.sh ./scripts/setup.sh
           ./scripts/dev-env/run.sh ./scripts/build.sh
-      - name: Generate ZIP files
+      - name: Generate ZIP file
         run: |
-          node ./scripts/fragment.js
-
           mkdir tmp_A32NX
           mv A32NX tmp_A32NX/
           mv tmp_A32NX A32NX
       - uses: actions/upload-artifact@v2
         with:
           name: A32NX
-          path: ./build-modules/full.zip
+          path: A32NX

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,7 +61,7 @@ jobs:
           password: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
           localDir: ./build-modules/
           remoteDir: ${{ env.CDN_DIR }}
-          options: "--delete --ascii --transfer-all --verbose"
+          options: "--delete --transfer-all --verbose"
       - uses: actions/upload-artifact@v2
         with:
           name: A32NX

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,7 +61,7 @@ jobs:
           password: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
           localDir: ./build-modules/
           remoteDir: ${{ env.CDN_DIR }}
-          options: "--delete --asci --transfer-all --verbose"
+          options: "--delete --ascii --transfer-all --verbose"
       - uses: actions/upload-artifact@v2
         with:
           name: A32NX

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,6 +33,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    env:
+      ZIP_NAME: A32NX.zip
+      BUILD_DIR_NAME: zip-build
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -42,10 +45,9 @@ jobs:
           ./scripts/dev-env/run.sh ./scripts/build.sh
       - name: Generate ZIP file
         run: |
-          mkdir tmp_A32NX
-          mv A32NX tmp_A32NX/
-          mv tmp_A32NX A32NX
+          mkdir ./${{ env.BUILD_DIR_NAME }}
+          zip -r ./${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME }} ./A32NX/
       - uses: actions/upload-artifact@v2
         with:
           name: A32NX
-          path: A32NX
+          path: ${{ env.BUILD_DIR_NAME }}/${{ env.ZIP_NAME }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,8 +10,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    env:
-      CDN_DIR: /flybywiresim/addons/a32nx/fragmenter-test/
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout source
@@ -34,6 +32,8 @@ jobs:
           docker run --rm -v "$(pwd)":/external ghcr.io/flybywiresim/dev-env@sha256:0bf0844b914cbd45a8a0a866a71c7a07fa09308f48cb961708be479f0d63aa0f scripts/test-rust.sh
   build:
     runs-on: ubuntu-latest
+    env:
+      CDN_DIR: /flybywiresim/addons/a32nx/fragmenter-test/
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout source
@@ -44,7 +44,7 @@ jobs:
           ./scripts/dev-env/run.sh ./scripts/build.sh
       - name: Generate ZIP files
         run: |
-          ./scripts/dev-env/run.sh node ./scripts/fragment.js
+          node ./scripts/fragment.js
 
           mkdir tmp_A32NX
           mv A32NX tmp_A32NX/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           password: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
           localDir: ./build-modules/
           remoteDir: ${{ env.CDN_DIR }}
-          options: "--delete --asci --transfer-all --verbose"
+          options: "--delete --transfer-all --verbose"
       - name: Upload to DigitalOcean CDN
         uses: LibreTexts/do-space-sync-action@master
         with:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",
     "@babel/preset-typescript": "~7.12.7",
-    "@flybywiresim/fragmenter": "^0.1.5",
+    "@flybywiresim/fragmenter": "^0.1.6",
     "@flybywiresim/rnp": "^2.1.0",
     "@flybywiresim/rollup-plugin-msfs": "0.1.3",
     "@rollup/plugin-babel": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",
     "@babel/preset-typescript": "~7.12.7",
-    "@flybywiresim/fragmenter": "^0.1.6",
+    "@flybywiresim/fragmenter": "^0.1.5",
     "@flybywiresim/rnp": "^2.1.0",
     "@flybywiresim/rollup-plugin-msfs": "0.1.3",
     "@rollup/plugin-babel": "^5.2.1",


### PR DESCRIPTION
## Summary of Changes
- Remove the `--ascii` option from the lftp mirror action
- Zip artifacts beforehand to reduce the size since Github doesn't compress the zip when uploading the artifact.

## Screenshots (if necessary)
N/A

## References
N/A

## Additional context
N/A

Discord username (if different from GitHub): nistei#1362

## Testing instructions
The artifact size should be reduced by ~50%. The downside of this is a zip file within the downloaded zip artifact. Make sure you can still fully unzip the A32NX directory and that the A32NX is loading screens + systems in the sim.

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
