### PR TITLE
feat(mcdu): Progress Page line 5R only shows GPS Primary when it is available

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## 0.7.0
 1. [MCDU] Fixed input and display issues on PERF/W&B and INIT pages - @felixharnstrom (Felix Härnström)
+1. [MCDU] Progress page only shows GPS Primary when it should - @Username23-23 (NONAmr2433 #8777) 
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_ProgressPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_ProgressPage.js
@@ -6,6 +6,7 @@ class CDUProgressPage {
         const flightNo = SimVar.GetSimVarValue("ATC FLIGHT NUMBER", "string");
         const flMax = mcdu.getMaxFlCorrected();
         const flOpt = (mcdu._zeroFuelWeightZFWCGEntered && mcdu._blockFuelEntered && (mcdu.isAllEngineOn() || Simplane.getIsGrounded())) ? "{green}FL" + (Math.floor(flMax / 5) * 5).toString() + "{end}" : "-----";
+        const gpsPrimaryStatus = (SimVar.GetSimVarValue("L:A320_Neo_ADIRS_STATE", "Number") === 2) ? "{green}GPS PRIMARY{end}" : "";
         let flCrz = "-----";
         switch (mcdu.currentFlightPhase) {
             case FmgcFlightPhases.PREFLIGHT:
@@ -84,7 +85,7 @@ class CDUProgressPage {
             ["\xa0\xa0BRG / DIST"],
             ["{small}\xa0---°/----.-{end}", "{small}TO{end} {cyan}[{sp}{sp}{sp}{sp}{sp}]{end}"],
             ["\xa0PREDICTIVE"],
-            ["<GPS", "GPS PRIMARY[color]green"],
+            ["<GPS", gpsPrimaryStatus],
             ["REQUIRED", "ESTIMATED", "ACCUR{sp}"],
             ["{small}3.4NM{end}[color]cyan", "{small}0.07NM{end}[color]green", "HIGH[color]green"]
         ]);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #4328 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
When the navigation mode is not GPS Primary (i.e. ADIRS is not fully aligned), line 5R of the progress page displays nothing. When it is (i.e. ADIRS is fully aligned), "GPS PRIMARY" is shown in green. 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
ADIRS not aligned:
![Screenshot 2021-04-06 205747](https://user-images.githubusercontent.com/69996778/113800553-c67ea880-971c-11eb-85c3-ef2572d9df71.png)
Aligned (Line 5R shows the same thing as before this PR):
![Screenshot 2021-04-06 205831](https://user-images.githubusercontent.com/69996778/113800665-f8900a80-971c-11eb-9990-611ae52522c2.png)



## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
Step 1A manual prog page chapter
![Screenshot 2021-04-06 211441](https://user-images.githubusercontent.com/69996778/113800770-283f1280-971d-11eb-882a-8efb7256f192.png)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): NONAmr2433#8777

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- When spawning in C&D, line 5R of the progress page shouldn't say GPS PRIMARY until the ADIRS is fully aligned
- It should disappear with the GPS PRIMARY LOST scratchpad message and appear with the GPS Primary message

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
