### PR TITLE
build: force version of @flybywiresim/rollup-plugin-msfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@babel/preset-typescript": "~7.12.7",
     "@flybywiresim/fragmenter": "^0.1.5",
     "@flybywiresim/rnp": "^2.1.0",
-    "@flybywiresim/rollup-plugin-msfs": "~0.1.3",
+    "@flybywiresim/rollup-plugin-msfs": "0.1.3",
     "@rollup/plugin-babel": "^5.2.1",
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-image": "~2.0.6",


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

* Forces version of rollup plugin to not update to 1.0.4

Discord username (if different from GitHub): someperson#4953

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
