### PR TITLE
refactor: emergency electrical logic for hydraulics

### DIFF
--- a/src/systems/a320_systems/src/electrical/alternating_current.rs
+++ b/src/systems/a320_systems/src/electrical/alternating_current.rs
@@ -5,9 +5,9 @@ use super::{
 use std::time::Duration;
 use systems::{
     electrical::{
-        consumption::SuppliedPower, Contactor, ElectricalBus, ElectricalBusType,
-        EmergencyElecElectricalSystem, EmergencyGenerator, EngineGenerator, ExternalPowerSource,
-        Potential, PotentialOrigin, PotentialSource, PotentialTarget, TransformerRectifier,
+        consumption::SuppliedPower, AlternatingCurrentBusesState, Contactor, ElectricalBus,
+        ElectricalBusType, EmergencyGenerator, EngineGenerator, ExternalPowerSource, Potential,
+        PotentialOrigin, PotentialSource, PotentialTarget, TransformerRectifier,
     },
     shared::DelayedTrueLogicGate,
     simulation::{SimulationElement, SimulationElementVisitor, UpdateContext},
@@ -70,6 +70,11 @@ impl A320AlternatingCurrentElectrical {
     ) {
         self.main_power_sources
             .update(context, ext_pwr, overhead, emergency_overhead, arguments);
+
+        self.ac_bus_1
+            .powered_by(&self.main_power_sources.ac_bus_1_electric_sources());
+        self.ac_bus_2
+            .powered_by(&self.main_power_sources.ac_bus_2_electric_sources());
     }
 
     pub fn update<'a>(
@@ -79,11 +84,6 @@ impl A320AlternatingCurrentElectrical {
         overhead: &A320ElectricalOverheadPanel,
         emergency_generator: &EmergencyGenerator,
     ) {
-        self.ac_bus_1
-            .powered_by(&self.main_power_sources.ac_bus_1_electric_sources());
-        self.ac_bus_2
-            .powered_by(&self.main_power_sources.ac_bus_2_electric_sources());
-
         self.ac_bus_2_to_tr_2_contactor.powered_by(&self.ac_bus_2);
         self.ac_bus_2_to_tr_2_contactor
             .close_when(self.ac_bus_2.is_powered() && !self.tr_2.failed());
@@ -293,7 +293,7 @@ impl AlternatingCurrentState for A320AlternatingCurrentElectrical {
         &self.tr_ess
     }
 }
-impl EmergencyElecElectricalSystem for A320AlternatingCurrentElectrical {
+impl AlternatingCurrentBusesState for A320AlternatingCurrentElectrical {
     fn ac_buses_unpowered(&self) -> bool {
         self.ac_bus_1_and_2_unpowered()
     }

--- a/src/systems/a320_systems/src/electrical/alternating_current.rs
+++ b/src/systems/a320_systems/src/electrical/alternating_current.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 use systems::{
     electrical::{
         consumption::SuppliedPower, Contactor, ElectricalBus, ElectricalBusType,
-        EmergencyGenerator, EngineGenerator, ExternalPowerSource, Potential, PotentialOrigin,
-        PotentialSource, PotentialTarget, TransformerRectifier,
+        EmergencyElecElectricalSystem, EmergencyGenerator, EngineGenerator, ExternalPowerSource,
+        Potential, PotentialOrigin, PotentialSource, PotentialTarget, TransformerRectifier,
     },
     shared::DelayedTrueLogicGate,
     simulation::{SimulationElement, SimulationElementVisitor, UpdateContext},
@@ -27,7 +27,6 @@ pub(super) struct A320AlternatingCurrentElectrical {
     ac_bus_2_to_tr_2_contactor: Contactor,
     tr_ess: TransformerRectifier,
     ac_ess_to_tr_ess_contactor: Contactor,
-    emergency_gen: EmergencyGenerator,
     emergency_gen_contactor: Contactor,
     static_inv_to_ac_ess_bus_contactor: Contactor,
     ac_stat_inv_bus: ElectricalBus,
@@ -49,7 +48,6 @@ impl A320AlternatingCurrentElectrical {
             ac_bus_2_to_tr_2_contactor: Contactor::new("14PU"),
             tr_ess: TransformerRectifier::new(3),
             ac_ess_to_tr_ess_contactor: Contactor::new("15XE1"),
-            emergency_gen: EmergencyGenerator::new(),
             emergency_gen_contactor: Contactor::new("2XE"),
             static_inv_to_ac_ess_bus_contactor: Contactor::new("15XE2"),
             ac_stat_inv_bus: ElectricalBus::new(
@@ -62,7 +60,7 @@ impl A320AlternatingCurrentElectrical {
         }
     }
 
-    pub fn update<'a>(
+    pub fn update_main_power_sources<'a>(
         &mut self,
         context: &UpdateContext,
         ext_pwr: &ExternalPowerSource,
@@ -72,20 +70,15 @@ impl A320AlternatingCurrentElectrical {
     ) {
         self.main_power_sources
             .update(context, ext_pwr, overhead, emergency_overhead, arguments);
+    }
 
-        if (self.ac_bus_1_and_2_unpowered()
-            && context.indicated_airspeed() > Velocity::new::<knot>(100.))
-            || emergency_overhead.rat_and_emer_gen_man_on()
-        {
-            self.emergency_gen.start();
-        }
-
-        self.emergency_gen.update(
-            context,
-            arguments.is_blue_hydraulic_circuit_pressurised()
-                && context.indicated_airspeed() > Velocity::new::<knot>(100.),
-        );
-
+    pub fn update<'a>(
+        &mut self,
+        context: &UpdateContext,
+        ext_pwr: &ExternalPowerSource,
+        overhead: &A320ElectricalOverheadPanel,
+        emergency_generator: &EmergencyGenerator,
+    ) {
         self.ac_bus_1
             .powered_by(&self.main_power_sources.ac_bus_1_electric_sources());
         self.ac_bus_2
@@ -121,9 +114,10 @@ impl A320AlternatingCurrentElectrical {
             .powered_by(&self.ac_ess_feed_contactors.electric_sources());
 
         self.emergency_gen_contactor.close_when(
-            self.ac_bus_1_and_2_unpowered() && self.emergency_gen.output_within_normal_parameters(),
+            self.ac_bus_1_and_2_unpowered()
+                && emergency_generator.output_within_normal_parameters(),
         );
-        self.emergency_gen_contactor.powered_by(&self.emergency_gen);
+        self.emergency_gen_contactor.powered_by(emergency_generator);
 
         self.ac_ess_to_tr_ess_contactor.powered_by(&self.ac_ess_bus);
         self.ac_ess_to_tr_ess_contactor
@@ -142,27 +136,28 @@ impl A320AlternatingCurrentElectrical {
         self.tr_ess.powered_by(&self.ac_ess_to_tr_ess_contactor);
         self.tr_ess.or_powered_by(&self.emergency_gen_contactor);
 
-        self.update_shedding();
+        self.update_shedding(emergency_generator);
     }
 
-    pub fn update_with_direct_current_state<T: DirectCurrentState>(
+    pub fn update_after_direct_current<T: DirectCurrentState>(
         &mut self,
         context: &UpdateContext,
+        emergency_generator: &EmergencyGenerator,
         dc_state: &T,
     ) {
         self.ac_stat_inv_bus.powered_by(dc_state.static_inverter());
         self.static_inv_to_ac_ess_bus_contactor
-            .close_when(self.should_close_15xe2_contactor(context));
+            .close_when(self.should_close_15xe2_contactor(context, emergency_generator));
         self.static_inv_to_ac_ess_bus_contactor
             .powered_by(dc_state.static_inverter());
         self.ac_ess_bus
             .or_powered_by(&self.static_inv_to_ac_ess_bus_contactor);
     }
 
-    fn update_shedding(&mut self) {
+    fn update_shedding(&mut self, emergency_generator: &EmergencyGenerator) {
         let ac_bus_or_emergency_gen_provides_power = self.ac_bus_1.is_powered()
             || self.ac_bus_2.is_powered()
-            || self.emergency_gen.is_powered();
+            || emergency_generator.is_powered();
         self.ac_ess_shed_contactor
             .close_when(ac_bus_or_emergency_gen_provides_power);
 
@@ -219,8 +214,13 @@ impl A320AlternatingCurrentElectrical {
 
     /// Determines if 15XE2 should be closed. 15XE2 is the contactor which connects
     /// the static inverter to the AC ESS BUS.
-    fn should_close_15xe2_contactor(&self, context: &UpdateContext) -> bool {
-        self.ac_1_and_2_and_emergency_gen_unpowered()
+    fn should_close_15xe2_contactor(
+        &self,
+        context: &UpdateContext,
+        emergency_generator: &EmergencyGenerator,
+    ) -> bool {
+        self.ac_bus_1_and_2_unpowered()
+            && emergency_generator.is_unpowered()
             && context.indicated_airspeed() >= Velocity::new::<knot>(50.)
     }
 
@@ -241,11 +241,6 @@ impl A320AlternatingCurrentElectrical {
     #[cfg(test)]
     pub fn fail_tr_2(&mut self) {
         self.tr_2.fail();
-    }
-
-    #[cfg(test)]
-    pub fn attempt_emergency_gen_start(&mut self) {
-        self.emergency_gen.start();
     }
 
     pub fn gen_1_contactor_open(&self) -> bool {
@@ -286,10 +281,6 @@ impl AlternatingCurrentState for A320AlternatingCurrentElectrical {
         self.tr_1.is_powered() && self.tr_2.is_powered()
     }
 
-    fn ac_1_and_2_and_emergency_gen_unpowered(&self) -> bool {
-        self.ac_bus_1_and_2_unpowered() && self.emergency_gen.is_unpowered()
-    }
-
     fn tr_1(&self) -> &TransformerRectifier {
         &self.tr_1
     }
@@ -301,14 +292,14 @@ impl AlternatingCurrentState for A320AlternatingCurrentElectrical {
     fn tr_ess(&self) -> &TransformerRectifier {
         &self.tr_ess
     }
-
-    fn emergency_generator_available(&self) -> bool {
-        self.emergency_gen.is_powered()
+}
+impl EmergencyElecElectricalSystem for A320AlternatingCurrentElectrical {
+    fn ac_buses_unpowered(&self) -> bool {
+        self.ac_bus_1_and_2_unpowered()
     }
 }
 impl SimulationElement for A320AlternatingCurrentElectrical {
     fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
-        self.emergency_gen.accept(visitor);
         self.main_power_sources.accept(visitor);
         self.ac_ess_feed_contactors.accept(visitor);
         self.tr_1.accept(visitor);

--- a/src/systems/a320_systems/src/electrical/alternating_current.rs
+++ b/src/systems/a320_systems/src/electrical/alternating_current.rs
@@ -77,7 +77,7 @@ impl A320AlternatingCurrentElectrical {
             .powered_by(&self.main_power_sources.ac_bus_2_electric_sources());
     }
 
-    pub fn update<'a>(
+    pub fn update(
         &mut self,
         context: &UpdateContext,
         ext_pwr: &ExternalPowerSource,

--- a/src/systems/a320_systems/src/electrical/direct_current.rs
+++ b/src/systems/a320_systems/src/electrical/direct_current.rs
@@ -7,7 +7,7 @@ use systems::electrical::Potential;
 use systems::{
     electrical::{
         consumption::SuppliedPower, Battery, BatteryChargeLimiter, BatteryChargeLimiterArguments,
-        Contactor, ElectricalBus, ElectricalBusType, EmergencyElec, EmergencyGenerator,
+        Contactor, ElectricalBus, ElectricalBusType, EmergencyElectrical, EmergencyGenerator,
         PotentialSource, PotentialTarget, StaticInverter,
     },
     simulation::{SimulationElement, SimulationElementVisitor, UpdateContext},
@@ -78,12 +78,12 @@ impl A320DirectCurrentElectrical {
         }
     }
 
-    pub fn update_with_alternating_current_state<'a, T: AlternatingCurrentState>(
+    pub fn update<'a, T: AlternatingCurrentState>(
         &mut self,
         context: &UpdateContext,
         overhead: &A320ElectricalOverheadPanel,
         ac_state: &T,
-        emergency_elec: &EmergencyElec,
+        emergency_elec: &EmergencyElectrical,
         emergency_generator: &EmergencyGenerator,
         arguments: &mut A320ElectricalUpdateArguments<'a>,
     ) {

--- a/src/systems/a320_systems/src/electrical/direct_current.rs
+++ b/src/systems/a320_systems/src/electrical/direct_current.rs
@@ -7,8 +7,8 @@ use systems::electrical::Potential;
 use systems::{
     electrical::{
         consumption::SuppliedPower, Battery, BatteryChargeLimiter, BatteryChargeLimiterArguments,
-        Contactor, ElectricalBus, ElectricalBusType, PotentialSource, PotentialTarget,
-        StaticInverter,
+        Contactor, ElectricalBus, ElectricalBusType, EmergencyElec, EmergencyGenerator,
+        PotentialSource, PotentialTarget, StaticInverter,
     },
     simulation::{SimulationElement, SimulationElementVisitor, UpdateContext},
 };
@@ -83,6 +83,8 @@ impl A320DirectCurrentElectrical {
         context: &UpdateContext,
         overhead: &A320ElectricalOverheadPanel,
         ac_state: &T,
+        emergency_elec: &EmergencyElec,
+        emergency_generator: &EmergencyGenerator,
         arguments: &mut A320ElectricalUpdateArguments<'a>,
     ) {
         self.tr_1_contactor.close_when(ac_state.tr_1().is_powered());
@@ -137,6 +139,7 @@ impl A320DirectCurrentElectrical {
 
         self.battery_1_charge_limiter.update(
             context,
+            emergency_elec,
             &BatteryChargeLimiterArguments::new(
                 ac_state.ac_bus_1_and_2_unpowered(),
                 &self.battery_1,
@@ -146,7 +149,7 @@ impl A320DirectCurrentElectrical {
                 arguments.apu_is_available(),
                 overhead.bat_1_is_auto(),
                 arguments.landing_gear_is_up_and_locked(),
-                ac_state.emergency_generator_available(),
+                emergency_generator.is_powered(),
             ),
         );
         self.battery_1_contactor
@@ -154,6 +157,7 @@ impl A320DirectCurrentElectrical {
 
         self.battery_2_charge_limiter.update(
             context,
+            emergency_elec,
             &BatteryChargeLimiterArguments::new(
                 ac_state.ac_bus_1_and_2_unpowered(),
                 &self.battery_2,
@@ -163,7 +167,7 @@ impl A320DirectCurrentElectrical {
                 arguments.apu_is_available(),
                 overhead.bat_2_is_auto(),
                 arguments.landing_gear_is_up_and_locked(),
-                ac_state.emergency_generator_available(),
+                emergency_generator.is_powered(),
             ),
         );
         self.battery_2_contactor
@@ -199,7 +203,8 @@ impl A320DirectCurrentElectrical {
 
         arguments.apu_start_motor_powered_by(self.apu_start_contactors.output());
 
-        let should_close_2xb_contactor = self.should_close_2xb_contactors(context, ac_state);
+        let should_close_2xb_contactor =
+            self.should_close_2xb_contactors(context, emergency_generator, ac_state);
         self.hot_bus_1_to_static_inv_contactor
             .close_when(should_close_2xb_contactor);
         self.hot_bus_1_to_static_inv_contactor
@@ -234,9 +239,11 @@ impl A320DirectCurrentElectrical {
     fn should_close_2xb_contactors<T: AlternatingCurrentState>(
         &self,
         context: &UpdateContext,
+        emergency_generator: &EmergencyGenerator,
         ac_state: &T,
     ) -> bool {
-        ac_state.ac_1_and_2_and_emergency_gen_unpowered()
+        ac_state.ac_bus_1_and_2_unpowered()
+            && !emergency_generator.is_powered()
             && ((context.indicated_airspeed() < Velocity::new::<knot>(50.)
                 && self.batteries_connected_to_bat_bus())
                 || context.indicated_airspeed() >= Velocity::new::<knot>(50.))

--- a/src/systems/systems/src/apu/mod.rs
+++ b/src/systems/systems/src/apu/mod.rs
@@ -1674,7 +1674,7 @@ pub mod tests {
                 .released_apu_fire_pb()
                 .run(Duration::from_secs(1));
 
-            assert!(test_bed.is_inoperable(), true);
+            assert_eq!(test_bed.is_inoperable(), true);
         }
 
         #[test]

--- a/src/systems/systems/src/electrical/battery_charge_limiter.rs
+++ b/src/systems/systems/src/electrical/battery_charge_limiter.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use super::{PotentialSource, ProvideCurrent};
+use super::{EmergencyElec, PotentialSource, ProvideCurrent};
 use crate::{
     shared::DelayedTrueLogicGate,
     simulation::{SimulationElement, SimulatorWriter, UpdateContext},
@@ -110,11 +110,16 @@ impl BatteryChargeLimiter {
         }
     }
 
-    pub fn update(&mut self, context: &UpdateContext, arguments: &BatteryChargeLimiterArguments) {
+    pub fn update(
+        &mut self,
+        context: &UpdateContext,
+        emergency_elec: &EmergencyElec,
+        arguments: &BatteryChargeLimiterArguments,
+    ) {
         self.arrow.update(context, arguments);
 
         if let Some(observer) = self.observer.take() {
-            self.observer = Some(observer.update(context, arguments));
+            self.observer = Some(observer.update(context, emergency_elec, arguments));
         }
     }
 
@@ -138,6 +143,7 @@ trait BatteryStateObserver {
     fn update(
         self: Box<Self>,
         context: &UpdateContext,
+        emergency_elec: &EmergencyElec,
         arguments: &BatteryChargeLimiterArguments,
     ) -> Box<dyn BatteryStateObserver>;
 }
@@ -167,6 +173,7 @@ impl BatteryStateObserver for OffPushButtonObserver {
     fn update(
         mut self: Box<Self>,
         context: &UpdateContext,
+        _: &EmergencyElec,
         arguments: &BatteryChargeLimiterArguments,
     ) -> Box<dyn BatteryStateObserver> {
         self.bcl_startup_delay
@@ -186,15 +193,14 @@ struct OpenContactorObserver {
     begin_charging_cycle_delay: DelayedTrueLogicGate,
     open_due_to_discharge_protection: bool,
     open_due_to_exceeding_emergency_elec_closing_time_allowance: bool,
-    emergency_elec: EmergencyElec,
 }
 impl OpenContactorObserver {
     const CHARGE_BATTERY_BELOW_VOLTAGE: f64 = 26.5;
     const BATTERY_BUS_BELOW_CHARGING_VOLTAGE: f64 = 27.;
     const BATTERY_CHARGING_CLOSE_DELAY_MILLISECONDS: u64 = 225;
+    const APU_START_INHIBIT_DELAY_SECONDS: u64 = 45;
 
     fn new(
-        emergency_elec: EmergencyElec,
         open_due_to_discharge_protection: bool,
         open_due_to_exceeding_emergency_elec_closing_time_allowance: bool,
     ) -> Self {
@@ -202,32 +208,28 @@ impl OpenContactorObserver {
             begin_charging_cycle_delay: DelayedTrueLogicGate::new(Duration::from_millis(
                 OpenContactorObserver::BATTERY_CHARGING_CLOSE_DELAY_MILLISECONDS,
             )),
-            emergency_elec,
             open_due_to_discharge_protection,
             open_due_to_exceeding_emergency_elec_closing_time_allowance,
         }
     }
 
     fn for_initial_bcl_state() -> Self {
-        Self::new(EmergencyElec::new(), false, false)
+        Self::new(false, false)
     }
 
-    fn from_closed(emergency_elec: EmergencyElec) -> Self {
-        Self::new(emergency_elec, false, false)
+    fn from_closed() -> Self {
+        Self::new(false, false)
     }
 
-    fn with_discharge_protection(emergency_elec: EmergencyElec) -> Self {
-        Self::new(emergency_elec, true, false)
+    fn with_discharge_protection() -> Self {
+        Self::new(true, false)
     }
 
-    fn after_exceeding_emergency_elec_closing_time_allowance(
-        emergency_elec: EmergencyElec,
-    ) -> Self {
-        Self::new(emergency_elec, false, true)
+    fn after_exceeding_emergency_elec_closing_time_allowance() -> Self {
+        Self::new(false, true)
     }
 
     fn update_state(&mut self, context: &UpdateContext, arguments: &BatteryChargeLimiterArguments) {
-        self.emergency_elec.update(context, arguments);
         self.update_begin_charging_cycle_delay(context, arguments);
 
         if self.open_due_to_exceeding_emergency_elec_closing_time_allowance
@@ -240,10 +242,11 @@ impl OpenContactorObserver {
     fn should_close(
         &self,
         context: &UpdateContext,
+        emergency_elec: &EmergencyElec,
         arguments: &BatteryChargeLimiterArguments,
     ) -> bool {
         !self.open_due_to_exceeding_emergency_elec_closing_time_allowance
-            && !self.emergency_elec_inhibited(arguments)
+            && !self.emergency_elec_inhibited(emergency_elec, arguments)
             && !self.open_due_to_discharge_protection
             && (self.should_get_ready_for_apu_start(arguments)
                 || on_ground_at_low_speed_with_unpowered_ac_buses(context, arguments)
@@ -258,11 +261,16 @@ impl OpenContactorObserver {
         self.begin_charging_cycle_delay.output()
     }
 
-    fn emergency_elec_inhibited(&self, arguments: &BatteryChargeLimiterArguments) -> bool {
-        self.emergency_elec.is_active()
+    fn emergency_elec_inhibited(
+        &self,
+        emergency_elec: &EmergencyElec,
+        arguments: &BatteryChargeLimiterArguments,
+    ) -> bool {
+        emergency_elec.is_active()
             && (!arguments.landing_gear_is_up_and_locked()
                 || (!arguments.emergency_generator_available()
-                    && self.emergency_elec.apu_start_inhibited()))
+                    && emergency_elec.active_duration()
+                        < Duration::from_secs(Self::APU_START_INHIBIT_DELAY_SECONDS)))
     }
 
     fn update_begin_charging_cycle_delay(
@@ -291,14 +299,17 @@ impl BatteryStateObserver for OpenContactorObserver {
     fn update(
         mut self: Box<Self>,
         context: &UpdateContext,
+        emergency_elec: &EmergencyElec,
         arguments: &BatteryChargeLimiterArguments,
     ) -> Box<dyn BatteryStateObserver> {
         self.update_state(context, arguments);
 
         if !arguments.battery_push_button_is_auto() {
             Box::new(OffPushButtonObserver::new())
-        } else if self.should_close(context, arguments) {
-            Box::new(ClosedContactorObserver::from_open(self.emergency_elec))
+        } else if self.should_close(context, emergency_elec, arguments) {
+            Box::new(ClosedContactorObserver::from_open(
+                emergency_elec.is_active(),
+            ))
         } else {
             self
         }
@@ -311,7 +322,6 @@ struct ClosedContactorObserver {
     below_4_ampere_charging_duration: Duration,
     below_23_volt_duration: Duration,
     apu_master_sw_pb_on_duration: Duration,
-    emergency_elec: EmergencyElec,
     had_apu_start: bool,
     entered_in_emergency_elec: bool,
 }
@@ -321,28 +331,25 @@ impl ClosedContactorObserver {
     const BATTERY_DISCHARGE_PROTECTION_DELAY_SECONDS: u64 = 15;
     const EMER_ELEC_APU_MASTER_MAXIMUM_CLOSED_SECONDS: u64 = 180;
 
-    fn new(emergency_elec: EmergencyElec) -> Self {
+    fn new(entered_in_emergency_elec: bool) -> Self {
         Self {
             below_4_ampere_charging_duration: Duration::from_secs(0),
             below_23_volt_duration: Duration::from_secs(0),
             apu_master_sw_pb_on_duration: Duration::from_secs(0),
-            entered_in_emergency_elec: emergency_elec.is_active(),
-            emergency_elec,
+            entered_in_emergency_elec,
             had_apu_start: false,
         }
     }
 
-    fn from_open(emergency_elec: EmergencyElec) -> Self {
-        Self::new(emergency_elec)
+    fn from_open(entered_in_emergency_elec: bool) -> Self {
+        Self::new(entered_in_emergency_elec)
     }
 
     fn from_off() -> Self {
-        Self::new(EmergencyElec::new())
+        Self::new(false)
     }
 
     fn update_state(&mut self, context: &UpdateContext, arguments: &BatteryChargeLimiterArguments) {
-        self.emergency_elec.update(context, arguments);
-
         if arguments.apu_start_sw_pb_on() {
             self.had_apu_start = true;
         }
@@ -374,16 +381,20 @@ impl ClosedContactorObserver {
                 )
     }
 
-    fn should_open_due_to_exceeding_emergency_elec_closed_time_allowance(&self) -> bool {
-        self.emergency_elec.is_active() && self.beyond_emergency_elec_closed_time_allowance()
+    fn should_open_due_to_exceeding_emergency_elec_closed_time_allowance(
+        &self,
+        emergency_elec: &EmergencyElec,
+    ) -> bool {
+        emergency_elec.is_active() && self.beyond_emergency_elec_closed_time_allowance()
     }
 
     fn should_open(
         &self,
         context: &UpdateContext,
+        emergency_elec: &EmergencyElec,
         arguments: &BatteryChargeLimiterArguments,
     ) -> bool {
-        if self.emergency_elec.is_active() {
+        if emergency_elec.is_active() {
             !arguments.apu_master_sw_pb_on() || self.emergency_elec_inhibited(arguments)
         } else {
             !self.awaiting_apu_start(arguments)
@@ -436,6 +447,7 @@ impl BatteryStateObserver for ClosedContactorObserver {
     fn update(
         mut self: Box<Self>,
         context: &UpdateContext,
+        emergency_elec: &EmergencyElec,
         arguments: &BatteryChargeLimiterArguments,
     ) -> Box<dyn BatteryStateObserver> {
         self.update_state(context, arguments);
@@ -443,17 +455,13 @@ impl BatteryStateObserver for ClosedContactorObserver {
         if !arguments.battery_push_button_is_auto() {
             Box::new(OffPushButtonObserver::new())
         } else if self.should_open_due_to_discharge_protection(context) {
-            Box::new(OpenContactorObserver::with_discharge_protection(
-                self.emergency_elec,
-            ))
-        } else if self.should_open_due_to_exceeding_emergency_elec_closed_time_allowance() {
-            Box::new(
-                OpenContactorObserver::after_exceeding_emergency_elec_closing_time_allowance(
-                    self.emergency_elec,
-                ),
-            )
-        } else if self.should_open(context, arguments) {
-            Box::new(OpenContactorObserver::from_closed(self.emergency_elec))
+            Box::new(OpenContactorObserver::with_discharge_protection())
+        } else if self
+            .should_open_due_to_exceeding_emergency_elec_closed_time_allowance(emergency_elec)
+        {
+            Box::new(OpenContactorObserver::after_exceeding_emergency_elec_closing_time_allowance())
+        } else if self.should_open(context, emergency_elec, arguments) {
+            Box::new(OpenContactorObserver::from_closed())
         } else {
             self
         }
@@ -467,38 +475,6 @@ fn on_ground_at_low_speed_with_unpowered_ac_buses(
     arguments.ac_buses_unpowered()
         && context.is_on_ground()
         && context.indicated_airspeed() < Velocity::new::<knot>(100.)
-}
-
-struct EmergencyElec {
-    is_active_for_duration: Duration,
-}
-impl EmergencyElec {
-    const APU_START_INHIBIT_DELAY_SECONDS: u64 = 45;
-
-    fn new() -> Self {
-        Self {
-            is_active_for_duration: Duration::from_secs(0),
-        }
-    }
-
-    fn update(&mut self, context: &UpdateContext, arguments: &BatteryChargeLimiterArguments) {
-        if arguments.ac_buses_unpowered()
-            && context.indicated_airspeed() > Velocity::new::<knot>(100.)
-        {
-            self.is_active_for_duration += context.delta();
-        } else {
-            self.is_active_for_duration = Duration::from_secs(0)
-        }
-    }
-
-    fn is_active(&self) -> bool {
-        self.is_active_for_duration > Duration::from_secs(0)
-    }
-
-    fn apu_start_inhibited(&self) -> bool {
-        self.is_active_for_duration
-            < Duration::from_secs(EmergencyElec::APU_START_INHIBIT_DELAY_SECONDS)
-    }
 }
 
 struct ArrowBetweenBatteryAndBatBus {
@@ -545,8 +521,8 @@ mod tests {
             electrical::{
                 battery::Battery,
                 consumption::{PowerConsumer, SuppliedPower},
-                Contactor, ElectricalBus, ElectricalBusType, Potential, PotentialOrigin,
-                PotentialTarget,
+                Contactor, ElectricalBus, ElectricalBusType, EmergencyElecElectricalSystem,
+                Potential, PotentialOrigin, PotentialTarget,
             },
             simulation::{test::SimulationTestBed, Aircraft, SimulationElementVisitor},
         };
@@ -618,7 +594,7 @@ mod tests {
 
             fn wait_for_emergency_elec_apu_no_longer_inhibited(mut self) -> Self {
                 self = self.emergency_elec().run(Duration::from_secs(
-                    EmergencyElec::APU_START_INHIBIT_DELAY_SECONDS,
+                    OpenContactorObserver::APU_START_INHIBIT_DELAY_SECONDS,
                 ));
 
                 self
@@ -777,19 +753,40 @@ mod tests {
             }
         }
 
+        struct TestElectricalSystem {
+            ac_buses_powered: bool,
+        }
+        impl TestElectricalSystem {
+            fn new() -> Self {
+                Self {
+                    ac_buses_powered: true,
+                }
+            }
+
+            fn unpower(&mut self) {
+                self.ac_buses_powered = false;
+            }
+        }
+        impl EmergencyElecElectricalSystem for TestElectricalSystem {
+            fn ac_buses_unpowered(&self) -> bool {
+                !self.ac_buses_powered
+            }
+        }
+
         struct TestAircraft {
             battery: Battery,
             battery_charge_limiter: BatteryChargeLimiter,
             battery_bus: ElectricalBus,
             battery_contactor: Contactor,
             consumer: PowerConsumer,
-            both_ac_buses_unpowered: bool,
             apu_master_sw_pb_on: bool,
             apu_start_pb_on: bool,
             apu_available: bool,
             battery_push_button_auto: bool,
             gear_is_down: bool,
             emergency_generator_available: bool,
+            emergency_elec: EmergencyElec,
+            electrical_system: TestElectricalSystem,
         }
         impl TestAircraft {
             fn new(battery: Battery) -> Self {
@@ -799,13 +796,14 @@ mod tests {
                     battery_bus: ElectricalBus::new(ElectricalBusType::DirectCurrentBattery),
                     battery_contactor: Contactor::new("TEST"),
                     consumer: PowerConsumer::from(ElectricalBusType::DirectCurrentBattery),
-                    both_ac_buses_unpowered: false,
                     apu_master_sw_pb_on: false,
                     apu_start_pb_on: false,
                     apu_available: false,
                     battery_push_button_auto: true,
                     gear_is_down: false,
                     emergency_generator_available: false,
+                    emergency_elec: EmergencyElec::new(),
+                    electrical_system: TestElectricalSystem::new(),
                 }
             }
 
@@ -840,7 +838,7 @@ mod tests {
             }
 
             fn set_both_ac_buses_unpowered(&mut self) {
-                self.both_ac_buses_unpowered = true;
+                self.electrical_system.unpower();
             }
 
             fn set_apu_master_sw_pb_on(&mut self) {
@@ -893,10 +891,13 @@ mod tests {
         }
         impl Aircraft for TestAircraft {
             fn update_before_power_distribution(&mut self, context: &UpdateContext) {
+                self.emergency_elec.update(context, &self.electrical_system);
+
                 self.battery_charge_limiter.update(
                     context,
+                    &self.emergency_elec,
                     &BatteryChargeLimiterArguments::new(
-                        self.both_ac_buses_unpowered,
+                        self.electrical_system.ac_buses_unpowered(),
                         &self.battery,
                         &self.battery_bus,
                         self.apu_master_sw_pb_on,
@@ -1488,7 +1489,7 @@ mod tests {
                 .and()
                 .apu_master_sw_pb_on()
                 .run(
-                    Duration::from_secs(EmergencyElec::APU_START_INHIBIT_DELAY_SECONDS)
+                    Duration::from_secs(OpenContactorObserver::APU_START_INHIBIT_DELAY_SECONDS)
                         - Duration::from_millis(1),
                 );
 
@@ -1503,7 +1504,7 @@ mod tests {
                 .and()
                 .apu_master_sw_pb_on()
                 .run(Duration::from_secs(
-                    EmergencyElec::APU_START_INHIBIT_DELAY_SECONDS,
+                    OpenContactorObserver::APU_START_INHIBIT_DELAY_SECONDS,
                 ));
 
             assert!(test_bed.battery_contactor_is_closed());
@@ -1517,7 +1518,7 @@ mod tests {
                 .and()
                 .apu_master_sw_pb_on()
                 .run(
-                    Duration::from_secs(EmergencyElec::APU_START_INHIBIT_DELAY_SECONDS)
+                    Duration::from_secs(OpenContactorObserver::APU_START_INHIBIT_DELAY_SECONDS)
                         - Duration::from_millis(1),
                 );
 
@@ -1600,7 +1601,7 @@ mod tests {
                 .and()
                 .apu_master_sw_pb_on()
                 .run(Duration::from_secs(
-                    EmergencyElec::APU_START_INHIBIT_DELAY_SECONDS,
+                    OpenContactorObserver::APU_START_INHIBIT_DELAY_SECONDS,
                 ));
 
             assert!(

--- a/src/systems/systems/src/electrical/mod.rs
+++ b/src/systems/systems/src/electrical/mod.rs
@@ -472,22 +472,22 @@ pub trait ProvideLoad {
     fn load_normal(&self) -> bool;
 }
 
-pub trait EmergencyElecElectricalSystem {
+pub trait AlternatingCurrentBusesState {
     fn ac_buses_unpowered(&self) -> bool;
 }
 
 /// Determines if and for how long the aircraft is in an emergency electrical situation.
-pub struct EmergencyElec {
+pub struct EmergencyElectrical {
     is_active_for_duration: Duration,
 }
-impl EmergencyElec {
+impl EmergencyElectrical {
     pub fn new() -> Self {
         Self {
             is_active_for_duration: Duration::from_secs(0),
         }
     }
 
-    pub fn update<T: EmergencyElecElectricalSystem>(
+    pub fn update<T: AlternatingCurrentBusesState>(
         &mut self,
         context: &UpdateContext,
         arguments: &T,

--- a/src/systems/systems/src/electrical/mod.rs
+++ b/src/systems/systems/src/electrical/mod.rs
@@ -509,6 +509,11 @@ impl EmergencyElectrical {
         self.is_active_for_duration
     }
 }
+impl Default for EmergencyElectrical {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/systems/systems/src/electrical/mod.rs
+++ b/src/systems/systems/src/electrical/mod.rs
@@ -8,7 +8,7 @@ mod engine_generator;
 mod external_power_source;
 mod static_inverter;
 mod transformer_rectifier;
-use std::{cmp::Ordering, fmt::Display, hash::Hash};
+use std::{cmp::Ordering, fmt::Display, hash::Hash, time::Duration};
 
 pub use battery::Battery;
 pub use battery_charge_limiter::{BatteryChargeLimiter, BatteryChargeLimiterArguments};
@@ -22,9 +22,10 @@ use itertools::Itertools;
 pub use static_inverter::StaticInverter;
 pub use transformer_rectifier::TransformerRectifier;
 
-use crate::simulation::{SimulationElement, SimulatorWriter};
+use crate::simulation::{SimulationElement, SimulatorWriter, UpdateContext};
 use uom::si::{
     electric_current::ampere, electric_potential::volt, f64::*, frequency::hertz, ratio::percent,
+    velocity::knot,
 };
 
 use self::consumption::SuppliedPower;
@@ -469,6 +470,44 @@ pub trait ProvideFrequency {
 pub trait ProvideLoad {
     fn load(&self) -> Ratio;
     fn load_normal(&self) -> bool;
+}
+
+pub trait EmergencyElecElectricalSystem {
+    fn ac_buses_unpowered(&self) -> bool;
+}
+
+/// Determines if and for how long the aircraft is in an emergency electrical situation.
+pub struct EmergencyElec {
+    is_active_for_duration: Duration,
+}
+impl EmergencyElec {
+    pub fn new() -> Self {
+        Self {
+            is_active_for_duration: Duration::from_secs(0),
+        }
+    }
+
+    pub fn update<T: EmergencyElecElectricalSystem>(
+        &mut self,
+        context: &UpdateContext,
+        arguments: &T,
+    ) {
+        if arguments.ac_buses_unpowered()
+            && context.indicated_airspeed() > Velocity::new::<knot>(100.)
+        {
+            self.is_active_for_duration += context.delta();
+        } else {
+            self.is_active_for_duration = Duration::from_secs(0)
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.is_active_for_duration > Duration::from_secs(0)
+    }
+
+    fn active_duration(&self) -> Duration {
+        self.is_active_for_duration
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary of Changes
Goal is to expose `A320Electrical.in_emergency_elec()` so this information can be used by the hydraulic system. The logic which determines if the aircraft is in an emergency electrical situation was scattered in various places. Now unified in `EmergencyElectrical` type which no longer is exclusive to the battery charge limiter.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Everything was and is covered by extensive automated tests. No manual testing is necessary.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
