### PR TITLE
feat(elec): eng fire and gen buttons affect idg

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -72,6 +72,7 @@
 1. [AP] Fixed and improved mode transitions related to LAND modes - @aguther (Andreas Guther)
 1. [ENGINE] Adapt engine IDLE N1 based on environmental conditions - @Taz5150 (TazX [Z+2]#0405), @aguther (Andreas Guther)
 1. [ND] ND Waypoint Icon Size, Icon Outlines, Airplane Icon Color and Outline - @marcman86 (marcman86#4907)
+1. [ELEC] ENG FIRE push button deactivates IDG - @davidwalschots (David Walschots)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ name = "a320_systems"
 version = "0.1.0"
 dependencies = [
  "rand",
+ "rstest",
  "systems",
  "uom",
 ]
@@ -539,6 +540,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,9 +599,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
@@ -670,6 +680,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
+name = "rstest"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "041bb0202c14f6a158bbbf086afb03d0c6e975c2dec7d4912f8061ed44f290af"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,10 +705,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustplotlib"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4326f7ac67e4ff419282ad12dabf1fcad09481a849b72108c890e01414ebb88a"
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -719,9 +769,9 @@ checksum = "3685c82a045a6af0c488f0550b0f52b4c77d2a52b0ca8aba719f9d268fa96965"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -793,6 +843,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-width"

--- a/src/systems/a320_systems/Cargo.toml
+++ b/src/systems/a320_systems/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2018"
 uom = "0.30.0"
 rand = "0.8.0"
 systems = { path = "../systems" }
+
+[dev-dependencies]
+rstest = "0.10.0"

--- a/src/systems/a320_systems/src/electrical/alternating_current.rs
+++ b/src/systems/a320_systems/src/electrical/alternating_current.rs
@@ -374,10 +374,18 @@ impl A320MainPowerSources {
         emergency_overhead: &A320EmergencyElectricalOverheadPanel,
         arguments: &mut A320ElectricalUpdateArguments<'a, T, U, V>,
     ) {
-        self.engine_1_gen
-            .update(context, arguments.engine(1), overhead);
-        self.engine_2_gen
-            .update(context, arguments.engine(2), overhead);
+        self.engine_1_gen.update(
+            context,
+            arguments.engine(1),
+            overhead,
+            arguments.engine_fire_push_buttons(),
+        );
+        self.engine_2_gen.update(
+            context,
+            arguments.engine(2),
+            overhead,
+            arguments.engine_fire_push_buttons(),
+        );
 
         let gen_1_provides_power = overhead.generator_is_on(1)
             && emergency_overhead.generator_1_line_is_on()

--- a/src/systems/a320_systems/src/electrical/alternating_current.rs
+++ b/src/systems/a320_systems/src/electrical/alternating_current.rs
@@ -372,9 +372,11 @@ impl A320MainPowerSources {
 
         let gen_1_provides_power = overhead.generator_1_is_on()
             && emergency_overhead.generator_1_line_is_on()
+            && !arguments.engine_fire_push_button_is_released(1)
             && self.engine_1_gen.output_within_normal_parameters();
-        let gen_2_provides_power =
-            overhead.generator_2_is_on() && self.engine_2_gen.output_within_normal_parameters();
+        let gen_2_provides_power = overhead.generator_2_is_on()
+            && !arguments.engine_fire_push_button_is_released(2)
+            && self.engine_2_gen.output_within_normal_parameters();
         let only_one_engine_gen_is_powered = gen_1_provides_power ^ gen_2_provides_power;
         let both_engine_gens_provide_power = gen_1_provides_power && gen_2_provides_power;
         let ext_pwr_provides_power = overhead.external_power_is_on()

--- a/src/systems/a320_systems/src/electrical/alternating_current.rs
+++ b/src/systems/a320_systems/src/electrical/alternating_current.rs
@@ -1,6 +1,6 @@
 use super::{
-    A320AlternatingCurrentElectricalSystem, A320ElectricalOverheadPanel,
-    A320EmergencyElectricalOverheadPanel, DirectCurrentState,
+    A320AlternatingCurrentElectricalSystem, A320DirectCurrentElectricalSystem,
+    A320ElectricalOverheadPanel, A320EmergencyElectricalOverheadPanel,
 };
 use std::time::Duration;
 use systems::{
@@ -152,11 +152,11 @@ impl A320AlternatingCurrentElectrical {
         self.update_shedding(emergency_generator);
     }
 
-    pub fn update_after_direct_current<T: DirectCurrentState>(
+    pub fn update_after_direct_current(
         &mut self,
         context: &UpdateContext,
         emergency_generator: &EmergencyGenerator,
-        dc_state: &T,
+        dc_state: &impl A320DirectCurrentElectricalSystem,
     ) {
         self.ac_stat_inv_bus.powered_by(dc_state.static_inverter());
         self.static_inv_to_ac_ess_bus_contactor

--- a/src/systems/a320_systems/src/electrical/direct_current.rs
+++ b/src/systems/a320_systems/src/electrical/direct_current.rs
@@ -1,5 +1,6 @@
 use super::{
-    A320AlternatingCurrentElectricalSystem, A320ElectricalOverheadPanel, DirectCurrentState,
+    A320AlternatingCurrentElectricalSystem, A320DirectCurrentElectricalSystem,
+    A320ElectricalOverheadPanel,
 };
 #[cfg(test)]
 use systems::electrical::Potential;
@@ -310,7 +311,7 @@ impl A320DirectCurrentElectrical {
         state.add_bus(&self.dc_gnd_flt_service_bus);
     }
 }
-impl DirectCurrentState for A320DirectCurrentElectrical {
+impl A320DirectCurrentElectricalSystem for A320DirectCurrentElectrical {
     fn static_inverter(&self) -> &StaticInverter {
         &self.static_inverter
     }

--- a/src/systems/a320_systems/src/electrical/direct_current.rs
+++ b/src/systems/a320_systems/src/electrical/direct_current.rs
@@ -10,6 +10,7 @@ use systems::{
         Contactor, ElectricalBus, ElectricalBusType, PotentialSource, PotentialTarget,
         StaticInverter,
     },
+    shared::{AuxiliaryPowerUnitElectrical, EngineCorrectedN2, EngineFirePushButtons},
     simulation::{SimulationElement, SimulationElementVisitor, UpdateContext},
 };
 use uom::si::{f64::*, velocity::knot};
@@ -78,12 +79,18 @@ impl A320DirectCurrentElectrical {
         }
     }
 
-    pub fn update_with_alternating_current_state<'a, T: AlternatingCurrentState>(
+    pub fn update_with_alternating_current_state<
+        'a,
+        T: AlternatingCurrentState,
+        U: EngineCorrectedN2,
+        V: AuxiliaryPowerUnitElectrical,
+        W: EngineFirePushButtons,
+    >(
         &mut self,
         context: &UpdateContext,
         overhead: &A320ElectricalOverheadPanel,
         ac_state: &T,
-        arguments: &mut A320ElectricalUpdateArguments<'a>,
+        arguments: &mut A320ElectricalUpdateArguments<'a, U, V, W>,
     ) {
         self.tr_1_contactor.close_when(ac_state.tr_1().is_powered());
         self.tr_1_contactor.powered_by(ac_state.tr_1());

--- a/src/systems/a320_systems/src/electrical/galley.rs
+++ b/src/systems/a320_systems/src/electrical/galley.rs
@@ -1,8 +1,5 @@
-use super::{
-    alternating_current::A320AlternatingCurrentElectrical, A320ElectricalOverheadPanel,
-    AlternatingCurrentState,
-};
-use systems::simulation::UpdateContext;
+use super::{alternating_current::A320AlternatingCurrentElectrical, A320ElectricalOverheadPanel};
+use systems::{electrical::AlternatingCurrentElectricalSystem, simulation::UpdateContext};
 
 pub(super) struct MainGalley {
     is_shed: bool,
@@ -22,7 +19,7 @@ impl MainGalley {
         alternating_current: &A320AlternatingCurrentElectrical,
         overhead: &A320ElectricalOverheadPanel,
     ) {
-        self.is_shed = alternating_current.ac_bus_1_and_2_unpowered()
+        self.is_shed = !alternating_current.any_non_essential_bus_powered()
             || alternating_current.main_ac_buses_powered_by_single_engine_generator_only()
             || (alternating_current.main_ac_buses_powered_by_apu_generator_only()
                 && context.is_in_flight())
@@ -48,7 +45,7 @@ impl SecondaryGalley {
         alternating_current: &A320AlternatingCurrentElectrical,
         overhead: &A320ElectricalOverheadPanel,
     ) {
-        self.is_shed = alternating_current.ac_bus_1_and_2_unpowered()
+        self.is_shed = !alternating_current.any_non_essential_bus_powered()
             || overhead.commercial_is_off()
             || overhead.galy_and_cab_is_off();
     }

--- a/src/systems/a320_systems/src/electrical/mod.rs
+++ b/src/systems/a320_systems/src/electrical/mod.rs
@@ -95,6 +95,10 @@ impl<'a, T: EngineCorrectedN2, U: AuxiliaryPowerUnitElectrical, V: EngineFirePus
         self.engine_fire_push_buttons.is_released(engine_number)
     }
 
+    fn engine_fire_push_buttons(&self) -> &V {
+        self.engine_fire_push_buttons
+    }
+
     fn engine(&self, number: usize) -> &T {
         &self.engines[number - 1]
     }

--- a/src/systems/a320_systems/src/electrical/mod.rs
+++ b/src/systems/a320_systems/src/electrical/mod.rs
@@ -207,7 +207,7 @@ impl SimulationElement for A320Electrical {
     }
 }
 
-trait DirectCurrentState {
+trait A320DirectCurrentElectricalSystem {
     fn static_inverter(&self) -> &StaticInverter;
 }
 
@@ -2713,10 +2713,7 @@ mod a320_electrical_circuit_tests {
         /// As power sources can take some time before they become available
         /// by wrapping the functions that enable such a power sources we ensure it cannot
         /// trigger the deployment of the RAT or start of EMER GEN.
-        fn without_triggering_emergency_elec<T: FnMut(Self) -> Self>(
-            mut self,
-            mut func: T,
-        ) -> Self {
+        fn without_triggering_emergency_elec(mut self, mut func: impl FnMut(Self) -> Self) -> Self {
             let ias = self.simulation_test_bed.indicated_airspeed();
             self.simulation_test_bed
                 .set_indicated_airspeed(Velocity::new::<knot>(0.));

--- a/src/systems/a320_systems/src/hydraulic.rs
+++ b/src/systems/a320_systems/src/hydraulic.rs
@@ -4,10 +4,6 @@ use uom::si::{
     ratio::percent, velocity::knot, volume::gallon,
 };
 
-use systems::overhead::{AutoOffFaultPushButton, AutoOnFaultPushButton, OnOffFaultPushButton};
-use systems::simulation::{
-    SimulationElement, SimulationElementVisitor, SimulatorReader, SimulatorWriter, UpdateContext,
-};
 use systems::{
     hydraulic::{
         ElectricPump, EngineDrivenPump, Fluid, HydraulicLoop, HydraulicLoopController,
@@ -15,6 +11,17 @@ use systems::{
         RamAirTurbine, RamAirTurbineController,
     },
     shared::EngineFirePushButtons,
+};
+use systems::{
+    overhead::{AutoOffFaultPushButton, AutoOnFaultPushButton, OnOffFaultPushButton},
+    shared::RamAirTurbineHydraulicLoopPressurised,
+};
+use systems::{
+    shared::LandingGearPosition,
+    simulation::{
+        SimulationElement, SimulationElementVisitor, SimulatorReader, SimulatorWriter,
+        UpdateContext,
+    },
 };
 
 use systems::{engine::Engine, landing_gear::LandingGear};
@@ -273,7 +280,7 @@ impl A320Hydraulic {
             .nose_wheel_steering_pin_is_inserted()
     }
 
-    pub(super) fn is_blue_pressurised(&self) -> bool {
+    fn is_blue_pressurised(&self) -> bool {
         self.blue_loop.is_pressurised()
     }
 
@@ -463,6 +470,11 @@ impl A320Hydraulic {
 
         self.braking_circuit_norm.update(context, &self.green_loop);
         self.braking_circuit_altn.update(context, &self.yellow_loop);
+    }
+}
+impl RamAirTurbineHydraulicLoopPressurised for A320Hydraulic {
+    fn is_rat_hydraulic_loop_pressurised(&self) -> bool {
+        self.is_blue_pressurised()
     }
 }
 impl SimulationElement for A320Hydraulic {

--- a/src/systems/a320_systems/src/hydraulic.rs
+++ b/src/systems/a320_systems/src/hydraulic.rs
@@ -4,16 +4,17 @@ use uom::si::{
     ratio::percent, velocity::knot, volume::gallon,
 };
 
-use systems::hydraulic::{
-    ElectricPump, EngineDrivenPump, Fluid, HydraulicLoop, HydraulicLoopController,
-    PowerTransferUnit, PowerTransferUnitController, PressureSwitch, PumpController, RamAirTurbine,
-    RamAirTurbineController,
-};
-use systems::overhead::{
-    AutoOffFaultPushButton, AutoOnFaultPushButton, FirePushButton, OnOffFaultPushButton,
-};
+use systems::overhead::{AutoOffFaultPushButton, AutoOnFaultPushButton, OnOffFaultPushButton};
 use systems::simulation::{
     SimulationElement, SimulationElementVisitor, SimulatorReader, SimulatorWriter, UpdateContext,
+};
+use systems::{
+    hydraulic::{
+        ElectricPump, EngineDrivenPump, Fluid, HydraulicLoop, HydraulicLoopController,
+        PowerTransferUnit, PowerTransferUnitController, PressureSwitch, PumpController,
+        RamAirTurbine, RamAirTurbineController,
+    },
+    shared::EngineFirePushButtons,
 };
 
 use systems::{engine::Engine, landing_gear::LandingGear};
@@ -167,13 +168,13 @@ impl A320Hydraulic {
         }
     }
 
-    pub(super) fn update<T: Engine>(
+    pub(super) fn update<T: Engine, U: EngineFirePushButtons>(
         &mut self,
         context: &UpdateContext,
         engine1: &T,
         engine2: &T,
         overhead_panel: &A320HydraulicOverheadPanel,
-        engine_fire_overhead: &A320EngineFireOverheadPanel,
+        engine_fire_push_buttons: &U,
         landing_gear: &LandingGear,
     ) {
         let min_hyd_loop_timestep =
@@ -222,7 +223,7 @@ impl A320Hydraulic {
                     engine1,
                     engine2,
                     overhead_panel,
-                    engine_fire_overhead,
+                    engine_fire_push_buttons,
                     landing_gear,
                 );
             }
@@ -323,13 +324,13 @@ impl A320Hydraulic {
     fn update_blue_actuators_volume(&mut self) {}
 
     // All the core hydraulics updates that needs to be done at the slowest fixed step rate
-    fn update_fixed_step<T: Engine>(
+    fn update_fixed_step<T: Engine, U: EngineFirePushButtons>(
         &mut self,
         context: &UpdateContext,
         engine1: &T,
         engine2: &T,
         overhead_panel: &A320HydraulicOverheadPanel,
-        engine_fire_overhead: &A320EngineFireOverheadPanel,
+        engine_fire_push_buttons: &U,
         landing_gear: &LandingGear,
     ) {
         // Process brake logic (which circuit brakes) and send brake demands (how much)
@@ -365,7 +366,7 @@ impl A320Hydraulic {
             .update(self.green_loop.pressure());
         self.engine_driven_pump_1_controller.update(
             overhead_panel,
-            engine_fire_overhead,
+            engine_fire_push_buttons,
             engine1.corrected_n2(),
             engine1.oil_pressure(),
             self.engine_driven_pump_1_pressure_switch.is_pressurised(),
@@ -384,7 +385,7 @@ impl A320Hydraulic {
             .update(self.yellow_loop.pressure());
         self.engine_driven_pump_2_controller.update(
             overhead_panel,
-            engine_fire_overhead,
+            engine_fire_push_buttons,
             engine2.corrected_n2(),
             engine2.oil_pressure(),
             self.engine_driven_pump_2_pressure_switch.is_pressurised(),
@@ -430,7 +431,7 @@ impl A320Hydraulic {
         self.ram_air_turbine
             .update(context, &self.blue_loop, &self.ram_air_turbine_controller);
 
-        self.green_loop_controller.update(engine_fire_overhead);
+        self.green_loop_controller.update(engine_fire_push_buttons);
         self.green_loop.update(
             context,
             Vec::new(),
@@ -440,7 +441,7 @@ impl A320Hydraulic {
             &self.green_loop_controller,
         );
 
-        self.yellow_loop_controller.update(engine_fire_overhead);
+        self.yellow_loop_controller.update(engine_fire_push_buttons);
         self.yellow_loop.update(
             context,
             vec![&self.yellow_electric_pump],
@@ -450,7 +451,7 @@ impl A320Hydraulic {
             &self.yellow_loop_controller,
         );
 
-        self.blue_loop_controller.update(engine_fire_overhead);
+        self.blue_loop_controller.update(engine_fire_push_buttons);
         self.blue_loop.update(
             context,
             vec![&self.blue_electric_pump],
@@ -513,10 +514,9 @@ impl A320HydraulicLoopController {
         }
     }
 
-    fn update(&mut self, engine_fire_overhead: &A320EngineFireOverheadPanel) {
+    fn update<T: EngineFirePushButtons>(&mut self, engine_fire_push_buttons: &T) {
         if let Some(eng_number) = self.engine_number {
-            self.should_open_fire_shutoff_valve =
-                !engine_fire_overhead.fire_push_button_is_released(eng_number);
+            self.should_open_fire_shutoff_valve = !engine_fire_push_buttons.is_released(eng_number);
         }
     }
 }
@@ -572,20 +572,20 @@ impl A320EngineDrivenPumpController {
             self.is_pressure_low && (!is_engine_low_oil_pressure || !self.weight_on_wheels);
     }
 
-    fn update(
+    fn update<T: EngineFirePushButtons>(
         &mut self,
         overhead_panel: &A320HydraulicOverheadPanel,
-        engine_fire_overhead: &A320EngineFireOverheadPanel,
+        engine_fire_push_buttons: &T,
         engine_n2: Ratio,
         engine_oil_pressure: Pressure,
         pressure_switch_state: bool,
     ) {
         if overhead_panel.edp_push_button_is_auto(self.engine_number)
-            && !engine_fire_overhead.fire_push_button_is_released(self.engine_number)
+            && !engine_fire_push_buttons.is_released(self.engine_number)
         {
             self.should_pressurise = true;
         } else if overhead_panel.edp_push_button_is_off(self.engine_number)
-            || engine_fire_overhead.fire_push_button_is_released(self.engine_number)
+            || engine_fire_push_buttons.is_released(self.engine_number)
         {
             self.should_pressurise = false;
         }
@@ -1244,35 +1244,6 @@ impl SimulationElement for A320HydraulicOverheadPanel {
     }
 }
 
-pub(super) struct A320EngineFireOverheadPanel {
-    eng1_fire_pb: FirePushButton,
-    eng2_fire_pb: FirePushButton,
-}
-impl A320EngineFireOverheadPanel {
-    pub(super) fn new() -> Self {
-        Self {
-            eng1_fire_pb: FirePushButton::new("ENG1"),
-            eng2_fire_pb: FirePushButton::new("ENG2"),
-        }
-    }
-
-    fn fire_push_button_is_released(&self, engine_number: usize) -> bool {
-        match engine_number {
-            1 => self.eng1_fire_pb.is_released(),
-            2 => self.eng2_fire_pb.is_released(),
-            _ => panic!("The A320 only supports two engines."),
-        }
-    }
-}
-impl SimulationElement for A320EngineFireOverheadPanel {
-    fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
-        self.eng1_fire_pb.accept(visitor);
-        self.eng2_fire_pb.accept(visitor);
-
-        visitor.visit(self);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1280,7 +1251,7 @@ mod tests {
 
     mod a320_hydraulics {
         use super::*;
-        use systems::engine::leap_engine::LeapEngine;
+        use systems::engine::{leap_engine::LeapEngine, EngineFireOverheadPanel};
         use systems::simulation::{test::SimulationTestBed, Aircraft};
         use uom::si::{
             acceleration::foot_per_second_squared, length::foot, ratio::percent,
@@ -1292,7 +1263,7 @@ mod tests {
             engine_2: LeapEngine,
             hydraulics: A320Hydraulic,
             overhead: A320HydraulicOverheadPanel,
-            engine_fire_overhead: A320EngineFireOverheadPanel,
+            engine_fire_overhead: EngineFireOverheadPanel,
             landing_gear: LandingGear,
         }
         impl A320HydraulicsTestAircraft {
@@ -1302,7 +1273,7 @@ mod tests {
                     engine_2: LeapEngine::new(2),
                     hydraulics: A320Hydraulic::new(),
                     overhead: A320HydraulicOverheadPanel::new(),
-                    engine_fire_overhead: A320EngineFireOverheadPanel::new(),
+                    engine_fire_overhead: EngineFireOverheadPanel::new(),
                     landing_gear: LandingGear::new(),
                 }
             }
@@ -3539,7 +3510,7 @@ mod tests {
         #[test]
         fn controller_engine_driven_pump1_overhead_button_logic_with_eng_on() {
             let mut overhead_panel = A320HydraulicOverheadPanel::new();
-            let fire_overhead_panel = A320EngineFireOverheadPanel::new();
+            let fire_overhead_panel = EngineFireOverheadPanel::new();
             overhead_panel.edp1_push_button.push_auto();
 
             let mut edp1_controller = A320EngineDrivenPumpController::new(1);
@@ -3578,9 +3549,8 @@ mod tests {
         #[test]
         fn controller_engine_driven_pump1_fire_overhead_released_stops_pump() {
             let mut overhead_panel = A320HydraulicOverheadPanel::new();
-            let mut fire_overhead_panel = A320EngineFireOverheadPanel::new();
+            let mut fire_overhead_panel = EngineFireOverheadPanel::new();
             overhead_panel.edp1_push_button.push_auto();
-            fire_overhead_panel.eng1_fire_pb.set(false);
 
             let mut edp1_controller = A320EngineDrivenPumpController::new(1);
             edp1_controller.engine_master_on = true;
@@ -3594,7 +3564,10 @@ mod tests {
             );
             assert!(edp1_controller.should_pressurise());
 
-            fire_overhead_panel.eng1_fire_pb.set(true);
+            let mut test_bed = SimulationTestBed::new();
+            test_bed.write_bool("FIRE_BUTTON_ENG1", true);
+            test_bed.run(&mut fire_overhead_panel, |_, _| {});
+
             edp1_controller.update(
                 &overhead_panel,
                 &fire_overhead_panel,
@@ -3608,7 +3581,7 @@ mod tests {
         #[test]
         fn controller_engine_driven_pump2_overhead_button_logic_with_eng_on() {
             let mut overhead_panel = A320HydraulicOverheadPanel::new();
-            let fire_overhead_panel = A320EngineFireOverheadPanel::new();
+            let fire_overhead_panel = EngineFireOverheadPanel::new();
             overhead_panel.edp2_push_button.push_auto();
 
             let mut edp2_controller = A320EngineDrivenPumpController::new(2);
@@ -3647,9 +3620,8 @@ mod tests {
         #[test]
         fn controller_engine_driven_pump2_fire_overhead_released_stops_pump() {
             let mut overhead_panel = A320HydraulicOverheadPanel::new();
-            let mut fire_overhead_panel = A320EngineFireOverheadPanel::new();
+            let mut fire_overhead_panel = EngineFireOverheadPanel::new();
             overhead_panel.edp2_push_button.push_auto();
-            fire_overhead_panel.eng2_fire_pb.set(false);
 
             let mut edp2_controller = A320EngineDrivenPumpController::new(2);
             edp2_controller.engine_master_on = true;
@@ -3663,7 +3635,10 @@ mod tests {
             );
             assert!(edp2_controller.should_pressurise());
 
-            fire_overhead_panel.eng2_fire_pb.set(true);
+            let mut test_bed = SimulationTestBed::new();
+            test_bed.write_bool("FIRE_BUTTON_ENG2", true);
+            test_bed.run(&mut fire_overhead_panel, |_, _| {});
+
             edp2_controller.update(
                 &overhead_panel,
                 &fire_overhead_panel,

--- a/src/systems/a320_systems/src/lib.rs
+++ b/src/systems/a320_systems/src/lib.rs
@@ -7,8 +7,7 @@ mod power_consumption;
 use self::{fuel::A320Fuel, pneumatic::A320PneumaticOverheadPanel};
 
 use electrical::{
-    A320Electrical, A320ElectricalOverheadPanel, A320ElectricalUpdateArguments,
-    A320EmergencyElectricalOverheadPanel,
+    A320Electrical, A320ElectricalOverheadPanel, A320EmergencyElectricalOverheadPanel,
 };
 
 use hydraulic::{A320Hydraulic, A320HydraulicOverheadPanel};
@@ -91,15 +90,12 @@ impl Aircraft for A320 {
             &self.ext_pwr,
             &self.electrical_overhead,
             &self.emergency_electrical_overhead,
-            &mut A320ElectricalUpdateArguments::new(
-                [&self.engine_1, &self.engine_2],
-                &mut self.apu,
-                self.hydraulic.is_blue_pressurised(),
-                self.apu_overhead.master_is_on(),
-                self.apu_overhead.start_is_on(),
-                self.landing_gear.is_up_and_locked(),
-                &self.engine_fire_overhead,
-            ),
+            &mut self.apu,
+            &self.apu_overhead,
+            &self.engine_fire_overhead,
+            [&self.engine_1, &self.engine_2],
+            &self.hydraulic,
+            &self.landing_gear,
         );
 
         self.apu.update_after_electrical();

--- a/src/systems/a320_systems/src/lib.rs
+++ b/src/systems/a320_systems/src/lib.rs
@@ -102,6 +102,7 @@ impl Aircraft for A320 {
                 self.apu_overhead.master_is_on(),
                 self.apu_overhead.start_is_on(),
                 self.landing_gear.is_up_and_locked(),
+                &self.engine_fire_overhead,
             ),
         );
 

--- a/src/systems/a320_systems/src/lib.rs
+++ b/src/systems/a320_systems/src/lib.rs
@@ -20,7 +20,7 @@ use systems::{
         AuxiliaryPowerUnitFireOverheadPanel, AuxiliaryPowerUnitOverheadPanel,
     },
     electrical::{consumption::SuppliedPower, ElectricalSystem, ExternalPowerSource},
-    engine::{leap_engine::LeapEngine, Engine, EngineFireOverheadPanel},
+    engine::{leap_engine::LeapEngine, EngineFireOverheadPanel},
     landing_gear::LandingGear,
     simulation::{Aircraft, SimulationElement, SimulationElementVisitor, UpdateContext},
 };
@@ -92,11 +92,7 @@ impl Aircraft for A320 {
             &self.electrical_overhead,
             &self.emergency_electrical_overhead,
             &mut A320ElectricalUpdateArguments::new(
-                [self.engine_1.corrected_n2(), self.engine_2.corrected_n2()],
-                [
-                    self.electrical_overhead.idg_1_push_button_released(),
-                    self.electrical_overhead.idg_2_push_button_released(),
-                ],
+                [&self.engine_1, &self.engine_2],
                 &mut self.apu,
                 self.hydraulic.is_blue_pressurised(),
                 self.apu_overhead.master_is_on(),

--- a/src/systems/a320_systems/src/lib.rs
+++ b/src/systems/a320_systems/src/lib.rs
@@ -11,7 +11,7 @@ use electrical::{
     A320EmergencyElectricalOverheadPanel,
 };
 
-use hydraulic::{A320EngineFireOverheadPanel, A320Hydraulic, A320HydraulicOverheadPanel};
+use hydraulic::{A320Hydraulic, A320HydraulicOverheadPanel};
 
 use power_consumption::A320PowerConsumption;
 use systems::{
@@ -20,7 +20,7 @@ use systems::{
         AuxiliaryPowerUnitFireOverheadPanel, AuxiliaryPowerUnitOverheadPanel,
     },
     electrical::{consumption::SuppliedPower, ElectricalSystem, ExternalPowerSource},
-    engine::{leap_engine::LeapEngine, Engine},
+    engine::{leap_engine::LeapEngine, Engine, EngineFireOverheadPanel},
     landing_gear::LandingGear,
     simulation::{Aircraft, SimulationElement, SimulationElementVisitor, UpdateContext},
 };
@@ -35,7 +35,7 @@ pub struct A320 {
     fuel: A320Fuel,
     engine_1: LeapEngine,
     engine_2: LeapEngine,
-    engine_fire_overhead: A320EngineFireOverheadPanel,
+    engine_fire_overhead: EngineFireOverheadPanel,
     electrical: A320Electrical,
     power_consumption: A320PowerConsumption,
     ext_pwr: ExternalPowerSource,
@@ -55,7 +55,7 @@ impl A320 {
             fuel: A320Fuel::new(),
             engine_1: LeapEngine::new(1),
             engine_2: LeapEngine::new(2),
-            engine_fire_overhead: A320EngineFireOverheadPanel::new(),
+            engine_fire_overhead: EngineFireOverheadPanel::new(),
             electrical: A320Electrical::new(),
             power_consumption: A320PowerConsumption::new(),
             ext_pwr: ExternalPowerSource::new(),

--- a/src/systems/systems/src/apu/air_intake_flap.rs
+++ b/src/systems/systems/src/apu/air_intake_flap.rs
@@ -25,7 +25,7 @@ impl AirIntakeFlap {
         }
     }
 
-    pub fn update<T: AirIntakeFlapController>(&mut self, context: &UpdateContext, controller: &T) {
+    pub fn update(&mut self, context: &UpdateContext, controller: &impl AirIntakeFlapController) {
         if controller.should_open_air_intake_flap()
             && self.open_amount < Ratio::new::<percent>(100.)
         {

--- a/src/systems/systems/src/apu/electronic_control_box.rs
+++ b/src/systems/systems/src/apu/electronic_control_box.rs
@@ -72,7 +72,7 @@ impl ElectronicControlBox {
         self.air_intake_flap_fully_open = air_intake_flap.is_fully_open();
     }
 
-    pub fn update_start_motor_state<T: PotentialSource>(&mut self, start_motor: &T) {
+    pub fn update_start_motor_state(&mut self, start_motor: &impl PotentialSource) {
         self.start_motor_is_powered = start_motor.is_powered();
 
         if self.should_close_start_contactors() && !self.start_motor_is_powered {
@@ -100,10 +100,10 @@ impl ElectronicControlBox {
         }
     }
 
-    pub fn update_bleed_air_valve_state<T: Valve>(
+    pub fn update_bleed_air_valve_state(
         &mut self,
         context: &UpdateContext,
-        bleed_air_valve: &T,
+        bleed_air_valve: &impl Valve,
     ) {
         if bleed_air_valve.is_open() {
             self.bleed_air_valve_last_open_time_ago = Duration::from_secs(0);

--- a/src/systems/systems/src/apu/electronic_control_box.rs
+++ b/src/systems/systems/src/apu/electronic_control_box.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     electrical::PotentialSource,
     pneumatic::{BleedAirValveController, Valve},
-    shared::ApuStartContactorsController,
+    shared::{ApuMaster, ApuStart, ApuStartContactorsController},
     simulation::UpdateContext,
 };
 use std::time::Duration;
@@ -59,7 +59,7 @@ impl ElectronicControlBox {
         fire_overhead: &AuxiliaryPowerUnitFireOverheadPanel,
         apu_bleed_is_on: bool,
     ) {
-        self.master_is_on = overhead.master_is_on();
+        self.master_is_on = overhead.master_sw_is_on();
         self.start_is_on = overhead.start_is_on();
         self.bleed_is_on = apu_bleed_is_on;
         self.fire_button_is_released = fire_overhead.fire_button_is_released();

--- a/src/systems/systems/src/apu/mod.rs
+++ b/src/systems/systems/src/apu/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     electrical::{Potential, PotentialSource, PotentialTarget, ProvideFrequency, ProvidePotential},
     overhead::{FirePushButton, OnOffAvailablePushButton, OnOffFaultPushButton},
     pneumatic::{BleedAirValve, BleedAirValveState, Valve},
-    shared::{ApuStartContactorsController, AuxiliaryPowerUnitElectrical},
+    shared::{ApuMaster, ApuStart, ApuStartContactorsController, AuxiliaryPowerUnitElectrical},
     simulation::{SimulationElement, SimulationElementVisitor, SimulatorWriter, UpdateContext},
 };
 #[cfg(test)]
@@ -297,19 +297,21 @@ impl AuxiliaryPowerUnitOverheadPanel {
         if self.start_is_on()
             && (apu.is_available()
                 || apu.has_fault()
-                || (!self.master_is_on() && !apu.is_starting()))
+                || (!self.master_sw_is_on() && !apu.is_starting()))
         {
             self.start.turn_off();
         }
 
         self.master.set_fault(apu.has_fault());
     }
-
-    pub fn master_is_on(&self) -> bool {
+}
+impl ApuMaster for AuxiliaryPowerUnitOverheadPanel {
+    fn master_sw_is_on(&self) -> bool {
         self.master.is_on()
     }
-
-    pub fn start_is_on(&self) -> bool {
+}
+impl ApuStart for AuxiliaryPowerUnitOverheadPanel {
+    fn start_is_on(&self) -> bool {
         self.start.is_on()
     }
 }

--- a/src/systems/systems/src/apu/mod.rs
+++ b/src/systems/systems/src/apu/mod.rs
@@ -6,7 +6,10 @@ use crate::{
     electrical::{Potential, PotentialSource, PotentialTarget, ProvideFrequency, ProvidePotential},
     overhead::{FirePushButton, OnOffAvailablePushButton, OnOffFaultPushButton},
     pneumatic::{BleedAirValve, BleedAirValveState, Valve},
-    shared::{ApuMaster, ApuStart, ApuStartContactorsController, AuxiliaryPowerUnitElectrical},
+    shared::{
+        ApuAvailable, ApuMaster, ApuStart, ApuStartContactorsController,
+        AuxiliaryPowerUnitElectrical,
+    },
     simulation::{SimulationElement, SimulationElementVisitor, SimulatorWriter, UpdateContext},
 };
 #[cfg(test)]
@@ -166,12 +169,13 @@ impl<T: ApuGenerator, U: ApuStartMotor> AuxiliaryPowerUnitElectrical for Auxilia
         self.start_motor.powered_by(&source);
     }
 
-    fn is_available(&self) -> bool {
-        self.ecb.is_available()
-    }
-
     fn output_within_normal_parameters(&self) -> bool {
         self.generator.output_within_normal_parameters()
+    }
+}
+impl<T: ApuGenerator, U: ApuStartMotor> ApuAvailable for AuxiliaryPowerUnit<T, U> {
+    fn is_available(&self) -> bool {
+        self.ecb.is_available()
     }
 }
 impl<T: ApuGenerator, U: ApuStartMotor> ApuStartContactorsController for AuxiliaryPowerUnit<T, U> {

--- a/src/systems/systems/src/electrical/battery.rs
+++ b/src/systems/systems/src/electrical/battery.rs
@@ -220,7 +220,7 @@ mod tests {
                 }
             }
 
-            fn run_aircraft<T: Aircraft>(&mut self, aircraft: &mut T) {
+            fn run_aircraft(&mut self, aircraft: &mut impl Aircraft) {
                 self.test_bed.run_aircraft(aircraft);
             }
 

--- a/src/systems/systems/src/electrical/battery.rs
+++ b/src/systems/systems/src/electrical/battery.rs
@@ -143,7 +143,7 @@ impl ProvidePotential for Battery {
 
     fn potential_normal(&self) -> bool {
         (ElectricPotential::new::<volt>(25.0)..=ElectricPotential::new::<volt>(31.0))
-            .contains(&self.potential())
+            .contains(&ProvidePotential::potential(self))
     }
 }
 impl SimulationElement for Battery {

--- a/src/systems/systems/src/electrical/consumption.rs
+++ b/src/systems/systems/src/electrical/consumption.rs
@@ -38,12 +38,12 @@ impl ElectricPower {
         }
     }
 
-    pub fn distribute_to<T: SimulationElement>(&self, element: &mut T) {
+    pub fn distribute_to(&self, element: &mut impl SimulationElement) {
         let mut visitor = ReceivePowerVisitor::new(&self.supplied_power);
         element.accept(&mut visitor);
     }
 
-    pub fn consume_in<T: SimulationElement>(&mut self, element: &mut T) {
+    pub fn consume_in(&mut self, element: &mut impl SimulationElement) {
         let mut visitor = ConsumePowerVisitor::new(&mut self.power_consumption);
         element.accept(&mut visitor);
 
@@ -51,7 +51,7 @@ impl ElectricPower {
         element.accept(&mut visitor);
     }
 
-    pub fn report_consumption_to<T: SimulationElement>(&mut self, element: &mut T) {
+    pub fn report_consumption_to(&mut self, element: &mut impl SimulationElement) {
         let mut visitor = ProcessPowerConsumptionReportVisitor::new(&self.power_consumption);
         element.accept(&mut visitor);
     }

--- a/src/systems/systems/src/electrical/emergency_generator.rs
+++ b/src/systems/systems/src/electrical/emergency_generator.rs
@@ -4,7 +4,10 @@ use super::{
     consumption::PowerConsumptionReport, ElectricalStateWriter, Potential, PotentialOrigin,
     PotentialSource, ProvideFrequency, ProvidePotential,
 };
-use crate::simulation::{SimulationElement, SimulatorWriter, UpdateContext};
+use crate::{
+    shared::RamAirTurbineHydraulicLoopPressurised,
+    simulation::{SimulationElement, SimulatorWriter, UpdateContext},
+};
 use uom::si::{electric_potential::volt, f64::*, frequency::hertz};
 
 pub struct EmergencyGenerator {
@@ -27,14 +30,18 @@ impl EmergencyGenerator {
         }
     }
 
-    pub fn update(&mut self, context: &UpdateContext, can_supply_when_running: bool) {
+    pub fn update(
+        &mut self,
+        context: &UpdateContext,
+        hydraulic: &impl RamAirTurbineHydraulicLoopPressurised,
+    ) {
         // TODO: All of this is a very simple implementation.
         // Once hydraulics is available we should improve it.
         if self.starting_or_started {
             self.time_since_start += context.delta();
         }
 
-        self.supplying = can_supply_when_running
+        self.supplying = hydraulic.is_rat_hydraulic_loop_pressurised()
             && self.starting_or_started
             && self.time_since_start > Duration::from_secs(8);
     }
@@ -126,16 +133,36 @@ mod emergency_generator_tests {
         }
     }
 
+    struct TestHydraulicSystem {
+        is_rat_hydraulic_loop_pressurised: bool,
+    }
+    impl TestHydraulicSystem {
+        fn new() -> Self {
+            Self {
+                is_rat_hydraulic_loop_pressurised: true,
+            }
+        }
+
+        fn set_rat_hydraulic_loop_pressurised(&mut self, pressurised: bool) {
+            self.is_rat_hydraulic_loop_pressurised = pressurised;
+        }
+    }
+    impl RamAirTurbineHydraulicLoopPressurised for TestHydraulicSystem {
+        fn is_rat_hydraulic_loop_pressurised(&self) -> bool {
+            self.is_rat_hydraulic_loop_pressurised
+        }
+    }
+
     struct TestAircraft {
         emer_gen: EmergencyGenerator,
-        is_blue_pressurised: bool,
+        hydraulic: TestHydraulicSystem,
         generator_output_within_normal_parameters_before_processing_power_consumption_report: bool,
     }
     impl TestAircraft {
         fn new() -> Self {
             Self {
                 emer_gen: EmergencyGenerator::new(),
-                is_blue_pressurised: true,
+                hydraulic: TestHydraulicSystem::new(),
                 generator_output_within_normal_parameters_before_processing_power_consumption_report: false,
             }
         }
@@ -152,8 +179,9 @@ mod emergency_generator_tests {
             self.emer_gen.stop();
         }
 
-        fn set_blue_pressurisation(&mut self, pressurised: bool) {
-            self.is_blue_pressurised = pressurised;
+        fn set_rat_hydraulic_loop_pressurised(&mut self, pressurised: bool) {
+            self.hydraulic
+                .set_rat_hydraulic_loop_pressurised(pressurised);
         }
 
         fn generator_output_within_normal_parameters_before_processing_power_consumption_report(
@@ -170,7 +198,7 @@ mod emergency_generator_tests {
     }
     impl Aircraft for TestAircraft {
         fn update_before_power_distribution(&mut self, context: &UpdateContext) {
-            self.emer_gen.update(context, self.is_blue_pressurised);
+            self.emer_gen.update(context, &self.hydraulic);
 
             self.generator_output_within_normal_parameters_before_processing_power_consumption_report = self.emer_gen.output_within_normal_parameters();
         }
@@ -210,7 +238,7 @@ mod emergency_generator_tests {
         let mut test_bed = EmergencyGeneratorTestBed::new();
 
         aircraft.attempt_emer_gen_start();
-        aircraft.set_blue_pressurisation(false);
+        aircraft.set_rat_hydraulic_loop_pressurised(false);
         test_bed.run_aircraft(&mut aircraft, Duration::from_secs(100));
 
         assert!(!aircraft.emer_gen_is_powered());

--- a/src/systems/systems/src/electrical/emergency_generator.rs
+++ b/src/systems/systems/src/electrical/emergency_generator.rs
@@ -119,7 +119,7 @@ mod emergency_generator_tests {
             }
         }
 
-        fn run_aircraft<T: Aircraft>(&mut self, aircraft: &mut T, delta: Duration) {
+        fn run_aircraft(&mut self, aircraft: &mut impl Aircraft, delta: Duration) {
             self.test_bed.set_delta(delta);
             self.test_bed.run_aircraft(aircraft);
         }

--- a/src/systems/systems/src/electrical/engine_generator.rs
+++ b/src/systems/systems/src/electrical/engine_generator.rs
@@ -34,12 +34,12 @@ impl EngineGenerator {
         }
     }
 
-    pub fn update<T: EngineCorrectedN2, U: EngineGeneratorPushButtons, V: EngineFirePushButtons>(
+    pub fn update(
         &mut self,
         context: &UpdateContext,
-        engine: &T,
-        generator_buttons: &U,
-        fire_buttons: &V,
+        engine: &impl EngineCorrectedN2,
+        generator_buttons: &impl EngineGeneratorPushButtons,
+        fire_buttons: &impl EngineFirePushButtons,
     ) {
         self.idg
             .update(context, engine, generator_buttons, fire_buttons);
@@ -139,12 +139,12 @@ impl IntegratedDriveGenerator {
         }
     }
 
-    pub fn update<T: EngineCorrectedN2, U: EngineGeneratorPushButtons, V: EngineFirePushButtons>(
+    pub fn update(
         &mut self,
         context: &UpdateContext,
-        engine: &T,
-        generator_buttons: &U,
-        fire_buttons: &V,
+        engine: &impl EngineCorrectedN2,
+        generator_buttons: &impl EngineGeneratorPushButtons,
+        fire_buttons: &impl EngineFirePushButtons,
     ) {
         if generator_buttons.idg_push_button_is_released(self.number) {
             // The IDG cannot be reconnected.
@@ -340,7 +340,7 @@ mod tests {
                 }
             }
 
-            fn run_aircraft<T: Aircraft>(&mut self, aircraft: &mut T) {
+            fn run_aircraft(&mut self, aircraft: &mut impl Aircraft) {
                 self.test_bed.run_aircraft(aircraft);
             }
 

--- a/src/systems/systems/src/electrical/external_power_source.rs
+++ b/src/systems/systems/src/electrical/external_power_source.rs
@@ -108,7 +108,7 @@ mod external_power_source_tests {
                 .write_bool("EXTERNAL POWER AVAILABLE:1", false);
         }
 
-        fn run_aircraft<T: Aircraft>(&mut self, aircraft: &mut T) {
+        fn run_aircraft(&mut self, aircraft: &mut impl Aircraft) {
             self.test_bed.run_aircraft(aircraft);
         }
 

--- a/src/systems/systems/src/electrical/mod.rs
+++ b/src/systems/systems/src/electrical/mod.rs
@@ -420,49 +420,49 @@ impl ElectricalStateWriter {
         }
     }
 
-    pub fn write_direct<T: ProvideCurrent + ProvidePotential>(
+    pub fn write_direct(
         &self,
-        source: &T,
+        source: &(impl ProvideCurrent + ProvidePotential),
         writer: &mut SimulatorWriter,
     ) {
         self.write_current(source, writer);
         self.write_potential(source, writer);
     }
 
-    pub fn write_alternating<T: ProvidePotential + ProvideFrequency>(
+    pub fn write_alternating(
         &self,
-        source: &T,
+        source: &(impl ProvidePotential + ProvideFrequency),
         writer: &mut SimulatorWriter,
     ) {
         self.write_potential(source, writer);
         self.write_frequency(source, writer);
     }
 
-    pub fn write_alternating_with_load<T: ProvidePotential + ProvideFrequency + ProvideLoad>(
+    pub fn write_alternating_with_load(
         &self,
-        source: &T,
+        source: &(impl ProvidePotential + ProvideFrequency + ProvideLoad),
         writer: &mut SimulatorWriter,
     ) {
         self.write_alternating(source, writer);
         self.write_load(source, writer);
     }
 
-    fn write_current<T: ProvideCurrent>(&self, source: &T, writer: &mut SimulatorWriter) {
+    fn write_current(&self, source: &impl ProvideCurrent, writer: &mut SimulatorWriter) {
         writer.write_f64(&self.current_id, source.current().get::<ampere>());
         writer.write_bool(&self.current_normal_id, source.current_normal());
     }
 
-    fn write_potential<T: ProvidePotential>(&self, source: &T, writer: &mut SimulatorWriter) {
+    fn write_potential(&self, source: &impl ProvidePotential, writer: &mut SimulatorWriter) {
         writer.write_f64(&self.potential_id, source.potential().get::<volt>());
         writer.write_bool(&self.potential_normal_id, source.potential_normal());
     }
 
-    fn write_frequency<T: ProvideFrequency>(&self, source: &T, writer: &mut SimulatorWriter) {
+    fn write_frequency(&self, source: &impl ProvideFrequency, writer: &mut SimulatorWriter) {
         writer.write_f64(&self.frequency_id, source.frequency().get::<hertz>());
         writer.write_bool(&self.frequency_normal_id, source.frequency_normal());
     }
 
-    fn write_load<T: ProvideLoad>(&self, source: &T, writer: &mut SimulatorWriter) {
+    fn write_load(&self, source: &impl ProvideLoad, writer: &mut SimulatorWriter) {
         writer.write_f64(&self.load_id, source.load().get::<percent>());
         writer.write_bool(&self.load_normal_id, source.load_normal());
     }

--- a/src/systems/systems/src/electrical/mod.rs
+++ b/src/systems/systems/src/electrical/mod.rs
@@ -14,8 +14,7 @@ pub use battery::Battery;
 pub use battery_charge_limiter::{BatteryChargeLimiter, BatteryChargeLimiterArguments};
 pub use emergency_generator::EmergencyGenerator;
 pub use engine_generator::{
-    EngineGenerator, EngineGeneratorUpdateArguments,
-    INTEGRATED_DRIVE_GENERATOR_STABILIZATION_TIME_IN_MILLISECONDS,
+    EngineGenerator, INTEGRATED_DRIVE_GENERATOR_STABILIZATION_TIME_IN_MILLISECONDS,
 };
 pub use external_power_source::ExternalPowerSource;
 use itertools::Itertools;
@@ -31,6 +30,11 @@ use self::consumption::SuppliedPower;
 
 pub trait ElectricalSystem {
     fn get_supplied_power(&self) -> SuppliedPower;
+}
+
+pub trait EngineGeneratorPushButtons {
+    fn engine_gen_push_button_is_on(&self, number: usize) -> bool;
+    fn idg_push_button_is_released(&self, number: usize) -> bool;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/src/systems/systems/src/electrical/static_inverter.rs
+++ b/src/systems/systems/src/electrical/static_inverter.rs
@@ -117,7 +117,7 @@ mod static_inverter_tests {
             }
         }
 
-        fn run_aircraft<T: Aircraft>(&mut self, aircraft: &mut T) {
+        fn run_aircraft(&mut self, aircraft: &mut impl Aircraft) {
             self.test_bed.run_aircraft(aircraft);
         }
 

--- a/src/systems/systems/src/electrical/transformer_rectifier.rs
+++ b/src/systems/systems/src/electrical/transformer_rectifier.rs
@@ -117,7 +117,7 @@ mod transformer_rectifier_tests {
             }
         }
 
-        fn run_aircraft<T: Aircraft>(&mut self, aircraft: &mut T) {
+        fn run_aircraft(&mut self, aircraft: &mut impl Aircraft) {
             self.test_bed.run_aircraft(aircraft);
         }
 

--- a/src/systems/systems/src/engine/leap_engine.rs
+++ b/src/systems/systems/src/engine/leap_engine.rs
@@ -1,6 +1,9 @@
 use uom::si::{angular_velocity::revolution_per_minute, f64::*, pressure::psi, ratio::percent};
 
-use crate::simulation::{SimulationElement, SimulatorReader, UpdateContext};
+use crate::{
+    shared::EngineCorrectedN2,
+    simulation::{SimulationElement, SimulatorReader, UpdateContext},
+};
 
 use super::Engine;
 pub struct LeapEngine {
@@ -48,12 +51,12 @@ impl SimulationElement for LeapEngine {
         self.update_parameters();
     }
 }
-
-impl Engine for LeapEngine {
+impl EngineCorrectedN2 for LeapEngine {
     fn corrected_n2(&self) -> Ratio {
         self.corrected_n2
     }
-
+}
+impl Engine for LeapEngine {
     fn hydraulic_pump_output_speed(&self) -> AngularVelocity {
         self.hydraulic_pump_output_speed
     }

--- a/src/systems/systems/src/engine/mod.rs
+++ b/src/systems/systems/src/engine/mod.rs
@@ -2,14 +2,13 @@ use uom::si::f64::*;
 
 use crate::{
     overhead::FirePushButton,
-    shared::EngineFirePushButtons,
+    shared::{EngineCorrectedN2, EngineFirePushButtons},
     simulation::{SimulationElement, SimulationElementVisitor},
 };
 
 pub mod leap_engine;
 
-pub trait Engine {
-    fn corrected_n2(&self) -> Ratio;
+pub trait Engine: EngineCorrectedN2 {
     fn hydraulic_pump_output_speed(&self) -> AngularVelocity;
     fn oil_pressure(&self) -> Pressure;
     fn is_above_minimum_idle(&self) -> bool;
@@ -29,10 +28,7 @@ impl EngineFireOverheadPanel {
 }
 impl EngineFirePushButtons for EngineFireOverheadPanel {
     fn is_released(&self, engine_number: usize) -> bool {
-        match self.engine_fire_push_buttons.get(engine_number - 1) {
-            Some(button) => button.is_released(),
-            None => false,
-        }
+        self.engine_fire_push_buttons[engine_number - 1].is_released()
     }
 }
 impl SimulationElement for EngineFireOverheadPanel {
@@ -84,12 +80,5 @@ mod engine_fire_overhead_panel_tests {
         test_bed.run(&mut panel, |_, _| {});
 
         assert_eq!(panel.is_released(1), true);
-    }
-
-    #[test]
-    fn fire_push_button_is_released_returns_false_when_engine_number_out_of_range() {
-        let panel = EngineFireOverheadPanel::new();
-
-        assert_eq!(panel.is_released(9999), false);
     }
 }

--- a/src/systems/systems/src/engine/mod.rs
+++ b/src/systems/systems/src/engine/mod.rs
@@ -44,6 +44,11 @@ impl SimulationElement for EngineFireOverheadPanel {
         visitor.visit(self);
     }
 }
+impl Default for EngineFireOverheadPanel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(test)]
 mod engine_fire_overhead_panel_tests {

--- a/src/systems/systems/src/engine/mod.rs
+++ b/src/systems/systems/src/engine/mod.rs
@@ -1,5 +1,11 @@
 use uom::si::f64::*;
 
+use crate::{
+    overhead::FirePushButton,
+    shared::EngineFirePushButtons,
+    simulation::{SimulationElement, SimulationElementVisitor},
+};
+
 pub mod leap_engine;
 
 pub trait Engine {
@@ -7,4 +13,78 @@ pub trait Engine {
     fn hydraulic_pump_output_speed(&self) -> AngularVelocity;
     fn oil_pressure(&self) -> Pressure;
     fn is_above_minimum_idle(&self) -> bool;
+}
+
+pub struct EngineFireOverheadPanel {
+    // TODO: Once const generics are available in the dev-env rustc version, we can replace
+    // this with an array sized by the const.
+    engine_fire_push_buttons: [FirePushButton; 2],
+}
+impl EngineFireOverheadPanel {
+    pub fn new() -> Self {
+        Self {
+            engine_fire_push_buttons: [FirePushButton::new("ENG1"), FirePushButton::new("ENG2")],
+        }
+    }
+}
+impl EngineFirePushButtons for EngineFireOverheadPanel {
+    fn is_released(&self, engine_number: usize) -> bool {
+        match self.engine_fire_push_buttons.get(engine_number - 1) {
+            Some(button) => button.is_released(),
+            None => false,
+        }
+    }
+}
+impl SimulationElement for EngineFireOverheadPanel {
+    fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
+        self.engine_fire_push_buttons.iter_mut().for_each(|el| {
+            el.accept(visitor);
+        });
+
+        visitor.visit(self);
+    }
+}
+
+#[cfg(test)]
+mod engine_fire_overhead_panel_tests {
+    use crate::simulation::test::SimulationTestBed;
+
+    use super::*;
+
+    #[test]
+    fn after_construction_fire_push_buttons_are_not_released() {
+        let panel = EngineFireOverheadPanel::new();
+
+        assert_eq!(panel.is_released(1), false);
+        assert_eq!(panel.is_released(2), false);
+    }
+
+    #[test]
+    fn fire_push_button_is_released_returns_false_when_not_released() {
+        let mut panel = EngineFireOverheadPanel::new();
+
+        let mut test_bed = SimulationTestBed::new();
+        test_bed.write_bool("FIRE_BUTTON_ENG1", false);
+        test_bed.run(&mut panel, |_, _| {});
+
+        assert_eq!(panel.is_released(1), false);
+    }
+
+    #[test]
+    fn fire_push_button_is_released_returns_true_when_released() {
+        let mut panel = EngineFireOverheadPanel::new();
+
+        let mut test_bed = SimulationTestBed::new();
+        test_bed.write_bool("FIRE_BUTTON_ENG1", true);
+        test_bed.run(&mut panel, |_, _| {});
+
+        assert_eq!(panel.is_released(1), true);
+    }
+
+    #[test]
+    fn fire_push_button_is_released_returns_false_when_engine_number_out_of_range() {
+        let panel = EngineFireOverheadPanel::new();
+
+        assert_eq!(panel.is_released(9999), false);
+    }
 }

--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -1,4 +1,7 @@
-use crate::simulation::{SimulationElement, SimulatorReader};
+use crate::{
+    shared::LandingGearPosition,
+    simulation::{SimulationElement, SimulatorReader},
+};
 use uom::si::{f64::*, ratio::percent};
 
 /// Represents a landing gear on Airbus aircraft.
@@ -16,12 +19,13 @@ impl LandingGear {
             position: Ratio::new::<percent>(0.),
         }
     }
-
-    pub fn is_up_and_locked(&self) -> bool {
+}
+impl LandingGearPosition for LandingGear {
+    fn is_up_and_locked(&self) -> bool {
         (self.position.get::<percent>() - 0.).abs() < f64::EPSILON
     }
 
-    pub fn is_down_and_locked(&self) -> bool {
+    fn is_down_and_locked(&self) -> bool {
         (self.position.get::<percent>() - 100.).abs() < f64::EPSILON
     }
 }

--- a/src/systems/systems/src/pneumatic/mod.rs
+++ b/src/systems/systems/src/pneumatic/mod.rs
@@ -21,7 +21,7 @@ impl BleedAirValve {
         BleedAirValve { open: false }
     }
 
-    pub fn update<T: BleedAirValveController>(&mut self, controller: &T) {
+    pub fn update(&mut self, controller: &impl BleedAirValveController) {
         self.open = controller.should_open_bleed_air_valve();
     }
 }

--- a/src/systems/systems/src/shared/mod.rs
+++ b/src/systems/systems/src/shared/mod.rs
@@ -20,6 +20,11 @@ pub trait AuxiliaryPowerUnitElectrical: PotentialSource + ApuStartContactorsCont
     fn output_within_normal_parameters(&self) -> bool;
 }
 
+pub trait EngineFirePushButtons {
+    /// Indicates if the fire push button of the given engine is released.
+    fn is_released(&self, engine_number: usize) -> bool;
+}
+
 #[derive(FromPrimitive)]
 pub(crate) enum FwcFlightPhase {
     ElecPwr = 1,

--- a/src/systems/systems/src/shared/mod.rs
+++ b/src/systems/systems/src/shared/mod.rs
@@ -25,6 +25,23 @@ pub trait EngineFirePushButtons {
     fn is_released(&self, engine_number: usize) -> bool;
 }
 
+pub trait ApuMaster {
+    fn master_sw_is_on(&self) -> bool;
+}
+
+pub trait ApuStart {
+    fn start_is_on(&self) -> bool;
+}
+
+pub trait RamAirTurbineHydraulicLoopPressurised {
+    fn is_rat_hydraulic_loop_pressurised(&self) -> bool;
+}
+
+pub trait LandingGearPosition {
+    fn is_up_and_locked(&self) -> bool;
+    fn is_down_and_locked(&self) -> bool;
+}
+
 pub trait EngineCorrectedN2 {
     fn corrected_n2(&self) -> Ratio;
 }

--- a/src/systems/systems/src/shared/mod.rs
+++ b/src/systems/systems/src/shared/mod.rs
@@ -25,6 +25,10 @@ pub trait EngineFirePushButtons {
     fn is_released(&self, engine_number: usize) -> bool;
 }
 
+pub trait EngineCorrectedN2 {
+    fn corrected_n2(&self) -> Ratio;
+}
+
 #[derive(FromPrimitive)]
 pub(crate) enum FwcFlightPhase {
     ElecPwr = 1,

--- a/src/systems/systems/src/shared/mod.rs
+++ b/src/systems/systems/src/shared/mod.rs
@@ -14,10 +14,15 @@ pub trait ApuStartContactorsController {
     fn should_close_start_contactors(&self) -> bool;
 }
 
-pub trait AuxiliaryPowerUnitElectrical: PotentialSource + ApuStartContactorsController {
+pub trait AuxiliaryPowerUnitElectrical:
+    PotentialSource + ApuStartContactorsController + ApuAvailable
+{
     fn start_motor_powered_by(&mut self, source: Potential);
-    fn is_available(&self) -> bool;
     fn output_within_normal_parameters(&self) -> bool;
+}
+
+pub trait ApuAvailable {
+    fn is_available(&self) -> bool;
 }
 
 pub trait EngineFirePushButtons {

--- a/src/systems/systems/src/simulation/test.rs
+++ b/src/systems/systems/src/simulation/test.rs
@@ -45,7 +45,7 @@ impl SimulationTestBed {
     ///
     /// By default the unseeded simulation will return 0.0 or false for any requested
     /// variables. If this is a problem for your test, then use this function.
-    pub fn seeded_with<T: SimulationElement>(element: &mut T) -> Self {
+    pub fn seeded_with(element: &mut impl SimulationElement) -> Self {
         let mut test_bed = Self::new();
 
         let mut writer = SimulatorWriter::new(&mut test_bed.reader_writer);
@@ -59,7 +59,7 @@ impl SimulationTestBed {
     ///
     /// [`Aircraft`]: ../trait.Aircraft.html
     /// [`Simulation`]: ../struct.Simulation.html
-    pub fn run_aircraft<T: Aircraft>(&mut self, aircraft: &mut T) {
+    pub fn run_aircraft(&mut self, aircraft: &mut impl Aircraft) {
         let mut simulation = Simulation::new(aircraft, &mut self.reader_writer);
         simulation.tick(self.delta);
     }
@@ -113,7 +113,7 @@ impl SimulationTestBed {
     ///
     /// [`Simulation`]: ../struct.Simulation.html
     /// [`SimulationElement`]: ../trait.SimulationElement.html
-    pub fn run_without_update<T: SimulationElement>(&mut self, element: &mut T) {
+    pub fn run_without_update(&mut self, element: &mut impl SimulationElement) {
         self.run(element, |_, _| {});
     }
 
@@ -177,9 +177,9 @@ impl SimulationTestBed {
         );
     }
 
-    pub fn supplied_power_fn<T: Fn() -> SuppliedPower + 'static>(
+    pub fn supplied_power_fn(
         mut self,
-        supplied_power_fn: T,
+        supplied_power_fn: impl Fn() -> SuppliedPower + 'static,
     ) -> Self {
         self.get_supplied_power_fn = Box::new(supplied_power_fn);
         self

--- a/src/systems/systems/src/simulation/test.rs
+++ b/src/systems/systems/src/simulation/test.rs
@@ -253,7 +253,9 @@ impl<'a, T: SimulationElement, U: Fn(&mut T, &UpdateContext)> SimulationElement
     for TestAircraft<'a, T, U>
 {
     fn accept<W: SimulationElementVisitor>(&mut self, visitor: &mut W) {
-        visitor.visit(self.element);
+        self.element.accept(visitor);
+
+        visitor.visit(self);
     }
 }
 


### PR DESCRIPTION
## Summary of Changes
Primarily makes the ENG FIRE push button affect the IDG's ability to provide energy.

- [x] Pressing the ENG FIRE button deactivates the IDG, resulting in 0V/0Hz.
- [x] Pressing the ENG FIRE button makes the GEN FAULT light illuminate, as the contactor opens with the ENG GEN push button in the ON position.
- [x] Pressing the ENG GEN button deactivates the IDG, resulting in 0V/0Hz (cannot be observed as the ECAM displays OFF, however the IDG was wrongly providing 115V/400Hz; though the energy didn't flow beyond the gen line contactor).

This PR doesn't improve the inner workings of the IDG. There are still a lot of possible improvements in this area.

## Code reviewing

Next to the main feature of the PR, it also addresses some other things.

3c82c3d1075b7c3760350e98fde80cdd922afab4: moves the `EngineFireOverheadPanel` out of hydraulics so it can be used elsewhere.
8378f1d75f312323189c3f8e57fdf9c345a0fca4: as I was adding tests for the fire push button's effect on the electrical system I got fed up with some of the duplication and thus introduced parameterised tests.
265d99627087af4f743159dae6ce1137ca17a582: The effect of the fire push button on the contactors.
623cfa989b9522d99a5678d9aec96d1772a5cba3: Preparing to share the fire push button state with the `EngineGenerator` and `IntegratedDriveGenerator` by rearranging traits. 
e4bb7cde75ef50ec34ac9a4a04c8e081e36eb295: Make the IDG actually look at GEN and FIRE pb state.
a62b869cd056244f9f8833698d1be66b9d8e55e8: I wasn't quite satisfied with the `A320ElectricalUpdateArguments` still being around. So I deleted it by using the great `impl Trait` as argument syntax (it creates hidden generic fn templates under the hood).
3905bb3a2ddb2b98ae6a6195ee0a4e28551610a2: Similarly the `BatteryChargeLimiterArguments` was another type that was "in the way". I deleted it and replaced it with `impl Trait` as argument syntax. I also replaced the `Box`ing of BCL states with an enum-based state machine which is a bit more code, but allows for the compiler to optimise more as it knows the relevant types at compile time.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
