### PR TITLE
feat(efb): add button for forward pushback

### DIFF
--- a/src/instruments/src/EFB/Ground/Ground.scss
+++ b/src/instruments/src/EFB/Ground/Ground.scss
@@ -21,10 +21,6 @@
 .control-grid {
   grid-gap: 1rem;
 }
-
-.stop {
-  grid-column: 2 / 3;
-}
 button:active {
   @apply transform;
   @apply translate-y-1;

--- a/src/instruments/src/EFB/Ground/Ground.tsx
+++ b/src/instruments/src/EFB/Ground/Ground.tsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import React, { useEffect, useState } from 'react';
-import { IconCornerDownLeft, IconCornerDownRight, IconArrowDown, IconHandStop, IconTruck, IconBriefcase, IconBuildingArch, IconArchive, IconPlug, IconTir } from '@tabler/icons';
+import { IconCornerDownLeft, IconCornerDownRight, IconArrowUp, IconArrowDown, IconHandStop, IconTruck, IconBriefcase, IconBuildingArch, IconArchive, IconPlug, IconTir } from '@tabler/icons';
 import './Ground.scss';
 import fuselage from '../Assets/320neo-outline-upright.svg';
 import { useSimVar, useSplitSimVar } from '../../Common/simVars';
@@ -28,6 +28,7 @@ export const Ground = ({
 
     const [fuelingActive, setFuelingActive] = useSplitSimVar('A:INTERACTIVE POINT OPEN:9', 'Percent over 100', 'K:REQUEST_FUEL_KEY', 'bool', 1000);
     const [tugHeading, setTugHeading] = useSplitSimVar('PLANE HEADING DEGREES TRUE', 'degrees', 'K:KEY_TUG_HEADING', 'UINT32', 1000);
+    const [tugSpeed, setTugSpeed] = useSplitSimVar('VELOCITY BODY Z', 'feet per second', 'K:KEY_TUG_SPEED', 'FLOAT64', 1000);
     const [pushBack, setPushBack] = useSplitSimVar('PUSHBACK STATE', 'enum', 'K:TOGGLE_PUSHBACK', 'bool', 1000);
     const [powerActive, setPowerActive] = useSplitSimVar('A:INTERACTIVE POINT OPEN:8', 'Percent over 100', 'K:REQUEST_POWER_SUPPLY', 'bool', 1000);
 
@@ -68,6 +69,10 @@ export const Ground = ({
         if (tugRequestOnly) {
             setTugRequestOnly(false);
         }
+
+        const directionSign = (direction > 90 && direction < 270) ? -1 : 1;
+        setTugSpeed(directionSign * Math.abs(tugSpeed));
+
         const tugHeading = getTugHeading(direction);
         // KEY_TUG_HEADING is an unsigned integer, so let's convert
         /* eslint no-bitwise: ["error", { "allow": ["&"] }] */
@@ -269,8 +274,18 @@ export const Ground = ({
                         <IconTir size="2.825rem" stroke="1.5" />
                     </Button>
                 </div>
-
-                <div className="stop">
+                <div>
+                    <h1 className="text-white font-medium text-xl text-center">Direction</h1>
+                    <Button
+                        id="up"
+                        type={BUTTON_TYPE.NONE}
+                        onClick={(e) => handlePushBackClick(() => computeAndSetTugHeading(180), e)}
+                        className={applySelected('w-32 up', 'up')}
+                    >
+                        <IconArrowUp size="2.825rem" stroke="1.5" />
+                    </Button>
+                </div>
+                <div>
                     <h1 className="text-white font-medium text-xl text-center">Pushback</h1>
                     <Button
                         id="stop"


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #4801

## Summary of Changes
Adds a button to the Ground page of the EFB to pushback forwards.

Note: Setting the tug speed does not work yet, so this cannot be merged yet.
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![Screenshot 2021-05-15 153410](https://user-images.githubusercontent.com/11857441/118363096-0b56f400-b593-11eb-9e42-58cb74eef017.png)


## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username: Erik Vroon#0182

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Just click on the forward pushback button on the EFB.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page