### PR TITLE
fix: prefill cruise FL/TEMP when creating flightplan in msfs

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -104,8 +104,7 @@ class CDUInitPage {
                         "{end}";
                 }
                 if (mcdu._cruiseEntered == false && mcdu.flightPlanManager.cruisingAltitude) {
-                    cruiseFlTemp = "{cyan}FL" + mcdu.flightPlanManager.cruisingAltitude / 100 + "\xa0" + "{small}/" + mcdu.tempCurve.evaluate(mcdu.flightPlanManager.cruisingAltitude / 100).toFixed(0) + "°{end}" +
-                    "{end}";
+                    cruiseFlTemp = "{cyan}FL" + mcdu.flightPlanManager.cruisingAltitude / 100 + "\xa0" + "{small}/" + mcdu.tempCurve.evaluate(mcdu.flightPlanManager.cruisingAltitude / 100).toFixed(0) + "°{end}";
                 }
 
                 // CRZ FL / FLX TEMP

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -105,7 +105,7 @@ class CDUInitPage {
                 }
                 if (mcdu._cruiseEntered == false && mcdu.flightPlanManager.getcruisingAltitude())
                 {
-                    cruiseFlTemp = "{cyan}FL" + mcdu.flightPlanManager.getcruisingAltitude()/100 + "\xa0" + (mcdu.cruiseTemperature ? "/" + mcdu.cruiseTemperature.toFixed(0) + "°" : "{small}/" + mcdu.tempCurve.evaluate(mcdu.flightPlanManager.getcruisingAltitude()/100).toFixed(0) + "°{end}") +
+                    cruiseFlTemp = "{cyan}FL" + mcdu.flightPlanManager.getcruisingAltitude() /100 + "\xa0" + (mcdu.cruiseTemperature ? "/" + mcdu.cruiseTemperature.toFixed(0) + "°" : "{small}/" + mcdu.tempCurve.evaluate(mcdu.flightPlanManager.getcruisingAltitude() /100).toFixed(0) + "°{end}") +
                     "{end}";
                 }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -105,7 +105,7 @@ class CDUInitPage {
                 }
                 if (mcdu._cruiseEntered == false && mcdu.flightPlanManager.getcruisingAltitude())
                 {
-                    cruiseFlTemp = "{cyan}FL" + mcdu.flightPlanManager.getcruisingAltitude() /100 + "\xa0" + (mcdu.cruiseTemperature ? "/" + mcdu.cruiseTemperature.toFixed(0) + "°" : "{small}/" + mcdu.tempCurve.evaluate(mcdu.flightPlanManager.getcruisingAltitude() /100).toFixed(0) + "°{end}") +
+                    cruiseFlTemp = "{cyan}FL" + mcdu.flightPlanManager.getcruisingAltitude() / 100 + "\xa0" + (mcdu.cruiseTemperature ? "/" + mcdu.cruiseTemperature.toFixed(0) + "°" : "{small}/" + mcdu.tempCurve.evaluate(mcdu.flightPlanManager.getcruisingAltitude() / 100).toFixed(0) + "°{end}") +
                     "{end}";
                 }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -104,7 +104,7 @@ class CDUInitPage {
                         "{end}";
                 }
                 if (mcdu._cruiseEntered == false && mcdu.flightPlanManager.cruisingAltitude) {
-                    cruiseFlTemp = "{cyan}FL" + mcdu.flightPlanManager.cruisingAltitude / 100 + "\xa0" + (mcdu.cruiseTemperature ? "/" + mcdu.cruiseTemperature.toFixed(0) + "°" : "{small}/" + mcdu.tempCurve.evaluate(mcdu.flightPlanManager.cruisingAltitude / 100).toFixed(0) + "°{end}") +
+                    cruiseFlTemp = "{cyan}FL" + mcdu.flightPlanManager.cruisingAltitude / 100 + "\xa0" + "{small}/" + mcdu.tempCurve.evaluate(mcdu.flightPlanManager.cruisingAltitude / 100).toFixed(0) + "°{end}" +
                     "{end}";
                 }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -103,8 +103,8 @@ class CDUInitPage {
                         (mcdu.cruiseTemperature ? "/" + mcdu.cruiseTemperature.toFixed(0) + "°" : "{small}/" + mcdu.tempCurve.evaluate(mcdu._cruiseFlightLevel).toFixed(0) + "°{end}") +
                         "{end}";
                 }
-                if (mcdu._cruiseEntered == false && mcdu.flightPlanManager.getcruisingAltitude()) {
-                    cruiseFlTemp = "{cyan}FL" + mcdu.flightPlanManager.getcruisingAltitude() / 100 + "\xa0" + (mcdu.cruiseTemperature ? "/" + mcdu.cruiseTemperature.toFixed(0) + "°" : "{small}/" + mcdu.tempCurve.evaluate(mcdu.flightPlanManager.getcruisingAltitude() / 100).toFixed(0) + "°{end}") +
+                if (mcdu._cruiseEntered == false && mcdu.flightPlanManager.cruisingAltitude) {
+                    cruiseFlTemp = "{cyan}FL" + mcdu.flightPlanManager.cruisingAltitude / 100 + "\xa0" + (mcdu.cruiseTemperature ? "/" + mcdu.cruiseTemperature.toFixed(0) + "°" : "{small}/" + mcdu.tempCurve.evaluate(mcdu.flightPlanManager.cruisingAltitude / 100).toFixed(0) + "°{end}") +
                     "{end}";
                 }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -103,6 +103,11 @@ class CDUInitPage {
                         (mcdu.cruiseTemperature ? "/" + mcdu.cruiseTemperature.toFixed(0) + "°" : "{small}/" + mcdu.tempCurve.evaluate(mcdu._cruiseFlightLevel).toFixed(0) + "°{end}") +
                         "{end}";
                 }
+                if (mcdu._cruiseEntered == false && mcdu.flightPlanManager.getcruisingAltitude())
+                {
+                    cruiseFlTemp = "{cyan}FL" + mcdu.flightPlanManager.getcruisingAltitude()/100 + "\xa0" + (mcdu.cruiseTemperature ? "/" + mcdu.cruiseTemperature.toFixed(0) + "°" : "{small}/" + mcdu.tempCurve.evaluate(mcdu.flightPlanManager.getcruisingAltitude()/100).toFixed(0) + "°{end}") +
+                    "{end}";
+                }
 
                 // CRZ FL / FLX TEMP
                 mcdu.onLeftInput[5] = (value) => {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -103,8 +103,7 @@ class CDUInitPage {
                         (mcdu.cruiseTemperature ? "/" + mcdu.cruiseTemperature.toFixed(0) + "°" : "{small}/" + mcdu.tempCurve.evaluate(mcdu._cruiseFlightLevel).toFixed(0) + "°{end}") +
                         "{end}";
                 }
-                if (mcdu._cruiseEntered == false && mcdu.flightPlanManager.getcruisingAltitude())
-                {
+                if (mcdu._cruiseEntered == false && mcdu.flightPlanManager.getcruisingAltitude()) {
                     cruiseFlTemp = "{cyan}FL" + mcdu.flightPlanManager.getcruisingAltitude() / 100 + "\xa0" + (mcdu.cruiseTemperature ? "/" + mcdu.cruiseTemperature.toFixed(0) + "°" : "{small}/" + mcdu.tempCurve.evaluate(mcdu.flightPlanManager.getcruisingAltitude() / 100).toFixed(0) + "°{end}") +
                     "{end}";
                 }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
@@ -654,7 +654,7 @@ class FlightPlanManager {
             callback();
         });
     }
-    getcruisingAltitude() {
+    get cruisingAltitude() {
         return this._cruisingAltitude;
     }
     getCurrentFlightPlanIndex() {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
@@ -654,7 +654,7 @@ class FlightPlanManager {
             callback();
         });
     }
-    get cruisingAltitude() {
+    getcruisingAltitude() {
         return this._cruisingAltitude;
     }
     getCurrentFlightPlanIndex() {


### PR DESCRIPTION
Fixes #3544 

## Summary of Changes
prefills the cruise FL and cruise temp when creating the flightplan via the main menu

## Screenshots (if necessary)

## References


## Additional context

Discord username (if different from GitHub): Nyhmbo#9999

## Testing instructions
create flightplan via msfs main menu
spawn in
check INIT page in mcdu for prefilled CRZ FL/TEMP

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
