### PR TITLE
feat(du): self-test only when unpowered over 10 seconds

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [ADIRS] Add on delay for ON BAT light - @tracernz (Mike)
 1. [MISC] Added 3D brake gauge - @tyler58546 (tyler58546), @DarkOfNova (DarkOfNova)
 1. [ELEC] The BCL commands the BAT contactor be closed when the BAT push button is moved from OFF to AUTO - @davidwalschots (David Walschots)
+1. [DU] Display units only run their self-test when unpowered over 10 seconds - @davidwalschots (David Walschots)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/DisplayUnit.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/DisplayUnit.js
@@ -1,40 +1,67 @@
 class DisplayUnit {
     constructor(isPoweredFn, getSelfTestTimeInSecondsFn, potentiometerId, selfTestElement) {
+        this.selfTest = new DisplayUnitSelfTest(selfTestElement, getSelfTestTimeInSecondsFn);
         this.isPowered = isPoweredFn;
-        this.getSelfTestTimeInSeconds = getSelfTestTimeInSecondsFn;
         this.potentiometerId = potentiometerId;
-        this.selfTestElement = selfTestElement;
 
-        this.turnedOnDuringThisUpdate = false;
-        this.previousUpdateBrightness = 0;
-        this.wasPoweredDuringPreviousUpdate = false;
-        this.selfTestTimerMilliseconds = 0;
+        this.previouslyOff = false;
     }
 
-    updateBeforeThrottle() {
+    isJustNowTurnedOn() {
+        return this.previouslyOff && this.isOn();
+    }
+
+    isOn() {
         const brightness = SimVar.GetSimVarValue(`LIGHT POTENTIOMETER:${this.potentiometerId}`, "number");
-        this.turnedOnDuringThisUpdate = (brightness >= 0.1 && this.previousUpdateBrightness < 0.1);
-        this.previousUpdateBrightness = brightness;
-    }
-
-    isTurnedOnDuringThisUpdate() {
-        return this.turnedOnDuringThisUpdate;
+        return brightness >= 0.1 && this.isPowered();
     }
 
     update(deltaTime) {
-        this.selfTestTimerMilliseconds -= deltaTime / 1000;
-
-        const isPowered = this.isPowered();
-        const powerStateChanged = isPowered != this.wasPoweredDuringPreviousUpdate;
-
-        if ((this.isTurnedOnDuringThisUpdate() || powerStateChanged) && isPowered) {
-            this.selfTestTimerMilliseconds = this.getSelfTestTimeInSeconds() * 1000;
+        if (this.isJustNowTurnedOn()) {
+            this.selfTest.execute();
         }
 
-        this.selfTestTimerMilliseconds -= deltaTime;
+        const isOn = this.isOn();
+        this.selfTest.update(deltaTime, isOn);
 
-        this.selfTestElement.style.visibility = this.selfTestTimerMilliseconds > 0 ? "visible" : "hidden";
+        this.previouslyOff = !isOn;
+    }
+}
 
-        this.wasPoweredDuringPreviousUpdate = isPowered;
+class DisplayUnitSelfTest {
+    constructor(element, getSelfTestTimeInSecondsFn) {
+        this.element = element;
+        this.getSelfTestTimeInSeconds = getSelfTestTimeInSecondsFn;
+
+        this.remainingTestDurationInMilliseconds = 0;
+
+        // Start with a state where turning on the display unit within 10 seconds after starting the flight
+        // will trigger the self test.
+        this.offDurationInMilliseconds = DisplayUnitSelfTest.RequiredAfterBeingOffForMilliseconds;
+    }
+
+    static get RequiredAfterBeingOffForMilliseconds() {
+        return 10000;
+    }
+
+    isRequired() {
+        return this.offDurationInMilliseconds >= DisplayUnitSelfTest.RequiredAfterBeingOffForMilliseconds;
+    }
+
+    execute() {
+        if (this.isRequired()) {
+            this.remainingTestDurationInMilliseconds = this.getSelfTestTimeInSeconds() * 1000;
+        }
+    }
+
+    update(deltaTime, displayUnitIsOn) {
+        this.remainingTestDurationInMilliseconds -= deltaTime;
+        this.element.style.visibility = this.remainingTestDurationInMilliseconds > 0 ? "visible" : "hidden";
+
+        if (displayUnitIsOn) {
+            this.offDurationInMilliseconds = 0;
+        } else {
+            this.offDurationInMilliseconds += deltaTime;
+        }
     }
 }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/DisplayUnit.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/DisplayUnit.js
@@ -1,0 +1,40 @@
+class DisplayUnit {
+    constructor(isPoweredFn, getSelfTestTimeInSecondsFn, potentiometerId, selfTestElement) {
+        this.isPowered = isPoweredFn;
+        this.getSelfTestTimeInSeconds = getSelfTestTimeInSecondsFn;
+        this.potentiometerId = potentiometerId;
+        this.selfTestElement = selfTestElement;
+
+        this.turnedOnDuringThisUpdate = false;
+        this.previousUpdateBrightness = 0;
+        this.wasPoweredDuringPreviousUpdate = false;
+        this.selfTestTimerMilliseconds = 0;
+    }
+
+    updateBeforeThrottle() {
+        const brightness = SimVar.GetSimVarValue(`LIGHT POTENTIOMETER:${this.potentiometerId}`, "number");
+        this.turnedOnDuringThisUpdate = (brightness >= 0.1 && this.previousUpdateBrightness < 0.1);
+        this.previousUpdateBrightness = brightness;
+    }
+
+    isTurnedOnDuringThisUpdate() {
+        return this.turnedOnDuringThisUpdate;
+    }
+
+    update(deltaTime) {
+        this.selfTestTimerMilliseconds -= deltaTime / 1000;
+
+        const isPowered = this.isPowered();
+        const powerStateChanged = isPowered != this.wasPoweredDuringPreviousUpdate;
+
+        if ((this.isTurnedOnDuringThisUpdate() || powerStateChanged) && isPowered) {
+            this.selfTestTimerMilliseconds = this.getSelfTestTimeInSeconds() * 1000;
+        }
+
+        this.selfTestTimerMilliseconds -= deltaTime;
+
+        this.selfTestElement.style.visibility = this.selfTestTimerMilliseconds > 0 ? "visible" : "hidden";
+
+        this.wasPoweredDuringPreviousUpdate = isPowered;
+    }
+}

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/A320_Neo_EICAS.html
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/A320_Neo_EICAS.html
@@ -93,6 +93,7 @@
 <script type="text/html" import-script="/Pages/A32NX_Utils/NXFMGCFlightPhases.js"></script>
 <script type="text/html" import-script="/Pages/A32NX_Utils/NXLogic.js"></script>
 <script type="text/html" import-script="/Pages/A32NX_Core/A32NX_DMC.js"></script>
+<script type="text/html" import-script="/Pages/A32NX_Core/DisplayUnit.js"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/Utils/RadioNav.js"></script>
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -1,5 +1,4 @@
 class A320_Neo_EICAS extends Airliners.BaseEICAS {
-
     get templateID() {
         return "A320_Neo_EICAS";
     }
@@ -100,14 +99,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         this.CrzCondTimer = 60;
         this.PrevFailPage = -1;
 
-        this.topSelfTestDiv = this.querySelector("#TopSelfTest");
-        this.selfTestTimer = -1;
-        this.selfTestTimerStarted = false;
-        this.selfTestLastKnobValue = 1;
-
         this.doorVideoWrapper = this.querySelector("#door-video-wrapper");
-
-        this.bottomSelfTestDiv = this.querySelector("#BottomSelfTest");
 
         this.upperEngTestDiv = this.querySelector("#Eicas1EngTest");
         this.lowerEngTestDiv = this.querySelector("#Eicas2EngTest");
@@ -137,21 +129,29 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
 
         this.ecamAllButtonPrevState = false;
         this.updateThrottler = new UpdateThrottler(500);
+
+        this.displayUnit = new DisplayUnit(
+            () => this.isPowered(),
+            () => parseInt(NXDataStore.get("CONFIG_SELF_TEST_TIME", "15")),
+            this.isTopScreen ? 92 : 93,
+            this.querySelector(`#${this.isTopScreen ? "Top" : "Bottom"}SelfTest`)
+        );
     }
 
     onUpdate() {
-        let _deltaTime = this.getDeltaTime();
-        super.onUpdate(_deltaTime);
+        let deltaTime = this.getDeltaTime();
+        super.onUpdate(deltaTime);
 
-        const selfTestCurrentKnobValue = SimVar.GetSimVarValue(this.isTopScreen ? "LIGHT POTENTIOMETER:92" : "LIGHT POTENTIOMETER:93", "number");
-        const knobChanged = (selfTestCurrentKnobValue >= 0.1 && this.selfTestLastKnobValue < 0.1);
+        this.displayUnit.updateBeforeThrottle();
 
         const ecamAllButtonBeingPushed = SimVar.GetSimVarValue("L:A32NX_ECAM_ALL_Push_IsDown", "Bool");
 
-        _deltaTime = this.updateThrottler.canUpdate(_deltaTime, knobChanged || ecamAllButtonBeingPushed);
-        if (_deltaTime === -1) {
+        deltaTime = this.updateThrottler.canUpdate(deltaTime, this.displayUnit.isTurnedOnDuringThisUpdate() || ecamAllButtonBeingPushed);
+        if (deltaTime === -1) {
             return;
         }
+
+        this.displayUnit.update(deltaTime);
 
         this.updateDoorVideoState();
 
@@ -160,24 +160,22 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
 
         // TODO Move anything dependent on ac power change to A32NX_Core
         const engineOn = Simplane.getEngineActive(0) || Simplane.getEngineActive(1);
-        const externalPowerOn = SimVar.GetSimVarValue("EXTERNAL POWER AVAILABLE:1", "Bool") === 1 && SimVar.GetSimVarValue("EXTERNAL POWER ON", "Bool") === 1;
-        const apuOn = SimVar.GetSimVarValue("L:APU_GEN_ONLINE", "bool");
-        const isACPowerAvailable = engineOn || apuOn || externalPowerOn;
+        const isPowered = this.isPowered();
         let DCBus = false;
 
-        const ACPowerStateChange = (isACPowerAvailable != this.ACPowerLastState);
+        const ACPowerStateChange = (isPowered != this.ACPowerLastState);
         SimVar.SetSimVarValue("L:ACPowerStateChange", "Bool", ACPowerStateChange);
 
         if (SimVar.GetSimVarValue("ELECTRICAL MAIN BUS VOLTAGE", "Volts") >= 20) {
             DCBus = true;
         }
-        const isDCPowerAvailable = isACPowerAvailable || DCBus;
+        const isDCPowerAvailable = isPowered || DCBus;
         if (isDCPowerAvailable) {
             SimVar.SetSimVarValue("L:DCPowerAvailable", "bool", 1); //True if any AC|DC bus is online
         } else {
             SimVar.SetSimVarValue("L:DCPowerAvailable", "bool", 0);
         }
-        if (isACPowerAvailable) {
+        if (isPowered) {
             SimVar.SetSimVarValue("L:ACPowerAvailable", "bool", 1); //True if any AC bus is online
         } else {
             SimVar.SetSimVarValue("L:ACPowerAvailable", "bool", 0);
@@ -187,35 +185,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         updateDisplayDMC("EICAS1", this.upperEngTestDiv, this.upperEngMaintDiv);
         updateDisplayDMC("EICAS2", this.lowerEngTestDiv, this.lowerEngMaintDiv);
 
-        /**
-         * Self test on ECAM screen
-         **/
-
-        if ((knobChanged || ACPowerStateChange) && isACPowerAvailable && !this.selfTestTimerStarted) {
-            if (this.isTopScreen) {
-                this.topSelfTestDiv.style.visibility = "visible";
-            } else {
-                this.bottomSelfTestDiv.style.visibility = "visible";
-            }
-            this.selfTestTimer = parseInt(NXDataStore.get("CONFIG_SELF_TEST_TIME", "15"));
-            this.selfTestTimerStarted = true;
-        }
-
-        if (this.selfTestTimer >= 0) {
-            this.selfTestTimer -= _deltaTime / 1000;
-            if (this.selfTestTimer <= 0) {
-                if (this.isTopScreen) {
-                    this.topSelfTestDiv.style.visibility = "hidden";
-                } else {
-                    this.bottomSelfTestDiv.style.visibility = "hidden";
-                }
-                this.selfTestTimerStarted = false;
-            }
-        }
-
-        this.selfTestLastKnobValue = selfTestCurrentKnobValue;
-
-        this.ACPowerLastState = isACPowerAvailable;
+        this.ACPowerLastState = isPowered;
 
         // modification start here
         const currentAPUMasterState = SimVar.GetSimVarValue("L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON", "Bool");
@@ -239,14 +209,14 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         if ((currFlightPhase != FmgcFlightPhases.CLIMB || currFlightPhase == FmgcFlightPhases.CRUISE) || (!spoilerOrFlapsDeployed && !ToPowerSet) && this.CrzCondTimer >= 0) {
             this.CrzCondTimer = 60;
         } else if ((spoilerOrFlapsDeployed || ToPowerSet) && (currFlightPhase == FmgcFlightPhases.CLIMB || currFlightPhase == FmgcFlightPhases.CRUISE) && this.CrzCondTimer >= 0) {
-            this.CrzCondTimer -= _deltaTime / 1000;
+            this.CrzCondTimer -= deltaTime / 1000;
         }
 
         if (EngModeSel == 2 || EngModeSel == 0 || this.MainEngineStarterOffTimer >= 0) {
             if (EngModeSel == 0 || EngModeSel == 2) {
                 this.MainEngineStarterOffTimer = 10;
             } else if (this.MainEngineStarterOffTimer >= 0) {
-                this.MainEngineStarterOffTimer -= _deltaTime / 1000;
+                this.MainEngineStarterOffTimer -= deltaTime / 1000;
             }
             this.pageNameWhenUnselected = "ENG";
         } else if (currentAPUMasterState && (!apuAvailable || this.ApuAboveThresholdTimer >= 0)) {
@@ -254,11 +224,11 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
             if (this.ApuAboveThresholdTimer <= 0 && !apuAvailable) {
                 this.ApuAboveThresholdTimer = 10;
             } else if (apuAvailable) {
-                this.ApuAboveThresholdTimer -= _deltaTime / 1000;
+                this.ApuAboveThresholdTimer -= deltaTime / 1000;
             }
 
             this.pageNameWhenUnselected = "APU";
-        } else if (isACPowerAvailable && !engineOn && Simplane.getIsGrounded()) {
+        } else if (isPowered && !engineOn && Simplane.getIsGrounded()) {
             // reset minIndex and cruise timer after shutdown
             this.minPageIndexWhenUnselected = 0;
             this.CrzCondTimer = 60;
@@ -276,7 +246,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
                 this.ecamFCTLTimer = 20;
             } else if (this.ecamFCTLTimer >= 0) {
                 this.pageNameWhenUnselected = "FTCL";
-                this.ecamFCTLTimer -= _deltaTime / 1000;
+                this.ecamFCTLTimer -= deltaTime / 1000;
             }
         } else if ((ToPowerSet || !Simplane.getIsGrounded()) && !crzCond && this.minPageIndexWhenUnselected <= 2) {
             this.pageNameWhenUnselected = "ENG";
@@ -316,6 +286,14 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
 
         this.ecamAllButtonPrevState = ecamAllButtonBeingPushed;
         this.PrevFailPage = sFailPage;
+    }
+
+    isPowered() {
+        const engineOn = Simplane.getEngineActive(0) || Simplane.getEngineActive(1);
+        const externalPowerOn = SimVar.GetSimVarValue("EXTERNAL POWER AVAILABLE:1", "Bool") === 1 && SimVar.GetSimVarValue("EXTERNAL POWER ON", "Bool") === 1;
+        const apuOn = SimVar.GetSimVarValue("L:APU_GEN_ONLINE", "bool");
+
+        return engineOn || apuOn || externalPowerOn;
     }
 
     updateDoorVideoState() {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -142,11 +142,9 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         let deltaTime = this.getDeltaTime();
         super.onUpdate(deltaTime);
 
-        this.displayUnit.updateBeforeThrottle();
-
         const ecamAllButtonBeingPushed = SimVar.GetSimVarValue("L:A32NX_ECAM_ALL_Push_IsDown", "Bool");
 
-        deltaTime = this.updateThrottler.canUpdate(deltaTime, this.displayUnit.isTurnedOnDuringThisUpdate() || ecamAllButtonBeingPushed);
+        deltaTime = this.updateThrottler.canUpdate(deltaTime, this.displayUnit.isJustNowTurnedOn() || ecamAllButtonBeingPushed);
         if (deltaTime === -1) {
             return;
         }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/MFD/A320_Neo_MFD.html
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/MFD/A320_Neo_MFD.html
@@ -156,7 +156,7 @@
                 </svg>
             </div>
 
-            <div style="position: absolute; left: 0%; top: 0%; width: 100%; height: 100%; border: none; display: none;" id="SelfTestDiv">
+            <div style="position: absolute; left: 0%; top: 0%; width: 100%; height: 100%; border: none;" id="SelfTestDiv">
                 <svg id="SelfTest" viewBox="0 0 600 600" style="position:absolute; top:0%; left: 0%; width: 100%; height:100%;">
                     <rect fill="url(#Backlight)" x="0" y="0" width="100%" height="100%"></rect>
                     <text id="self_test_text" class="valueText" text-anchor="middle" x="50%" y="50%" font-size="24px">SELF TEST IN PROGRESS</text>
@@ -189,6 +189,7 @@
 <script type="text/html" import-script="/JS/dataStorage.js"></script>
 <script type="text/html" import-script="/Pages/A32NX_Utils/NXDataStore.js"></script>
 <script type="text/html" import-script="/Pages/A32NX_Core/A32NX_DMC.js"></script>
+<script type="text/html" import-script="/Pages/A32NX_Core/DisplayUnit.js"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/Utils/RadioNav.js"></script>
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/MFD/A320_Neo_MFD.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/MFD/A320_Neo_MFD.js
@@ -171,9 +171,7 @@ class A320_Neo_MFD_MainPage extends NavSystemPage {
             this.updateMap(mapDeltaTime);
         }
 
-        this.displayUnit.updateBeforeThrottle();
-
-        deltaTime = this.updateThrottler.canUpdate(deltaTime, this.displayUnit.isTurnedOnDuringThisUpdate());
+        deltaTime = this.updateThrottler.canUpdate(deltaTime, this.displayUnit.isJustNowTurnedOn());
         if (deltaTime === -1) {
             return;
         }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/PFD/A320_Neo_PFD.html
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/PFD/A320_Neo_PFD.html
@@ -91,7 +91,7 @@
                 <airbus-fma id="FMA"></airbus-fma>
                 <jet-pfd-ils-indicator id="ILS"></jet-pfd-ils-indicator>
             </div>
-            <div style="position: absolute; left: 0%; top: 0%; width: 100%; height: 100%; border: none; display: none;" id="SelfTestDiv">
+            <div style="position: absolute; left: 0%; top: 0%; width: 100%; height: 100%; border: none;" id="SelfTestDiv">
                 <svg id="SelfTest" viewBox="0 0 600 600" style="position:absolute; top:0%; left: 0%; width: 100%; height:100%;">
                     <rect fill="url(#Backlight)" x="0" y="0" width="100%" height="100%"></rect>
                     <text id="self_test_text" class="valueText" text-anchor="middle" x="50%" y="50%" font-size="24px">SELF TEST IN PROGRESS</text>
@@ -109,6 +109,7 @@
 <script type="text/html" import-script="/Pages/A32NX_Utils/NXDataStore.js"></script>
 <script type="text/html" import-script="/Pages/A32NX_Utils/NXFMGCFlightPhases.js"></script>
 <script type="text/html" import-script="/Pages/A32NX_Core/A32NX_DMC.js"></script>
+<script type="text/html" import-script="/Pages/A32NX_Core/DisplayUnit.js"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/Utils/RadioNav.js"></script>
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/PFD/A320_Neo_PFD.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/PFD/A320_Neo_PFD.js
@@ -112,8 +112,6 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
         let deltaTime = this.getDeltaTime();
         super.onUpdate(deltaTime);
 
-        this.displayUnit.updateBeforeThrottle();
-
         if (!this.hasInitialized) {
             return;
         }
@@ -126,7 +124,7 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
             this.groundCursor.style.top = YokeYPosition.toString() + "%";
         }
 
-        deltaTime = this.updateThrottler.canUpdate(deltaTime, this.displayUnit.isTurnedOnDuringThisUpdate());
+        deltaTime = this.updateThrottler.canUpdate(deltaTime, this.displayUnit.isJustNowTurnedOn());
         if (deltaTime === -1) {
             return;
         }


### PR DESCRIPTION
Fixes #945

## Summary of Changes
Display units run a self-test. This self-test should only be executed when the display unit was unpowered for 10 seconds or more.

Additionally this PR also fixes an issue I uncovered where turning on the chrono (shown on the MFD) with the DU off wouldn't turn the chrono on until the DU was turned on. Now the chrono runs irrespective of the DU being powered or not.

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/1074786/114397385-f0155500-9b9e-11eb-9811-4433c5f98447.png)

<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
@komp1821 posted a video showing the behaviour which can be found [here](https://discord.com/channels/738864299392630914/754851312306487326/758257387432968222).

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

## Known issues
In some instances the original screen content still appears for a brief instant when turning the display unit on. This was already happening before this PR, and isn't fixed by this PR.

## Testing instructions
- For each display, turn it off and on to check if the self-test only runs after being off for 10 seconds or more.
- Similarly, test the same thing with power becoming available/unavailable. The easiest way to test this is at the gate by turning EXT PWR on and off.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
