### PR TITLE
feat: improved OP CLB/DES, CLB/DES speed hold characteristic

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -73,6 +73,7 @@
 1. [ENGINE] Adapt engine IDLE N1 based on environmental conditions - @Taz5150 (TazX [Z+2]#0405), @aguther (Andreas Guther)
 1. [ND] ND Waypoint Icon Size, Icon Outlines, Airplane Icon Color and Outline - @marcman86 (marcman86#4907)
 1. [ELEC] ENG FIRE push button deactivates IDG - @davidwalschots (David Walschots)
+1. [AP] Improved OP CLB/DES, CLB/DES speed hold characteristics - @aguther (Andreas Guther)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/src/fbw/src/model/AutopilotLaws.cpp
+++ b/src/fbw/src/model/AutopilotLaws.cpp
@@ -296,31 +296,32 @@ void AutopilotLawsModelClass::step()
   real_T result_tmp[9];
   real_T result[3];
   real_T result_0[3];
-  real_T rtb_AP_b;
   real_T rtb_Divide_h;
   real_T rtb_Gain4;
   real_T rtb_Gain5;
   real_T rtb_GainTheta;
   real_T rtb_GainTheta1;
-  real_T rtb_Gain_ar;
-  real_T rtb_Gain_et;
+  real_T rtb_Gain_a3;
   real_T rtb_Gain_gd;
   real_T rtb_Gain_hl;
-  real_T rtb_Gain_lf;
+  real_T rtb_Gain_hz;
   real_T rtb_Gain_ny;
   real_T rtb_ManualSwitch;
   real_T rtb_Mod2_f;
   real_T rtb_Mod2_k;
   real_T rtb_Saturation;
   real_T rtb_Saturation1;
-  real_T rtb_Sum2_d;
-  real_T rtb_Sum2_j;
+  real_T rtb_Sum2_f;
+  real_T rtb_Sum2_h;
+  real_T rtb_Sum2_j4;
+  real_T rtb_Sum_gh;
   real_T rtb_Sum_ib_tmp;
   real_T rtb_Sum_j;
+  real_T rtb_Y_fh;
   real_T rtb_Y_ic;
-  real_T rtb_Y_m4;
   real_T rtb_Y_p;
   real_T rtb_out_c;
+  real_T u1;
   int32_T i;
   int32_T rtb_on_ground;
   boolean_T rtb_Compare;
@@ -342,9 +343,9 @@ void AutopilotLawsModelClass::step()
   result_tmp[4] = rtb_Mod2_k;
   result_tmp[7] = -rtb_ManualSwitch;
   result_tmp[2] = 0.0;
-  rtb_Y_m4 = 1.0 / std::cos(rtb_Saturation);
-  result_tmp[5] = rtb_Y_m4 * rtb_ManualSwitch;
-  result_tmp[8] = rtb_Y_m4 * rtb_Mod2_k;
+  rtb_Y_fh = 1.0 / std::cos(rtb_Saturation);
+  result_tmp[5] = rtb_Y_fh * rtb_ManualSwitch;
+  result_tmp[8] = rtb_Y_fh * rtb_Mod2_k;
   rtb_ManualSwitch = AutopilotLaws_P.Gain_Gain_de * AutopilotLaws_U.in.data.p_rad_s * AutopilotLaws_P.Gainpk_Gain;
   rtb_Mod2_k = AutopilotLaws_P.Gain_Gain_d * AutopilotLaws_U.in.data.q_rad_s * AutopilotLaws_P.Gainqk_Gain;
   rtb_out_c = AutopilotLaws_P.Gain_Gain_m * AutopilotLaws_U.in.data.r_rad_s;
@@ -514,14 +515,14 @@ void AutopilotLawsModelClass::step()
   }
 
   if (AutopilotLaws_U.in.data.nav_dme_nmi > AutopilotLaws_P.Saturation_UpperSat_c) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_c;
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_c;
   } else if (AutopilotLaws_U.in.data.nav_dme_nmi < AutopilotLaws_P.Saturation_LowerSat_d) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_d;
+    rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_d;
   } else {
-    rtb_Y_m4 = AutopilotLaws_U.in.data.nav_dme_nmi;
+    rtb_Y_fh = AutopilotLaws_U.in.data.nav_dme_nmi;
   }
 
-  rtb_Saturation1 = std::sin(AutopilotLaws_P.Gain1_Gain_g * AutopilotLaws_U.in.data.nav_loc_error_deg) * rtb_Y_m4;
+  rtb_Saturation1 = std::sin(AutopilotLaws_P.Gain1_Gain_g * AutopilotLaws_U.in.data.nav_loc_error_deg) * rtb_Y_fh;
   rtb_Saturation = rtb_Saturation1 * look1_binlxpw(AutopilotLaws_U.in.data.nav_dme_nmi,
     AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1, AutopilotLaws_P.ScheduledGain_Table, 4U);
   rtb_Saturation1 = look1_binlxpw(rtb_Saturation1, AutopilotLaws_P.ScheduledGain3_BreakpointsForDimension1,
@@ -556,14 +557,14 @@ void AutopilotLawsModelClass::step()
     rtb_Saturation, AutopilotLaws_P.Constant3_Value_j), AutopilotLaws_P.Constant2_Value, &rtb_out_c,
                         &AutopilotLaws_DWork.sf_Chart_j);
   if (AutopilotLaws_U.in.data.nav_dme_nmi > AutopilotLaws_P.Saturation_UpperSat_o) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_o;
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_o;
   } else if (AutopilotLaws_U.in.data.nav_dme_nmi < AutopilotLaws_P.Saturation_LowerSat_o) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_o;
+    rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_o;
   } else {
-    rtb_Y_m4 = AutopilotLaws_U.in.data.nav_dme_nmi;
+    rtb_Y_fh = AutopilotLaws_U.in.data.nav_dme_nmi;
   }
 
-  rtb_Saturation1 = std::sin(AutopilotLaws_P.Gain1_Gain_h5 * AutopilotLaws_U.in.data.nav_loc_error_deg) * rtb_Y_m4 *
+  rtb_Saturation1 = std::sin(AutopilotLaws_P.Gain1_Gain_h5 * AutopilotLaws_U.in.data.nav_loc_error_deg) * rtb_Y_fh *
     AutopilotLaws_P.Gain2_Gain_g;
   if (rtb_Saturation1 > AutopilotLaws_P.Saturation1_UpperSat_g) {
     rtb_Saturation1 = AutopilotLaws_P.Saturation1_UpperSat_g;
@@ -665,7 +666,7 @@ void AutopilotLawsModelClass::step()
   rtb_Saturation = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain * AutopilotLaws_U.in.data.nav_loc_error_deg;
   AutopilotLaws_LagFilter(AutopilotLaws_U.in.data.nav_loc_error_deg + AutopilotLaws_P.Gain3_Gain_i * ((rtb_Saturation -
     AutopilotLaws_DWork.Delay_DSTATE_i) / AutopilotLaws_U.in.time.dt), AutopilotLaws_P.LagFilter_C1,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_p, &AutopilotLaws_DWork.sf_LagFilter);
+    AutopilotLaws_U.in.time.dt, &rtb_Y_fh, &AutopilotLaws_DWork.sf_LagFilter);
   switch (static_cast<int32_T>(rtb_ManualSwitch)) {
    case 0:
     rtb_Saturation1 = rtb_GainTheta1;
@@ -682,16 +683,16 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 3:
-    rtb_Y_m4 = AutopilotLaws_P.Gain_Gain_n * AutopilotLaws_U.in.data.flight_guidance_xtk_nmi;
-    if (rtb_Y_m4 > AutopilotLaws_P.Saturation_UpperSat) {
-      rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat;
+    rtb_Y_fh = AutopilotLaws_P.Gain_Gain_n * AutopilotLaws_U.in.data.flight_guidance_xtk_nmi;
+    if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat) {
+      rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat;
     } else {
-      if (rtb_Y_m4 < AutopilotLaws_P.Saturation_LowerSat) {
-        rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat;
+      if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat) {
+        rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat;
       }
     }
 
-    rtb_Saturation1 = (AutopilotLaws_P.Gain2_Gain * AutopilotLaws_U.in.data.flight_guidance_tae_deg + rtb_Y_m4) *
+    rtb_Saturation1 = (AutopilotLaws_P.Gain2_Gain * AutopilotLaws_U.in.data.flight_guidance_tae_deg + rtb_Y_fh) *
       AutopilotLaws_P.Gain1_Gain_n * look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn,
       AutopilotLaws_P.ScheduledGain2_BreakpointsForDimension1_k, AutopilotLaws_P.ScheduledGain2_Table_g, 5U) +
       AutopilotLaws_U.in.data.flight_guidance_phi_deg;
@@ -702,7 +703,7 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 5:
-    rtb_Saturation1 = rtb_Y_p * look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft,
+    rtb_Saturation1 = rtb_Y_fh * look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft,
       AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_e, AutopilotLaws_P.ScheduledGain_Table_pf, 4U) *
       look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn, AutopilotLaws_P.ScheduledGain2_BreakpointsForDimension1_j,
                     AutopilotLaws_P.ScheduledGain2_Table_h, 5U);
@@ -732,18 +733,18 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.Delay_DSTATE_h = rtb_GainTheta1;
   }
 
-  rtb_Y_m4 = rtb_Saturation1 - AutopilotLaws_DWork.Delay_DSTATE_h;
-  rtb_AP_b = AutopilotLaws_P.Constant2_Value_h * AutopilotLaws_U.in.time.dt;
-  if (rtb_Y_m4 < rtb_AP_b) {
-    rtb_AP_b = rtb_Y_m4;
+  rtb_Y_fh = rtb_Saturation1 - AutopilotLaws_DWork.Delay_DSTATE_h;
+  u1 = AutopilotLaws_P.Constant2_Value_h * AutopilotLaws_U.in.time.dt;
+  if (rtb_Y_fh < u1) {
+    u1 = rtb_Y_fh;
   }
 
-  rtb_Divide_h = AutopilotLaws_P.Gain1_Gain_k * AutopilotLaws_P.Constant2_Value_h * AutopilotLaws_U.in.time.dt;
-  if (rtb_AP_b > rtb_Divide_h) {
-    rtb_Divide_h = rtb_AP_b;
+  rtb_Y_p = AutopilotLaws_P.Gain1_Gain_k * AutopilotLaws_P.Constant2_Value_h * AutopilotLaws_U.in.time.dt;
+  if (u1 > rtb_Y_p) {
+    rtb_Y_p = u1;
   }
 
-  AutopilotLaws_DWork.Delay_DSTATE_h += rtb_Divide_h;
+  AutopilotLaws_DWork.Delay_DSTATE_h += rtb_Y_p;
   AutopilotLaws_LagFilter(AutopilotLaws_DWork.Delay_DSTATE_h, AutopilotLaws_P.LagFilter_C1_l, AutopilotLaws_U.in.time.dt,
     &rtb_Divide_h, &AutopilotLaws_DWork.sf_LagFilter_d);
   AutopilotLaws_RateLimiter(static_cast<real_T>(rtb_OR), AutopilotLaws_P.RateLimiterVariableTs_up,
@@ -762,12 +763,12 @@ void AutopilotLawsModelClass::step()
   rtb_Gain_ny *= rtb_GainTheta1;
   AutopilotLaws_Y.out.output.autopilot.Phi_c_deg = rtb_Divide_h + rtb_Gain_ny;
   if (AutopilotLaws_U.in.data.H_radio_ft <= AutopilotLaws_P.CompareToConstant_const_d) {
-    rtb_Y_m4 = AutopilotLaws_P.Gain_Gain_a * rtb_out_c;
+    rtb_Y_fh = AutopilotLaws_P.Gain_Gain_a * rtb_out_c;
   } else {
-    rtb_Y_m4 = AutopilotLaws_P.Constant1_Value;
+    rtb_Y_fh = AutopilotLaws_P.Constant1_Value;
   }
 
-  AutopilotLaws_LagFilter(rtb_Y_m4, AutopilotLaws_P.LagFilter1_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_p,
+  AutopilotLaws_LagFilter(rtb_Y_fh, AutopilotLaws_P.LagFilter1_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_p,
     &AutopilotLaws_DWork.sf_LagFilter_j);
   switch (static_cast<int32_T>(rtb_ManualSwitch)) {
    case 0:
@@ -839,45 +840,45 @@ void AutopilotLawsModelClass::step()
   }
 
   rtb_Saturation1 -= AutopilotLaws_U.in.data.H_dot_ft_min;
-  rtb_Y_m4 = AutopilotLaws_P.kntoms_Gain * AutopilotLaws_U.in.data.V_tas_kn;
-  if (rtb_Y_m4 > AutopilotLaws_P.Saturation_UpperSat_n3) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_n3;
+  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain * AutopilotLaws_U.in.data.V_tas_kn;
+  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_n3) {
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_n3;
   } else {
-    if (rtb_Y_m4 < AutopilotLaws_P.Saturation_LowerSat_m) {
-      rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_m;
+    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_m) {
+      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_m;
     }
   }
 
-  rtb_Y_m4 = AutopilotLaws_P.ftmintoms_Gain * rtb_Saturation1 / rtb_Y_m4;
-  if (rtb_Y_m4 > 1.0) {
-    rtb_Y_m4 = 1.0;
+  rtb_Y_fh = AutopilotLaws_P.ftmintoms_Gain * rtb_Saturation1 / rtb_Y_fh;
+  if (rtb_Y_fh > 1.0) {
+    rtb_Y_fh = 1.0;
   } else {
-    if (rtb_Y_m4 < -1.0) {
-      rtb_Y_m4 = -1.0;
+    if (rtb_Y_fh < -1.0) {
+      rtb_Y_fh = -1.0;
     }
   }
 
-  rtb_ManualSwitch = AutopilotLaws_P.Gain_Gain_kr * std::asin(rtb_Y_m4);
-  rtb_Y_m4 = AutopilotLaws_P.kntoms_Gain_a * AutopilotLaws_U.in.data.V_tas_kn;
-  if (rtb_Y_m4 > AutopilotLaws_P.Saturation_UpperSat_d) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_d;
+  rtb_ManualSwitch = AutopilotLaws_P.Gain_Gain_kr * std::asin(rtb_Y_fh);
+  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain_a * AutopilotLaws_U.in.data.V_tas_kn;
+  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_d) {
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_d;
   } else {
-    if (rtb_Y_m4 < AutopilotLaws_P.Saturation_LowerSat_b) {
-      rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_b;
+    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_b) {
+      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_b;
     }
   }
 
-  rtb_Y_m4 = (AutopilotLaws_U.in.input.H_dot_c_fpm - AutopilotLaws_U.in.data.H_dot_ft_min) *
-    AutopilotLaws_P.ftmintoms_Gain_h / rtb_Y_m4;
-  if (rtb_Y_m4 > 1.0) {
-    rtb_Y_m4 = 1.0;
+  rtb_Y_fh = (AutopilotLaws_U.in.input.H_dot_c_fpm - AutopilotLaws_U.in.data.H_dot_ft_min) *
+    AutopilotLaws_P.ftmintoms_Gain_h / rtb_Y_fh;
+  if (rtb_Y_fh > 1.0) {
+    rtb_Y_fh = 1.0;
   } else {
-    if (rtb_Y_m4 < -1.0) {
-      rtb_Y_m4 = -1.0;
+    if (rtb_Y_fh < -1.0) {
+      rtb_Y_fh = -1.0;
     }
   }
 
-  rtb_Divide_h = AutopilotLaws_P.Gain_Gain_df * std::asin(rtb_Y_m4);
+  rtb_Divide_h = AutopilotLaws_P.Gain_Gain_df * std::asin(rtb_Y_fh);
   rtb_Saturation1 = AutopilotLaws_P.Gain1_Gain_fu * AutopilotLaws_U.in.data.alpha_deg;
   rtb_Gain_ny = result_0[2] * std::sin(rtb_Saturation1);
   rtb_Saturation1 = std::cos(rtb_Saturation1);
@@ -894,77 +895,77 @@ void AutopilotLawsModelClass::step()
     }
   }
 
-  rtb_Y_p = AutopilotLaws_P.Gain_Gain_o * rtb_Mod2_k + rtb_Saturation1;
+  rtb_Sum2_j4 = AutopilotLaws_P.Gain_Gain_o * rtb_Mod2_k + rtb_Saturation1;
   rtb_Saturation1 = AutopilotLaws_P.Gain1_Gain_nv * AutopilotLaws_U.in.data.alpha_deg;
   rtb_Gain_ny = result_0[2] * std::sin(rtb_Saturation1);
   rtb_Saturation1 = std::cos(rtb_Saturation1);
   rtb_Saturation1 *= result_0[0];
   rtb_Mod2_f = AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.data.VMAX_kn;
-  rtb_Y_m4 = rtb_Mod2_f * AutopilotLaws_P.Gain1_Gain_ji;
-  if (rtb_Y_m4 > AutopilotLaws_P.Saturation_UpperSat_jm) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_jm;
+  rtb_Y_fh = rtb_Mod2_f * AutopilotLaws_P.Gain1_Gain_ji;
+  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_jm) {
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_jm;
   } else {
-    if (rtb_Y_m4 < AutopilotLaws_P.Saturation_LowerSat_on) {
-      rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_on;
+    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_on) {
+      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_on;
     }
   }
 
   rtb_Saturation1 = (rtb_Gain_ny + rtb_Saturation1) * AutopilotLaws_P.Gain_Gain_e1 * AutopilotLaws_P.Gain_Gain_eq +
-    rtb_Y_m4;
+    rtb_Y_fh;
   AutopilotLaws_SpeedProtectionMode(&AutopilotLaws_Y.out, rtb_Divide_h, AutopilotLaws_P.VS_Gain_h * rtb_Divide_h,
-    rtb_Y_p, AutopilotLaws_P.Gain_Gain_of * rtb_Y_p, rtb_Saturation1, AutopilotLaws_P.Gain_Gain_mw * rtb_Saturation1,
-    &rtb_Mod2_k, &rtb_out_c);
-  rtb_Y_m4 = AutopilotLaws_P.kntoms_Gain_p * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Y_m4 > AutopilotLaws_P.Saturation_UpperSat_k) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_k;
+    rtb_Sum2_j4, AutopilotLaws_P.Gain_Gain_of * rtb_Sum2_j4, rtb_Saturation1, AutopilotLaws_P.Gain_Gain_mw *
+    rtb_Saturation1, &rtb_Mod2_k, &rtb_out_c);
+  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain_p * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_k) {
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_k;
   } else {
-    if (rtb_Y_m4 < AutopilotLaws_P.Saturation_LowerSat_l) {
-      rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_l;
+    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_l) {
+      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_l;
     }
   }
 
   rtb_Divide_h = AutopilotLaws_U.in.input.FPA_c_deg - std::atan(AutopilotLaws_P.fpmtoms_Gain *
-    AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Y_m4) * AutopilotLaws_P.Gain_Gain_l;
+    AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Y_fh) * AutopilotLaws_P.Gain_Gain_l;
   rtb_Saturation1 = AutopilotLaws_P.Gain1_Gain_b2 * AutopilotLaws_U.in.data.alpha_deg;
   rtb_Gain_ny = result_0[2] * std::sin(rtb_Saturation1);
   rtb_Saturation1 = std::cos(rtb_Saturation1);
   rtb_Saturation1 *= result_0[0];
   AutopilotLaws_V_LSSpeedSelection(&AutopilotLaws_Y.out, &rtb_Y_ic);
-  rtb_Y_m4 = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_ic) * AutopilotLaws_P.Gain1_Gain_fq;
-  if (rtb_Y_m4 > AutopilotLaws_P.Saturation_UpperSat_h) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_h;
+  rtb_Y_fh = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_ic) * AutopilotLaws_P.Gain1_Gain_fq;
+  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_h) {
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_h;
   } else {
-    if (rtb_Y_m4 < AutopilotLaws_P.Saturation_LowerSat_a) {
-      rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_a;
+    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_a) {
+      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_a;
     }
   }
 
-  rtb_Y_p = (rtb_Gain_ny + rtb_Saturation1) * AutopilotLaws_P.Gain_Gain_p2 * AutopilotLaws_P.Gain_Gain_n1 + rtb_Y_m4;
+  rtb_Y_p = (rtb_Gain_ny + rtb_Saturation1) * AutopilotLaws_P.Gain_Gain_p2 * AutopilotLaws_P.Gain_Gain_n1 + rtb_Y_fh;
   rtb_Saturation1 = AutopilotLaws_P.Gain1_Gain_ib * AutopilotLaws_U.in.data.alpha_deg;
   rtb_Gain_ny = result_0[2] * std::sin(rtb_Saturation1);
   rtb_Saturation1 = std::cos(rtb_Saturation1);
   rtb_Saturation1 *= result_0[0];
-  rtb_Y_m4 = rtb_Mod2_f * AutopilotLaws_P.Gain1_Gain_gs;
-  if (rtb_Y_m4 > AutopilotLaws_P.Saturation_UpperSat_l) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_l;
+  rtb_Y_fh = rtb_Mod2_f * AutopilotLaws_P.Gain1_Gain_gs;
+  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_l) {
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_l;
   } else {
-    if (rtb_Y_m4 < AutopilotLaws_P.Saturation_LowerSat_i) {
-      rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_i;
+    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_i) {
+      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_i;
     }
   }
 
   rtb_Saturation1 = (rtb_Gain_ny + rtb_Saturation1) * AutopilotLaws_P.Gain_Gain_he * AutopilotLaws_P.Gain_Gain_p4 +
-    rtb_Y_m4;
+    rtb_Y_fh;
   AutopilotLaws_SpeedProtectionMode(&AutopilotLaws_Y.out, rtb_Divide_h, AutopilotLaws_P.Gain_Gain_c * rtb_Divide_h,
     rtb_Y_p, AutopilotLaws_P.Gain_Gain_i * rtb_Y_p, rtb_Saturation1, AutopilotLaws_P.Gain_Gain_e5 * rtb_Saturation1,
-    &rtb_Mod2_f, &rtb_AP_b);
+    &rtb_Mod2_f, &rtb_Sum2_j4);
   AutopilotLaws_WashoutFilter(result_0[2], AutopilotLaws_P.WashoutFilter_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_ic,
     &AutopilotLaws_DWork.sf_WashoutFilter_c);
   AutopilotLaws_LagFilter(AutopilotLaws_U.in.data.nav_gs_error_deg, AutopilotLaws_P.LagFilter1_C1_a,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_p, &AutopilotLaws_DWork.sf_LagFilter_h);
-  rtb_Divide_h = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain_l * rtb_Y_p;
-  AutopilotLaws_LagFilter(rtb_Y_p + AutopilotLaws_P.Gain3_Gain_o * ((rtb_Divide_h - AutopilotLaws_DWork.Delay_DSTATE_g) /
-    AutopilotLaws_U.in.time.dt), AutopilotLaws_P.LagFilter_C1_n, AutopilotLaws_U.in.time.dt, &rtb_Saturation1,
+    AutopilotLaws_U.in.time.dt, &rtb_Y_fh, &AutopilotLaws_DWork.sf_LagFilter_h);
+  rtb_Divide_h = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain_l * rtb_Y_fh;
+  AutopilotLaws_LagFilter(rtb_Y_fh + AutopilotLaws_P.Gain3_Gain_o * ((rtb_Divide_h - AutopilotLaws_DWork.Delay_DSTATE_g)
+    / AutopilotLaws_U.in.time.dt), AutopilotLaws_P.LagFilter_C1_n, AutopilotLaws_U.in.time.dt, &rtb_Saturation1,
     &AutopilotLaws_DWork.sf_LagFilter_d2);
   AutopilotLaws_storevalue(rtb_GainTheta1 == AutopilotLaws_P.CompareToConstant6_const,
     AutopilotLaws_Y.out.data.nav_gs_deg, &rtb_Y_p, &AutopilotLaws_DWork.sf_storevalue_m);
@@ -976,30 +977,30 @@ void AutopilotLawsModelClass::step()
     }
   }
 
-  rtb_Y_m4 = AutopilotLaws_P.kntoms_Gain_i * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Y_m4 > AutopilotLaws_P.Saturation_UpperSat_g) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_g;
+  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain_i * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_g) {
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_g;
   } else {
-    if (rtb_Y_m4 < AutopilotLaws_P.Saturation_LowerSat_c) {
-      rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_c;
+    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_c) {
+      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_c;
     }
   }
 
-  rtb_Gain_ny = std::atan(AutopilotLaws_P.fpmtoms_Gain_e * AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Y_m4) *
+  rtb_Gain_ny = std::atan(AutopilotLaws_P.fpmtoms_Gain_e * AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Y_fh) *
     AutopilotLaws_P.Gain_Gain_nu;
   if ((AutopilotLaws_U.in.data.H_radio_ft > AutopilotLaws_P.CompareToConstant_const_n) &&
       AutopilotLaws_U.in.data.nav_gs_valid) {
-    rtb_Y_m4 = AutopilotLaws_P.Gain_Gain_h * rtb_Y_ic + rtb_Saturation1 * look1_binlxpw
+    rtb_Y_fh = AutopilotLaws_P.Gain_Gain_h * rtb_Y_ic + rtb_Saturation1 * look1_binlxpw
       (AutopilotLaws_U.in.data.H_radio_ft, AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_h,
        AutopilotLaws_P.ScheduledGain_Table_ir, 5U);
   } else {
-    rtb_Y_m4 = (rtb_Y_p - rtb_Gain_ny) * AutopilotLaws_P.Gain2_Gain_j;
+    rtb_Y_fh = (rtb_Y_p - rtb_Gain_ny) * AutopilotLaws_P.Gain2_Gain_j;
   }
 
-  AutopilotLaws_Voter1(rtb_Y_m4, AutopilotLaws_P.Gain1_Gain_nq * ((rtb_Y_p + AutopilotLaws_P.Bias_Bias) - rtb_Gain_ny),
+  AutopilotLaws_Voter1(rtb_Y_fh, AutopilotLaws_P.Gain1_Gain_nq * ((rtb_Y_p + AutopilotLaws_P.Bias_Bias) - rtb_Gain_ny),
                        AutopilotLaws_P.Gain_Gain_p2b * ((rtb_Y_p + AutopilotLaws_P.Bias1_Bias) - rtb_Gain_ny), &rtb_Y_ic);
   rtb_Sum_ib_tmp = AutopilotLaws_U.in.input.H_c_ft - AutopilotLaws_U.in.data.H_ind_ft;
-  rtb_Y_m4 = AutopilotLaws_P.kntoms_Gain_e * AutopilotLaws_U.in.data.V_tas_kn;
+  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain_e * AutopilotLaws_U.in.data.V_tas_kn;
   if (rtb_Sum_ib_tmp < 0.0) {
     rtb_Saturation1 = -1.0;
   } else if (rtb_Sum_ib_tmp > 0.0) {
@@ -1008,61 +1009,92 @@ void AutopilotLawsModelClass::step()
     rtb_Saturation1 = rtb_Sum_ib_tmp;
   }
 
-  if (rtb_Y_m4 > AutopilotLaws_P.Saturation_UpperSat_dn) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_dn;
+  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_dn) {
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_dn;
   } else {
-    if (rtb_Y_m4 < AutopilotLaws_P.Saturation_LowerSat_bx) {
-      rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_bx;
+    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_bx) {
+      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_bx;
     }
   }
 
-  rtb_Y_m4 = ((AutopilotLaws_P.Constant_Value_b * rtb_Saturation1 + rtb_Sum_ib_tmp) * AutopilotLaws_P.Gain_Gain_el -
-              AutopilotLaws_U.in.data.H_dot_ft_min) * AutopilotLaws_P.ftmintoms_Gain_g / rtb_Y_m4;
-  if (rtb_Y_m4 > 1.0) {
-    rtb_Y_m4 = 1.0;
+  rtb_Y_fh = ((AutopilotLaws_P.Constant_Value_b * rtb_Saturation1 + rtb_Sum_ib_tmp) * AutopilotLaws_P.Gain_Gain_el -
+              AutopilotLaws_U.in.data.H_dot_ft_min) * AutopilotLaws_P.ftmintoms_Gain_g / rtb_Y_fh;
+  if (rtb_Y_fh > 1.0) {
+    rtb_Y_fh = 1.0;
   } else {
-    if (rtb_Y_m4 < -1.0) {
-      rtb_Y_m4 = -1.0;
+    if (rtb_Y_fh < -1.0) {
+      rtb_Y_fh = -1.0;
     }
   }
 
-  rtb_Gain_hl = AutopilotLaws_P.Gain_Gain_da * std::asin(rtb_Y_m4);
+  rtb_Gain_hl = AutopilotLaws_P.Gain_Gain_da * std::asin(rtb_Y_fh);
   rtb_Saturation1 = AutopilotLaws_P.Gain1_Gain_kw * AutopilotLaws_U.in.data.alpha_deg;
   rtb_Gain_ny = result_0[2] * std::sin(rtb_Saturation1);
   rtb_Saturation1 = std::cos(rtb_Saturation1);
   rtb_Saturation1 *= result_0[0];
   AutopilotLaws_Voter1(AutopilotLaws_U.in.data.VLS_kn, AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VMAX_kn,
-                       &rtb_Y_p);
-  rtb_Y_m4 = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_p) * AutopilotLaws_P.Gain1_Gain_hn;
-  if (rtb_Y_m4 > AutopilotLaws_P.Saturation_UpperSat_j4) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_j4;
+                       &rtb_Y_fh);
+  rtb_Sum_gh = AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_fh;
+  if (!AutopilotLaws_DWork.eventTime_not_empty) {
+    AutopilotLaws_DWork.eventTime = AutopilotLaws_U.in.time.simulation_time;
+    AutopilotLaws_DWork.eventTime_not_empty = true;
+  }
+
+  u1 = std::abs(rtb_Sum_gh);
+  if ((rtb_GainTheta1 != AutopilotLaws_P.CompareToConstant2_const_e) || (u1 > 5.0) || (AutopilotLaws_DWork.eventTime ==
+       0.0)) {
+    AutopilotLaws_DWork.eventTime = AutopilotLaws_U.in.time.simulation_time;
+  }
+
+  if (10.0 < u1) {
+    u1 = 10.0;
+  }
+
+  rtb_Y_p = (AutopilotLaws_U.in.time.simulation_time - AutopilotLaws_DWork.eventTime) - 5.0;
+  if (0.0 > rtb_Y_p) {
+    rtb_Y_p = 0.0;
+  }
+
+  rtb_Y_fh = AutopilotLaws_P.Gain1_Gain_hn * rtb_Sum_gh;
+  if (1.0 > u1) {
+    u1 = 1.0;
+  }
+
+  if (AutopilotLaws_P.GammaTCorrection_time < rtb_Y_p) {
+    rtb_Y_p = AutopilotLaws_P.GammaTCorrection_time;
+  }
+
+  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_j4) {
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_j4;
   } else {
-    if (rtb_Y_m4 < AutopilotLaws_P.Saturation_LowerSat_bb) {
-      rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_bb;
+    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_bb) {
+      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_bb;
     }
   }
 
-  rtb_Sum2_d = (rtb_Gain_ny + rtb_Saturation1) * AutopilotLaws_P.Gain_Gain_bi * AutopilotLaws_P.Gain_Gain_ei + rtb_Y_m4;
-  rtb_Y_m4 = AutopilotLaws_P.kntoms_Gain_iw * AutopilotLaws_U.in.data.V_tas_kn;
-  if (rtb_Y_m4 > AutopilotLaws_P.Saturation_UpperSat_kg) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_kg;
+  rtb_Sum2_h = ((1.0 - (u1 - 1.0) * 0.1111111111111111) * AutopilotLaws_P.GammaTCorrection_gain * (1.0 /
+    AutopilotLaws_P.GammaTCorrection_time * rtb_Y_p) * rtb_Sum_gh + (rtb_Gain_ny + rtb_Saturation1) *
+                AutopilotLaws_P.Gain_Gain_bi * AutopilotLaws_P.Gain_Gain_ei) + rtb_Y_fh;
+  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain_iw * AutopilotLaws_U.in.data.V_tas_kn;
+  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_kg) {
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_kg;
   } else {
-    if (rtb_Y_m4 < AutopilotLaws_P.Saturation_LowerSat_ce) {
-      rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_ce;
+    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_ce) {
+      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_ce;
     }
   }
 
-  rtb_Y_m4 = (AutopilotLaws_P.Constant_Value_k - AutopilotLaws_U.in.data.H_dot_ft_min) *
-    AutopilotLaws_P.ftmintoms_Gain_p / rtb_Y_m4;
-  if (rtb_Y_m4 > 1.0) {
-    rtb_Y_m4 = 1.0;
+  rtb_Y_fh = (AutopilotLaws_P.Constant_Value_k - AutopilotLaws_U.in.data.H_dot_ft_min) *
+    AutopilotLaws_P.ftmintoms_Gain_p / rtb_Y_fh;
+  if (rtb_Y_fh > 1.0) {
+    rtb_Y_fh = 1.0;
   } else {
-    if (rtb_Y_m4 < -1.0) {
-      rtb_Y_m4 = -1.0;
+    if (rtb_Y_fh < -1.0) {
+      rtb_Y_fh = -1.0;
     }
   }
 
-  rtb_Gain_gd = AutopilotLaws_P.Gain_Gain_md * std::asin(rtb_Y_m4);
+  rtb_Gain_gd = AutopilotLaws_P.Gain_Gain_md * std::asin(rtb_Y_fh);
   rtb_Saturation1 = rtb_GainTheta - AutopilotLaws_P.Constant2_Value_f;
   rtb_Gain4 = AutopilotLaws_P.Gain4_Gain * rtb_Saturation1;
   rtb_Gain5 = AutopilotLaws_P.Gain5_Gain_c * AutopilotLaws_U.in.data.bz_m_s2;
@@ -1071,22 +1103,22 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_WashoutFilter(AutopilotLaws_U.in.data.H_ind_ft, AutopilotLaws_P.WashoutFilter_C1_h,
     AutopilotLaws_U.in.time.dt, &rtb_Saturation1, &AutopilotLaws_DWork.sf_WashoutFilter);
   if (AutopilotLaws_U.in.data.H_radio_ft > AutopilotLaws_P.Saturation_UpperSat_e0) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_e0;
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_e0;
   } else if (AutopilotLaws_U.in.data.H_radio_ft < AutopilotLaws_P.Saturation_LowerSat_mg) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_mg;
+    rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_mg;
   } else {
-    rtb_Y_m4 = AutopilotLaws_U.in.data.H_radio_ft;
+    rtb_Y_fh = AutopilotLaws_U.in.data.H_radio_ft;
   }
 
-  AutopilotLaws_LagFilter(rtb_Y_m4, AutopilotLaws_P.LagFilter_C1_h, AutopilotLaws_U.in.time.dt, &rtb_Gain_ny,
+  AutopilotLaws_LagFilter(rtb_Y_fh, AutopilotLaws_P.LagFilter_C1_h, AutopilotLaws_U.in.time.dt, &rtb_Gain_ny,
     &AutopilotLaws_DWork.sf_LagFilter_g);
-  rtb_Gain_lf = (rtb_Saturation1 + rtb_Gain_ny) * AutopilotLaws_P.DiscreteDerivativeVariableTs2_Gain;
-  rtb_Saturation1 = (rtb_Gain_lf - AutopilotLaws_DWork.Delay_DSTATE_k) / AutopilotLaws_U.in.time.dt;
+  rtb_Sum_gh = (rtb_Saturation1 + rtb_Gain_ny) * AutopilotLaws_P.DiscreteDerivativeVariableTs2_Gain;
+  rtb_Saturation1 = (rtb_Sum_gh - AutopilotLaws_DWork.Delay_DSTATE_k) / AutopilotLaws_U.in.time.dt;
   AutopilotLaws_LagFilter(AutopilotLaws_P.Gain2_Gain_c * rtb_Saturation1, AutopilotLaws_P.LagFilter3_C1,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_m4, &AutopilotLaws_DWork.sf_LagFilter_e);
+    AutopilotLaws_U.in.time.dt, &rtb_Y_fh, &AutopilotLaws_DWork.sf_LagFilter_e);
   AutopilotLaws_WashoutFilter(AutopilotLaws_U.in.data.H_dot_ft_min, AutopilotLaws_P.WashoutFilter1_C1,
     AutopilotLaws_U.in.time.dt, &rtb_Saturation1, &AutopilotLaws_DWork.sf_WashoutFilter_h);
-  rtb_Saturation1 += rtb_Y_m4;
+  rtb_Saturation1 += rtb_Y_fh;
   rtb_OR = (rtb_GainTheta1 == AutopilotLaws_P.CompareToConstant7_const);
   if (!AutopilotLaws_DWork.wasActive_not_empty) {
     AutopilotLaws_DWork.wasActive = rtb_OR;
@@ -1094,9 +1126,9 @@ void AutopilotLawsModelClass::step()
   }
 
   if ((!AutopilotLaws_DWork.wasActive) && rtb_OR) {
-    rtb_Y_m4 = std::abs(rtb_Saturation1) / 60.0;
-    AutopilotLaws_DWork.Tau = AutopilotLaws_U.in.data.H_radio_ft / (rtb_Y_m4 - 1.6666666666666667);
-    AutopilotLaws_DWork.H_bias = AutopilotLaws_DWork.Tau * rtb_Y_m4 - AutopilotLaws_U.in.data.H_radio_ft;
+    rtb_Y_fh = std::abs(rtb_Saturation1) / 60.0;
+    AutopilotLaws_DWork.Tau = AutopilotLaws_U.in.data.H_radio_ft / (rtb_Y_fh - 1.6666666666666667);
+    AutopilotLaws_DWork.H_bias = AutopilotLaws_DWork.Tau * rtb_Y_fh - AutopilotLaws_U.in.data.H_radio_ft;
   }
 
   if (rtb_OR) {
@@ -1107,61 +1139,61 @@ void AutopilotLawsModelClass::step()
   }
 
   AutopilotLaws_DWork.wasActive = rtb_OR;
-  rtb_Y_m4 = AutopilotLaws_P.kntoms_Gain_av * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Y_m4 > AutopilotLaws_P.Saturation_UpperSat_m) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_m;
+  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain_av * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_m) {
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_m;
   } else {
-    if (rtb_Y_m4 < AutopilotLaws_P.Saturation_LowerSat_d1) {
-      rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_d1;
+    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_d1) {
+      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_d1;
     }
   }
 
-  rtb_Y_m4 = (rtb_Gain_ny - rtb_Saturation1) * AutopilotLaws_P.ftmintoms_Gain_i / rtb_Y_m4;
-  if (rtb_Y_m4 > 1.0) {
-    rtb_Y_m4 = 1.0;
+  rtb_Y_fh = (rtb_Gain_ny - rtb_Saturation1) * AutopilotLaws_P.ftmintoms_Gain_i / rtb_Y_fh;
+  if (rtb_Y_fh > 1.0) {
+    rtb_Y_fh = 1.0;
   } else {
-    if (rtb_Y_m4 < -1.0) {
-      rtb_Y_m4 = -1.0;
+    if (rtb_Y_fh < -1.0) {
+      rtb_Y_fh = -1.0;
     }
   }
 
-  rtb_Gain_ar = AutopilotLaws_P.Gain_Gain_fz * std::asin(rtb_Y_m4);
+  rtb_Gain_hz = AutopilotLaws_P.Gain_Gain_fz * std::asin(rtb_Y_fh);
   rtb_Sum_j = AutopilotLaws_P.Constant1_Value_d - rtb_GainTheta;
   rtb_Saturation1 = AutopilotLaws_P.Gain1_Gain_fy * AutopilotLaws_U.in.data.alpha_deg;
   rtb_Gain_ny = result_0[2] * std::sin(rtb_Saturation1);
   rtb_Saturation1 = std::cos(rtb_Saturation1);
   rtb_Saturation1 *= result_0[0];
-  rtb_Y_m4 = (AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.input.V_c_kn) * AutopilotLaws_P.Gain1_Gain_fr;
-  if (rtb_Y_m4 > AutopilotLaws_P.Saturation_UpperSat_e3) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_e3;
+  rtb_Y_fh = (AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.input.V_c_kn) * AutopilotLaws_P.Gain1_Gain_fr;
+  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_e3) {
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_e3;
   } else {
-    if (rtb_Y_m4 < AutopilotLaws_P.Saturation_LowerSat_py) {
-      rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_py;
+    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_py) {
+      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_py;
     }
   }
 
-  rtb_Sum2_j = (rtb_Gain_ny + rtb_Saturation1) * AutopilotLaws_P.Gain_Gain_nub * AutopilotLaws_P.Gain_Gain_ao + rtb_Y_m4;
-  rtb_Y_m4 = AutopilotLaws_P.kntoms_Gain_f * AutopilotLaws_U.in.data.V_tas_kn;
-  if (rtb_Y_m4 > AutopilotLaws_P.Saturation_UpperSat_b) {
-    rtb_Y_m4 = AutopilotLaws_P.Saturation_UpperSat_b;
+  rtb_Sum2_f = (rtb_Gain_ny + rtb_Saturation1) * AutopilotLaws_P.Gain_Gain_nub * AutopilotLaws_P.Gain_Gain_ao + rtb_Y_fh;
+  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain_f * AutopilotLaws_U.in.data.V_tas_kn;
+  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_b) {
+    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_b;
   } else {
-    if (rtb_Y_m4 < AutopilotLaws_P.Saturation_LowerSat_ow) {
-      rtb_Y_m4 = AutopilotLaws_P.Saturation_LowerSat_ow;
+    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_ow) {
+      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_ow;
     }
   }
 
-  rtb_Y_m4 = (AutopilotLaws_P.Constant_Value_i - AutopilotLaws_U.in.data.H_dot_ft_min) *
-    AutopilotLaws_P.ftmintoms_Gain_j / rtb_Y_m4;
-  if (rtb_Y_m4 > 1.0) {
-    rtb_Y_m4 = 1.0;
+  rtb_Y_fh = (AutopilotLaws_P.Constant_Value_i - AutopilotLaws_U.in.data.H_dot_ft_min) *
+    AutopilotLaws_P.ftmintoms_Gain_j / rtb_Y_fh;
+  if (rtb_Y_fh > 1.0) {
+    rtb_Y_fh = 1.0;
   } else {
-    if (rtb_Y_m4 < -1.0) {
-      rtb_Y_m4 = -1.0;
+    if (rtb_Y_fh < -1.0) {
+      rtb_Y_fh = -1.0;
     }
   }
 
-  rtb_Gain_et = AutopilotLaws_P.Gain_Gain_bd * std::asin(rtb_Y_m4);
-  AutopilotLaws_Voter1(rtb_Sum_j, AutopilotLaws_P.Gain_Gain_b2 * rtb_Sum2_j, AutopilotLaws_P.VS_Gain_c * rtb_Gain_et,
+  rtb_Gain_a3 = AutopilotLaws_P.Gain_Gain_bd * std::asin(rtb_Y_fh);
+  AutopilotLaws_Voter1(rtb_Sum_j, AutopilotLaws_P.Gain_Gain_b2 * rtb_Sum2_f, AutopilotLaws_P.VS_Gain_c * rtb_Gain_a3,
                        &rtb_Saturation1);
   switch (static_cast<int32_T>(rtb_GainTheta1)) {
    case 0:
@@ -1178,16 +1210,16 @@ void AutopilotLawsModelClass::step()
 
    case 3:
     if (rtb_Sum_ib_tmp > AutopilotLaws_P.Switch_Threshold_n) {
-      rtb_Y_m4 = AutopilotLaws_P.Gain_Gain_kg * rtb_Sum2_d;
+      rtb_Y_fh = AutopilotLaws_P.Gain_Gain_kg * rtb_Sum2_h;
       rtb_Saturation1 = AutopilotLaws_P.VS_Gain_j * rtb_Gain_gd;
-      if (rtb_Y_m4 > rtb_Saturation1) {
-        rtb_Saturation1 = rtb_Y_m4;
+      if (rtb_Y_fh > rtb_Saturation1) {
+        rtb_Saturation1 = rtb_Y_fh;
       }
     } else {
-      rtb_Y_m4 = AutopilotLaws_P.Gain_Gain_kg * rtb_Sum2_d;
+      rtb_Y_fh = AutopilotLaws_P.Gain_Gain_kg * rtb_Sum2_h;
       rtb_Saturation1 = AutopilotLaws_P.VS_Gain_j * rtb_Gain_gd;
-      if (rtb_Y_m4 < rtb_Saturation1) {
-        rtb_Saturation1 = rtb_Y_m4;
+      if (rtb_Y_fh < rtb_Saturation1) {
+        rtb_Saturation1 = rtb_Y_fh;
       }
     }
     break;
@@ -1197,7 +1229,7 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 5:
-    rtb_Saturation1 = rtb_AP_b;
+    rtb_Saturation1 = rtb_Sum2_j4;
     break;
 
    case 6:
@@ -1208,7 +1240,7 @@ void AutopilotLawsModelClass::step()
     if (rtb_on_ground > AutopilotLaws_P.Switch_Threshold_c) {
       rtb_Saturation1 = rtb_Gain4;
     } else {
-      rtb_Saturation1 = (AutopilotLaws_P.Gain3_Gain * rtb_Y_p + rtb_Gain5) + AutopilotLaws_P.VS_Gain_e * rtb_Gain_ar;
+      rtb_Saturation1 = (AutopilotLaws_P.Gain3_Gain * rtb_Y_p + rtb_Gain5) + AutopilotLaws_P.VS_Gain_e * rtb_Gain_hz;
     }
     break;
   }
@@ -1232,17 +1264,17 @@ void AutopilotLawsModelClass::step()
   }
 
   rtb_Saturation1 -= AutopilotLaws_DWork.Delay_DSTATE_h2;
-  rtb_AP_b = AutopilotLaws_P.Constant2_Value_h1 * AutopilotLaws_U.in.time.dt;
-  if (rtb_Saturation1 >= rtb_AP_b) {
-    rtb_Saturation1 = rtb_AP_b;
+  u1 = AutopilotLaws_P.Constant2_Value_h1 * AutopilotLaws_U.in.time.dt;
+  if (rtb_Saturation1 >= u1) {
+    rtb_Saturation1 = u1;
   }
 
-  rtb_AP_b = AutopilotLaws_P.Gain1_Gain_i0 * AutopilotLaws_P.Constant2_Value_h1 * AutopilotLaws_U.in.time.dt;
-  if (rtb_Saturation1 > rtb_AP_b) {
-    rtb_AP_b = rtb_Saturation1;
+  u1 = AutopilotLaws_P.Gain1_Gain_i0 * AutopilotLaws_P.Constant2_Value_h1 * AutopilotLaws_U.in.time.dt;
+  if (rtb_Saturation1 > u1) {
+    u1 = rtb_Saturation1;
   }
 
-  AutopilotLaws_DWork.Delay_DSTATE_h2 += rtb_AP_b;
+  AutopilotLaws_DWork.Delay_DSTATE_h2 += u1;
   AutopilotLaws_LagFilter(AutopilotLaws_DWork.Delay_DSTATE_h2, AutopilotLaws_P.LagFilter_C1_i,
     AutopilotLaws_U.in.time.dt, &rtb_out_c, &AutopilotLaws_DWork.sf_LagFilter_n);
   AutopilotLaws_RateLimiter(AutopilotLaws_Y.out.output.ap_on, AutopilotLaws_P.RateLimiterVariableTs_up_i,
@@ -1260,7 +1292,7 @@ void AutopilotLawsModelClass::step()
   rtb_Saturation1 = AutopilotLaws_P.Constant_Value_f - rtb_Saturation1;
   rtb_Saturation1 *= rtb_GainTheta;
   AutopilotLaws_Y.out.output.autopilot.Theta_c_deg = rtb_out_c + rtb_Saturation1;
-  AutopilotLaws_Voter1(rtb_Sum_j, rtb_Sum2_j, rtb_Gain_et, &rtb_Gain_ny);
+  AutopilotLaws_Voter1(rtb_Sum_j, rtb_Sum2_f, rtb_Gain_a3, &rtb_Gain_ny);
   switch (static_cast<int32_T>(rtb_GainTheta1)) {
    case 0:
     rtb_Gain_ny = rtb_GainTheta;
@@ -1276,13 +1308,13 @@ void AutopilotLawsModelClass::step()
 
    case 3:
     if (rtb_Sum_ib_tmp > AutopilotLaws_P.Switch_Threshold) {
-      if (rtb_Sum2_d > rtb_Gain_gd) {
-        rtb_Gain_ny = rtb_Sum2_d;
+      if (rtb_Sum2_h > rtb_Gain_gd) {
+        rtb_Gain_ny = rtb_Sum2_h;
       } else {
         rtb_Gain_ny = rtb_Gain_gd;
       }
-    } else if (rtb_Sum2_d < rtb_Gain_gd) {
-      rtb_Gain_ny = rtb_Sum2_d;
+    } else if (rtb_Sum2_h < rtb_Gain_gd) {
+      rtb_Gain_ny = rtb_Sum2_h;
     } else {
       rtb_Gain_ny = rtb_Gain_gd;
     }
@@ -1304,7 +1336,7 @@ void AutopilotLawsModelClass::step()
     if (rtb_on_ground > AutopilotLaws_P.Switch1_Threshold) {
       rtb_Gain_ny = AutopilotLaws_P.Gain2_Gain_h * rtb_Gain4;
     } else {
-      rtb_Gain_ny = (AutopilotLaws_P.Gain1_Gain_i * rtb_Y_p + rtb_Gain5) + rtb_Gain_ar;
+      rtb_Gain_ny = (AutopilotLaws_P.Gain1_Gain_i * rtb_Y_p + rtb_Gain5) + rtb_Gain_hz;
     }
     break;
   }
@@ -1331,7 +1363,7 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_DWork.Delay_DSTATE_i = rtb_Saturation;
   AutopilotLaws_DWork.icLoad = 0U;
   AutopilotLaws_DWork.Delay_DSTATE_g = rtb_Divide_h;
-  AutopilotLaws_DWork.Delay_DSTATE_k = rtb_Gain_lf;
+  AutopilotLaws_DWork.Delay_DSTATE_k = rtb_Sum_gh;
   AutopilotLaws_DWork.icLoad_f = 0U;
 }
 

--- a/src/fbw/src/model/AutopilotLaws.h
+++ b/src/fbw/src/model/AutopilotLaws.h
@@ -51,6 +51,7 @@ class AutopilotLawsModelClass {
     real_T Delay_DSTATE_g;
     real_T Delay_DSTATE_k;
     real_T Delay_DSTATE_h2;
+    real_T eventTime;
     real_T Tau;
     real_T H_bias;
     real_T limit;
@@ -60,6 +61,7 @@ class AutopilotLawsModelClass {
     uint8_T icLoad_f;
     uint8_T is_active_c5_AutopilotLaws;
     uint8_T is_c5_AutopilotLaws;
+    boolean_T eventTime_not_empty;
     boolean_T wasActive;
     boolean_T wasActive_not_empty;
     boolean_T limit_not_empty;
@@ -159,9 +161,12 @@ class AutopilotLawsModelClass {
     real_T CompareToConstant5_const_e;
     real_T CompareToConstant_const_n;
     real_T CompareToConstant6_const;
+    real_T CompareToConstant2_const_e;
     real_T CompareToConstant7_const;
+    real_T GammaTCorrection_gain;
     real_T RateLimiterVariableTs_lo;
     real_T RateLimiterVariableTs_lo_o;
+    real_T GammaTCorrection_time;
     real_T RateLimiterVariableTs_up;
     real_T RateLimiterVariableTs_up_i;
     boolean_T CompareToConstant_const_h;

--- a/src/fbw/src/model/AutopilotLaws_data.cpp
+++ b/src/fbw/src/model/AutopilotLaws_data.cpp
@@ -260,11 +260,17 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
 
   6.0,
 
+  3.0,
+
   7.0,
 
+  0.8,
+
   -10.0,
 
   -10.0,
+
+  15.0,
 
   1.0,
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
This PR improves the speed hold characteristic of OP CLB/DES and CLB/DES modes. Especially on (OP) CLB there was a small offset in speed hold. This should be solved now.

## Testing instructions
- fly normal flights and check if OP CLB/DES works properly
- fly also in turbulence and check if it's acceptable (also in comparison with previous version)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
