### PR TITLE
fix(mcdu): empty weather request

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsWeather.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsWeather.js
@@ -93,7 +93,7 @@ class CDUAocRequestsWeather {
         mcdu.onRightInput[5] = async () => {
             const icaos = [store["arpt1"], store["arpt2"], store["arpt3"], store["arpt4"]];
             if (icaos[0] == "" && icaos[1] == "" && icaos[2] == "" && icaos[3] == "") {
-                // mcdu.addNewMessage(NXFictionalMessages.noAiportSpecified);
+                mcdu.addNewMessage(NXFictionalMessages.noAiportSpecified);
                 return;
             }
             store["sendStatus"] = "QUEUED";

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsWeather.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsWeather.js
@@ -93,7 +93,7 @@ class CDUAocRequestsWeather {
         mcdu.onRightInput[5] = async () => {
             const icaos = [store["arpt1"], store["arpt2"], store["arpt3"], store["arpt4"]];
             if (icaos[0] == "" && icaos[1] == "" && icaos[2] == "" && icaos[3] == "") {
-                mcdu.addNewMessage(NXFictionalMessages.noAiportSpecified);
+                mcdu.addNewMessage(NXFictionalMessages.noAirportSpecified);
                 return;
             }
             store["sendStatus"] = "QUEUED";

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsWeather.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsWeather.js
@@ -91,9 +91,13 @@ class CDUAocRequestsWeather {
         };
 
         mcdu.onRightInput[5] = async () => {
+            const icaos = [store["arpt1"], store["arpt2"], store["arpt3"], store["arpt4"]];
+            if (icaos[0] == "" && icaos[1] == "" && icaos[2] == "" && icaos[3] == "") {
+                // mcdu.addNewMessage(NXFictionalMessages.noAiportSpecified);
+                return;
+            }
             store["sendStatus"] = "QUEUED";
             updateView();
-            const icaos = [store["arpt1"], store["arpt2"], store["arpt3"], store["arpt4"]];
             const lines = [];
             const newMessage = { "id": Date.now(), "type": reqTypes[store.reqID], "time": '00:00', "opened": null, "content": lines, };
             mcdu.clearUserInput();

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsWeather.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsWeather.js
@@ -92,7 +92,7 @@ class CDUAocRequestsWeather {
 
         mcdu.onRightInput[5] = async () => {
             const icaos = [store["arpt1"], store["arpt2"], store["arpt3"], store["arpt4"]];
-            if (icaos[0] == "" && icaos[1] == "" && icaos[2] == "" && icaos[3] == "") {
+            if (icaos.every((current) => current === "")) {
                 mcdu.addNewMessage(NXFictionalMessages.noAirportSpecified);
                 return;
             }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Similar to #4629 the returned weather report is blank when no airport was specified on request. This PR fixes this issue in that it cancels the request when no airport is specified and displays `NO AIRPORT SPECIFIED` in the scratchpad.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Check that weather cannot be requested when no airport is entered in the above fields and you get a `NO AIRPORT SPECIFIED` message in the scratchpad.
- Make sure that weather can be requested if the the upper two fields are automatically  filled in with the departure and arrival airport.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
