### PR TITLE
feat: External decals upscale

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -109,7 +109,6 @@
 1. [TEXTURE] Improved cockpit decal fonts and emissives, and remade various labels in the cockpit. @FoxinTale (Aubrey)
 1. [FWC] Add aural Altitude Alert (C Chord) - @Kimbyeongjang (김병장#7165)
 1. [CAMERA] Added new interior views - @Snapmatics (Harry)
-1. [TEXTURE] Improved cockpit decal fonts and emissives, and remade various labels in the cockpit. @FoxinTale (Aubrey)
 1. [CDU] RADNAV - A manual VOR/ADF ident input is now permament - @St54Kevin
 1. [CDU] RADNAV - ID/Frequency fields now format to correct font size depending on pilot input - @St54Kevin
 1. [CDU] RADNAV - All fields now have correct format display and input restricitons - @St54Kevin
@@ -174,6 +173,7 @@
 1. [TEXTURE] Improved overhead panel decals - @ImenesFBW (Imenes)
 1. [MCDU] Import cost index when importing flight plan from SimBrief - @aviadnissel (Aviad)
 1. [FLIGHTMODEL] Revert flaps hotfix due to MSFS hotfix in MSFS update 1.13.17.0 - @donstim (donbikes#4084)
+1. [TEXTURE] Upscaled the external airframe decals to go nicely with the upscaled livery. @FoxinTale (Aubrey)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Upscaled the external airframe decals to 4k resolution and fixed a spelling error, specifically "portable water" is now "potable water". I have no idea where it appears on the airframe however.   Somewhere towards the rear, but since it's in 33px font, good luck finding it. 

Also removed a duplicate entry of mine that was in the changelog.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Door decals, before and after:
![Pre Upscale - Door Decals](https://user-images.githubusercontent.com/51178662/110015106-85484280-7cf1-11eb-822f-ae66a7fcb07a.PNG)

![Post Upscale - Door Decals](https://user-images.githubusercontent.com/51178662/110015129-8aa58d00-7cf1-11eb-8d29-72bc22dc7ecc.PNG)


Over wing doors, before and after: 
![Pre Upscale - wing Doors](https://user-images.githubusercontent.com/51178662/110015190-98f3a900-7cf1-11eb-839b-068c3a66318f.PNG)
![Post Upscale - Wing Doors](https://user-images.githubusercontent.com/51178662/110015215-9e50f380-7cf1-11eb-8dbe-c17048b15a63.PNG)

Any others are either in #3797 , or too small to have a notable difference. 

## Additional context
<!-- Add any other context about the pull request here. -->
Once undrafted, it can probably wait to be merged until the textures become their own modular unit with the installer. This PR would also go nicely with #3797 , when able to be merged. 

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):  Aubrey Jane#7563

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it --> 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
