### PR TITLE
fix: #4795 and other transition improvements

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -69,7 +69,7 @@
 1. [AP] Improved V/S and FPA speed protection mode - @aguther (Andreas Guther)
 1. [MISC] Seatbelt sign state can be toggled via external events - @Saschl (saschl#9432)
 1. [MISC] Standby instrument brightness buttons can now be held down rather than pressed to -/+ brightness - @2hwk (2Cas#1022)
-
+1. [AP] Fixed and improved mode transitions related to LAND modes - @aguther (Andreas Guther)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
@@ -889,6 +889,10 @@ class A320_Neo_FCU_VerticalSpeed extends A320_Neo_FCU_Component {
     }
 
     onPush() {
+        const mode = SimVar.GetSimVarValue("L:A32NX_FMA_VERTICAL_MODE", "Number");
+        if (mode >= 30 && _mode <= 34) {
+            return;
+        }
         clearTimeout(this._resetSelectionTimeout);
         this.forceUpdate = true;
 

--- a/src/fbw/src/model/AutopilotStateMachine.h
+++ b/src/fbw/src/model/AutopilotStateMachine.h
@@ -43,6 +43,7 @@ class AutopilotStateMachineModelClass {
     real_T local_H_constraint_ft;
     real_T local_H_GA_init_ft;
     real_T eventTime;
+    real_T eventTime_n;
     real_T eventTime_i;
     real_T eventTime_p;
     real_T lastTargetSpeed;
@@ -50,6 +51,7 @@ class AutopilotStateMachineModelClass {
     real_T timeDeltaSpeed10;
     real_T timeConditionSoftAlt;
     real_T eventTime_a;
+    real_T eventTime_iz;
     real_T eventTime_c;
     real_T newFcuAltitudeSelected;
     real_T newFcuAltitudeSelected_b;
@@ -84,7 +86,10 @@ class AutopilotStateMachineModelClass {
     boolean_T sAP1;
     boolean_T sAP2;
     boolean_T sLandModeArmedOrActive;
+    boolean_T sRollOutActive;
+    boolean_T sGoAroundModeActive;
     boolean_T eventTime_not_empty;
+    boolean_T eventTime_not_empty_b;
     boolean_T eventTime_not_empty_h;
     boolean_T eventTime_not_empty_p;
     boolean_T lastTargetSpeed_not_empty;
@@ -95,6 +100,7 @@ class AutopilotStateMachineModelClass {
     boolean_T newFcuAltitudeSelected_c;
     boolean_T state;
     boolean_T eventTime_not_empty_m;
+    boolean_T eventTime_not_empty_i;
     boolean_T eventTime_not_empty_e;
     boolean_T sThrottleCondition;
     boolean_T state_h;
@@ -231,8 +237,10 @@ class AutopilotStateMachineModelClass {
   void AutopilotStateMachine_LAND_entry(void);
   boolean_T AutopilotStateMachine_NAV_TO_HDG(const ap_sm_output *BusAssignment);
   boolean_T AutopilotStateMachine_RWY_TO_RWY_TRK(const ap_sm_output *BusAssignment);
+  boolean_T AutopilotStateMachine_RWY_TO_OFF(const ap_sm_output *BusAssignment);
   void AutopilotStateMachine_RWY_TRK_entry(const ap_sm_output *BusAssignment);
   void AutopilotStateMachine_GA_TRK_entry(const ap_sm_output *BusAssignment);
+  void AutopilotStateMachine_ON(const ap_sm_output *BusAssignment);
   void AutopilotStateMachine_GA_TRK_during(void);
   boolean_T AutopilotStateMachine_OFF_TO_HDG(const ap_sm_output *BusAssignment);
   boolean_T AutopilotStateMachine_OFF_TO_NAV(const ap_sm_output *BusAssignment);
@@ -269,6 +277,8 @@ class AutopilotStateMachineModelClass {
   void AutopilotStateMachine_DES(void);
   void AutopilotStateMachine_ROLL_OUT_entry_o(void);
   boolean_T AutopilotStateMachine_GS_TO_X(void);
+  boolean_T AutopilotStateMachine_GS_TO_X_MR(void);
+  boolean_T AutopilotStateMachine_GS_TO_ALT(void);
   void AutopilotStateMachine_GS_TRACK_entry(void);
   void AutopilotStateMachine_LAND_entry_i(void);
   void AutopilotStateMachine_FLARE_entry_g(void);
@@ -279,7 +289,7 @@ class AutopilotStateMachineModelClass {
   void AutopilotStateMachine_SRS_during(void);
   void AutopilotStateMachine_SRS(void);
   void AutopilotStateMachine_exit_internal_ON(void);
-  void AutopilotStateMachine_ON(void);
+  void AutopilotStateMachine_ON_l(void);
 };
 
 #endif


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->
Fixes #4795

## Summary of Changes
This PR improves the following transitions in the autopilot around LAND modes (G/S*, G/S, LAND, FLARE, ROLLOUT):
- when HDG knob is pulled G/S now correctly reverts to V/S (fix for #4795)
- V/S knob can now be pulled to exit G/S
- ALT knob can be pulled or pushed to exit G/S
- to engage LAND track mode radio altitude must be 1.2 s below 400 ft
- to engage RWY the SRS mode must be engaged 0.9 s
- disengage AP1+2 on go around after either lateral or vertical GA mode disengages and not directly on go around engagement
- disengage autopilot when applying go around on ground
- do not allow V/S knob to be pushed in LAND modes

## Screenshots (if necessary)
Videos from my own testing:
- https://youtu.be/DcrRhIiYvm8
- https://youtu.be/k7ghKZMPa7I
- https://youtu.be/9fX2JA3QC34
- https://youtu.be/hPVWpcV_wVk
- https://youtu.be/zfBPaTkenus

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- test the above mentioned cases if they work properly for both HDG/VS and TRK/FPA mode

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page