### PR TITLE
fix(mcdu): revise route reserve calculation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -231,7 +231,7 @@
 1. [SOUND] Added electrical system sounds - @hotshotp (Boris)
 1. [SOUND] General improvements to cockpit and cabin ambience - @hotshotp (Boris)
 1. [MISC] Added custom loading tips - @Armankir (Arman#5297)
-1. [MCDU] Revised Reserve Weight Calculation and Default weight rule-set added (Lucky38i)
+1. [MCDU] Revised Reserve Weight Calculation and Default weight rule-set added - @Lucky38i (Lucky38i)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -231,6 +231,7 @@
 1. [SOUND] Added electrical system sounds - @hotshotp (Boris)
 1. [SOUND] General improvements to cockpit and cabin ambience - @hotshotp (Boris)
 1. [MISC] Added custom loading tips - @Armankir (Arman#5297)
+1. [MCDU] Revised Reserve Weight Calculation and Default weight rule-set added (Lucky38i)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_FuelPredPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_FuelPredPage.js
@@ -210,11 +210,7 @@ class CDUFuelPredPage {
                 };
                 mcdu.checkEFOBBelowMin();
 
-                if (isFlying) {
-                    extraFuelCell = "{small}" + ((mcdu.tryGetExtraFuel(true) + mcdu.getRouteReservedWeight()) * mcdu._conversionWeight).toFixed(1);
-                } else {
-                    extraFuelCell = "{small}" + (mcdu.tryGetExtraFuel(true) * mcdu._conversionWeight).toFixed(1);
-                }
+                extraFuelCell = "{small}" + (mcdu.tryGetExtraFuel(true) * mcdu._conversionWeight).toFixed(1);
                 extraCellColor = "[color]green";
                 extraTimeCell = FMCMainDisplay.minutesTohhmm(mcdu.tryGetExtraTime(true)) + "{end}";
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -2203,6 +2203,7 @@ class FMCMainDisplay extends BaseAirliners {
         if (!this._rteReservedEntered && (this._rteFinalCoeffecient !== 0)) {
             const fivePercentWeight = this._routeReservedPercent * this._routeTripFuelWeight / 100;
             const fiveMinuteHoldingWeight = (5 * this._rteFinalCoeffecient) / 1000;
+
             return fivePercentWeight > fiveMinuteHoldingWeight ? fivePercentWeight : fiveMinuteHoldingWeight;
         }
         if (isFinite(this._routeReservedWeight) && this._routeReservedWeight !== 0) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -2200,6 +2200,11 @@ class FMCMainDisplay extends BaseAirliners {
     }
 
     getRouteReservedWeight() {
+        if (!this._rteReservedEntered && (this._rteFinalCoeffecient !== 0)) {
+            const fivePercentWeight = this._routeReservedPercent * this._routeTripFuelWeight / 100;
+            const fiveMinuteHoldingWeight = (5 * this._rteFinalCoeffecient) / 1000;
+            return fivePercentWeight > fiveMinuteHoldingWeight ? fivePercentWeight : fiveMinuteHoldingWeight;
+        }
         if (isFinite(this._routeReservedWeight) && this._routeReservedWeight !== 0) {
             return this._routeReservedWeight;
         } else {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #4093

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Route reserve weight is now calculated from trip weight rather than block fuel.
- retrieving extra fuel now correctly removes or adds route reserve weight to it's calculation depending on if the plane is flying or not.
- Minimum Destination FOB now update at the correct sequence when using fuel planning

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
- Pegasus Step 1A (Rev 0), 2009 edition manual

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
Lucky38i
## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
For Testers, verify the following:
- After entering block fuel/using fuel planning, try to change the reserve fuel percentage, confirm the extra fuel changes
- MinDestFob is Alternate Fuel + Final Fuel.
- After entering block fuel, default route reserve weight is 5% of trip weight, if not ignore, this is instead 5 minutes of holding fuel.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
