### PR TITLE
fix(autopilot): enable detent sounds

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/sound/sound.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/sound/sound.xml
@@ -1282,7 +1282,7 @@
             <WwiseRTPC LocalVar="XMLVAR_Throttle2Position" RTPCName="LOCALVAR_GENERAL_ENG_THROTTLE2_LEVER_POSITION" />
         </Sound>
 
-                <Sound WwiseData="true" WwiseEvent="detent" Continuous="false" ViewPoint="Inside" NodeName="LEVER_THROTTLE_1" LocalVar="A32NX_3D_THROTTLE_LEVER_POSITION_1" Units="PERCENT">
+        <Sound WwiseData="true" WwiseEvent="detent" Continuous="false" ViewPoint="Inside" NodeName="LEVER_THROTTLE_1" LocalVar="A32NX_3D_THROTTLE_LEVER_POSITION_1" Units="PERCENT">
             <Range LowerBound="73" UpperBound="77" />
         </Sound>
 

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/sound/sound.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/sound/sound.xml
@@ -1282,31 +1282,31 @@
             <WwiseRTPC LocalVar="XMLVAR_Throttle2Position" RTPCName="LOCALVAR_GENERAL_ENG_THROTTLE2_LEVER_POSITION" />
         </Sound>
 
-        <Sound WwiseData="true" WwiseEvent="detent" Continuous="false" ViewPoint="Inside" NodeName="LEVER_THROTTLE_1" LocalVar="XMLVAR_Throttle1Position">
-            <Range LowerBound="2.9" UpperBound="3.1" />
+                <Sound WwiseData="true" WwiseEvent="detent" Continuous="false" ViewPoint="Inside" NodeName="LEVER_THROTTLE_1" LocalVar="A32NX_3D_THROTTLE_LEVER_POSITION_1" Units="PERCENT">
+            <Range LowerBound="73" UpperBound="77" />
         </Sound>
 
-        <Sound WwiseData="true" WwiseEvent="detent" Continuous="false" ViewPoint="Inside" NodeName="LEVER_THROTTLE_2" LocalVar="XMLVAR_Throttle2Position">
-            <Range LowerBound="2.9" UpperBound="3.1" />
+        <Sound WwiseData="true" WwiseEvent="detent" Continuous="false" ViewPoint="Inside" NodeName="LEVER_THROTTLE_2" LocalVar="A32NX_3D_THROTTLE_LEVER_POSITION_2" Units="PERCENT">
+            <Range LowerBound="73" UpperBound="77" />
         </Sound>
 
-        <Sound WwiseData="true" WwiseEvent="TOGAdetent" Continuous="false" ViewPoint="Inside" NodeName="LEVER_THROTTLE_1" LocalVar="XMLVAR_Throttle1Position">
-            <Range LowerBound="1.9" UpperBound="2.1" />
+        <Sound WwiseData="true" WwiseEvent="TOGAdetent" Continuous="false" ViewPoint="Inside" NodeName="LEVER_THROTTLE_1" LocalVar="A32NX_3D_THROTTLE_LEVER_POSITION_1" Units="PERCENT">
+            <Range LowerBound="48" UpperBound="52" />
         </Sound>
 
-        <Sound WwiseData="true" WwiseEvent="TOGAdetent" Continuous="false" ViewPoint="Inside" NodeName="LEVER_THROTTLE_2" LocalVar="XMLVAR_Throttle2Position">
-            <Range LowerBound="1.9" UpperBound="2.1" />
+        <Sound WwiseData="true" WwiseEvent="TOGAdetent" Continuous="false" ViewPoint="Inside" NodeName="LEVER_THROTTLE_2" LocalVar="A32NX_3D_THROTTLE_LEVER_POSITION_2" Units="PERCENT">
+            <Range LowerBound="48" UpperBound="52" />
         </Sound>
 
-        <Sound WwiseData="true" WwiseEvent="IdleDetent" Continuous="false" ViewPoint="Inside" NodeName="LEVER_THROTTLE_1" LocalVar="XMLVAR_Throttle1Position">
-            <Range LowerBound="0.9" UpperBound="1.1" />
-            <Range LowerBound="3.9" />
+        <Sound WwiseData="true" WwiseEvent="IdleDetent" Continuous="false" ViewPoint="Inside" NodeName="LEVER_THROTTLE_1" LocalVar="A32NX_3D_THROTTLE_LEVER_POSITION_1" Units="PERCENT">
+            <Range LowerBound="23" UpperBound="27" />
+            <Range LowerBound="98" />
             <Range UpperBound="0" />
         </Sound>
 
-        <Sound WwiseData="true" WwiseEvent="IdleDetent" Continuous="false" ViewPoint="Inside" NodeName="LEVER_THROTTLE_2" LocalVar="XMLVAR_Throttle2Position">
-            <Range LowerBound="0.9" UpperBound="1.1" />
-            <Range LowerBound="3.9" />
+        <Sound WwiseData="true" WwiseEvent="IdleDetent" Continuous="false" ViewPoint="Inside" NodeName="LEVER_THROTTLE_2" LocalVar="A32NX_3D_THROTTLE_LEVER_POSITION_2" Units="PERCENT">
+            <Range LowerBound="23" UpperBound="27" />
+            <Range LowerBound="98" />
             <Range UpperBound="0" />
         </Sound>
 
@@ -1432,7 +1432,7 @@
                 <Range LowerBound="28" />
             </Requires>
         </Sound>
-        
+
         <!-- Altitude deviation warning =====================================================================-->
 
         <Sound WwiseData="true" WwiseEvent="cchordloop" NodeName="PEDALS_LEFT" ViewPoint="Inside" LocalVar="A32NX_ALT_DEVIATION" Continuous="true">

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,8 +42,7 @@
 - :x: N1 thrust limit displayed and achieved may differ
 - :x: FLEX thrust limit is MCT limit whatever temperature you use
 - :x: Thrust limits are preliminary and not finished, they could be sometimes way off
-- :x: SPD/MACH hold might not perform satisfying in all situations yet
-- :x: throttle detent sounds are missing
+- :x: SPD/MACH hold might not perform correctly in all situations yet
 
 #### First implementation available
 

--- a/src/behavior/src/A32NX_Interior_Misc.xml
+++ b/src/behavior/src/A32NX_Interior_Misc.xml
@@ -641,8 +641,8 @@
 			</UseTemplate>
 			<UseTemplate Name="ASOBO_GT_AnimTriggers_2SoundEvents">
 				<ANIM_NAME>LEVER_THROTTLE_#ID#_LOCK</ANIM_NAME>
-				<WWISE_EVENT_1>throttle_lever_lock_on</WWISE_EVENT_1>
-				<WWISE_EVENT_2>throttle_lever_lock_off</WWISE_EVENT_2>
+				<WWISE_EVENT_1>detent</WWISE_EVENT_1>
+				<WWISE_EVENT_2>detent</WWISE_EVENT_2>
 			</UseTemplate>
 
             <!-- MAIN LEVER -->


### PR DESCRIPTION
## Summary of Changes

Adds the missing throttle levers detent and reverse lock sounds

## Additional context

Discord username (if different from GitHub): Imenes#8739

## Testing instructions

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
