### PR TITLE
fix(nd): quick fix for PPOS/Wpt when ADIRS not aligned

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.html
@@ -87,6 +87,9 @@
                                 <text id="WP_Distance_Units" class="Units" x="100%" y="12.9%" alignment-baseline="middle"></text>
                                 <text id="WP_Time" class="Value" x="100%" y="30%" alignment-baseline="baseline"></text>
                             </g>
+                            <g id="Waypoint_PPOS">
+                                <text id="WP_PPOS" class="Large" x="72%" y="0%" alignment-baseline="baseline">PPOS</text>
+                            </g>
                         </svg>
                     </div>
                 </div>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
@@ -859,6 +859,7 @@ class A320_Neo_MFD_NDInfo extends NavSystemElement {
         const ws = this.ndInfo.querySelector("#Wind_Strength");
         const wa = this.ndInfo.querySelector("#Wind_Arrow");
         const wptg = this.ndInfo.querySelector("#Waypoint_Group");
+        const wptPPOS = this.ndInfo.querySelector("#Waypoint_PPOS");
         if (ADIRSState != 2 || groundSpeed <= 100) {
             //Hide TAS, and wind info
             tas.textContent = "---";
@@ -873,8 +874,9 @@ class A320_Neo_MFD_NDInfo extends NavSystemElement {
         } else {
             gs.textContent = groundSpeed.toString().padStart(3);
         }
-        //Shows waypoint group when ADIRS not aligned (PPOS)
-        wptg.setAttribute("visibility", (ADIRSState != 2) ? "visible" : "visible");
+        // Show/Hide waypoint group when ADIRS not aligned
+        wptPPOS.setAttribute("visibility", (ADIRSState != 2) ? "visible" : "hidden");
+        wptg.setAttribute("visibility", (ADIRSState != 2) ? "hidden" : "visible");
     }
     onExit() {
     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->


## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
A very short and quick fix for a bug I inadvertently introduced in #3870 where waypoint and it's details appeared instantly after setting it on the MCDU, even before ADIRS aligned. Added a separate condition to fix this.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/29005005/111491407-d892aa00-8761-11eb-85b2-445ab482cdd6.png)
![image](https://user-images.githubusercontent.com/29005005/111491441-e0524e80-8761-11eb-9e75-ca8cbc656514.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): sidnov#8337

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->


1. Spawn C/D, power up the aircraft, align ADIRS, observe ND loads completely with waypoint set to PPOS and no other visible details.

2. Restart, spawn C/D, power up the aircraft, set departure/arrival airports on the MCDU. It should not instantly update waypoint name, time/distance on the ND (top-right corner). Should stay on "PPOS". Now, align ADIRS and wait, check the waypoint details appear only after alignment is complete.


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
