### PR TITLE
fix(adirs): delay "on bat" activation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,7 @@
 1. [MCDU] Progress page only shows GPS Primary when it should - @Username23-23 (NONAmr2433 #8777)
 1. [ND] Add VOR/ADF needles to ILS arc display - @tracernz (Mike)
 1. [MCDU] Add hard sign to temp field on PERF APPR, remove FLS/FINAL APP, adjust alignment - @tracernz (Mike)
+1. [ADIRS] Add on delay for ON BAT light - @tracernz (Mike)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_ADIRS.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_ADIRS.js
@@ -50,7 +50,7 @@ class ADIRS {
                 this.timer = Math.max(this.timer - (deltaTime / 1000), 0);
             }
             if (this.onBatTimer === -1) {
-                this.onBatTimer = 5.5;
+                this.onBatTimer = 16;
             } else if (this.onBatTimer > 0) {
                 this.onBatTimer = Math.max(this.onBatTimer - (deltaTime / 1000), 0);
             }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
In the [video supplied by Parorng[Z+7]#4524](https://discord.com/channels/738864299392630914/739225362642501672/825628162271477760) the ON BAT light doesn't activate until approx. 10.5 seconds after the ADIRS selectors are moved to the NAV position. Adjust the ADIRS on bat timer to match this.
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

https://discord.com/channels/738864299392630914/739225362642501672/825628162271477760

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Power up aircraft, and switch an ADIRS on. Observe 10.5 second delay until ON BAT light illumination (note, alignment time is not affected), and 5 seconds later extinguishment.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
