### PR TITLE
fix(mcdu): Duplicate waypoints page callback

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -39,6 +39,7 @@
 1. [FLIGHTMODEL] Added separated flaps position for 1 and 1+F - @donstim (donbikes#4084), @aguther (Andreas Guther)
 1. [FLIGHTMODEL] Custom spoiler logic and realistic impact on flight model - @donstim (donbikes#4084), @aguther (Andreas Guther)
 1. [EFB] Added throttle calibration for autothrust system - @Saschl (saschl#9432)
+1. [MCDU] Do not show duplicate names page with 1 option, fix return key - @tracernz (Mike)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_DirectToPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_DirectToPage.js
@@ -2,6 +2,9 @@ class CDUDirectToPage {
     static ShowPage(mcdu, directWaypoint, wptsListIndex = 0) {
         mcdu.clearDisplay();
         mcdu.page.Current = mcdu.page.DirectToPage;
+        mcdu.returnPageCallback = () => {
+            CDUDirectToPage.ShowPage(mcdu, directWaypoint, wptsListIndex);
+        };
         mcdu.activeSystem = 'FMGC';
         let directWaypointCell = "";
         if (directWaypoint) {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -5,7 +5,7 @@ class CDUFlightPlanPage {
         mcdu.clearDisplay();
         mcdu.page.Current = mcdu.page.FlightPlanPage;
         mcdu.returnPageCallback = () => {
-            CDUFlightPlanPage.ShowPage(mcdu);
+            CDUFlightPlanPage.ShowPage(mcdu, offset);
         };
         mcdu.activeSystem = 'FMGC';
         CDUFlightPlanPage._timer = 0;

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -4,7 +4,9 @@ class CDUFlightPlanPage {
         mcdu.flightPlanManager.updateWaypointDistances(true /* approach */);
         mcdu.clearDisplay();
         mcdu.page.Current = mcdu.page.FlightPlanPage;
-        mcdu.returnCallback = CDUFlightPlanPage.ShowPage;
+        mcdu.returnPageCallback = () => {
+            CDUFlightPlanPage.ShowPage(mcdu);
+        };
         mcdu.activeSystem = 'FMGC';
         CDUFlightPlanPage._timer = 0;
         mcdu.pageUpdate = () => {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -6,6 +6,9 @@ class CDUNavRadioPage {
         mcdu.refreshPageCallback = () => {
             CDUNavRadioPage.ShowPage(mcdu);
         };
+        mcdu.returnPageCallback = () => {
+            CDUNavRadioPage.ShowPage(mcdu);
+        };
         const radioOn = mcdu.isRadioNavActive();
         let vor1FrequencyCell = "";
         let vor1CourseCell = "";

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -54,6 +54,8 @@ class CDUNavRadioPage {
                             mcdu.requestCall(() => {
                                 CDUNavRadioPage.ShowPage(mcdu);
                             });
+                        } else {
+                            mcdu.addNewMessage(NXSystemMessages.notInDatabase);
                         }
                     });
                 } else if (isFinite(numValue)) {
@@ -143,14 +145,18 @@ class CDUNavRadioPage {
                 const numValue = parseFloat(value);
                 if (!isFinite(numValue) && value.length >= 2 && value.length <= 3) {
                     mcdu.getOrSelectNDBsByIdent(value, (navaids) => {
-                        mcdu.adf1FreqIsPilotEntered = false;
-                        mcdu.adf1IdIsPilotEntered = true;
-                        mcdu.adf1IdPilotValue = value;
-                        mcdu.adf1Frequency = navaids.infos.frequencyMHz;
-                        mcdu.radioNav.setADFActiveFrequency(1, mcdu.adf1Frequency);
-                        mcdu.requestCall(() => {
-                            CDUNavRadioPage.ShowPage(mcdu);
-                        });
+                        if (navaids) {
+                            mcdu.adf1FreqIsPilotEntered = false;
+                            mcdu.adf1IdIsPilotEntered = true;
+                            mcdu.adf1IdPilotValue = value;
+                            mcdu.adf1Frequency = navaids.infos.frequencyMHz;
+                            mcdu.radioNav.setADFActiveFrequency(1, mcdu.adf1Frequency);
+                            mcdu.requestCall(() => {
+                                CDUNavRadioPage.ShowPage(mcdu);
+                            });
+                        } else {
+                            mcdu.addNewMessage(NXSystemMessages.notInDatabase);
+                        }
                     });
                 } else if (isFinite(numValue)) {
                     if (!/^\d{3,4}(\.\d{1})?$/.test(value)) {
@@ -211,6 +217,8 @@ class CDUNavRadioPage {
                             mcdu.requestCall(() => {
                                 CDUNavRadioPage.ShowPage(mcdu);
                             });
+                        } else {
+                            mcdu.addNewMessage(NXSystemMessages.notInDatabase);
                         }
                     });
                 } else if (isFinite(numValue)) {
@@ -280,11 +288,15 @@ class CDUNavRadioPage {
                     mcdu.adf2IdIsPilotEntered = true;
                     mcdu.adf2IdPilotValue = value;
                     mcdu.getOrSelectNDBsByIdent(value, (navaids) => {
-                        mcdu.adf2Frequency = navaids.infos.frequencyMHz;
-                        mcdu.radioNav.setADFActiveFrequency(2, mcdu.adf2Frequency);
-                        mcdu.requestCall(() => {
-                            CDUNavRadioPage.ShowPage(mcdu);
-                        });
+                        if (navaids) {
+                            mcdu.adf2Frequency = navaids.infos.frequencyMHz;
+                            mcdu.radioNav.setADFActiveFrequency(2, mcdu.adf2Frequency);
+                            mcdu.requestCall(() => {
+                                CDUNavRadioPage.ShowPage(mcdu);
+                            });
+                        } else {
+                            mcdu.addNewMessage(NXSystemMessages.notInDatabase);
+                        }
                     });
                 } else if (isFinite(numValue)) {
                     if (!/^\d{3,4}(\.\d{1})?$/.test(value)) {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavaidPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavaidPage.js
@@ -7,6 +7,9 @@ class CDUNavaidPage {
     static ShowPage(mcdu) {
         mcdu.clearDisplay();
         mcdu.page.Current = mcdu.page.NavaidPage;
+        mcdu.returnPageCallback = () => {
+            CDUNavaidPage.ShowPage(mcdu);
+        };
 
         mcdu.setTemplate([
             ["NAVAID"],

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_ProgressPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_ProgressPage.js
@@ -2,7 +2,9 @@ class CDUProgressPage {
     static ShowPage(mcdu) {
         mcdu.clearDisplay();
         mcdu.page.Current = mcdu.page.ProgressPage;
-        mcdu.returnCallback = CDUProgressPage.ShowPage;
+        mcdu.returnPageCallback = () => {
+            CDUProgressPage.ShowPage(mcdu);
+        };
         mcdu.activeSystem = 'FMGC';
         const flightNo = SimVar.GetSimVarValue("ATC FLIGHT NUMBER", "string");
         const flMax = mcdu.getMaxFlCorrected();

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_SelectWptPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_SelectWptPage.js
@@ -53,7 +53,11 @@ class A320_Neo_CDU_SelectWptPage {
                     callback(w);
                 };
                 mcdu.onLeftInput[5] = () => {
-                    mcdu.returnCallback(mcdu);
+                    if (mcdu.returnPageCallback) {
+                        mcdu.returnPageCallback();
+                    } else {
+                        console.error("No returnPageCallback!");
+                    }
                 };
             }
         }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_SelectWptPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_SelectWptPage.js
@@ -56,7 +56,7 @@ class A320_Neo_CDU_SelectWptPage {
                     if (mcdu.returnPageCallback) {
                         mcdu.returnPageCallback();
                     } else {
-                        console.error("No returnPageCallback!");
+                        console.error("A return page callback was expected but not declared. Add a returnPageCallback to page: " + mcdu.page.Current);
                     }
                 };
             }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_SelectWptPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_SelectWptPage.js
@@ -21,9 +21,7 @@ class A320_Neo_CDU_SelectWptPage {
             return Avionics.Utils.computeGreatCircleDistance(planeLla, w.infos.coordinates);
         }
 
-        const orderedWaypoints = [...waypoints].filter((v, i, a) => a.map((e) => e.infos.coordinates.toDegreeString()).indexOf(v.infos.coordinates.toDegreeString()) === i).sort((a, b) => {
-            return calculateDistance(a) - calculateDistance(b);
-        });
+        const orderedWaypoints = [...waypoints].sort((a, b) => calculateDistance(a) - calculateDistance(b));
 
         for (let i = 0; i < 5; i++) {
             const w = orderedWaypoints[i + 5 * page];

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_WaypointPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_WaypointPage.js
@@ -7,6 +7,9 @@ class CDUWaypointPage {
     static ShowPage(mcdu) {
         mcdu.clearDisplay();
         mcdu.page.Current = mcdu.page.WaypointPage;
+        mcdu.returnPageCallback = () => {
+            CDUWaypointPage.ShowPage(mcdu);
+        };
 
         mcdu.setTemplate([
             ["WAYPOINT"],

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCDataManager.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCDataManager.js
@@ -50,6 +50,11 @@ class FMCDataManager {
         const airportWaypoint = await this.fmc.facilityLoader.getAirport(icao);
         return airportWaypoint;
     }
+
+    _filterDuplicateWaypoints(waypoints) {
+        return waypoints.filter((wp, idx, wps) => wps.map((v) => v.icao).indexOf(wp.icao) === idx);
+    }
+
     async GetWaypointsByIdent(ident) {
         const waypoints = [];
         const intersections = await this.GetWaypointsByIdentAndType(ident, "W");
@@ -60,7 +65,7 @@ class FMCDataManager {
         waypoints.push(...ndbs);
         const airports = await this.GetWaypointsByIdentAndType(ident, "A");
         waypoints.push(...airports);
-        return waypoints;
+        return this._filterDuplicateWaypoints(waypoints);
     }
     async GetVORsByIdent(ident) {
         const navaids = [];

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -1619,41 +1619,29 @@ class FMCMainDisplay extends BaseAirliners {
         return this._routeTripFuelWeight;
     }
 
-    getOrSelectVORsByIdent(ident, callback) {
-        this.dataManager.GetVORsByIdent(ident).then((navaids) => {
-            if (!navaids || navaids.length === 0) {
-                this.addNewMessage(NXSystemMessages.notInDatabase);
-                return callback(undefined);
-            }
-            if (navaids.length === 1) {
-                return callback(navaids[0]);
-            }
-            A320_Neo_CDU_SelectWptPage.ShowPage(this, navaids, callback);
-        });
-    }
-    getOrSelectNDBsByIdent(ident, callback) {
-        this.dataManager.GetNDBsByIdent(ident).then((navaids) => {
-            if (!navaids || navaids.length === 0) {
-                this.addNewMessage(NXSystemMessages.notInDatabase);
-                return callback(undefined);
-            }
-            if (navaids.length === 1) {
-                return callback(navaids[0]);
-            }
-            A320_Neo_CDU_SelectWptPage.ShowPage(this, navaids, callback);
-        });
-    }
-
-    getOrSelectWaypointByIdent(ident, callback) {
-        this.dataManager.GetWaypointsByIdent(ident).then((waypoints) => {
+    _getOrSelectWaypoints(getter, ident, callback) {
+        getter(ident).then((waypoints) => {
+            console.log(waypoints);
             if (!waypoints || waypoints.length === 0) {
                 return callback(undefined);
             }
-            if (waypoints.length === 1) {
-                return callback(waypoints[0]);
+            const filtered = waypoints.filter((wp, idx, wps) => wps.map((v) => v.icao).indexOf(wp.icao) === idx);
+            if (filtered.length === 1) {
+                return callback(filtered[0]);
             }
-            A320_Neo_CDU_SelectWptPage.ShowPage(this, waypoints, callback);
+            A320_Neo_CDU_SelectWptPage.ShowPage(this, filtered, callback);
         });
+    }
+
+    getOrSelectVORsByIdent(ident, callback) {
+        this._getOrSelectWaypoints(this.dataManager.GetVORsByIdent.bind(this.dataManager), ident, callback);
+    }
+    getOrSelectNDBsByIdent(ident, callback) {
+        this._getOrSelectWaypoints(this.dataManager.GetNDBsByIdent.bind(this.dataManager), ident, callback);
+    }
+
+    getOrSelectWaypointByIdent(ident, callback) {
+        this._getOrSelectWaypoints(this.dataManager.GetWaypointsByIdent.bind(this.dataManager), ident, callback);
     }
 
     insertWaypoint(newWaypointTo, index, callback = EmptyCallback.Boolean) {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -1621,15 +1621,13 @@ class FMCMainDisplay extends BaseAirliners {
 
     _getOrSelectWaypoints(getter, ident, callback) {
         getter(ident).then((waypoints) => {
-            console.log(waypoints);
-            if (!waypoints || waypoints.length === 0) {
+            if (waypoints.length === 0) {
                 return callback(undefined);
             }
-            const filtered = waypoints.filter((wp, idx, wps) => wps.map((v) => v.icao).indexOf(wp.icao) === idx);
-            if (filtered.length === 1) {
-                return callback(filtered[0]);
+            if (waypoints.length === 1) {
+                return callback(waypoints[0]);
             }
-            A320_Neo_CDU_SelectWptPage.ShowPage(this, filtered, callback);
+            A320_Neo_CDU_SelectWptPage.ShowPage(this, waypoints, callback);
         });
     }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The data manager sometimes returns the same waypoint/navaid more than once in result list. This was worked around previously by a filter on the duplicate names page, after we'd already decided to show that page which sometimes resulted in us showing that page with only one option (see https://github.com/flybywiresim/a32nx/pull/3752#issuecomment-817873934). I have implemented a filter in the FMC instead, so it can check properly the de-duplicated list before deciding if the duplicate names page is needed. I changed the criteria to the `icao` field matching as this identifies unique waypoints/navaids/airports/etc. in the MSFS database, rather than simply comparing locations.

Additionally there are quite a few pages that use GetOrSelect*ByIdent will not return to the correct page when the return key is pressed on the duplicate names page (I replaced the hardcoded f-pln with a function in #3752), so I have fixed those up (cc @St54Kevin, who pointed out the RADIO NAV page).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
The duplicate names page is reachable by entering a waypoint or navaid in PROG, F-PLN, RAD NAV, DIR TO. Enter a navaid or waypoint that has duplicates at any of these places, and see the duplicate names page shows up, press the return key and make sure you get back to where you were. Enter DVR on the PROG page and make sure it doesn't show the duplicate names page, and does enter correctly (see example of the bug here https://youtu.be/SbbJH42vS-w?t=1964).

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
