### PR TITLE
revert: isis brightness buttons push&hold (#4736)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -68,8 +68,6 @@
 1. [FBW] Elevator trim wheels no longer move when stop is reached - @aguther (Andreas Guther)
 1. [AP] Improved V/S and FPA speed protection mode - @aguther (Andreas Guther)
 1. [MISC] Seatbelt sign state can be toggled via external events - @Saschl (saschl#9432)
-1. [MISC] Standby instrument brightness buttons can now be held down rather than pressed to -/+ brightness - @2hwk (2Cas#1022)
-
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/flybywire-aircraft-a320-neo/ModelBehaviorDefs/A32NX/Airbus.xml
+++ b/flybywire-aircraft-a320-neo/ModelBehaviorDefs/A32NX/Airbus.xml
@@ -1138,6 +1138,7 @@
             </UseTemplate>
         </Component>
   </Template>
+
     <Template Name="A32NX_Push_BARO_Template">
         <Component ID="#NODE_ID#" Node="#NODE_ID#">
             <UseTemplate Name="ASOBO_GT_Push_Button_Airliner">
@@ -1148,17 +1149,6 @@
                 <WWISE_EVENT_2>autopilot_push_button_off</WWISE_EVENT_2>
                 <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
                 <NORMALIZED_TIME_2>0.3</NORMALIZED_TIME_2>
-                <TOOLTIPID>#TOOLTIPID#</TOOLTIPID>
-            </UseTemplate>
-        </Component>
-    </Template>
-    <Template Name="A32NX_Push_Held_BARO_Template">
-        <Component ID="#NODE_ID#" Node="#NODE_ID#">
-            <UseTemplate Name="FBW_Push_Held">
-                <WWISE_EVENT_1>autopilot_push_button_on</WWISE_EVENT_1>
-                <WWISE_EVENT_2>autopilot_push_button_off</WWISE_EVENT_2>
-                <PART_ID>#NODE_ID#</PART_ID>
-                <HOLD_SIMVAR>H:A320_Neo_SAI_BTN_#BTN_ID#</HOLD_SIMVAR>
                 <TOOLTIPID>#TOOLTIPID#</TOOLTIPID>
             </UseTemplate>
         </Component>

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -831,13 +831,13 @@
                         <BTN_ID>BARO_LS</BTN_ID>
                         <ONLY_SEQ1/>
                     </UseTemplate>
-                    <UseTemplate Name="A32NX_Push_Held_BARO_Template">
+                    <UseTemplate Name="A32NX_Push_BARO_Template">
                         <NODE_ID>PUSH_BARO_PLUS</NODE_ID>
                         <TOOLTIPID>Increase ISI brightness</TOOLTIPID>
                         <BTN_ID>BARO_PLUS</BTN_ID>
                         <ONLY_SEQ1/>
                     </UseTemplate>
-                    <UseTemplate Name="A32NX_Push_Held_BARO_Template">
+                    <UseTemplate Name="A32NX_Push_BARO_Template">
                         <NODE_ID>PUSH_BARO_MINUS</NODE_ID>
                         <TOOLTIPID>Decrease ISI brightness</TOOLTIPID>
                         <BTN_ID>BARO_MINUS</BTN_ID>

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/SAI/A320_Neo_SAI.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/SAI/A320_Neo_SAI.js
@@ -1120,11 +1120,6 @@ class A320_Neo_SAI_Brightness extends NavSystemElement {
     init(root) {
         this.brightnessElement = this.gps.getChildById("Brightness");
         this.bugsElement = this.gps.getChildById("Bugs");
-        this.plus_state = false;
-        this.minus_state = false;
-        this.maximum = 0.99;
-        this.minimum = 0.15;
-        this.bright_gran = 0.05;
     }
     onEnter() {
     }
@@ -1135,53 +1130,24 @@ class A320_Neo_SAI_Brightness extends NavSystemElement {
     }
     onExit() {
     }
-    getBrightness() {
-        return SimVar.GetSimVarValue("L:A32NX_BARO_BRIGHTNESS","number");
-    }
-    setBrightness(b) {
-        SimVar.SetSimVarValue("L:A32NX_BARO_BRIGHTNESS","number", b);
-        this.brightnessElement.updateBrightness(b); //TODO: Remove line on model update
-    }
-    brightnessUp() {
-        const brightness = this.getBrightness();
-        if (this.bugsElement.getDisplay() === "none" && brightness < this.maximum) {
-            this.setBrightness(brightness + this.bright_gran);
-        }
-    }
-    brightnessDown() {
-        const brightness = this.getBrightness();
-        if (this.bugsElement.getDisplay() === "none" && brightness > this.minimum) {
-            this.setBrightness(brightness - this.bright_gran);
-        }
-    }
     onEvent(_event) {
+        const brightness = SimVar.GetSimVarValue("L:A32NX_BARO_BRIGHTNESS","number");
+        const bright_gran = 0.05;
+        const minimum = 0.15;
         switch (_event) {
             case "BTN_BARO_PLUS":
-                this.plus_state = !this.plus_state;
-                if (this.plus_state) {
-                    this.brightnessUp();
-                    const bright_up_cont = setInterval(() => {
-                        if (this.plus_state) {
-                            this.brightnessUp();
-                        } else {
-                            clearInterval(bright_up_cont);
-                        }
-                    }, 150);
+                if (this.bugsElement.getDisplay() === "none" && brightness < 1) {
+                    const new_brightness = brightness + bright_gran;
+                    SimVar.SetSimVarValue("L:A32NX_BARO_BRIGHTNESS","number", new_brightness);
+                    this.brightnessElement.updateBrightness(new_brightness); //TODO: Remove line on model update
                 }
                 break;
             case "BTN_BARO_MINUS":
-                this.minus_state = !this.minus_state;
-                if (this.minus_state) {
-                    this.brightnessDown();
-                    const bright_down_cont = setInterval(() => {
-                        if (this.minus_state) {
-                            this.brightnessDown();
-                        } else {
-                            clearInterval(bright_down_cont);
-                        }
-                    }, 150);
+                if (this.bugsElement.getDisplay() === "none" && brightness > minimum) {
+                    const new_brightness = brightness - bright_gran;
+                    SimVar.SetSimVarValue("L:A32NX_BARO_BRIGHTNESS","number", new_brightness);
+                    this.brightnessElement.updateBrightness(new_brightness); //TODO: Remove line on model update
                 }
-
                 break;
         }
     }
@@ -1530,7 +1496,7 @@ class A320_Neo_SAI_AttResetIndicator extends HTMLElement {
 
         const att_x = 33.5;
         const boxHeight = 7;
-        const boxWidth = 33;
+        const boxWidth = 30;
         const boxRow = 64;
         const txt_off_x = 2.5;
         const txt_off_y = 6;
@@ -1623,8 +1589,6 @@ class A320_Neo_SAI_Bugs extends NavSystemElement {
         this.blink_status = false;
         this.current_bug = 0;
         this.getFrameCounter = A32NX_Util.createFrameCounter(check_interval);
-        this.plus_state = false;
-        this.minus_state = false;
     }
 
     onEnter() {
@@ -1650,23 +1614,17 @@ class A320_Neo_SAI_Bugs extends NavSystemElement {
                 this.bugsElement.togglePage();
                 break;
             case "BTN_BARO_PLUS":
-                this.plus_state = !this.plus_state;
-                if (this.plus_state) {
-                    this.blink_status = true;
-                    if (this.bugsElement.getDisplay() !== "none") {
-                        this.bugsElement.freezeBugBox(this.current_bug);
-                        this.current_bug = (this.current_bug + 5) % 6;
-                    }
+                this.blink_status = true;
+                if (this.bugsElement.getDisplay() !== "none") {
+                    this.bugsElement.freezeBugBox(this.current_bug);
+                    this.current_bug = (this.current_bug + 5) % 6;
                 }
                 break;
             case "BTN_BARO_MINUS":
-                this.minus_state = !this.minus_state;
-                if (this.minus_state) {
-                    this.blink_status = true;
-                    if (this.bugsElement.getDisplay() !== "none") {
-                        this.bugsElement.freezeBugBox(this.current_bug);
-                        this.current_bug = (this.current_bug + 1) % 6;
-                    }
+                this.blink_status = true;
+                if (this.bugsElement.getDisplay() !== "none") {
+                    this.bugsElement.freezeBugBox(this.current_bug);
+                    this.current_bug = (this.current_bug + 1) % 6;
                 }
                 break;
             case "KNOB_BARO_C":


### PR DESCRIPTION
## Summary of Changes
This reverts commit 4eea0e70433019ca8893859545e5a7f8e612051b.
The PR contained a bug where the + and - buttons always emit light, even when AC 1 isn't powered.
The PR uses a template that isn't currently suited for handling this type of button.

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
