### PR TITLE
feat(nd): fixed bearing markers on rose

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -230,6 +230,7 @@
 1. [EFB] Set font of OFP to monospace - @chkgk (Chriskgk#4359)
 1. [SOUND] Added electrical system sounds - @hotshotp (Boris)
 1. [SOUND] General improvements to cockpit and cabin ambience - @hotshotp (Boris)
+1. [ND] Add fixed bearing markers on rose display - @tracernz (Mike)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A32NX_NDCompass.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A32NX_NDCompass.js
@@ -667,6 +667,22 @@ class Jet_MFD_NDCompass extends Jet_NDCompass {
             neutralLine.setAttribute("stroke-width", "6");
             this.root.appendChild(neutralLine);
         }
+        // fixed angle markers at 45 degree intervals, except 0
+        const arrowMarkGroup = document.createElementNS(Avionics.SVG.NS, "g");
+        this.root.appendChild(arrowMarkGroup);
+        for (let a = 45; a < 360; a = a + 45) {
+            const height = 26;
+            const p1 = (500) + ", " + (500 - circleRadius);
+            const p2 = (500 + height / 2) + ", " + (500 - circleRadius - height);
+            const p3 = (500 - height / 2) + ", " + (500 - circleRadius - height);
+            const arrowMark = document.createElementNS(Avionics.SVG.NS, "polygon");
+            arrowMark.setAttribute("id", `ArrowMark${a}`);
+            arrowMark.setAttribute("transform", `rotate(${a} 500 500)`);
+            arrowMark.setAttribute("points", `${p1} ${p2} ${p3}`);
+            arrowMark.setAttribute("stroke", "white");
+            arrowMark.setAttribute("fill", "white");
+            arrowMarkGroup.appendChild(arrowMark);
+        }
     }
     updateFail() {
         const failed = SimVar.GetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum") != 2;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #4071

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Add fixed markers at 45 degree angles on the ND rose displays (except 12 o'clock). I have made these the same size as the long graduations, per both of my references, but our graduation ticks are really not the right length... in general you can see our ND needs a lot of visual improvement..

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/9995998/112111486-20f61000-8c19-11eb-9daa-5117b957fee7.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->
https://www.youtube.com/watch?v=vL60msOxA3w
![image](https://user-images.githubusercontent.com/9995998/112111587-41be6580-8c19-11eb-83d5-1b921de48d4d.png)

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Test ND rose modes (ILS, VOR, NAV) and ensure fixed triangle markers appear and stay fixed as the rose rotates.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
