### PR TITLE
fix(mcdu): Remove Degree Symbol from GND TEMP INIT A Page

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -222,7 +222,7 @@ class CDUInitPage {
             ["COST INDEX", "TROPO"],
             [costIndex, tropo],
             ["CRZ FL/TEMP", "GND TEMP"],
-            [cruiseFlTemp, "---°[color]inop"],
+            [cruiseFlTemp, "--- [color]inop"],
         ]);
 
         mcdu.setArrows(false, false, true, true);


### PR DESCRIPTION
## Summary of Changes
Remove Degree Symbol from GND TEMP INIT A Page

## Screenshots (if necessary)
Before:
![Microsoft Flight Simulator - 1 14 5 0 15_03_2021 13_02_31](https://user-images.githubusercontent.com/77690813/111826039-2dc9e980-8923-11eb-9990-8e92ec31f70d.png)
After:
![Microsoft Flight Simulator - 1 14 5 0 15_03_2021 13_02_31_LI](https://user-images.githubusercontent.com/77690813/111826081-36babb00-8923-11eb-901c-5407fcfd3f5b.jpg)

## References
![initapgpgpg](https://user-images.githubusercontent.com/77690813/111826155-4d611200-8923-11eb-8ae3-8e67bdc20786.jpg)
The degree symbol will automatically generate after entering the temperature. (Source from BehEh)

## Additional context
Discord username (if different from GitHub): Wesley#0008

## Testing instructions
Load in and check for visual bugs on the INT A page

## How to download the PR for QA
Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
2. Click on the **Checks** tab on the PR
3. On the left side, click on the bottom **PR** tab
4. Click on the **A32NX** download link at the bottom of the page
