### PR TITLE
fix(elec): lack of power not detected in same tick

### DIFF
--- a/src/systems/systems/src/apu/aps3200.rs
+++ b/src/systems/systems/src/apu/aps3200.rs
@@ -633,7 +633,7 @@ impl ApuGenerator for Aps3200ApuGenerator {
     /// overtemperature which over time will trigger a mechanical
     /// disconnect of the generator.
     fn output_within_normal_parameters(&self) -> bool {
-        self.potential_normal() && self.frequency_normal()
+        self.should_provide_output() && self.potential_normal() && self.frequency_normal()
     }
 }
 provide_potential!(Aps3200ApuGenerator, (110.0..=120.0));


### PR DESCRIPTION
## Summary of Changes
In #4064 @hotshotp mentioned an issue where "when the left engine is shut down the aircraft loses and gains power making many sounds at once play". This PR fixes this issue.

The frequency and potential of the power sources are only known at the end of a simulation tick, due to them being directly related to the power consumption (large changes can cause spikes and dips). However, the decision if a power source can supply power is made much earlier in the tick. This is especially of great consequence when the power source no longer supplies potential but the previous tick's frequency and potential are still normal.

To fix this, I include whether or not the power source `should_provide_output` in the `output_within_normal_parameters` function. `should_provide_output` is always up-to-date (doesn't have a one tick delay).

As a consequence, a power source losing power will be detected immediately, but a power source just starting providing output will only be within normal conditions after a single tick. I deem this acceptable.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

## Testing instructions
In an aircraft with running engines, shut down engine 1 and ensure you only hear the "clunk" indicating powering of AC BUS 1 transfers from GEN 1 to GEN 2.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
