### PR TITLE
build: use secret token for CDN purge

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Upload to Bunny CDN
         env:
           BUNNY_BUCKET_PASSWORD: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
+          BUNNY_SECRET_TOKEN: ${{ secrets.BUNNY_SECRET_TOKEN }}
           BUNNY_BUCKET_DESTINATION: addons/a32nx/master
         run: ./scripts/cdn.sh $BUNNY_BUCKET_DESTINATION
       - name: Upload to DigitalOcean CDN

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Upload to Bunny CDN
         env:
           BUNNY_BUCKET_PASSWORD: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
+          BUNNY_SECRET_TOKEN: ${{ secrets.BUNNY_SECRET_TOKEN }}
           BUNNY_BUCKET_DESTINATION: addons/a32nx/stable
         run: ./scripts/cdn.sh $BUNNY_BUCKET_DESTINATION
       - name: Upload to DigitalOcean CDN


### PR DESCRIPTION
## Summary of Changes
Enable the use of the secret token for CDN purges

## Screenshots (if necessary)
N/A

## References
N/A

## Additional context
N/A

Discord username (if different from GitHub): nistei#1362

## Testing instructions

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
