### PR TITLE
fix(mcdu): performance page refresh on flight phase transition

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -106,6 +106,7 @@
 1. [FCU] Init FCU with SPD 100 kn, HDG = 0° and ALT 100 ft - @aguther (Andreas Guther)
 1. [FBW] Inhibit alpha floor and protection law for 10 s after flight start / plane reload - @aguther (Andreas Guther)
 1. [ATHR/FADEC] Fixed potential engagement of reverse thrust in flight - @aguther (Andreas Guther)
+1. [MCDU] Fixed performance page refresh on flight phase transition - @MisterChocker (Leon)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -1,20 +1,15 @@
 class CDUPerformancePage {
     static ShowPage(mcdu, _phase = undefined) {
         mcdu.activeSystem = 'FMGC';
-        const phase = _phase || mcdu.currentFlightPhase;
 
-        if (phase <= FmgcFlightPhases.TAKEOFF) {
-            CDUPerformancePage.ShowTAKEOFFPage(mcdu);
-        } else if (phase === FmgcFlightPhases.CLIMB) {
-            CDUPerformancePage.ShowCLBPage(mcdu);
-        } else if (phase === FmgcFlightPhases.CRUISE) {
-            CDUPerformancePage.ShowCRZPage(mcdu);
-        } else if (phase === FmgcFlightPhases.DESCENT) {
-            CDUPerformancePage.ShowDESPage(mcdu);
-        } else if (phase === FmgcFlightPhases.APPROACH) {
-            CDUPerformancePage.ShowAPPRPage(mcdu);
-        } else if (phase === FmgcFlightPhases.GOAROUND) {
-            CDUPerformancePage.ShowGOAROUNDPage(mcdu);
+        switch (_phase || mcdu.currentFlightPhase) {
+            case FmgcFlightPhases.PREFLIGHT: CDUPerformancePage.ShowTAKEOFFPage(mcdu); break;
+            case FmgcFlightPhases.TAKEOFF: CDUPerformancePage.ShowTAKEOFFPage(mcdu); break;
+            case FmgcFlightPhases.CLIMB: CDUPerformancePage.ShowCLBPage(mcdu); break;
+            case FmgcFlightPhases.CRUISE: CDUPerformancePage.ShowCRZPage(mcdu); break;
+            case FmgcFlightPhases.DESCENT: CDUPerformancePage.ShowDESPage(mcdu); break;
+            case FmgcFlightPhases.APPROACH: CDUPerformancePage.ShowAPPRPage(mcdu); break;
+            case FmgcFlightPhases.GOAROUND: CDUPerformancePage.ShowGOAROUNDPage(mcdu); break;
         }
     }
     static ShowTAKEOFFPage(mcdu) {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -1,17 +1,19 @@
 class CDUPerformancePage {
-    static ShowPage(mcdu) {
+    static ShowPage(mcdu, _phase = undefined) {
         mcdu.activeSystem = 'FMGC';
-        if (mcdu.currentFlightPhase <= FmgcFlightPhases.TAKEOFF) {
+        const phase = _phase || mcdu.currentFlightPhase;
+
+        if (phase <= FmgcFlightPhases.TAKEOFF) {
             CDUPerformancePage.ShowTAKEOFFPage(mcdu);
-        } else if (mcdu.currentFlightPhase === FmgcFlightPhases.CLIMB) {
+        } else if (phase === FmgcFlightPhases.CLIMB) {
             CDUPerformancePage.ShowCLBPage(mcdu);
-        } else if (mcdu.currentFlightPhase === FmgcFlightPhases.CRUISE) {
+        } else if (phase === FmgcFlightPhases.CRUISE) {
             CDUPerformancePage.ShowCRZPage(mcdu);
-        } else if (mcdu.currentFlightPhase === FmgcFlightPhases.DESCENT) {
+        } else if (phase === FmgcFlightPhases.DESCENT) {
             CDUPerformancePage.ShowDESPage(mcdu);
-        } else if (mcdu.currentFlightPhase === FmgcFlightPhases.APPROACH) {
+        } else if (phase === FmgcFlightPhases.APPROACH) {
             CDUPerformancePage.ShowAPPRPage(mcdu);
-        } else if (mcdu.currentFlightPhase === FmgcFlightPhases.GOAROUND) {
+        } else if (phase === FmgcFlightPhases.GOAROUND) {
             CDUPerformancePage.ShowGOAROUNDPage(mcdu);
         }
     }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -3334,13 +3334,12 @@ class FMCMainDisplay extends BaseAirliners {
     }
 
     /**
-     * Evaluates whether the new performance page is in order and can be shown or the old one can be reloaded instead
-     * Updates the performance page relative to the current flight phase
+     * Switches to the next/new perf page (if new flight phase is in order) or reloads the current page
      * @param _old {FmgcFlightPhases}
      * @param _new {FmgcFlightPhases}
      */
     tryUpdatePerfPage(_old, _new) {
-        const phase = (() => {
+        const curPerfPagePhase = (() => {
             switch (this.page.Current) {
                 case this.page.PerformancePageTakeoff : return FmgcFlightPhases.TAKEOFF;
                 case this.page.PerformancePageClb : return FmgcFlightPhases.CLIMB;
@@ -3348,12 +3347,15 @@ class FMCMainDisplay extends BaseAirliners {
                 case this.page.PerformancePageDes : return FmgcFlightPhases.DESCENT;
                 case this.page.PerformancePageAppr : return FmgcFlightPhases.APPROACH;
                 case this.page.PerformancePageGoAround : return FmgcFlightPhases.GOAROUND;
-                default: return -1;
             }
         })();
 
-        if (phase !== -1 && (_old < _new ? phase <= _new : phase === _old)) {
-            CDUPerformancePage.ShowPage(this, phase === _old ? _old : _new);
+        if (_new > _old) {
+            if (_new >= curPerfPagePhase) {
+                CDUPerformancePage.ShowPage(this, _new);
+            }
+        } else if (_old === curPerfPagePhase) {
+            CDUPerformancePage.ShowPage(this, _old);
         }
     }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -3353,7 +3353,7 @@ class FMCMainDisplay extends BaseAirliners {
         })();
 
         if (phase !== -1 && (_old < _new ? phase <= _new : phase === _old)) {
-            CDUPerformancePage.ShowPage(this, phase === _old ? _old : undefined);
+            CDUPerformancePage.ShowPage(this, phase === _old ? _old : _new);
         }
     }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -366,7 +366,7 @@ class FMCMainDisplay extends BaseAirliners {
 
                 this._destDataChecked = false;
 
-                if (this.canShowNextPerfPage(_lastFlightPhase)) {
+                if (this.canShowNextPerfPage(_lastFlightPhase) || this.canShowNextPerfPage(_curFlightPhase)) {
                     CDUPerformancePage.ShowCLBPage(this);
                 } else if (this.page.Current === this.page.ProgressPage) {
                     CDUProgressPage.ShowPage(this);
@@ -386,7 +386,7 @@ class FMCMainDisplay extends BaseAirliners {
             }
 
             case FmgcFlightPhases.CRUISE: {
-                if (this.canShowNextPerfPage(_lastFlightPhase)) {
+                if (this.canShowNextPerfPage(_lastFlightPhase) || this.canShowNextPerfPage(_curFlightPhase)) {
                     CDUPerformancePage.ShowCRZPage(this);
                 } else if (this.page.Current === this.page.ProgressPage) {
                     CDUProgressPage.ShowPage(this);
@@ -407,7 +407,7 @@ class FMCMainDisplay extends BaseAirliners {
             }
 
             case FmgcFlightPhases.DESCENT: {
-                if (this.canShowNextPerfPage(_lastFlightPhase)) {
+                if (this.canShowNextPerfPage(_lastFlightPhase) || this.canShowNextPerfPage(_curFlightPhase)) {
                     CDUPerformancePage.ShowDESPage(this);
                 } else if (this.page.Current === this.page.ProgressPage) {
                     CDUProgressPage.ShowPage(this);
@@ -429,7 +429,7 @@ class FMCMainDisplay extends BaseAirliners {
             }
 
             case FmgcFlightPhases.APPROACH: {
-                if (this.canShowNextPerfPage(_lastFlightPhase)) {
+                if (this.canShowNextPerfPage(_lastFlightPhase) || this.canShowNextPerfPage(_curFlightPhase)) {
                     CDUPerformancePage.ShowAPPRPage(this);
                 } else if (this.page.Current === this.page.ProgressPage) {
                     CDUProgressPage.ShowPage(this);
@@ -471,7 +471,7 @@ class FMCMainDisplay extends BaseAirliners {
                 const currentHeading = Simplane.getHeadingMagnetic();
                 Coherent.call("HEADING_BUG_SET", 1, currentHeading);
 
-                if (this.canShowNextPerfPage(_lastFlightPhase)) {
+                if (this.canShowNextPerfPage(_lastFlightPhase) || this.canShowNextPerfPage(_curFlightPhase)) {
                     CDUPerformancePage.ShowGOAROUNDPage(this);
                 } else if (this.page.Current === this.page.ProgressPage) {
                     CDUProgressPage.ShowPage(this);

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -3339,6 +3339,11 @@ class FMCMainDisplay extends BaseAirliners {
      * @param _new {FmgcFlightPhases}
      */
     tryUpdatePerfPage(_old, _new) {
+        // Ensure we have a performance page selected...
+        if (this.page.Current < this.page.PerformancePageTakeoff || this.page.Current > this.page.PerformancePageGoAround) {
+            return;
+        }
+
         const curPerfPagePhase = (() => {
             switch (this.page.Current) {
                 case this.page.PerformancePageTakeoff : return FmgcFlightPhases.TAKEOFF;

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -3352,12 +3352,8 @@ class FMCMainDisplay extends BaseAirliners {
             }
         })();
 
-        if (_old < _new) {
-            if (phase <= _new) {
-                CDUPerformancePage.ShowPage(this);
-            }
-        } else if (phase === _old) {
-            CDUPerformancePage.ShowPage(this, _old);
+        if (phase !== -1 && (_old < _new ? phase <= _new : phase === _old)) {
+            CDUPerformancePage.ShowPage(this, phase === _old ? _old : undefined);
         }
     }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -3334,26 +3334,30 @@ class FMCMainDisplay extends BaseAirliners {
     }
 
     /**
-     * Evaluates whether the new performance page is in order an can be shown or the old one needs to be reloaded instead
+     * Evaluates whether the new performance page is in order and can be shown or the old one can be reloaded instead
      * Updates the performance page relative to the current flight phase
      * @param _old {FmgcFlightPhases}
      * @param _new {FmgcFlightPhases}
      */
     tryUpdatePerfPage(_old, _new) {
-        const phase = _old < _new ? _new : _old;
+        const phase = (() => {
+            switch (this.page.Current) {
+                case this.page.PerformancePageTakeoff : return FmgcFlightPhases.TAKEOFF;
+                case this.page.PerformancePageClb : return FmgcFlightPhases.CLIMB;
+                case this.page.PerformancePageCrz : return FmgcFlightPhases.CRUISE;
+                case this.page.PerformancePageDes : return FmgcFlightPhases.DESCENT;
+                case this.page.PerformancePageAppr : return FmgcFlightPhases.APPROACH;
+                case this.page.PerformancePageGoAround : return FmgcFlightPhases.GOAROUND;
+                default: return -1;
+            }
+        })();
 
-        if (phase === FmgcFlightPhases.TAKEOFF && this.page.Current === this.page.PerformancePageTakeoff) {
-            CDUPerformancePage.ShowTAKEOFFPage(this);
-        } else if (phase === FmgcFlightPhases.CLIMB && this.page.Current === this.page.PerformancePageClb) {
-            CDUPerformancePage.ShowCLBPage(this);
-        } else if (phase === FmgcFlightPhases.CRUISE && this.page.Current === this.page.PerformancePageCrz) {
-            CDUPerformancePage.ShowCRZPage(this);
-        } else if (phase === FmgcFlightPhases.DESCENT && this.page.Current === this.page.PerformancePageDes) {
-            CDUPerformancePage.ShowDESPage(this);
-        } else if (phase === FmgcFlightPhases.APPROACH && this.page.Current === this.page.PerformancePageAppr) {
-            CDUPerformancePage.ShowAPPRPage(this);
-        } else if (phase === FmgcFlightPhases.GOAROUND && this.page.Current === this.page.PerformancePageGoAround) {
-            CDUPerformancePage.ShowGOAROUNDPage(this);
+        if (_old < _new) {
+            if (phase <= _new) {
+                CDUPerformancePage.ShowPage(this);
+            }
+        } else if (phase === _old) {
+            CDUPerformancePage.ShowPage(this, _old);
         }
     }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -366,10 +366,10 @@ class FMCMainDisplay extends BaseAirliners {
 
                 this._destDataChecked = false;
 
-                if (this.canShowNextPerfPage(_lastFlightPhase) || this.canShowNextPerfPage(_curFlightPhase)) {
-                    CDUPerformancePage.ShowCLBPage(this);
-                } else if (this.page.Current === this.page.ProgressPage) {
+                if (this.page.Current === this.page.ProgressPage) {
                     CDUProgressPage.ShowPage(this);
+                } else {
+                    this.tryUpdatePerfPage(_lastFlightPhase, _curFlightPhase);
                 }
 
                 /** Activate pre selected speed/mach */
@@ -386,10 +386,10 @@ class FMCMainDisplay extends BaseAirliners {
             }
 
             case FmgcFlightPhases.CRUISE: {
-                if (this.canShowNextPerfPage(_lastFlightPhase) || this.canShowNextPerfPage(_curFlightPhase)) {
-                    CDUPerformancePage.ShowCRZPage(this);
-                } else if (this.page.Current === this.page.ProgressPage) {
+                if (this.page.Current === this.page.ProgressPage) {
                     CDUProgressPage.ShowPage(this);
+                } else {
+                    this.tryUpdatePerfPage(_lastFlightPhase, _curFlightPhase);
                 }
 
                 SimVar.SetSimVarValue("L:A32NX_GOAROUND_PASSED", "bool", 0);
@@ -407,10 +407,10 @@ class FMCMainDisplay extends BaseAirliners {
             }
 
             case FmgcFlightPhases.DESCENT: {
-                if (this.canShowNextPerfPage(_lastFlightPhase) || this.canShowNextPerfPage(_curFlightPhase)) {
-                    CDUPerformancePage.ShowDESPage(this);
-                } else if (this.page.Current === this.page.ProgressPage) {
+                if (this.page.Current === this.page.ProgressPage) {
                     CDUProgressPage.ShowPage(this);
+                } else {
+                    this.tryUpdatePerfPage(_lastFlightPhase, _curFlightPhase);
                 }
 
                 this.checkDestData();
@@ -429,10 +429,10 @@ class FMCMainDisplay extends BaseAirliners {
             }
 
             case FmgcFlightPhases.APPROACH: {
-                if (this.canShowNextPerfPage(_lastFlightPhase) || this.canShowNextPerfPage(_curFlightPhase)) {
-                    CDUPerformancePage.ShowAPPRPage(this);
-                } else if (this.page.Current === this.page.ProgressPage) {
+                if (this.page.Current === this.page.ProgressPage) {
                     CDUProgressPage.ShowPage(this);
+                } else {
+                    this.tryUpdatePerfPage(_lastFlightPhase, _curFlightPhase);
                 }
 
                 this.connectIls();
@@ -471,10 +471,10 @@ class FMCMainDisplay extends BaseAirliners {
                 const currentHeading = Simplane.getHeadingMagnetic();
                 Coherent.call("HEADING_BUG_SET", 1, currentHeading);
 
-                if (this.canShowNextPerfPage(_lastFlightPhase) || this.canShowNextPerfPage(_curFlightPhase)) {
-                    CDUPerformancePage.ShowGOAROUNDPage(this);
-                } else if (this.page.Current === this.page.ProgressPage) {
+                if (this.page.Current === this.page.ProgressPage) {
                     CDUProgressPage.ShowPage(this);
+                } else {
+                    this.tryUpdatePerfPage(_lastFlightPhase, _curFlightPhase);
                 }
 
                 break;
@@ -3334,21 +3334,26 @@ class FMCMainDisplay extends BaseAirliners {
     }
 
     /**
-     * Evaluates whether or not the shown performance page can be updated with the one corresponding to the new flight phase
-     * This function is in place to ensure only switching the performance page when the one currently showing is the one linked to the previous flight phase
-     * @param _lastFlightPhase {FmgcFlightPhases}
-     * @returns {boolean}
+     * Evaluates whether the new performance page is in order an can be shown or the old one needs to be reloaded instead
+     * Updates the performance page relative to the current flight phase
+     * @param _old {FmgcFlightPhases}
+     * @param _new {FmgcFlightPhases}
      */
-    canShowNextPerfPage(_lastFlightPhase) {
-        switch (_lastFlightPhase) {
-            case FmgcFlightPhases.TAKEOFF: return this.page.Current === this.page.PerformancePageTakeoff;
-            case FmgcFlightPhases.CLIMB: return this.page.Current === this.page.PerformancePageClb;
-            case FmgcFlightPhases.CRUISE: return this.page.Current === this.page.PerformancePageCrz;
-            case FmgcFlightPhases.DESCENT: return this.page.Current === this.page.PerformancePageDes;
-            case FmgcFlightPhases.APPROACH: return this.page.Current === this.page.PerformancePageAppr;
-            case FmgcFlightPhases.GOAROUND: return this.page.Current === this.page.PerformancePageGoAround;
+    tryUpdatePerfPage(_old, _new) {
+        const phase = _old < _new ? _new : _old;
 
-            default: return false;
+        if (phase === FmgcFlightPhases.TAKEOFF && this.page.Current === this.page.PerformancePageTakeoff) {
+            CDUPerformancePage.ShowTAKEOFFPage(this);
+        } else if (phase === FmgcFlightPhases.CLIMB && this.page.Current === this.page.PerformancePageClb) {
+            CDUPerformancePage.ShowCLBPage(this);
+        } else if (phase === FmgcFlightPhases.CRUISE && this.page.Current === this.page.PerformancePageCrz) {
+            CDUPerformancePage.ShowCRZPage(this);
+        } else if (phase === FmgcFlightPhases.DESCENT && this.page.Current === this.page.PerformancePageDes) {
+            CDUPerformancePage.ShowDESPage(this);
+        } else if (phase === FmgcFlightPhases.APPROACH && this.page.Current === this.page.PerformancePageAppr) {
+            CDUPerformancePage.ShowAPPRPage(this);
+        } else if (phase === FmgcFlightPhases.GOAROUND && this.page.Current === this.page.PerformancePageGoAround) {
+            CDUPerformancePage.ShowGOAROUNDPage(this);
         }
     }
 


### PR DESCRIPTION
<!-- Signed-off-by: Leon Beeser <leon.beeser@yahoo.de> -->

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #4635

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Added additional check for current performance page and current flight phase
- Fixed page refresh when when having next flight phases performance page open before flight phase transition into next phase
e.g. flight phase descent, performance page approach -> flight phase transition into approach -> performance page didn't reload (now reloads)

<!-- ## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

<!-- ## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): DerL30N#3751

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Any flight phase transition observe performance page is updated on every phase change.

Best example to test with:
From phase DES into APPR.
Go to performance page APPR during DES phase.
When reaching DECEL waypoint and FMGC transitions to flight phase approach -> monitor performance page reload (prev page indication and action will disappear)

Use managed speed mode and monitor pfd managed speed target to ensure approach phase is active (speed target GD speed)
 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
