### PR TITLE
fix(mcdu): do not round baro/radio, remove ILS check on PERF APPR

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -2633,7 +2633,7 @@ class FMCMainDisplay extends BaseAirliners {
             SimVar.SetSimVarValue("L:AIRLINER_MINIMUM_DESCENT_ALTITUDE", "feet", 0);
             return true;
         } else if (s.match(/^[0-9]{1,5}$/) !== null) {
-            const value = Math.round(parseInt(s) / 10) * 10;
+            const value = parseInt(s);
             let ldgRwy = this.flightPlanManager.getApproachRunway();
             if (!ldgRwy) {
                 const dest = this.flightPlanManager.getDestination();
@@ -2663,17 +2663,12 @@ class FMCMainDisplay extends BaseAirliners {
             return true;
         }
 
-        if (Simplane.getAutoPilotApproachType() !== 4) {
-            this.addNewMessage(NXSystemMessages.notAllowed);
-            return false;
-        }
-
         if (s === "NO" || s === "NO DH" || s === "NODH") {
             this.perfApprDH = "NO DH";
             SimVar.SetSimVarValue("L:AIRLINER_DECISION_HEIGHT", "feet", -2);
             return true;
         } else if (s.match(/^[0-9]{1,5}$/) !== null) {
-            const value = Math.round(parseInt(s) / 10) * 10;
+            const value = parseInt(s);
             if (value >= 0 && value <= 5000) {
                 this.perfApprDH = value;
                 SimVar.SetSimVarValue("L:AIRLINER_DECISION_HEIGHT", "feet", this.perfApprDH);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes discord issue

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Remove rounding inadvertently applied to BARO and RADIO during review fixes.
- Remove ILS check for RADIO (that's already in the UI code, but a slightly different check, don't want a disagreement)

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

Honeywell Step1A data formats.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

On PERF APPR:
- Ensure values in BARO and RADIO fields are not rounded to nearest 10 feet
- Ensure RADIO height (DH) can be entered when an ILS approach is selected in the flight plan

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
