### PR TITLE
fix(fmgc): bad flight phase change on spawn

### DIFF
--- a/A32NX/html_ui/Pages/A32NX_Core/FMGC/A32NX_FlightPhaseManager.js
+++ b/A32NX/html_ui/Pages/A32NX_Core/FMGC/A32NX_FlightPhaseManager.js
@@ -142,17 +142,14 @@ class A32NX_FlightPhase_PreFlight {
     }
 
     check(_deltaTime, _fmc) {
-        // Simplane.getAltitudeAboveGround() > 1500; is used to skip flight phase in case ac reloaded midair
         return this.takeoffConfirmation.write(
             (
-                (
-                    Simplane.getEngineThrottleMode(0) >= ThrottleMode.FLEX_MCT ||
-                    Simplane.getEngineThrottleMode(1) >= ThrottleMode.FLEX_MCT
-                ) && (
-                    SimVar.GetSimVarValue("ENG N1 RPM:1", "percent") > .75 ||
-                    SimVar.GetSimVarValue("ENG N1 RPM:2", "percent") > .75
-                )
-            ) || Simplane.getAltitudeAboveGround() > 1500,
+                Simplane.getEngineThrottleMode(0) >= ThrottleMode.FLEX_MCT ||
+                Simplane.getEngineThrottleMode(1) >= ThrottleMode.FLEX_MCT
+            ) && (
+                SimVar.GetSimVarValue("ENG N1 RPM:1", "percent") > .75 ||
+                SimVar.GetSimVarValue("ENG N1 RPM:2", "percent") > .75
+            ),
             _deltaTime
         );
     }


### PR DESCRIPTION
<!-- Signed-off-by: Leon Beeser <leon.beeser@yahoo.de> -->

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
<!-- Fixes #[issue_no] -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Removed not needed back door to skip flight phase preflight in case of mid air reload.

<!-- ## Screenshots (if necessary) -->
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

<!-- ## References -->
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

<!-- ## Additional context -->
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): DerL30N#3751

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
With this fix:
- Spawn on airport e.g. GCXO. observe flight phase is correctly preflight
Without this fix:
- Spawn on airport e.g. GCXO observe flight phase is CLIMB/CRUISE

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
