### PR TITLE
fix: make holds inop

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
@@ -95,6 +95,7 @@ class CDULateralRevisionPage {
                 return mcdu.getDelaySwitchPage();
             };
             mcdu.onLeftInput[2] = () => {
+                CDUHoldAtPage.ShowPage(mcdu, waypoint, waypointIndexFP);
                 mcdu.addNewMessage(NXFictionalMessages.notYetImplemented);
             };
         }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
@@ -90,12 +90,12 @@ class CDULateralRevisionPage {
 
         let holdCell = "";
         if (isWaypoint) {
-            holdCell = "<HOLD";
+            holdCell = "<HOLD[color]inop";
             mcdu.leftInputDelay[2] = () => {
                 return mcdu.getDelaySwitchPage();
             };
             mcdu.onLeftInput[2] = () => {
-                CDUHoldAtPage.ShowPage(mcdu, waypoint, waypointIndexFP);
+                mcdu.addNewMessage(NXFictionalMessages.notYetImplemented);
             };
         }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
@@ -95,7 +95,6 @@ class CDULateralRevisionPage {
                 return mcdu.getDelaySwitchPage();
             };
             mcdu.onLeftInput[2] = () => {
-                CDUHoldAtPage.ShowPage(mcdu, waypoint, waypointIndexFP);
                 mcdu.addNewMessage(NXFictionalMessages.notYetImplemented);
             };
         }


### PR DESCRIPTION
Fixes #[issue_no]

## Summary of Changes
makes holds show as inop until they can be properly flown


## Screenshots (if necessary)
![hold](https://user-images.githubusercontent.com/62574308/112754480-99bfe800-8fdc-11eb-9673-9704e7320407.png)


## References


## Additional context
should reduce the amount of questions why they don't work but can be inserted


Discord username (if different from GitHub): Nyhmbo#9999

## Testing instructions
spawn, load a flightplan, insert a hold

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
