### PR TITLE
feat(RMP): add illumination to the RMP volume knobs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -231,6 +231,7 @@
 1. [SOUND] Added electrical system sounds - @hotshotp (Boris)
 1. [SOUND] General improvements to cockpit and cabin ambience - @hotshotp (Boris)
 1. [MISC] Added custom loading tips - @Armankir (Arman#5297)
+1. [RMP] Added integral illumination to RMP volume knobs - @ImenesFBW (Imenes)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/A32NX/ModelBehaviorDefs/A32NX/Airbus.xml
+++ b/A32NX/ModelBehaviorDefs/A32NX/Airbus.xml
@@ -838,6 +838,13 @@
 	<Template Name="A32NX_Audio_Panel_Volume_Dummy">
 		<Component ID="#NODE_ID#_Light" Node="#NODE_ID#">
 			<UseTemplate Name="ASOBO_GT_Emissive_Gauge">
+				<EMISSIVE_CODE>
+                    (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == if{
+                    14
+                    } els{
+                    (A:LIGHT POTENTIOMETER:#POTENTIOMETER#, Percent over 100) 0.5 *
+                    }
+                </EMISSIVE_CODE>
 			</UseTemplate>
 		</Component>
 	</Template>

--- a/A32NX/ModelBehaviorDefs/A32NX/AirlinerCommon.xml
+++ b/A32NX/ModelBehaviorDefs/A32NX/AirlinerCommon.xml
@@ -564,7 +564,13 @@
 			<ANIM_KNOB_PARAM_NAME>ANIM_CODE_SWITCH</ANIM_KNOB_PARAM_NAME>
 		</DefaultTemplateParameters>
 		<OverrideTemplateParameters>
-			<TRANSMIT_EMISSIVE_CODE>(L:XMLVAR_COM_#ID#_#FREQ_ID#_Switch_Down) #Button_ID# (L:XMLVAR_COM_Transmit_Channel) == ! and (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or 16 *</TRANSMIT_EMISSIVE_CODE>
+			<TRANSMIT_EMISSIVE_CODE>
+                (L:XMLVAR_COM_#ID#_#FREQ_ID#_Switch_Down) #Button_ID# (L:XMLVAR_COM_Transmit_Channel) == ! and (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == or if{
+                14
+                } els{
+                (A:LIGHT POTENTIOMETER:#POTENTIOMETER#, Percent over 100) 0.5 *
+                }
+            </TRANSMIT_EMISSIVE_CODE>
 		</OverrideTemplateParameters>
 		<Condition Valid="Radio_ID">
 			<True>

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -3475,9 +3475,6 @@
                     </UseTemplate>
                 </Component>
                 <Component ID="Audio_Panel_Left_Volume_Dummies">
-                    <OverrideTemplateParameters>
-                        <EMISSIVE_CODE>(L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == 16 *</EMISSIVE_CODE>
-                    </OverrideTemplateParameters>
                     <UseTemplate Name="A32NX_Audio_Panel_Volume_Dummy">
                         <NODE_ID>PUSH_AUDIOL_VOR1_EMIS</NODE_ID>
                     </UseTemplate>
@@ -3582,9 +3579,6 @@
                     </UseTemplate>
                 </Component>
                 <Component ID="Audio_Panel_Right_Volume_Dummies">
-                    <OverrideTemplateParameters>
-                        <EMISSIVE_CODE>(L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 == 16 *</EMISSIVE_CODE>
-                    </OverrideTemplateParameters>
                     <UseTemplate Name="A32NX_Audio_Panel_Volume_Dummy">
                         <NODE_ID>PUSH_AUDIOR_VOR1_EMIS</NODE_ID>
                     </UseTemplate>


### PR DESCRIPTION
## Summary of Changes
This adds integral illumination to the RMP knobs as seen on never RMP panels.

- added illumination for the RMP volume knobs controlled by integral light knob with the rest of pedestal integral lighting
- reduced the brightness of the RMP volume knobs when selected or with the annunciator test light on by a small amount

Thanks to @Benjozork and @NathanInnes for helping out!
## Screenshots (if necessary)

![Untitled-2](https://user-images.githubusercontent.com/71195324/112554230-30ff2280-8dc6-11eb-8302-b5fee98e0fc5.png)


## References

![image](https://user-images.githubusercontent.com/71195324/112554771-3610a180-8dc7-11eb-9d61-babc46af2677.png)

![image](https://user-images.githubusercontent.com/71195324/112554783-3c9f1900-8dc7-11eb-93b2-e8ff087c07b2.png)

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
Brightness comparison :

![end](https://user-images.githubusercontent.com/71195324/112555214-09a95500-8dc8-11eb-9b27-d18e5a0801f9.png)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Imenes#8739

## Testing instructions

Make sure RMP volume knobs illuminate on both sides with the pedestal integral light knob and that they illuminate more brightly when the annul test light is on or they are pulled out.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
