### PR TITLE
fix(ecam): N2 value overlap and code cleanup

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.css
@@ -104,7 +104,7 @@ a320-neo-upper-ecam #EnginesPanel #LineStyleInfos .Inactive {
   letter-spacing: 5px;
 }
 a320-neo-upper-ecam #EnginesPanel #LineStyleInfos .decimal {
-  font-size: 38px !important;
+  font-size: 36px !important;
 }
 a320-neo-upper-ecam #EnginesPanel #LineStyleInfos .activeEngine {
   display: block;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -2331,13 +2331,17 @@ var A320_Neo_UpperECAM;
             return _min;
         }
 
-        /**
+        /*
          * @param _active {boolean}
          * @param _value {number}
          * @param _mode {ThrottleMode}
          * @param _grounded {boolean}
          * @param _phase {FlightPhase}
          */
+        formatDecimalSvg(value, digits) {
+            const [num, dec] = value.toFixed(digits).split(".");
+            return `${num}.<span>${dec}</span>`;
+        }
         setThrottle(_active, _value = 0, _mode = ThrottleMode.UNKNOWN, _grounded = true, _phase = SimVar.GetSimVarValue("L:A32NX_FMGC_FLIGHT_PHASE", "number")) {
             if (_active !== this.currentThrottleIsActive || _value !== this.currentThrottleValue || _mode !== this.currentThrottleMode || _grounded !== this.currentGrounded || this.currentStart || _phase != this.currentPhase) {
                 this.currentThrottleIsActive = _active;
@@ -2382,11 +2386,7 @@ var A320_Neo_UpperECAM;
                         if (_value >= 0) {
                             this.throttleState.style.visibility = "visible";
                             this.throttleValue.style.visibility = "visible";
-                            const strArray = _value.toFixed(1).split(".");
-                            const wholeNumber = strArray[0];
-                            const decimal = strArray[1];
-                            const throttleVal = wholeNumber + ".<span>" + decimal + "</span>";
-                            this.throttleValue.innerHTML = throttleVal;
+                            this.throttleValue.innerHTML = this.formatDecimalSvg(_value, 1);
                         } else {
                             this.throttleState.style.visibility = "hidden";
                             this.throttleValue.style.visibility = "hidden";

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -2077,17 +2077,19 @@ var A320_Neo_UpperECAM;
                 line.style.strokeWidth = "4";
                 _svgRoot.appendChild(line);
                 this.valueText = A320_Neo_UpperECAM.createSVGText("--.-", "Value", this.getValueTextX(), "88%", "bottom");
-                this.valueText2 = A320_Neo_UpperECAM.createSVGText("", "decimal", this.getValueTextX2(), "88%", "bottom");
-                this.valueTextpoint = A320_Neo_UpperECAM.createSVGText("", "decimalpoint", this.getValueTextXpoint(), "88%", "bottom");
                 //createRectangle(_class, _x, _y, _width, _height) {
                 this.N2Box = A320_Neo_UpperECAM.createRectangle("activeEngine", this.getBoxX(), "70", "150", "40");
                 _svgRoot.appendChild(this.N2Box);
                 _svgRoot.appendChild(this.valueText);
-                _svgRoot.appendChild(this.valueText2);
-                _svgRoot.appendChild(this.valueTextpoint);
             }
             this.refresh(false, 0, 0, true);
         }
+
+        formatN2DecimalSvg(N2value, N2digits) {
+            const [N2num, N2dec] = N2value.toFixed(N2digits).split(".");
+            return `${N2num}.<tspan class="decimal">${N2dec}</tspan>`;
+        }
+
         refresh(_active, _value, _valueDisplayPrecision, _force = false, _title = "", _displayEngine = "inactiveEngine") {
             if ((this.isActive != _active) || (this.currentValue != _value) || _force) {
                 this.N2Box.setAttribute("class", _displayEngine);
@@ -2097,26 +2099,9 @@ var A320_Neo_UpperECAM;
                     const valueClass = this.isActive ? "Value" : "Inactive";
                     if (this.isActive) {
                         if (_valueDisplayPrecision > 0) {
-                            const dx = 0;
-                            if (this.currentValue.toFixed(_valueDisplayPrecision) >= 10) {
-                                this.valueText2.setAttribute("dx", "2%");
-                                this.valueTextpoint.setAttribute("dx", "2%");
-                            } else {
-                                this.valueText2.setAttribute("dx", "0%");
-                                this.valueTextpoint.setAttribute("dx", "0%");
-                            }
-                            const strArray = this.currentValue.toFixed(_valueDisplayPrecision).split(".");
-                            const wholeNumber = strArray[0];
-                            this.valueText.textContent = wholeNumber;
                             this.valueText.setAttribute("x", this.getValueTextX());
                             this.valueText.setAttribute("class", valueClass);
-                            const decimal = strArray[1];
-                            this.valueText2.textContent = decimal;
-                            this.valueText2.setAttribute("class", valueClass + " decimal");
-                            this.valueText2.setAttribute("y", "88%");
-                            this.valueTextpoint.textContent = ".";
-                            this.valueTextpoint.setAttribute("class", valueClass + " decimalpoint");
-
+                            this.valueText.innerHTML = this.formatN2DecimalSvg(this.currentValue, 1);
                         } else {
                             if (_title == "FF") {
                                 this.valueText.setAttribute("x", this.getValueTextXFF());
@@ -2127,10 +2112,7 @@ var A320_Neo_UpperECAM;
 
                     } else {
                         this.valueText.textContent = "XX";
-                        this.valueTextpoint.textContent = "";
-                        this.valueText2.textContent = "";
                         this.valueText.setAttribute("class", valueClass);
-                        this.valueText2.setAttribute("class", valueClass);
                         this.valueText.setAttribute("x", this.getValueTextX2());
                     }
                 }
@@ -2146,7 +2128,7 @@ var A320_Neo_UpperECAM;
             return "42%";
         }
         getValueTextX() {
-            return "14%";
+            return "16%";
         }
         getBoxX() {
             return "15";
@@ -2154,11 +2136,8 @@ var A320_Neo_UpperECAM;
         getValueTextX2() {
             return "20%";
         }
-        getValueTextXpoint() {
-            return "17%";
-        }
         getValueTextXFF() {
-            return "17%";
+            return "19%";
         }
     }
     A320_Neo_UpperECAM.LinesStyleComponent_Left = LinesStyleComponent_Left;
@@ -2170,7 +2149,7 @@ var A320_Neo_UpperECAM;
             return "58%";
         }
         getValueTextX() {
-            return "79%";
+            return "83%";
         }
         getBoxX() {
             return "538";
@@ -2178,11 +2157,9 @@ var A320_Neo_UpperECAM;
         getValueTextX2() {
             return "85%";
         }
-        getValueTextXpoint() {
-            return "82%";
-        }
+
         getValueTextXFF() {
-            return "82%";
+            return "86%";
         }
     }
     A320_Neo_UpperECAM.LinesStyleComponent_Right = LinesStyleComponent_Right;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

Partial fix for known issue under custom AP/FBW branch

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Fixes-
- [x] N2 values overlapping when > 100 on EWD 
- [x] Code cleanup
- [x] Aligned Fuel Flow (FF value) according to references

Do note, changes will not be visible out-of-the-box on the current dev builds as there are certain limitations to the N2 values (they do not cross 100, as far as I tested)

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

### BEFORE:
![image](https://user-images.githubusercontent.com/29005005/113198461-91d5a180-9283-11eb-8b34-87166c95216e.png)

### AFTER:
![image](https://user-images.githubusercontent.com/29005005/113198757-ea0ca380-9283-11eb-883c-221a8191c69a.png)
![image](https://user-images.githubusercontent.com/29005005/113198792-f09b1b00-9283-11eb-8a68-6e91a90a805d.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

![image](https://user-images.githubusercontent.com/29005005/113198834-03155480-9284-11eb-94f4-5f08efb62753.png)
![image](https://user-images.githubusercontent.com/29005005/113198853-0c062600-9284-11eb-962a-a9bbd577ac36.png)


## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): sidnov#8337

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

(To observe accurate results especially for values above 100, download and replace the files changed with the ones in the experimental build)

1. Spawn at a runway.
2. Observe variations to N2 value with changing thrust.
3. Make sure alignments remain uniform throughout the testing, and there is no overlap.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
