### PR TITLE
fix(ACP): correct CALL buttons behaviour when ANN LT is on

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -232,6 +232,7 @@
 1. [SOUND] General improvements to cockpit and cabin ambience - @hotshotp (Boris)
 1. [MISC] Added custom loading tips - @Armankir (Arman#5297)
 1. [RMP] Added integral illumination to RMP volume knobs - @ImenesFBW (Imenes)
+1. [RMP] Fixed ACP CALL buttons emissive behavior - @ImenesFBW (Imenes)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -3445,6 +3445,8 @@
                 </UseTemplate>
                 <Component ID="Audio_Panel_Left_Dummies">
                     <OverrideTemplateParameters>
+                        <POTENTIOMETER>1</POTENTIOMETER>
+                        <POTENTIOMETER_SEQ2>85</POTENTIOMETER_SEQ2>
                         <SEQ1_EMISSIVE_CODE>(L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 ==</SEQ1_EMISSIVE_CODE>
                         <SEQ2_EMISSIVE_CODE>1</SEQ2_EMISSIVE_CODE>
                         <SEQ1_EMISSIVE_DRIVES_VISIBILITY>False</SEQ1_EMISSIVE_DRIVES_VISIBILITY>
@@ -3549,6 +3551,8 @@
                 </UseTemplate>
                 <Component ID="Audio_Panel_Right_Dummies">
                     <OverrideTemplateParameters>
+                        <POTENTIOMETER>1</POTENTIOMETER>
+                        <POTENTIOMETER_SEQ2>85</POTENTIOMETER_SEQ2>
                         <SEQ1_EMISSIVE_CODE>(L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position) 0 ==</SEQ1_EMISSIVE_CODE>
                         <SEQ2_EMISSIVE_CODE>1</SEQ2_EMISSIVE_CODE>
                         <SEQ1_EMISSIVE_DRIVES_VISIBILITY>False</SEQ1_EMISSIVE_DRIVES_VISIBILITY>


### PR DESCRIPTION
## Summary of Changes

Fixes the ACP CALL button green indicators to be independent of the integral light knob position, while the text is still controllable by the integral knob.

## Videos
BEFORE:

https://user-images.githubusercontent.com/71195324/112672181-7887bc00-8e63-11eb-890e-5265552f2acd.mp4

AFTER:

https://user-images.githubusercontent.com/71195324/112672149-6d349080-8e63-11eb-89bf-56c010f45f8a.mp4


## Additional context
Noticed this bug while working on volume knobs, this should hopefully fix it.

Discord username (if different from GitHub): Imenes#8739

## Testing instructions
Confirm that the ACP CALL buttons now light up with ANN LT on, regardless of the integral light knob. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
