### PR TITLE
feat: improved and custom rudder and elevator trim

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -63,6 +63,8 @@
 1. [FWC] Fix pushing of MASTER WARN and MASTER CAUT not disabling aural warnings - @davidwalschots (David Walschots)
 1. [ELEC] EMER ELEC PWR overhead MAN ON push button triggers emergency generator start (RAT not yet simulated) - @davidwalschots (David Walschots)
 1. [ELEC] RAT & EMER GEN fault light illuminates when applicable - @davidwalschots (David Walschots)
+1. [FBW] Realistic rudder trim deflection and reset rate - @aguther (Andreas Guther)
+1. [FBW] Elevator trim wheels no longer move when stop is reached - @aguther (Andreas Guther)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/src/behavior/src/A32NX_Interior_Handling.xml
+++ b/src/behavior/src/A32NX_Interior_Handling.xml
@@ -404,17 +404,9 @@
                     <UseTemplate Name = "ASOBO_GT_Switch_3States">
                         <SWITCH_POSITION_TYPE>L</SWITCH_POSITION_TYPE>
                         <SWITCH_POSITION_VAR>XMLVAR_RudderTrim</SWITCH_POSITION_VAR>
-                        <MOMENTARY_REPEAT_FREQUENCY>15</MOMENTARY_REPEAT_FREQUENCY>
-                        <CODE_POS_0>
-                            (L:A32NX_AUTOPILOT_ACTIVE, Bool) ! if{
-                                (&gt;K:RUDDER_TRIM_LEFT)
-                            }
-                        </CODE_POS_0>
-                        <CODE_POS_2>
-                            (L:A32NX_AUTOPILOT_ACTIVE, Bool) ! if{
-                                (&gt;K:RUDDER_TRIM_RIGHT)
-                            }
-                        </CODE_POS_2>
+                        <MOMENTARY_REPEAT_FREQUENCY>40</MOMENTARY_REPEAT_FREQUENCY>
+                        <CODE_POS_0>(&gt;K:RUDDER_TRIM_LEFT)</CODE_POS_0>
+                        <CODE_POS_2>(&gt;K:RUDDER_TRIM_RIGHT)</CODE_POS_2>
                         <MOMENTARY_SWITCH/>
                         <STATE_MAX_TIMER>0.1</STATE_MAX_TIMER>
                         <STATE0_TIMER>0.1</STATE0_TIMER>
@@ -427,7 +419,7 @@
                         <Component ID="#RESET_PUSH_NODE_ID#" Node="#RESET_PUSH_NODE_ID#">
                             <UseTemplate Name = "ASOBO_GT_Push_Button">
                                 <ANIM_NAME>#RESET_PUSH_ANIM_NAME#</ANIM_NAME>
-                                <LEFT_SINGLE_CODE>0 (&gt;K:RUDDER_TRIM_SET)</LEFT_SINGLE_CODE>
+                                <LEFT_SINGLE_CODE>(&gt;K:RUDDER_TRIM_RESET)</LEFT_SINGLE_CODE>
                                 <WWISE_EVENT_1>rudder_trim_rest_push_button_on</WWISE_EVENT_1>
                                 <WWISE_EVENT_2>rudder_trim_rest_push_button_on</WWISE_EVENT_2>
                                 <TOOLTIPID>TT:COCKPIT.TOOLTIPS.RUDDER_TRIM_RESET</TOOLTIPID>

--- a/src/fbw/build.sh
+++ b/src/fbw/build.sh
@@ -93,11 +93,13 @@ clang++ \
   "${DIR}/src/model/uMultiWord2Double.cpp" \
   -I "${DIR}/src/zlib" \
   "${DIR}/src/zlib/zfstream.cc" \
+  "${DIR}/src/ElevatorTrimHandler.cpp" \
   "${DIR}/src/FlapsHandler.cpp" \
   "${DIR}/src/FlyByWireInterface.cpp" \
   "${DIR}/src/FlightDataRecorder.cpp" \
   "${DIR}/src/LocalVariable.cpp" \
   "${DIR}/src/InterpolatingLookupTable.cpp" \
+  "${DIR}/src/RudderTrimHandler.cpp" \
   "${DIR}/src/SpoilersHandler.cpp" \
   "${DIR}/src/ThrottleAxisMapping.cpp" \
   "${DIR}/src/main.cpp" \

--- a/src/fbw/src/ElevatorTrimHandler.cpp
+++ b/src/fbw/src/ElevatorTrimHandler.cpp
@@ -1,0 +1,27 @@
+#include "ElevatorTrimHandler.h"
+#include <cmath>
+#include <iostream>
+
+void ElevatorTrimHandler::synchronizeValue(double value) {
+  targetValue = value;
+}
+
+void ElevatorTrimHandler::onEventElevatorTrimUp() {
+  targetValue = fmin(POSITION_MAX_UP, targetValue + POSITION_INCREMENT);
+}
+
+void ElevatorTrimHandler::onEventElevatorTrimDown() {
+  targetValue = fmax(POSITION_MAX_DOWN, targetValue - POSITION_INCREMENT);
+}
+
+void ElevatorTrimHandler::onEventElevatorTrimSet(double value) {
+  targetValue = fmax(POSITION_MAX_DOWN, fmin(POSITION_MAX_UP, value * VALUE_FACTOR));
+}
+
+void ElevatorTrimHandler::onEventElevatorTrimAxisSet(double value) {
+  targetValue = fmax(POSITION_MAX_DOWN, fmin(POSITION_MAX_UP, value * VALUE_FACTOR));
+}
+
+double ElevatorTrimHandler::getPosition() {
+  return targetValue;
+}

--- a/src/fbw/src/ElevatorTrimHandler.h
+++ b/src/fbw/src/ElevatorTrimHandler.h
@@ -1,0 +1,21 @@
+#pragma once
+
+class ElevatorTrimHandler {
+ public:
+  void synchronizeValue(double value);
+
+  void onEventElevatorTrimUp();
+  void onEventElevatorTrimDown();
+  void onEventElevatorTrimSet(double value);
+  void onEventElevatorTrimAxisSet(double value);
+
+  double getPosition();
+
+ private:
+  static constexpr double VALUE_FACTOR = 13.5 / 16384.0;
+  static constexpr double POSITION_MAX_UP = 13.5;
+  static constexpr double POSITION_MAX_DOWN = -4.0;
+  static constexpr double POSITION_INCREMENT = 0.025;
+
+  double targetValue = 0;
+};

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -20,6 +20,8 @@ bool FlyByWireInterface::connect() {
   // setup handlers
   flapsHandler = make_shared<FlapsHandler>();
   spoilersHandler = make_shared<SpoilersHandler>();
+  elevatorTrimHandler = make_shared<ElevatorTrimHandler>();
+  rudderTrimHandler = make_shared<RudderTrimHandler>();
 
   // initialize model
   autopilotStateMachine.initialize();
@@ -32,8 +34,8 @@ bool FlyByWireInterface::connect() {
 
   // connect to sim connect
   return simConnectInterface.connect(autopilotStateMachineEnabled, autopilotLawsEnabled, flyByWireEnabled, throttleAxis, flapsHandler,
-                                     spoilersHandler, flightControlsKeyChangeAileron, flightControlsKeyChangeElevator,
-                                     flightControlsKeyChangeRudder);
+                                     spoilersHandler, elevatorTrimHandler, rudderTrimHandler, flightControlsKeyChangeAileron,
+                                     flightControlsKeyChangeElevator, flightControlsKeyChangeRudder);
 }
 
 void FlyByWireInterface::disconnect() {
@@ -304,6 +306,9 @@ void FlyByWireInterface::setupLocalVariables() {
 }
 
 bool FlyByWireInterface::readDataAndLocalVariables(double sampleTime) {
+  // set sample time
+  simConnectInterface.setSampleTime(sampleTime);
+
   // reset input
   simConnectInterface.resetSimInputAutopilot();
 
@@ -970,28 +975,6 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
         std::cout << "WASM: Write data failed!" << endl;
         return false;
       }
-
-      if (flyByWireOutput.output.eta_trim_deg_should_write) {
-        // object to write without trim
-        SimOutputEtaTrim output = {flyByWireOutput.output.eta_trim_deg};
-
-        // send data via sim connect
-        if (!simConnectInterface.sendData(output)) {
-          std::cout << "WASM: Write data failed!" << endl;
-          return false;
-        }
-      }
-
-      if (flyByWireOutput.output.zeta_trim_pos_should_write) {
-        // object to write without trim
-        SimOutputZetaTrim output = {flyByWireOutput.output.zeta_trim_pos};
-
-        // send data via sim connect
-        if (!simConnectInterface.sendData(output)) {
-          std::cout << "WASM: Write data failed!" << endl;
-          return false;
-        }
-      }
     }
   } else {
     // send data to client data to be read by simulink
@@ -1004,10 +987,39 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
     simConnectInterface.setClientDataAutopilotLaws(clientDataLaws);
     // read data
     auto clientDataFlyByWire = simConnectInterface.getClientDataFlyByWire();
+    flyByWireOutput.output.eta_trim_deg_should_write = clientDataFlyByWire.eta_trim_deg_should_write;
+    flyByWireOutput.output.zeta_trim_pos_should_write = clientDataFlyByWire.zeta_trim_pos_should_write;
+    flyByWireOutput.sim.data_computed.tracking_mode_on = simData.slew_on || pauseDetected || idExternalOverride->get() == 1;
     flyByWireOutput.sim.data_computed.alpha_floor_command = clientDataFlyByWire.alpha_floor_command;
     flyByWireOutput.sim.data_computed.protection_ap_disc = clientDataFlyByWire.protection_ap_disc;
     flyByWireOutput.sim.data_speeds_aoa.v_alpha_prot_kn = clientDataFlyByWire.v_alpha_prot_kn;
     flyByWireOutput.sim.data_speeds_aoa.v_alpha_max_kn = clientDataFlyByWire.v_alpha_max_kn;
+  }
+
+  // set trim values
+  SimOutputEtaTrim outputEtaTrim = {};
+  if (flyByWireOutput.output.eta_trim_deg_should_write) {
+    outputEtaTrim.eta_trim_deg = flyByWireOutput.output.eta_trim_deg;
+    elevatorTrimHandler->synchronizeValue(outputEtaTrim.eta_trim_deg);
+  } else {
+    outputEtaTrim.eta_trim_deg = elevatorTrimHandler->getPosition();
+  }
+  if (!simConnectInterface.sendData(outputEtaTrim)) {
+    std::cout << "WASM: Write data failed!" << endl;
+    return false;
+  }
+
+  SimOutputZetaTrim outputZetaTrim = {};
+  rudderTrimHandler->update(sampleTime);
+  if (flyByWireOutput.output.zeta_trim_pos_should_write) {
+    outputZetaTrim.zeta_trim_pos = flyByWireOutput.output.zeta_trim_pos;
+    rudderTrimHandler->synchronizeValue(outputZetaTrim.zeta_trim_pos);
+  } else {
+    outputZetaTrim.zeta_trim_pos = rudderTrimHandler->getPosition();
+  }
+  if (!simConnectInterface.sendData(outputZetaTrim)) {
+    std::cout << "WASM: Write data failed!" << endl;
+    return false;
   }
 
   // calculate alpha max percentage

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -1004,9 +1004,11 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
   } else {
     outputEtaTrim.eta_trim_deg = elevatorTrimHandler->getPosition();
   }
-  if (!simConnectInterface.sendData(outputEtaTrim)) {
-    std::cout << "WASM: Write data failed!" << endl;
-    return false;
+  if (!flyByWireOutput.sim.data_computed.tracking_mode_on && (flyByWireEnabled || !flyByWireOutput.output.eta_trim_deg_should_write)) {
+    if (!simConnectInterface.sendData(outputEtaTrim)) {
+      std::cout << "WASM: Write data failed!" << endl;
+      return false;
+    }
   }
 
   SimOutputZetaTrim outputZetaTrim = {};
@@ -1017,9 +1019,11 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
   } else {
     outputZetaTrim.zeta_trim_pos = rudderTrimHandler->getPosition();
   }
-  if (!simConnectInterface.sendData(outputZetaTrim)) {
-    std::cout << "WASM: Write data failed!" << endl;
-    return false;
+  if (!flyByWireOutput.sim.data_computed.tracking_mode_on && (flyByWireEnabled || !flyByWireOutput.output.zeta_trim_pos_should_write)) {
+    if (!simConnectInterface.sendData(outputZetaTrim)) {
+      std::cout << "WASM: Write data failed!" << endl;
+      return false;
+    }
   }
 
   // calculate alpha max percentage

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -6,6 +6,7 @@
 #include "AutopilotLaws.h"
 #include "AutopilotStateMachine.h"
 #include "Autothrust.h"
+#include "ElevatorTrimHandler.h"
 #include "EngineData.h"
 #include "FlapsHandler.h"
 #include "FlightDataRecorder.h"
@@ -13,9 +14,11 @@
 #include "InterpolatingLookupTable.h"
 #include "LocalVariable.h"
 #include "RateLimiter.h"
+#include "RudderTrimHandler.h"
 #include "SimConnectInterface.h"
 #include "SpoilersHandler.h"
 #include "ThrottleAxisMapping.h"
+
 class FlyByWireInterface {
  public:
   bool connect();
@@ -204,6 +207,9 @@ class FlyByWireInterface {
   std::unique_ptr<LocalVariable> idSpoilersArmed;
   std::unique_ptr<LocalVariable> idSpoilersHandlePosition;
   std::shared_ptr<SpoilersHandler> spoilersHandler;
+
+  std::shared_ptr<ElevatorTrimHandler> elevatorTrimHandler;
+  std::shared_ptr<RudderTrimHandler> rudderTrimHandler;
 
   void loadConfiguration();
   void setupLocalVariables();

--- a/src/fbw/src/RateLimiter.h
+++ b/src/fbw/src/RateLimiter.h
@@ -1,5 +1,7 @@
 #include <stdlib.h>
 
+#pragma once
+
 class RateLimiter {
  public:
   void setRate(double rate) { changeRate = abs(rate); }

--- a/src/fbw/src/RudderTrimHandler.cpp
+++ b/src/fbw/src/RudderTrimHandler.cpp
@@ -1,0 +1,45 @@
+#include "RudderTrimHandler.h"
+#include <cmath>
+
+RudderTrimHandler::RudderTrimHandler() {
+  rateLimiter.setRate(RATE_LEFT_RIGHT);
+}
+
+void RudderTrimHandler::synchronizeValue(double value) {
+  targetValue = value;
+  rateLimiter.reset(value);
+}
+
+void RudderTrimHandler::onEventRudderTrimLeft(double dt) {
+  rateLimiter.setRate(RATE_LEFT_RIGHT);
+  if (targetValue == POSITION_RESET) {
+    targetValue = rateLimiter.getValue();
+  }
+  targetValue = fmax(POSITION_MAX_LEFT, targetValue - (RATE_LEFT_RIGHT * dt));
+}
+
+void RudderTrimHandler::onEventRudderTrimReset() {
+  rateLimiter.setRate(RATE_RESET);
+  targetValue = POSITION_RESET;
+}
+
+void RudderTrimHandler::onEventRudderTrimRight(double dt) {
+  rateLimiter.setRate(RATE_LEFT_RIGHT);
+  if (targetValue == POSITION_RESET) {
+    targetValue = rateLimiter.getValue();
+  }
+  targetValue = fmin(POSITION_MAX_RIGHT, targetValue + (RATE_LEFT_RIGHT * dt));
+}
+
+void RudderTrimHandler::onEventRudderTrimSet(double value) {
+  rateLimiter.setRate(RATE_LEFT_RIGHT);
+  targetValue = fmin(POSITION_MAX_RIGHT, fmax(POSITION_MAX_LEFT, value / SET_EVENT_DIVIDER));
+}
+
+void RudderTrimHandler::update(double dt) {
+  rateLimiter.update(targetValue, dt);
+}
+
+double RudderTrimHandler::getPosition() {
+  return rateLimiter.getValue();
+}

--- a/src/fbw/src/RudderTrimHandler.h
+++ b/src/fbw/src/RudderTrimHandler.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "RateLimiter.h"
+
+class RudderTrimHandler {
+ public:
+  RudderTrimHandler();
+
+  void synchronizeValue(double value);
+
+  void onEventRudderTrimLeft(double dt);
+  void onEventRudderTrimReset();
+  void onEventRudderTrimRight(double dt);
+  void onEventRudderTrimSet(double value);
+
+  void update(double dt);
+  double getPosition();
+
+ private:
+  static constexpr double SET_EVENT_DIVIDER = 16384.0;
+  static constexpr double POSITION_RESET = 0.0;
+  static constexpr double POSITION_MAX_LEFT = -1.0;
+  static constexpr double POSITION_MAX_RIGHT = +1.0;
+  static constexpr double RATE_LEFT_RIGHT = 0.05;
+  static constexpr double RATE_RESET = 0.075;
+
+  double targetValue = 0;
+  RateLimiter rateLimiter;
+};

--- a/src/fbw/src/interface/SimConnectData.h
+++ b/src/fbw/src/interface/SimConnectData.h
@@ -231,6 +231,8 @@ struct ClientDataAutothrust {
 };
 
 struct ClientDataFlyByWire {
+  double eta_trim_deg_should_write;
+  double zeta_trim_pos_should_write;
   double alpha_floor_command;
   double protection_ap_disc;
   double v_alpha_prot_kn;

--- a/src/fbw/src/interface/SimConnectInterface.h
+++ b/src/fbw/src/interface/SimConnectInterface.h
@@ -5,8 +5,10 @@
 #include <string>
 #include <vector>
 
+#include "../ElevatorTrimHandler.h"
 #include "../FlapsHandler.h"
 #include "../LocalVariable.h"
+#include "../RudderTrimHandler.h"
 #include "../SpoilersHandler.h"
 #include "../ThrottleAxisMapping.h"
 #include "SimConnectData.h"
@@ -23,6 +25,11 @@ class SimConnectInterface {
     RUDDER_CENTER,
     RUDDER_RIGHT,
     RUDDER_AXIS_MINUS,
+    RUDDER_TRIM_LEFT,
+    RUDDER_TRIM_RESET,
+    RUDDER_TRIM_RIGHT,
+    RUDDER_TRIM_SET,
+    RUDDER_TRIM_SET_EX1,
     AILERON_SET,
     AILERONS_LEFT,
     AILERONS_RIGHT,
@@ -30,6 +37,10 @@ class SimConnectInterface {
     ELEVATOR_SET,
     ELEV_DOWN,
     ELEV_UP,
+    ELEV_TRIM_DN,
+    ELEV_TRIM_UP,
+    ELEVATOR_TRIM_SET,
+    AXIS_ELEV_TRIM_SET,
     AP_MASTER,
     AUTOPILOT_OFF,
     AUTOPILOT_ON,
@@ -153,11 +164,15 @@ class SimConnectInterface {
                const std::vector<std::shared_ptr<ThrottleAxisMapping>>& throttleAxis,
                std::shared_ptr<FlapsHandler> flapsHandler,
                std::shared_ptr<SpoilersHandler> spoilersHandler,
+               std::shared_ptr<ElevatorTrimHandler> elevatorTrimHandler,
+               std::shared_ptr<RudderTrimHandler> rudderTrimHandler,
                double keyChangeAileron,
                double keyChangeElevator,
                double keyChangeRudder);
 
   void disconnect();
+
+  void setSampleTime(double sampleTime);
 
   bool requestReadData();
 
@@ -221,6 +236,8 @@ class SimConnectInterface {
   bool isConnected = false;
   HANDLE hSimConnect = 0;
 
+  double sampleTime = 0;
+
   SimData simData = {};
   SimInput simInput = {};
   SimInputAutopilot simInputAutopilot = {};
@@ -230,6 +247,8 @@ class SimConnectInterface {
 
   std::shared_ptr<FlapsHandler> flapsHandler;
   std::shared_ptr<SpoilersHandler> spoilersHandler;
+  std::shared_ptr<ElevatorTrimHandler> elevatorTrimHandler;
+  std::shared_ptr<RudderTrimHandler> rudderTrimHandler;
 
   ClientDataAutopilotStateMachine clientDataAutopilotStateMachine = {};
   ClientDataAutopilotLaws clientDataAutopilotLaws = {};

--- a/src/fbw/src/model/FlyByWire_data.cpp
+++ b/src/fbw/src/model/FlyByWire_data.cpp
@@ -937,7 +937,7 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P = {
 
   0.0,
 
-  0.14285714285714285,
+  0.33333333333333331,
 
   1.7,
 

--- a/src/fdr2csv/src/FlightDataRecorderConverter.cpp
+++ b/src/fdr2csv/src/FlightDataRecorderConverter.cpp
@@ -240,6 +240,7 @@ void FlightDataRecorderConverter::writeHeader(ofstream& out, const string& delim
   out << "athr.data_computed.ATHR_push" << delimiter;
   out << "athr.data_computed.ATHR_disabled" << delimiter;
   out << "athr.input.ATHR_push" << delimiter;
+  out << "athr.input.ATHR_disconnect" << delimiter;
   out << "athr.input.TLA_1_deg" << delimiter;
   out << "athr.input.TLA_2_deg" << delimiter;
   out << "athr.input.V_c_kn" << delimiter;
@@ -696,6 +697,7 @@ void FlightDataRecorderConverter::writeStruct(ofstream& out,
   out << static_cast<unsigned int>(athr.data_computed.ATHR_push) << delimiter;
   out << static_cast<unsigned int>(athr.data_computed.ATHR_disabled) << delimiter;
   out << static_cast<unsigned int>(athr.input.ATHR_push) << delimiter;
+  out << static_cast<unsigned int>(athr.input.ATHR_disconnect) << delimiter;
   out << athr.input.TLA_1_deg << delimiter;
   out << athr.input.TLA_2_deg << delimiter;
   out << athr.input.V_c_kn << delimiter;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
This PR introduces custom handling of rudder trim and elevator trim.

### Rudder Trim
The rudder trim now features a much more close deflection rate than it was before. It also has a realistic reset rate which is slightly different than the deflection rate (1.5°/s vs. 1.0°/s).

### Elevator Trim
The elevator trim now stops the trim wheels when end position is reached. Before this PR using the events the wheel was continuing to move. The change rate when using events has been reduced for finer control on ground.

## References

### Rudder Trim
- rudder trim switch is only operational when AP is off
- rudder trim moves by 1.0°/s when switch is operated
- rudder trim moves by 1.5°/s when reset switch is pressed
- rudder trim can be operated between L 20° and R 20°

### Elevator Trim
- elevator trim can be operated between 4.0 DN and 13.5 UP

## Additional context
The following items are not modelled / excluded from this PR:
- elevator trim cannot be moved during flight when automatic trim is active (was not changed by this PR)
- rudder trim operation to L or R with the 3D switch in cockpit might have a slightly different rate than using a hardware button, this is due to how this switch is working
- goal for rudder trim 3D switch is to have a *good enough* realistic rate for the start
- it seems the MSFS assignment `ELEVATOR TRIM AXIS (0 to 100%)` is misbehaving, it always sends event `ELEVATOR_TRIM_SET` with parameter `0`; the same event `ELEVATOR_TRIM_SET` is used by the dragging of the trim wheels with the mouse and therefore works correctly; in contrast MSFS assignment `ELEVATOR TRIM AXIS (-100 to 100%)` works without issues

## Testing instructions

### Rudder Trim
- check if rudder trim button in 3D cockpit works as expected
- check if rudder trim events work as expected
- check deflection and reset rates
- if AP is turned off / on the rudder trim should not jump

### Elevator Trim
- check if elevator trim can be operated on ground in the given range
- check if elevator trim responds correctly and within limits with all possible assignments of hardware buttons / axis
- elevator trim should not jump after lift-off when auto-trim starts working or after landing (beside the correct reset of elevator trim to 0°)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
