### PR TITLE
docs(readme): update aircraft folder name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,25 +65,25 @@ This version is the same as the regular master/development version, but with the
 
 ### Please follow ALL steps in this README if you encounter any issues with installation before seeking support.
 
-Open the zip that you downloaded from one of the links above, and drag the A32NX folder inside the zip into your Community folder.
+Open the zip that you downloaded from one of the links above, and drag the flybywire-aircraft-a320-neo folder inside the zip into your Community folder.
 
 See below for the location of your Community folder:
 
 For the Microsoft Store edition AND/OR Gamepass edition:
-- Copy the "A32NX" folder into your community package folder. It is located in:
+- Copy the "flybywire-aircraft-a320-neo" folder into your community package folder. It is located in:
 `C:\Users\[YOUR USERNAME]\AppData\Local\Packages\Microsoft.FlightSimulator_<RANDOMLETTERS>\LocalCache\Packages\Community`.
 
 For the Steam edition:
-- Copy the "A32NX" folder into your community package folder. It is located in:
+- Copy the "flybywire-aircraft-a320-neo" folder into your community package folder. It is located in:
 `C:\Users\[YOUR USERNAME]\AppData\Roaming\Microsoft Flight Simulator\Packages\Community`.
 
 For the Boxed edition:
-- Copy the "A32NX" folder into your community package folder. It is located in:
+- Copy the "flybywire-aircraft-a320-neo" folder into your community package folder. It is located in:
 `C:\Users\[YOUR USERNAME]\AppData\Local\MSFSPackages\Community`.
 
 If the above methods do not work:
 - You can find your community folder by going into FS2020 general options and enabling developer mode. You will see a menu appear on top. Go to tools and virtual file system. Click on watch bases and your community folder will be listed in one of the folders.
-- Please make sure you're copying the "A32NX" folder into your community package folder, NOT the "flybywiresim-a32nx" folder.
+- Please make sure you're copying the "flybywire-aircraft-a320-neo" folder into your community package folder, NOT the "flybywiresim-a32nx" folder.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR is partly a duplicate to #4205 and should be closed should #4205 get merged before this PR.
It updates the name of the aircraft folder, mentioned in the installation section of the readme to prevent future issue like [this one](https://github.com/flybywiresim/a32nx/discussions/4659#discussion-3345602).

## Additional context
<!-- Add any other context about the pull request here. -->
I make this PR because #4205 seems to still take a while.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): `ExampleWasTaken#0886`

<!-- ## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
<!-- ## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
