### PR TITLE
feat(ECP): EMER CANC emissive behaviour

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -75,6 +75,7 @@
 1. [ELEC] ENG FIRE push button deactivates IDG - @davidwalschots (David Walschots)
 1. [AP] Improved OP CLB/DES, CLB/DES speed hold characteristics - @aguther (Andreas Guther)
 1. [MCDU] Fixed sometimes bad error message on crz fl entry - @MisterChocker (Leon)
+1. [ECP] Corrected EMER CANC ECAM button emissive behavior - @ImenesFBW (Imenes)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/flybywire-aircraft-a320-neo/ModelBehaviorDefs/A32NX/Airbus.xml
+++ b/flybywire-aircraft-a320-neo/ModelBehaviorDefs/A32NX/Airbus.xml
@@ -399,6 +399,43 @@
         </Condition>
     </Template>
 
+    <Template Name="FBW_ECAM_EMERCANC_BUTTON_Template">
+        <DefaultTemplateParameters>
+            <BASE_NAME>UNKNOWN</BASE_NAME>
+            <NODE_ID>PUSH_ECAM_#BASE_NAME#</NODE_ID>
+            <ANIM_NAME_BUTTON>PUSH_ECAM_#BASE_NAME#</ANIM_NAME_BUTTON>
+            <BACKLIGHT_NODE_ID>PUSH_ECAM_#BASE_NAME#_SEQ1</BACKLIGHT_NODE_ID>
+            <WWISE_EVENT_1>radio_push_button_on</WWISE_EVENT_1>
+            <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
+            <WWISE_EVENT_2>radio_push_button_off</WWISE_EVENT_2>
+            <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
+            <SEQ2_POWERED>1</SEQ2_POWERED>
+        </DefaultTemplateParameters>
+
+        <Component ID="#NODE_ID#" Node="#NODE_ID#">
+            <UseTemplate Name="ASOBO_GT_Push_Button">
+                <ANIM_NAME>#ANIM_NAME_BUTTON#</ANIM_NAME>
+                <LEFT_SINGLE_CODE>
+                1 (&gt;L:A32NX_BTN_#BASE_NAME#)
+                </LEFT_SINGLE_CODE>
+            </UseTemplate>
+        </Component>
+
+        <Condition Check="POTENTIOMETER">
+            <True>
+                <Component ID="#BACKLIGHT_NODE_ID#" Node="#BACKLIGHT_NODE_ID#">
+                    <UseTemplate Name="ASOBO_GT_Emissive_Potentiometer">
+                        <EMISSIVE_CODE>#SEQ2_POWERED#</EMISSIVE_CODE>
+                    </UseTemplate>
+                </Component>
+            </True>
+        </Condition>
+
+        <UseTemplate Name="ASOBO_LIGHTING_Potentiometer_Emissive_Template">
+            <EMISSIVE_CODE>#SEQ2_POWERED# 0.3 *</EMISSIVE_CODE>
+        </UseTemplate>
+    </Template>
+
     <!-- This whole section is modified -->
     <Template Name="FBW_ECAM_PAGE_SELECTION_Template">
         <DefaultTemplateParameters>
@@ -504,7 +541,7 @@
             <TOOLTIPID>Test T.O CONFIG</TOOLTIPID>
         </UseTemplate>
 
-        <UseTemplate Name="FBW_ECAM_BUTTON_Template">
+        <UseTemplate Name="FBW_ECAM_EMERCANC_BUTTON_Template">
             <BASE_NAME>EMERCANC</BASE_NAME>
             <PART_ID>ECAM_EMERCANC</PART_ID>
             <TOOLTIPID>Emergency cancel (Inop.)</TOOLTIPID>
@@ -512,8 +549,7 @@
 
         <UseTemplate Name="FBW_Covered_Push_Toggle">
             <LOCK_NODE_ID>LOCK_ECAM_EMERCANC</LOCK_NODE_ID>
-
-           <TOOLTIPID>Emergency cancel (Inop.)</TOOLTIPID>
+            <TOOLTIPID>Emergency cancel (Inop.)</TOOLTIPID>
         </UseTemplate>
 
         <UseTemplate Name="A32NX_ECAM_CLR_BUTTON_Template">


### PR DESCRIPTION
## Summary of Changes

Added correct emissive behavior for the ECAM EMER CANC button. Both the button and the text now light up depending on the pedestal integral light setting.

## Screenshots (if necessary)

![Untitled-1](https://user-images.githubusercontent.com/71195324/119237760-cf95ce80-bb3e-11eb-9512-c723d3d68ecb.png)


## References
![5](https://user-images.githubusercontent.com/71195324/119237137-af184500-bb3b-11eb-9d76-1be9483608e8.PNG)

Discord username: Imenes#8739

## Testing instructions

Check the EMER CANC button behavior, you should only be able to turn the backlighting on when AC power is available like the rest of pedestal integral lighting. Make sure that the button still has its previous functionality (open cover, press in).  

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
