### PR TITLE
feat(RMP): enable RMP LED indicators when testing ANN lights

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -17,6 +17,7 @@
 1. [MCDU] Show max distance of 9999 NM on duplicate waypoint selection - @tracernz (Mike)
 1. [DU] Display units only run their self-test when unpowered over 10 seconds - @davidwalschots (David Walschots)
 1. [DISPLAYS] RMP backlight, ATC and RTPI font color and backlight - @marcman86 (marcman86#4907)
+1. [RMP] Enabled LED indicators when testing ANN lights - @ImenesFBW (Imenes)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/src/behavior/src/A32NX_Interior_RMP.xml
+++ b/src/behavior/src/A32NX_Interior_RMP.xml
@@ -128,7 +128,7 @@
                     alias toggleSwitch = (L:A32NX_RMP_#SIDE#_TOGGLE_SWITCH, bool);
                     alias selectedModeLeft = (L:A32NX_RMP_L_SELECTED_MODE, number);
                     alias selectedModeRight = (L:A32NX_RMP_R_SELECTED_MODE, number);
-					alias annunciatorLight = (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position, number);
+                    alias annunciatorLight = (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position, number);
                     // @todo abnormal defined differently with NAV modes available.
                     let rmpLeftAbnormal = selectedModeLeft != 1;
                     let rmpRightAbnormal = selectedModeRight != 2;

--- a/src/behavior/src/A32NX_Interior_RMP.xml
+++ b/src/behavior/src/A32NX_Interior_RMP.xml
@@ -128,10 +128,11 @@
                     alias toggleSwitch = (L:A32NX_RMP_#SIDE#_TOGGLE_SWITCH, bool);
                     alias selectedModeLeft = (L:A32NX_RMP_L_SELECTED_MODE, number);
                     alias selectedModeRight = (L:A32NX_RMP_R_SELECTED_MODE, number);
+					alias annunciatorLight = (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position, number);
                     // @todo abnormal defined differently with NAV modes available.
                     let rmpLeftAbnormal = selectedModeLeft != 1;
                     let rmpRightAbnormal = selectedModeRight != 2;
-                    elecBus and toggleSwitch and (rmpLeftAbnormal or rmpRightAbnormal)
+                    elecBus and toggleSwitch and (rmpLeftAbnormal or rmpRightAbnormal) or (annunciatorLight == 0)
                 </EMISSIVE_CODE>
             </UseTemplate>
         </Component>
@@ -237,7 +238,8 @@
                     let modeId = (#MODE_ID, number#);
                     alias toggleSwitch = (L:A32NX_RMP_#SIDE#_TOGGLE_SWITCH, bool);
                     alias selectedMode = (L:A32NX_RMP_#SIDE#_SELECTED_MODE, number);
-                    !inop and elecBus and toggleSwitch and (selectedMode == modeId)
+                    alias annunciatorLight = (L:XMLVAR_SWITCH_OVHD_INTLT_ANNLT_Position, number);
+                    (!inop and elecBus and toggleSwitch and (selectedMode == modeId)) or (annunciatorLight == 0)
                 </EMISSIVE_CODE>
             </UseTemplate>
         </Component>


### PR DESCRIPTION
## Summary of Changes
This enables the small round LED lights next to the RMP push buttons to illuminate when testing the annunciator lights.

Thanks, @davidwalschots for the help on this one.
## Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/71195324/114920316-983e4e80-9e29-11eb-8ec4-0022c63d9af5.png)

## Testing instructions

- Test if the LED lights illuminate when the Annunacatior light test is performed.
- Check for any unexpected behavior and previously implemented functionality is still there. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
