### PR TITLE
chore(eslint): turn linebreak-style rule off

### DIFF
--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -51,6 +51,7 @@ module.exports = {
         'jsx-a11y/click-events-have-key-events': 'off',
         'jsx-a11y/anchor-is-valid': 'off',
         'object-curly-newline': ['error', { multiline: true }],
+        'linebreak-style': 'off',
     },
     globals: {
         Simplane: 'readonly',


### PR DESCRIPTION
## Summary of Changes
As we already have automatic CRLF handling (#1927) there's no need to have AirBNB's linebreak-style rule. We can simply turn it off and all is well.