### PR TITLE
fix: ensure that on_ground always inhibits alpha floor (e.g. after using slew)

### DIFF
--- a/src/fbw/src/model/FlyByWire.cpp
+++ b/src/fbw/src/model/FlyByWire.cpp
@@ -361,6 +361,10 @@ void FlyByWireModelClass::step()
         FlyByWire_DWork.is_c15_FlyByWire = FlyByWire_IN_Landing100ft;
         rtb_alpha_floor_inhib = 1;
         rtb_ap_special_disc = 1;
+      } else if (rtb_on_ground != 0) {
+        FlyByWire_DWork.is_c15_FlyByWire = FlyByWire_IN_Landed;
+        rtb_alpha_floor_inhib = 1;
+        rtb_ap_special_disc = 0;
       } else {
         rtb_alpha_floor_inhib = 0;
         rtb_ap_special_disc = 0;
@@ -379,13 +383,13 @@ void FlyByWireModelClass::step()
       break;
 
      case FlyByWire_IN_Landing100ft:
-      if (rtb_on_ground != 0) {
-        FlyByWire_DWork.is_c15_FlyByWire = FlyByWire_IN_Landed;
-        rtb_alpha_floor_inhib = 1;
-        rtb_ap_special_disc = 0;
-      } else if (FlyByWire_U.in.data.H_radio_ft > 100.0) {
+      if (FlyByWire_U.in.data.H_radio_ft > 100.0) {
         FlyByWire_DWork.is_c15_FlyByWire = FlyByWire_IN_Flying;
         rtb_alpha_floor_inhib = 0;
+        rtb_ap_special_disc = 0;
+      } else if (rtb_on_ground != 0) {
+        FlyByWire_DWork.is_c15_FlyByWire = FlyByWire_IN_Landed;
+        rtb_alpha_floor_inhib = 1;
         rtb_ap_special_disc = 0;
       } else {
         rtb_alpha_floor_inhib = 1;
@@ -394,7 +398,11 @@ void FlyByWireModelClass::step()
       break;
 
      default:
-      if (FlyByWire_U.in.data.H_radio_ft > 100.0) {
+      if (rtb_on_ground != 0) {
+        FlyByWire_DWork.is_c15_FlyByWire = FlyByWire_IN_Landed;
+        rtb_alpha_floor_inhib = 1;
+        rtb_ap_special_disc = 0;
+      } else if (FlyByWire_U.in.data.H_radio_ft > 100.0) {
         FlyByWire_DWork.is_c15_FlyByWire = FlyByWire_IN_Flying;
         rtb_alpha_floor_inhib = 0;
         rtb_ap_special_disc = 0;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
This PR improves the state machine to determine if A.FLOOR should be inhibited. The A.FLOOR inhibit is now always triggered when the aircraft is on ground and not only when it was at least above 100 ft RA before.

This is hard to test and usually should barely happen, but on ground alpha sometimes reaches very high values (i.e. 170°).

## Summary of Changes
Fix a potential situation where A.FLOOR is not inhibited correctly, i.e. after using slew being shortly just above ground but not reaching higher than 100 ft RA and then going back to ground again.

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Try with extreme wind on ground
- Try from C&D
- Try after spawning on the runway
- Try after landing
- Try after using slew

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
