### PR TITLE
feat(ecam): Add Ecam Warning - AP, A/THR DISC, L/G NOT DOWN

### DIFF
--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -235,9 +235,13 @@
 
             <UseTemplate Name="FBW_AutoThrottle_Instinctive_Disconnect_Template">
                 <NODE_ID>PUSH_THROTTLE_1</NODE_ID>
+                <ANIM_NAME>PUSH_THROTTLE_1</ANIM_NAME>
+                <ID>1</ID>
             </UseTemplate>
             <UseTemplate Name="FBW_AutoThrottle_Instinctive_Disconnect_Template">
                 <NODE_ID>PUSH_THROTTLE_2</NODE_ID>
+                <ANIM_NAME>PUSH_THROTTLE_2</ANIM_NAME>
+                <ID>2</ID>
             </UseTemplate>
 
             <UseTemplate Name="FBW_HANDLING_Wheel_ElevatorTrim_Template">

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/sound/sound.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/sound/sound.xml
@@ -319,14 +319,6 @@
             <WwiseRTPC LocalVar="A32NX_SOUND_EXTERIOR_MASTER" Units="number" Index="0" RTPCName="LOCALVAR_A32NX_EXTERIOR_VOLUME" />
         </Sound>
 
-        <Sound WwiseData="true" WwiseEvent="ap_disengage_sound" Continuous="false" LocalVar="A32NX_AUTOPILOT_ACTIVE" Units="BOOL" Index="0">
-            <Range UpperBound="0" />
-        </Sound>
-
-        <Sound WwiseData="true" WwiseEvent="ap_disengage_sound" Continuous="false" LocalVar="A32NX_AUTOPILOT_ACTIVE" Units="BOOL" Index="0">
-            <Range UpperBound="0" />
-        </Sound>
-
         <Sound WwiseData="true" WwiseEvent="APUnlock" NodeName="SCREEN_PFD_L" ViewPoint="Inside" Continuous="false" LocalVar="A32NX_AUTOPILOT_ACTIVE" Units="BOOL" Index="0">
             <Range UpperBound="0" />
         </Sound>
@@ -490,7 +482,7 @@
             <WwiseRTPC SimVar="TURB ENG N1" Units="percent" Index="2" RTPCName="SIMVAR_TURB_ENG_N1" />
             <WwiseRTPC LocalVar="A32NX_SOUND_INTERIOR_ENGINE" Units="number" Index="0" RTPCName="LOCALVAR_A32NX_INTERIOR_ENG_VOLUME" />
         </Sound>
-        
+
         <Sound WwiseEvent="LowRumbleL"  NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" ConeHeading="180" WwiseData="true" SimVar="TURB ENG N1" Units="percent" Index="1" ViewPoint="Inside" Continuous="true">
             <Range LowerBound="1" />
             <WwiseRTPC SimVar="TURB ENG N1" Units="percent" Index="1" RTPCName="SIMVAR_TURB_ENG_N1" />
@@ -1420,7 +1412,7 @@
         <!-- Miscellaneous ==========================================================================================  -->
 
         <!-- Play sound whenever the seat belts switch position changes -->
-        
+
         <Sound WwiseData="true" WwiseEvent="light_switch_seatbelt" NodeName="LIGHT_ASOBO_NAVIGATIONTAILRIGHT" LocalVar="XMLVAR_SWITCH_OVHD_INTLT_SEATBELT_Position" ViewPoint="Inside" Continuous="false">
             <Range UpperBound="0" />
             <WwiseRTPC SimVar="ELECTRICAL MAIN BUS VOLTAGE" Units="VOLTS" Index="1" RTPCName="SIMVAR_ELECTRICAL_MAIN_BUS_VOLTAGE" />
@@ -1494,7 +1486,7 @@
                 <Range LowerBound="6" UpperBound="6" />
             </Requires>
         </Sound>
-        
+
         <Sound WwiseData="true" WwiseEvent="cvr_test" NodeName="PEDALS_LEFT" LocalVar="A32NX_RCDR_TEST" Continuous="true">
             <Range LowerBound="1" />
             <Requires LocalVar="A32NX_RCDR_GROUND_CONTROL_ON" Units="Bool" Index="1">
@@ -1529,6 +1521,22 @@
         </Sound>
 
         <Sound WwiseData="true" WwiseEvent="cchordshort" NodeName="PEDALS_LEFT" ViewPoint="Inside" LocalVar="A32NX_ALT_DEVIATION_SHORT" Continuous="false">
+            <Range LowerBound="1" />
+            <Requires SimVar="ELECTRICAL MAIN BUS VOLTAGE" Units="VOLTS" Index="1">
+                <Range LowerBound="28" />
+            </Requires>
+        </Sound>
+
+        <!-- Autopilot warning =====================================================================-->
+
+        <Sound WwiseData="true" WwiseEvent="cavcharge" NodeName="PEDALS_LEFT" ViewPoint="Inside" LocalVar="A32NX_CAVCHARGE" Continuous="true">
+            <Range LowerBound="1" />
+            <Requires SimVar="ELECTRICAL MAIN BUS VOLTAGE" Units="VOLTS" Index="1">
+                <Range LowerBound="28" />
+            </Requires>
+        </Sound>
+
+        <Sound WwiseData="true" WwiseEvent="3click" NodeName="PEDALS_LEFT" ViewPoint="Inside" LocalVar="A32NX_TRIPLE_CLICK" Continuous="false">
             <Range LowerBound="1" />
             <Requires SimVar="ELECTRICAL MAIN BUS VOLTAGE" Units="VOLTS" Index="1">
                 <Range LowerBound="28" />

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -491,6 +491,51 @@ var A320_Neo_UpperECAM;
                             },
                         ]
                     },
+                    {
+                        name: "L/G",
+                        messages: [
+                            {
+                                message: "GEAR NOT DOWN",
+                                level: 3,
+                                page: "WHEEL",
+                                isActive: () => (
+                                    this.getCachedSimVar("L:A32NX_LDG_NOT_DOWN", "Bool")
+                                )
+                            },
+                        ]
+                    },
+                    {
+                        name: "AUTO FLT",
+                        messages: [
+                            {
+                                message: "AP OFF",
+                                level: 2,
+                                warning: false,
+                                isActive: () => (
+                                    this.getCachedSimVar("L:A32NX_AUTOPILOT_DISCONNECT_BY_FCU", "Bool")
+                                ),
+                            },
+                        ]
+                    },
+                    {
+                        name: "AUTO FLT",
+                        messages: [
+                            {
+                                message: "A/THR OFF",
+                                level: 2,
+                                isActive: () => (
+                                    this.getCachedSimVar("L:A32NX_ATHR_DISCONNECT_BY_FCU", "Bool")
+                                ),
+                                actions: [
+                                    {
+                                        style: "action",
+                                        message: "THR LEVERS",
+                                        action: "MOVE",
+                                    }
+                                ]
+                            }
+                        ]
+                    },
                     //Ground
                     {
                         name: "ENG 1 FIRE",
@@ -1190,10 +1235,26 @@ var A320_Neo_UpperECAM;
                         isActive: () => this.leftEcamMessagePanel.landASAP === 3 && !Simplane.getIsGrounded()
                     },
                     {
+                        message: "AP OFF",
+                        style: "fail-3",
+                        important: true,
+                        isActive: () => {
+                            return this.getCachedSimVar("L:A32NX_AUTOPILOT_DISCONNECT_BY_SIDESTICK", "Bool");
+                        }
+                    },
+                    {
                         message: "LAND ASAP",
                         style: "fail-2",
                         important: true,
                         isActive: () => this.leftEcamMessagePanel.landASAP === 2 && !Simplane.getIsGrounded()
+                    },
+                    {
+                        message: "A/THR OFF",
+                        style: "InfoCaution",
+                        important: true,
+                        isActive: () => {
+                            return this.getCachedSimVar("L:A32NX_ATHR_DISCONNECT", "Bool");
+                        }
                     },
                     {
                         message: "T.O. INHIBIT",

--- a/src/behavior/src/A32NX_Interior_Autopilot.xml
+++ b/src/behavior/src/A32NX_Interior_Autopilot.xml
@@ -207,10 +207,24 @@
     </Template>
 
     <Template Name="FBW_AutoThrottle_Instinctive_Disconnect_Template">
-        <UseTemplate Name="FBW_Push_Held">
-            <HOLD_SIMVAR>K:AUTO_THROTTLE_DISCONNECT</HOLD_SIMVAR>
-            <TOOLTIPID>Disc. A/THR</TOOLTIPID>
-        </UseTemplate>
+        <DefaultTemplateParameters>
+            <WWISE_EVENT_1>yoke_push_button_on</WWISE_EVENT_1>
+            <WWISE_EVENT_2>yoke_push_button_off</WWISE_EVENT_2>
+            <ANIM_NAME>#NODE_ID#</ANIM_NAME>
+            <ID>1</ID>
+        </DefaultTemplateParameters>
+        <Component ID="#NODE_ID#" Node="#NODE_ID#">
+            <UseTemplate Name="ASOBO_GT_Push_Button_Held">
+                <TOOLTIPID>Disc. A/THR</TOOLTIPID>
+                <LEFT_SINGLE_CODE>
+                    1 (&gt;K:AUTO_THROTTLE_DISCONNECT)
+                    1 (&gt;L:PUSH_THROTTLE_BUTTON_#ID#)
+                </LEFT_SINGLE_CODE>
+                <LEFT_LEAVE_CODE>
+                    0 (&gt;L:PUSH_THROTTLE_BUTTON_#ID#)
+                </LEFT_LEAVE_CODE>
+            </UseTemplate>
+        </Component>
     </Template>
 
 </ModelBehaviors>

--- a/src/behavior/src/A32NX_Interior_Misc.xml
+++ b/src/behavior/src/A32NX_Interior_Misc.xml
@@ -516,12 +516,14 @@
                 <LEFT_SINGLE_CODE>
                     (L:A32NX_AUTOPILOT_ACTIVE, Bool) if{
                         (&gt;K:AUTOPILOT_OFF)
+                        1 (&gt;L:PUSH_SIDESTICK_AUTOPILOT_#ID#)
                     } els{
                         1 (&gt;L:A32NX_PRIORITY_TAKEOVER:#ID#)
                     }
                 </LEFT_SINGLE_CODE>
                 <LEFT_LEAVE_CODE>
                     0 (&gt;L:A32NX_PRIORITY_TAKEOVER:#ID#)
+                    0 (&gt;L:PUSH_SIDESTICK_AUTOPILOT_#ID#)
                 </LEFT_LEAVE_CODE>
             </UseTemplate>
         </Component>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #3727
Fixes #1503
Fixes #3888 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Origin here 
#3824 

re-open due to dirty commit & github bug( I really hate reopen same pr :( )

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![image](https://user-images.githubusercontent.com/23118756/110204652-8f1ba280-7eb7-11eb-8114-9bc2d104efc5.png)
![image](https://user-images.githubusercontent.com/23118756/110204653-917dfc80-7eb7-11eb-8fa9-cb34831c9bee.png)
![image](https://user-images.githubusercontent.com/23118756/110204657-9347c000-7eb7-11eb-8a32-dff512bcd747.png)
![image](https://user-images.githubusercontent.com/23118756/110811791-5bcb8000-82ca-11eb-9f72-b807dc8ed592.png)
![image](https://user-images.githubusercontent.com/23118756/110811798-5f5f0700-82ca-11eb-8f14-00c930838323.png)
![image](https://user-images.githubusercontent.com/23118756/110811837-67b74200-82ca-11eb-89cc-bd1e82fb6f17.png)
![image](https://user-images.githubusercontent.com/23118756/110811868-71d94080-82ca-11eb-8105-8777bf377871.png)



<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Spawn on runway or c&d as you wish
2. takeoff and "should" climb more than 1500ft
3. fly with autopilot & athr
4. disconnect autopilot & watch Upper ECAM & Master warning button
5. disconnect a/thr and watch UpperECAM & master caution, and play beep
6. if you check 1~5, next is l/g not down.
7. there is a 3 condition about l/g not down
7-1. Radio height lower than 750ft without gear downlocked(gear downlocked mean gear is fully down) / both engine's N1 lower than 75%
7-2. on 7-1 situation, if some engine is shutdown, other engine's N1 lower than 97%
7-3. In 7-1 situation, if flaps not retracted(so flap setting is 1 2 3 or full), if engine is not TOGA, alert will appear

note : you should clear of conflict L/G NOT DOWN first with gear down or climb more than RADIO HEIGHT 750ft and again test.
because current we can't use EMER CANC.

WARNING
1. L/G NOT DOWN CAN NOT CANCEL BY MASTER WARNING
    - please use under ECAM, CLR button
2. Correct behavior is can't cancel with CLR button before FWC Rewrite.

check all 7-1~3 situation please

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
