### PR TITLE
feat: F/CTL page hydraulic indications, small misc changes to F/CTL page

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -76,6 +76,7 @@
 1. [AP] Improved OP CLB/DES, CLB/DES speed hold characteristics - @aguther (Andreas Guther)
 1. [MCDU] Fixed sometimes bad error message on crz fl entry - @MisterChocker (Leon)
 1. [ECP] Corrected EMER CANC ECAM button emissive behavior - @ImenesFBW (Imenes)
+1. [ECAM] Change flight control page to use hydraulic simulation vars - @lukecologne (luke)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/src/instruments/src/SD/Pages/Fctl/Fctl.tsx
+++ b/src/instruments/src/SD/Pages/Fctl/Fctl.tsx
@@ -42,13 +42,14 @@ const HydraulicContext = React.createContext<HydraulicsContext>({
 });
 
 export const FctlPage = () => {
-    const [engine1State] = useSimVar('TURB ENG N2:1', 'Percent', 1000);
-    const [engine2State] = useSimVar('TURB ENG N2:2', 'Percent', 1000);
+    const [greenPress] = useSimVar('L:A32NX_HYD_GREEN_PRESSURE', 'number', 1000);
+    const [yellowPress] = useSimVar('L:A32NX_HYD_YELLOW_PRESSURE', 'number', 1000);
+    const [bluePress] = useSimVar('L:A32NX_HYD_BLUE_PRESSURE', 'number', 1000);
 
     const hydraulicContext: HydraulicsContext = {
-        G: { available: engine1State > 15 },
-        Y: { available: engine2State > 15 },
-        B: { available: engine1State > 15 || engine2State > 15 },
+        G: { available: greenPress > 1450 },
+        Y: { available: yellowPress > 1450 },
+        B: { available: bluePress > 1450 },
     };
 
     return (
@@ -138,7 +139,6 @@ interface SpoilerProps extends ComponentPositionProps, ComponentSidePositionProp
 }
 const Spoiler = ({ x, y, number, side, actuatedBy, upWhenActuated }: SpoilerProps) => {
     const hydraulics = useContext(HydraulicContext);
-    const showSpoilerInUpPosition = upWhenActuated && hydraulics[actuatedBy].available;
 
     return (
         <SvgGroup x={x} y={y}>
@@ -147,15 +147,20 @@ const Spoiler = ({ x, y, number, side, actuatedBy, upWhenActuated }: SpoilerProp
                 d={`M 0 0 l ${side === 'right' ? '-' : ''}15 0`}
             />
             <path
-                visibility={showSpoilerInUpPosition ? 'visible' : 'hidden'}
+                visibility={upWhenActuated ? 'visible' : 'hidden'}
+                className={hydraulics[actuatedBy].available ? 'GreenShape' : 'WarningShape'}
+                d={`M ${side === 'left' ? 8 : -8} -22 l -6 0 l 6 -12 l 6 12 l -6 0`}
+            />
+            <path
+                visibility={upWhenActuated && hydraulics[actuatedBy].available ? 'visible' : 'hidden'}
                 className="GreenShape"
-                d={`M ${side === 'left' ? 8 : -8} 0 l 0 -22 l -6 0 l 6 -12 l 6 12 l -6 0`}
+                d={`M ${side === 'left' ? 8 : -8} 0 l 0 -22`}
             />
             <text
                 x={side === 'left' ? 8 : -8}
-                y={-9}
+                y={-11}
                 visibility={hydraulics[actuatedBy].available ? 'hidden' : 'visible'}
-                className="Warning Medium"
+                className="Warning Standard"
                 textAnchor="middle"
                 alignmentBaseline="central"
             >
@@ -181,7 +186,14 @@ const PitchTrim = ({ x, y }: ComponentPositionProps) => {
             <text x={5} y={35} className={`${hydraulicAvailableClass} Standard`} textAnchor="middle" alignmentBaseline="central">.</text>
             <text x={14} y={37} className={`${hydraulicAvailableClass} Small`} textAnchor="middle" alignmentBaseline="central">{pitchFractional}</text>
             <text x={28} y={35} className="ValueCyan Standard" textAnchor="middle" alignmentBaseline="central">°</text>
-            <text x={48} y={37} className={`${hydraulicAvailableClass} Small`} textAnchor="middle" alignmentBaseline="central">
+            <text
+                x={48}
+                y={37}
+                visibility={Math.abs(adjustedPitchTrim) > 0.05 ? 'visible' : 'hidden'}
+                className={`${hydraulicAvailableClass} Small`}
+                textAnchor="middle"
+                alignmentBaseline="central"
+            >
                 {Math.sign(adjustedPitchTrim) === -1 ? 'DN' : 'UP'}
             </text>
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* Change F/CTL page hydraulic indications to use the hydraulic system simulation
* Pitch trim direction indication is not displayed when pitch trim is between -0.05° and 0.05°
* Visual changes to spoiler indication: 
   * Increase size of numbers when pressure is low
   * Display triangle indication in amber even when pressure is low and spoiler is deployed

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
* Make sure that the F/CTL indications behave as described above
* Make sure that the F/CTL hydraulic indications behave as expected

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
