### PR TITLE
feat(elec): emergency generator test

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -43,6 +43,7 @@
 1. [EFB] Disabled LINK MCDU button on dashboard page - @ExampleWasTaken (ExampleWasTaken#0886)
 1. [MCDU] Do not show duplicate names page with 1 option, fix return key - @tracernz (Mike)
 1. [MCDU] Removed invalid chars from- and updated AOC TELEX warning message - @ExampleWasTaken (ExampleWasTaken#0886)
+1. [ELEC] Pressing and holding the EMER GEN TEST pb executes the emergency generator test - @davidwalschots (David Walschots)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)


### PR DESCRIPTION
## Summary of Changes
Adds the emergency generator test which can be executed by pressing and holding the EMER GEN TEST guarded push button on the EMER ELEC PWR overhead panel.

## Functionality

Pressing the EMER GEN test push button:

- When only batteries supply the aircraft:
    - [ ] Powers AC ESS BUS through the static inverter.
- When AC BUSES are supplied<sup>1</sup> and the blue electric pump is running<sup>2</sup>:
    - [ ] Powers AC ESS BUS and DC ESS BUS through the EMER GEN.
    - [ ] Sheds the AC ESS SHED BUS and DC ESS SHED BUS.
    - [ ] Displays the ELEC page automatically on the ECAM<sup>3</sup> when on the ground.

<sup>1</sup> Which bus powers the blue electric pump?
<sup>2</sup> It runs when the ELEC PUMP push button is AUTO and at least one engine is running, or the BLUE PUMP OVRD push button is ON. The specifics are dealt with in #3782.
<sup>3</sup> As the lower ECAM pages currently cannot be displayed on the upper ECAM, one would only be able to see the ELEC page if AC BUS 2 is powered.

## Questions and assumptions

- Is the assumption that when AC BUS 1 and/or AC BUS 2 are powered and the test is executed, contactor 3XC1 and 3XC2 open correct?
- What happens when the blue hydraulic pump isn't providing pressure and you press the EMER GEN test push button? Does a powered AC BUS 1 or 2 still supply electricity to AC ESS BUS and further?
    - Do AC ESS SHED and DC ESS SHED still get shed in this scenario?
- The manual states that AC BUSES must be supplied. Is having one AC bus supplied enough, or are both AC BUSES needed for this condition to be true?
- If the blue ELEC pump is running, how long does it take from the moment you start pressing the EMER GEN TEST button until the moment the EMER GEN starts supplying the aircraft? Will AC BUS 1 still power AC ESS BUS and DC ESS BUS until that moment?
- The display of ELEC page is only listed for the AC BUSES available scenario. However, when AC ESS BUS is supplied through the static inverter, some of the displays would turn on. Why wouldn't the ELEC page be displayed automatically at that point?

## References
@komp1821

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
