### PR TITLE
fix(efb): Use monospace font to render OFP on EFB.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -225,6 +225,7 @@
 1. [MISC] Reimplemented BAT, rudder trim and Clock in react, add elapsed time feature to clock - @lukecologne (luke)
 1. [ND] Add VOR/ADF needles on ARC display mode - @tracernz (Mike)
 1. [MCDU] Rework PERF APPR page to Honeywell Rev. 2 standard - @tracernz (Mike)
+1. [EFB] Set font of OFP to monospace - @chkgk (Chriskgk#4359)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/src/instruments/src/EFB/Dispatch/Pages/LoadsheetPage.tsx
+++ b/src/instruments/src/EFB/Dispatch/Pages/LoadsheetPage.tsx
@@ -99,7 +99,7 @@ const LoadSheetWidget = (props: LoadsheetPageProps) => {
     return (
         <div className="px-6">
             <div className="w-full">
-                <div className="relative bg-gray-800 rounded-xl p-6 text-white shadow-lg mr-4">
+                <div className="relative bg-gray-800 rounded-xl p-6 text-white font-mono shadow-lg mr-4">
                     {props.loadsheet !== 'N/A' ? (
                         <>
                             <div className="flex flex-col justify-end absolute bottom-5 right-16">


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #4057 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
I have added the "font-mono" class to the container div holding the loadsheet. This causes it to show in monospace font as intended.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before
![EFB Dispatch OFP before](https://user-images.githubusercontent.com/4689714/111917157-bc06b280-8a7e-11eb-9df6-01dd9f9847f3.png)
After
![EFB Dispatch OFP after](https://user-images.githubusercontent.com/4689714/111917161-c032d000-8a7e-11eb-9765-4217c99c6e42.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
n/a

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
This is my first proper issue / pull request combination. Please be kind :-)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Chriskgk#4359

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Check if the OFP imported from simbrief is correctly shown with monospace font.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
