### PR TITLE
build: only enabled tailwindcss purging in production

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -10,6 +10,7 @@ jobs:
     if: github.repository_owner == 'flybywiresim'
     runs-on: ubuntu-latest
     env:
+      A32NX_PRODUCTION_BUILD: 1
       MASTER_ZIP_NAME: A32NX-experimental.zip
       BUILD_DIR_NAME: experimental
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,6 +10,7 @@ jobs:
     if: github.repository_owner == 'flybywiresim'
     runs-on: ubuntu-latest
     env:
+      A32NX_PRODUCTION_BUILD: 1
       MASTER_PRE_RELEASE_ID: 32243965
       MASTER_PRE_RELEASE_TAG: vmaster
       MASTER_ZIP_NAME: A32NX-master.zip

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     env:
+      A32NX_PRODUCTION_BUILD: 1
       ZIP_NAME: A32NX.zip
       BUILD_DIR_NAME: zip-build
     steps:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
+      A32NX_PRODUCTION_BUILD: 1
       RELEASE_ZIP_NAME: A32NX-stable.zip
       BUILD_DIR_NAME: stable
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
+      A32NX_PRODUCTION_BUILD: 1
       RELEASE_ZIP_NAME: A32NX-stable.zip
       BUILD_DIR_NAME: stable
     steps:

--- a/src/instruments/src/EFB/tailwind.config.js
+++ b/src/instruments/src/EFB/tailwind.config.js
@@ -2,7 +2,7 @@
 
 module.exports = {
     purge: {
-        enabled: true,
+        enabled: !!process.env.A32NX_PRODUCTION_BUILD,
         content: [
             './**/*.{jsx,tsx}',
         ],


### PR DESCRIPTION
## Summary of Changes

* Only enable tailwindcss purging in production to improve build times.

Discord username (if different from GitHub): someperson#4953

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

* Ensure EFB works properly and does not have UI glitches

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
