### PR TITLE
build: improve cdn upload script

### DIFF
--- a/scripts/cdn.sh
+++ b/scripts/cdn.sh
@@ -7,6 +7,6 @@ for FILE in ./build-modules/*; do
     DEST="$CDN_URL/$CDN_DIR/$(basename -- "$FILE")"
     echo "Syncing file: $FILE"
     echo "Destination: $DEST"
-    curl -X PUT -H "AccessKey: $BUNNY_BUCKET_PASSWORD" -F "data=@$FILE" "$DEST"
+    curl -X PUT -H "AccessKey: $BUNNY_BUCKET_PASSWORD" --data-binary "@$FILE" "$DEST"
     echo ""; echo ""
 done


### PR DESCRIPTION
## Summary of Changes
Certain cURL versions cause issues with the `-F` option. Replaced it with `--data-binary`.

## Screenshots (if necessary)
N/A

## References
N/A

## Additional context
N/A

Discord username (if different from GitHub): nistei#1362

## Testing instructions
N/A

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
