### PR TITLE
build: improve fragmenter modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@babel/preset-typescript": "~7.12.7",
     "@flybywiresim/igniter": "^1.1.4",
     "@flybywiresim/eslint-config": "~0.1.0",
-    "@flybywiresim/fragmenter": "^0.1.5",
+    "@flybywiresim/fragmenter": "^0.5.1",
     "@flybywiresim/rnp": "^2.1.0",
     "@flybywiresim/rollup-plugin-msfs": "~0.1.4",
     "@rollup/plugin-babel": "^5.2.1",

--- a/scripts/fragment.js
+++ b/scripts/fragment.js
@@ -30,6 +30,12 @@ const execute = async () => {
             }, {
                 name: 'Model',
                 sourceDir: './SimObjects/AirPlanes/FlyByWire_A320_NEO/model'
+            }, {
+                name: 'Panels',
+                sourceDir: './SimObjects/AirPlanes/FlyByWire_A320_NEO/panel'
+            }, {
+                name: 'MarketplaceData',
+                sourceDir: './MarketplaceData'
             }]
         });
         console.log(result);


### PR DESCRIPTION
## Summary of Changes
Add new modules to reduce the size of `base` which is downloaded every time. This leads to a size reduction from 28MB to 92KB. The new module `MarketplaceData` 27MB in size and should rarely change. The new `Panels` module is 550KB in size.

## Screenshots (if necessary)
N/A

## References
N/A

## Additional context
N/A

Discord username (if different from GitHub): nistei#1362

## Testing instructions
N/A

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
