### PR TITLE
fix(efb): restore interactivity after MSFS 1.14.5.0

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -45,16 +45,6 @@
             <UseTemplate Name="ASOBO_GT_Material_Emissive_Code">
                 <EMISSIVE_CODE>(L:A32NX_EFB_BRIGHTNESS, number) 10 max 100 min 100 /</EMISSIVE_CODE>
             </UseTemplate>
-
-            <UseTemplate Name="ASOBO_GT_Interaction_LeftSingle_Code">
-                <LEFT_SINGLE_CODE>
-                    (L:A32NX_EFB_TURNED_ON) 0 == if{
-                        1 (&gt;L:A32NX_EFB_TURNED_ON)
-                    }
-                </LEFT_SINGLE_CODE>
-
-                <TOOLTIPID>%((L:A32NX_EFB_TURNED_ON) 0 ==)%{if}Turn on flyPad%{end}</TOOLTIPID>
-            </UseTemplate>
         </Component>
 
         <!-- MCDU -->
@@ -1924,7 +1914,7 @@
                             <LEFT_SINGLE_CODE>(L:A32NX_EVAC_CAPT_TOGGLE) ! (>L:A32NX_EVAC_CAPT_TOGGLE)</LEFT_SINGLE_CODE>
                         </UseTemplate>
                     </Component>
-                    
+
 
                     <Component ID="EMER_ELEC_PWR">
                         <!-- EMER GEN TEST -->
@@ -1935,7 +1925,7 @@
                             <LEFT_SINGLE_CODE>1 (&gt;L:A32NX_EMERELECPWR_GEN_TEST)</LEFT_SINGLE_CODE>
 
                             <TOOLTIPID>Test emergency generator (Inop.)</TOOLTIPID>
-                            
+
                             <MOMENTARY/>
                         </UseTemplate>
 
@@ -1965,7 +1955,7 @@
                             <LOCK_NODE_ID>LOCK_OVHD_EMERELECPWR_MANON</LOCK_NODE_ID>
                             <LEFT_SINGLE_CODE>1 (&gt;L:A32NX_EMERELECPWR_MAN_ON)</LEFT_SINGLE_CODE>
                             <TOOLTIPID>%((L:A32NX_EMERELECPWR_MAN_ON, Bool))%{if}Ram air turbine deployed (Inop.)%{else}Deploy ram air turbine (Inop.)%{end}</TOOLTIPID>
-                            <MOMENTARY/>                       
+                            <MOMENTARY/>
                         </UseTemplate>
                     </Component>
 
@@ -2141,7 +2131,7 @@
                     <UseTemplate Name="FBW_Push_Toggle">
                         <NODE_ID>PUSH_OVHD_SVGEINT</NODE_ID>
                         <TOGGLE_SIMVAR>L:A32NX_SVGEINT_OVRD_ON</TOGGLE_SIMVAR>
-        
+
                         <SEQ2_CODE>(L:A32NX_SVGEINT_OVRD_ON, Bool)</SEQ2_CODE>
                         <TOOLTIPID>%((L:A32NX_SVGEINT_OVRD_ON, Bool))%{if}Turn OFF SVGE INT OVRD (Inop.)%{else}Turn ON SVGE INT OVRD (Inop.)%{end}</TOOLTIPID>
                     </UseTemplate>
@@ -2169,21 +2159,21 @@
                         <UseTemplate Name="FBW_Push_Toggle">
                             <NODE_ID>PUSH_OVHD_DLS_SELCTL</NODE_ID>
                             <LEFT_SINGLE_CODE></LEFT_SINGLE_CODE>
-            
+
                             <TOOLTIPID>Select/Control (Inop.)</TOOLTIPID>
                             <MOMENTARY/>
                         </UseTemplate>
                         <UseTemplate Name="FBW_Push_Toggle">
                             <NODE_ID>PUSH_OVHD_DLS_PREV</NODE_ID>
                             <LEFT_SINGLE_CODE></LEFT_SINGLE_CODE>
-            
+
                             <TOOLTIPID>Previous (Inop.)</TOOLTIPID>
                             <MOMENTARY/>
                         </UseTemplate>
                         <UseTemplate Name="FBW_Push_Toggle">
                             <NODE_ID>PUSH_OVHD_DLS_NEXT</NODE_ID>
                             <LEFT_SINGLE_CODE></LEFT_SINGLE_CODE>
-            
+
                             <TOOLTIPID>Next (Inop.)</TOOLTIPID>
                             <MOMENTARY/>
                         </UseTemplate>
@@ -2631,7 +2621,7 @@
                              <UseTemplate Name="FBW_Push_Toggle">
                              <NODE_ID>PUSH_OVHD_RCDR_GNDCTL</NODE_ID>
                              <TOGGLE_SIMVAR>L:A32NX_RCDR_GROUND_CONTROL_ON</TOGGLE_SIMVAR>
-            
+
                                 <SEQ2_CODE>(L:A32NX_RCDR_GROUND_CONTROL_ON, Bool)</SEQ2_CODE>
                                 <TOOLTIPID>%((L:A32NX_RCDR_GROUND_CONTROL_ON, Bool))%{if}Set Ground Control to AUTO (Inop.)%{else}Turn ON Ground Control (Inop.)%{end}</TOOLTIPID>
                             </UseTemplate>
@@ -2650,21 +2640,21 @@
                             <UseTemplate Name="FBW_Covered_Push_Toggle">
                                 <NODE_ID>PUSH_OVHD_OXYGEN_RATMANON</NODE_ID>
                                 <LOCK_NODE_ID>LOCK_OVHD_OXYGEN_RATMANON</LOCK_NODE_ID>
-                
+
                                 <LEFT_SINGLE_CODE>
                                 1 (&gt;L:A32NX_OXYGEN_MASKS_DEPLOYED)
                                 1 (&gt;L:A32NX_OXYGEN_PASSENGER_LIGHT_ON)</LEFT_SINGLE_CODE>
                             <TOOLTIPID>%((L:A32NX_OXYGEN_MASKS_DEPLOYED, Bool))%{if}Cabin oxygen masks deployed%{else}Deploy cabin oxygen masks%{end}</TOOLTIPID>
                             <MOMENTARY/>
                             </UseTemplate>
-                            
+
                             <UseTemplate Name="FBW_Push_Toggle">
                                 <NODE_ID>PUSH_OVHD_OXYGEN_PASSENGER</NODE_ID>
                                 <SEQ1_CODE>(L:A32NX_OXYGEN_PASSENGER_LIGHT_ON, Bool)</SEQ1_CODE>
                                 <TOOLTIPID>Oxygen mask doors annunciator</TOOLTIPID>
                                 <DUMMY_BUTTON/>
                             </UseTemplate>
-                        
+
                             <UseTemplate Name="FBW_Push_Toggle">
                                 <NODE_ID>PUSH_OVHD_OXYGEN_CREW</NODE_ID>
                                 <PART_ID>Crew_Supply</PART_ID>
@@ -2705,7 +2695,7 @@
                         </Component>
                     </Component>
                 </Component>
-                
+
                 <Component ID="Right_Pedestal_Misc">
                     <UseTemplate Name="FBW_Push_Held">
                         <NODE_ID>PUSH_PANELCS_AIDS</NODE_ID>

--- a/src/instruments/src/EFB/index.jsx
+++ b/src/instruments/src/EFB/index.jsx
@@ -25,26 +25,33 @@ import './Assets/Reset.scss';
 import './Assets/Efb.scss';
 import { render } from '../Common/index.tsx';
 import { readSettingsFromPersistentStorage } from './Settings/sync.ts';
+import { useSimVar } from '../Common/simVars.tsx';
 
-function ScreenLoading() {
+const ScreenBlank = () => {
+    const [, setTurnedOn] = useSimVar('L:A32NX_EFB_TURNED_ON', 'number');
+
     return (
-        <div className="loading-screen">
-            <div className="center">
-                <div className="placeholder">
-                    <img src={logo} className="fbw-logo" alt="logo" />
-                    {' '}
-                    flyPad
-                </div>
-                <div className="loading-bar">
-                    <div className="loaded" />
-                </div>
+        <div onClick={() => setTurnedOn(1)} style={{ width: '100vw', height: '100vh' }} />
+    );
+};
+
+const ScreenLoading = () => (
+    <div className="loading-screen">
+        <div className="center">
+            <div className="placeholder">
+                <img src={logo} className="fbw-logo" alt="logo" />
+                {' '}
+                flyPad
+            </div>
+            <div className="loading-bar">
+                <div className="loaded" />
             </div>
         </div>
-    );
-}
+    </div>
+);
 
-function EFBLoad() {
-    const [content, setContent] = useState(<></>);
+const EFBLoad = () => {
+    const [content, setContent] = useState('off');
     const [loadingTimeout, setLoadingTimeout] = useState();
 
     useEffect(() => {
@@ -53,10 +60,10 @@ function EFBLoad() {
 
             switch (nowPoweredOn) {
             case 0:
-                setContent(<></>);
+                setContent('off');
                 break;
             case 1:
-                setContent(<ScreenLoading />);
+                setContent('loading');
                 if (!loadingTimeout) {
                     setLoadingTimeout(setTimeout(() => {
                         setSimVar('L:A32NX_EFB_TURNED_ON', 2, 'number');
@@ -65,7 +72,7 @@ function EFBLoad() {
                 }
                 break;
             case 2:
-                setContent(<Efb currentFlight={getSimVar('ATC FLIGHT NUMBER', 'string')} />);
+                setContent('loaded');
                 break;
             default:
                 throw new RangeError();
@@ -75,8 +82,17 @@ function EFBLoad() {
         return () => clearInterval(interval);
     }, [loadingTimeout]);
 
-    return content;
-}
+    switch (content) {
+    case 'off':
+        return <ScreenBlank />;
+    case 'loading':
+        return <ScreenLoading />;
+    case 'loaded':
+        return <Efb currentFlight={getSimVar('ATC FLIGHT NUMBER', 'string')} />;
+    default:
+        throw new Error();
+    }
+};
 
 readSettingsFromPersistentStorage();
 


### PR DESCRIPTION
Fixes #3887

## Summary of Changes

* Remove `MouseRect` interactivity preventing use of touchscreen
* Handle interactivity directly inside of React

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): someperson#4953

## Testing instructions

* Make sure the EFB can be turned on by clicking on it (tooltip is gone, unfortunate side effect)
* Make sure EFB can be turned off and turned back on

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
