### PR TITLE
fix: vertical speed FCU logic

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -1924,7 +1924,7 @@
                             <LEFT_SINGLE_CODE>(L:A32NX_EVAC_CAPT_TOGGLE) ! (>L:A32NX_EVAC_CAPT_TOGGLE)</LEFT_SINGLE_CODE>
                         </UseTemplate>
                     </Component>
-                    
+
 
                     <Component ID="EMER_ELEC_PWR">
                         <!-- EMER GEN TEST -->
@@ -1935,7 +1935,7 @@
                             <LEFT_SINGLE_CODE>1 (&gt;L:A32NX_EMERELECPWR_GEN_TEST)</LEFT_SINGLE_CODE>
 
                             <TOOLTIPID>Test emergency generator (Inop.)</TOOLTIPID>
-                            
+
                             <MOMENTARY/>
                         </UseTemplate>
 
@@ -1965,7 +1965,7 @@
                             <LOCK_NODE_ID>LOCK_OVHD_EMERELECPWR_MANON</LOCK_NODE_ID>
                             <LEFT_SINGLE_CODE>1 (&gt;L:A32NX_EMERELECPWR_MAN_ON)</LEFT_SINGLE_CODE>
                             <TOOLTIPID>%((L:A32NX_EMERELECPWR_MAN_ON, Bool))%{if}Ram air turbine deployed (Inop.)%{else}Deploy ram air turbine (Inop.)%{end}</TOOLTIPID>
-                            <MOMENTARY/>                       
+                            <MOMENTARY/>
                         </UseTemplate>
                     </Component>
 
@@ -2141,7 +2141,7 @@
                     <UseTemplate Name="FBW_Push_Toggle">
                         <NODE_ID>PUSH_OVHD_SVGEINT</NODE_ID>
                         <TOGGLE_SIMVAR>L:A32NX_SVGEINT_OVRD_ON</TOGGLE_SIMVAR>
-        
+
                         <SEQ2_CODE>(L:A32NX_SVGEINT_OVRD_ON, Bool)</SEQ2_CODE>
                         <TOOLTIPID>%((L:A32NX_SVGEINT_OVRD_ON, Bool))%{if}Turn OFF SVGE INT OVRD (Inop.)%{else}Turn ON SVGE INT OVRD (Inop.)%{end}</TOOLTIPID>
                     </UseTemplate>
@@ -2169,21 +2169,21 @@
                         <UseTemplate Name="FBW_Push_Toggle">
                             <NODE_ID>PUSH_OVHD_DLS_SELCTL</NODE_ID>
                             <LEFT_SINGLE_CODE></LEFT_SINGLE_CODE>
-            
+
                             <TOOLTIPID>Select/Control (Inop.)</TOOLTIPID>
                             <MOMENTARY/>
                         </UseTemplate>
                         <UseTemplate Name="FBW_Push_Toggle">
                             <NODE_ID>PUSH_OVHD_DLS_PREV</NODE_ID>
                             <LEFT_SINGLE_CODE></LEFT_SINGLE_CODE>
-            
+
                             <TOOLTIPID>Previous (Inop.)</TOOLTIPID>
                             <MOMENTARY/>
                         </UseTemplate>
                         <UseTemplate Name="FBW_Push_Toggle">
                             <NODE_ID>PUSH_OVHD_DLS_NEXT</NODE_ID>
                             <LEFT_SINGLE_CODE></LEFT_SINGLE_CODE>
-            
+
                             <TOOLTIPID>Next (Inop.)</TOOLTIPID>
                             <MOMENTARY/>
                         </UseTemplate>
@@ -2631,7 +2631,7 @@
                              <UseTemplate Name="FBW_Push_Toggle">
                              <NODE_ID>PUSH_OVHD_RCDR_GNDCTL</NODE_ID>
                              <TOGGLE_SIMVAR>L:A32NX_RCDR_GROUND_CONTROL_ON</TOGGLE_SIMVAR>
-            
+
                                 <SEQ2_CODE>(L:A32NX_RCDR_GROUND_CONTROL_ON, Bool)</SEQ2_CODE>
                                 <TOOLTIPID>%((L:A32NX_RCDR_GROUND_CONTROL_ON, Bool))%{if}Set Ground Control to AUTO (Inop.)%{else}Turn ON Ground Control (Inop.)%{end}</TOOLTIPID>
                             </UseTemplate>
@@ -2650,21 +2650,21 @@
                             <UseTemplate Name="FBW_Covered_Push_Toggle">
                                 <NODE_ID>PUSH_OVHD_OXYGEN_RATMANON</NODE_ID>
                                 <LOCK_NODE_ID>LOCK_OVHD_OXYGEN_RATMANON</LOCK_NODE_ID>
-                
+
                                 <LEFT_SINGLE_CODE>
                                 1 (&gt;L:A32NX_OXYGEN_MASKS_DEPLOYED)
                                 1 (&gt;L:A32NX_OXYGEN_PASSENGER_LIGHT_ON)</LEFT_SINGLE_CODE>
                             <TOOLTIPID>%((L:A32NX_OXYGEN_MASKS_DEPLOYED, Bool))%{if}Cabin oxygen masks deployed%{else}Deploy cabin oxygen masks%{end}</TOOLTIPID>
                             <MOMENTARY/>
                             </UseTemplate>
-                            
+
                             <UseTemplate Name="FBW_Push_Toggle">
                                 <NODE_ID>PUSH_OVHD_OXYGEN_PASSENGER</NODE_ID>
                                 <SEQ1_CODE>(L:A32NX_OXYGEN_PASSENGER_LIGHT_ON, Bool)</SEQ1_CODE>
                                 <TOOLTIPID>Oxygen mask doors annunciator</TOOLTIPID>
                                 <DUMMY_BUTTON/>
                             </UseTemplate>
-                        
+
                             <UseTemplate Name="FBW_Push_Toggle">
                                 <NODE_ID>PUSH_OVHD_OXYGEN_CREW</NODE_ID>
                                 <PART_ID>Crew_Supply</PART_ID>
@@ -2705,7 +2705,7 @@
                         </Component>
                     </Component>
                 </Component>
-                
+
                 <Component ID="Right_Pedestal_Misc">
                     <UseTemplate Name="FBW_Push_Held">
                         <NODE_ID>PUSH_PANELCS_AIDS</NODE_ID>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.js
@@ -1,3 +1,21 @@
+/*
+ * A32NX
+ * Copyright (C) 2020-2021 FlyByWire Simulations and its contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 class A320_Neo_FCU extends BaseAirliners {
     constructor() {
         super();
@@ -487,7 +505,7 @@ class A320_Neo_FCU_VerticalSpeed extends A320_Neo_FCU_Component {
     }
     onFlightStart() {
         super.onFlightStart();
-        const selectedValue = Simplane.getAutoPilotSelectedVerticalSpeedHoldValue();
+        const selectedValue = Simplane.getAutoPilotDisplayedVerticalSpeedHoldValue();
         if (selectedValue == 0) {
             this._enterIdleState(0);
         } else {
@@ -522,7 +540,7 @@ class A320_Neo_FCU_VerticalSpeed extends A320_Neo_FCU_Component {
             this.gps.requestCall(() => {
                 this.currentState = A320_Neo_FCU_VSpeed_State.Flying;
                 if (!this.isFPAMode) {
-                    const selectedValue = Simplane.getAutoPilotSelectedVerticalSpeedHoldValue();
+                    const selectedValue = Simplane.getAutoPilotDisplayedVerticalSpeedHoldValue();
                     Coherent.call("AP_VS_VAR_SET_ENGLISH", 1, selectedValue);
                 }
                 SimVar.SetSimVarValue("K:VS_SLOT_INDEX_SET", "number", 1);
@@ -534,7 +552,7 @@ class A320_Neo_FCU_VerticalSpeed extends A320_Neo_FCU_Component {
         if (this.currentState != A320_Neo_FCU_VSpeed_State.Idle) {
             this.currentState = A320_Neo_FCU_VSpeed_State.Flying;
             if (!this.isFPAMode) {
-                const selectedValue = Simplane.getAutoPilotSelectedVerticalSpeedHoldValue();
+                const selectedValue = Simplane.getAutoPilotDisplayedVerticalSpeedHoldValue();
                 Coherent.call("AP_VS_VAR_SET_ENGLISH", 1, selectedValue);
             }
             SimVar.SetSimVarValue("K:VS_SLOT_INDEX_SET", "number", 1);
@@ -543,7 +561,7 @@ class A320_Neo_FCU_VerticalSpeed extends A320_Neo_FCU_Component {
             this.forceUpdate = true;
         } else {
             this.currentState = A320_Neo_FCU_VSpeed_State.Flying;
-            const currentValue = Simplane.getVerticalSpeed();
+            const currentValue = Simplane.getAutoPilotDisplayedVerticalSpeedHoldValue();
             if (this.isFPAMode) {
                 const angle = this.calculateAngleForVerticalSpeed(currentValue);
                 SimVar.SetSimVarValue("L:A32NX_AUTOPILOT_FPA_SELECTED", "Degree", angle);
@@ -626,7 +644,7 @@ class A320_Neo_FCU_VerticalSpeed extends A320_Neo_FCU_Component {
             const angle = SimVar.GetSimVarValue("L:A32NX_AUTOPILOT_FPA_SELECTED", "Degree");
             this.refresh(true, true, angle, lightsTest, this.forceUpdate);
         } else {
-            this.refresh(true, false, Simplane.getAutoPilotSelectedVerticalSpeedHoldValue(), lightsTest, this.forceUpdate);
+            this.refresh(true, false, Simplane.getAutoPilotDisplayedVerticalSpeedHoldValue(), lightsTest, this.forceUpdate);
         }
         this.forceUpdate = false;
     }

--- a/src/behavior/src/A32NX_Interior_FCU.xml
+++ b/src/behavior/src/A32NX_Interior_FCU.xml
@@ -1,3 +1,21 @@
+<!--
+  ~ A32NX
+  ~ Copyright (C) 2020-2021 FlyByWire Simulations and its contributors
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
 <ModelBehaviors>
     <Template Name="FBW_Airbus_FCU_Baro_Knob">
         <DefaultTemplateParameters>
@@ -287,7 +305,7 @@
                     (L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{
                         (&gt;H:A320_Neo_FCU_AP_INC_FPA)
                     } els{
-                        2 (&gt;K:AP_VS_VAR_INC)
+                        3 (&gt;K:AP_VS_VAR_INC)
                         (&gt;H:A320_Neo_FCU_VS_INC)
                     }
                 </CLOCKWISE_CODE>
@@ -295,7 +313,7 @@
                     (L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{
                         (&gt;H:A320_Neo_FCU_AP_DEC_FPA)
                     } els{
-                        2 (&gt;K:AP_VS_VAR_DEC)
+                        3 (&gt;K:AP_VS_VAR_DEC)
                         (&gt;H:A320_Neo_FCU_VS_DEC)
                     }
                 </ANTICLOCKWISE_CODE>


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

* Fix vertical speed knob and FCU not using the correct V/S holder variable indices

Discord username (if different from GitHub): someperson#4953

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

* Make sure that V/S and FPA works as it did before (behaviour is probably still wrong like it was before on the development version; correct behaviour is on the custom autopilot and isn't here)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
