### PR TITLE
fix(mcdu): fix empty ATIS request

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsAtis.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsAtis.js
@@ -30,11 +30,11 @@ class CDUAocRequestsAtis {
         }
 
         if (store.reqID == 0) {
-            arrivalText = "~ARRIVAL[color]cyan";
+            arrivalText = "ARRIVAL[color]cyan";
         } else if (store.reqID == 1) {
-            departureText = "~DEPARTURE[color]cyan";
+            departureText = "DEPARTURE[color]cyan";
         } else {
-            enrouteText = "ENROUTE~[color]cyan";
+            enrouteText = "ENROUTE[color]cyan";
         }
 
         let arrText;

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsAtis.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsAtis.js
@@ -121,6 +121,10 @@ class CDUAocRequestsAtis {
             return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[5] = async () => {
+            if (store["arpt1"] === "" && store["arrIcao"] === "") {
+                mcdu.addNewMessage(NXSystemMessages.notAllowed);
+                return;
+            }
             store["sendStatus"] = "QUEUED";
             updateView();
             const icao = store["arpt1"] || store["arrIcao"];


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
As reported in [this QA review](https://github.com/flybywiresim/a32nx/pull/4568#issuecomment-827554036) it is possible to request ATIS without specifying an airport. This PR fixes this in that it disallows ATIS request when no airport is entered.

## Additional context
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): `ExampleWasTaken#0886`

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

*not yet ready for testing*

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
