### PR TITLE
feat: aileron droop and anti-droop

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -79,6 +79,7 @@
 1. [ECP] Corrected EMER CANC ECAM button emissive behavior - @ImenesFBW (Imenes)
 1. [ECAM] Change flight control page to use hydraulic simulation vars - @lukecologne (luke)
 1. [PFD] Add baro setting flash when passing TA/TL - @lukecologne (luke)
+1. [FBW] Added visual aileron droop and anti-droop - @aguther (Andreas Guther)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -966,6 +966,24 @@
     - Percentage of current (filtered) alpha to alpha max
     - alpha max can be overshoot so values beyond 1.0 should be expected
 
+- A32NX_3D_AILERON_LEFT_DEFLECTION
+    - Number
+    - Provides the left aileron position
+      Value | Meaning
+      --- | ---
+      -1.0 | full up
+       0.0 | neutral
+      1.0 | full down
+
+- A32NX_3D_AILERON_RIGHT_DEFLECTION
+    - Number
+    - Provides the right aileron position
+      Value | Meaning
+      --- | ---
+      -1.0 | full down
+       0.0 | neutral
+      1.0 | full up
+
 ## Autopilot System
 
 - A32NX_FMA_LATERAL_MODE

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO.xml
@@ -20,7 +20,6 @@
         <!-- Alternatively we could script the angles for the wingflex -->
         <!-- Just define some nodes/bones to move for now (this configuration will likely change at some point) -->
         <!-- 	order	:	node 															-->
-        <!-- 	--------------------------------------------------------------------------- -->
         <!-- 	0	:	the left wing bone closest to the center 							-->
         <!-- 	1	:	in between 															-->
         <!-- 	2	:	in between 															-->
@@ -74,7 +73,7 @@
                 <TRIM_ONLY>True</TRIM_ONLY>
                 <ANIM_NAME_TRIM>trimtab_elevator_key</ANIM_NAME_TRIM>
             </UseTemplate>
-            <UseTemplate Name="ASOBO_HANDLING_Aileron_Template">
+            <UseTemplate Name="FBW_HANDLING_Aileron_Template">
                 <ANIM_NAME_LEFT>l_aileron_percent_key</ANIM_NAME_LEFT>
                 <ANIM_NAME_RIGHT>r_aileron_percent_key</ANIM_NAME_RIGHT>
             </UseTemplate>

--- a/src/behavior/src/A32NX_Exterior.xml
+++ b/src/behavior/src/A32NX_Exterior.xml
@@ -158,4 +158,16 @@
         </UseTemplate>
         <UseTemplate Name="ASOBO_GT_AnimTriggers_2SoundEvents"/>
     </Template>
+
+    <Template Name="FBW_HANDLING_Aileron_Template">
+        <UseTemplate Name="ASOBO_GT_Anim_Code">
+            <ANIM_NAME>l_aileron_percent_key</ANIM_NAME>
+            <ANIM_CODE>(L:A32NX_3D_AILERON_LEFT_DEFLECTION, number) 50 * 50 +</ANIM_CODE>
+        </UseTemplate>
+        <UseTemplate Name="ASOBO_GT_Anim_Code">
+            <ANIM_NAME>r_aileron_percent_key</ANIM_NAME>
+            <ANIM_CODE>(L:A32NX_3D_AILERON_RIGHT_DEFLECTION, number) 50 * 50 +</ANIM_CODE>
+        </UseTemplate>
+    </Template>
+
 </ModelBehaviors>

--- a/src/fbw/build.sh
+++ b/src/fbw/build.sh
@@ -93,6 +93,7 @@ clang++ \
   "${DIR}/src/model/uMultiWord2Double.cpp" \
   -I "${DIR}/src/zlib" \
   "${DIR}/src/zlib/zfstream.cc" \
+  "${DIR}/src/AnimationAileronHandler.cpp" \
   "${DIR}/src/ElevatorTrimHandler.cpp" \
   "${DIR}/src/FlapsHandler.cpp" \
   "${DIR}/src/FlyByWireInterface.cpp" \

--- a/src/fbw/src/AnimationAileronHandler.cpp
+++ b/src/fbw/src/AnimationAileronHandler.cpp
@@ -6,19 +6,23 @@ AnimationAileronHandler::AnimationAileronHandler() {
   rateLimiterRight.setRate(RATE);
 }
 
-void AnimationAileronHandler::update(bool groundSpoilersActive, double flapsPosition, double position, double dt) {
-  isGroundSpoilersActive = groundSpoilersActive;
-
+void AnimationAileronHandler::update(bool autopilotActive,
+                                     bool groundSpoilersActive,
+                                     double pitchAttitudeDegrees,
+                                     double flapsHandleIndex,
+                                     double flapsPosition,
+                                     double position,
+                                     double dt) {
   double flapsBias = fmax(0.0, fmin(1.0, (flapsPosition - FLAPS_ANGLE_REFERENCE) / FLAPS_ANGLE_REFERENCE));
   droopBiasLeft = flapsBias * BIAS_DROOP_LEFT;
   droopBiasRight = flapsBias * BIAS_DROOP_RIGHT;
 
-  if (!isGroundSpoilersActive) {
-    targetValueLeft = fmax(-1.0, fmin(1.0, droopBiasLeft + position));
-    targetValueRight = fmax(-1.0, fmin(1.0, droopBiasRight + position));
-  } else {
+  if (groundSpoilersActive && !autopilotActive && (-pitchAttitudeDegrees) < PITCH_ATTITUDE_REFERENCE && flapsHandleIndex > 0) {
     targetValueLeft = POSITION_ANTI_DROOP_LEFT;
     targetValueRight = POSITION_ANTI_DROOP_RIGHT;
+  } else {
+    targetValueLeft = fmax(-1.0, fmin(1.0, droopBiasLeft + position));
+    targetValueRight = fmax(-1.0, fmin(1.0, droopBiasRight + position));
   }
 
   rateLimiterLeft.update(targetValueLeft, dt);

--- a/src/fbw/src/AnimationAileronHandler.cpp
+++ b/src/fbw/src/AnimationAileronHandler.cpp
@@ -1,0 +1,34 @@
+#include "AnimationAileronHandler.h"
+#include <cmath>
+
+AnimationAileronHandler::AnimationAileronHandler() {
+  rateLimiterLeft.setRate(RATE);
+  rateLimiterRight.setRate(RATE);
+}
+
+void AnimationAileronHandler::update(bool groundSpoilersActive, double flapsPosition, double position, double dt) {
+  isGroundSpoilersActive = groundSpoilersActive;
+
+  double flapsBias = fmax(0.0, fmin(1.0, (flapsPosition - FLAPS_ANGLE_REFERENCE) / FLAPS_ANGLE_REFERENCE));
+  droopBiasLeft = flapsBias * BIAS_DROOP_LEFT;
+  droopBiasRight = flapsBias * BIAS_DROOP_RIGHT;
+
+  if (!isGroundSpoilersActive) {
+    targetValueLeft = fmax(-1.0, fmin(1.0, droopBiasLeft + position));
+    targetValueRight = fmax(-1.0, fmin(1.0, droopBiasRight + position));
+  } else {
+    targetValueLeft = POSITION_ANTI_DROOP_LEFT;
+    targetValueRight = POSITION_ANTI_DROOP_RIGHT;
+  }
+
+  rateLimiterLeft.update(targetValueLeft, dt);
+  rateLimiterRight.update(targetValueRight, dt);
+}
+
+double AnimationAileronHandler::getPositionLeft() {
+  return rateLimiterLeft.getValue();
+}
+
+double AnimationAileronHandler::getPositionRight() {
+  return rateLimiterRight.getValue();
+}

--- a/src/fbw/src/AnimationAileronHandler.cpp
+++ b/src/fbw/src/AnimationAileronHandler.cpp
@@ -4,29 +4,50 @@
 AnimationAileronHandler::AnimationAileronHandler() {
   rateLimiterLeft.setRate(RATE);
   rateLimiterRight.setRate(RATE);
+  rateLimiterDroop.setRate(DROOP_RATE);
+  rateLimiterAntiDroop.setRate(ANTI_DROOP_RATE);
 }
 
 void AnimationAileronHandler::update(bool autopilotActive,
                                      bool groundSpoilersActive,
+                                     double simulationTime,
                                      double pitchAttitudeDegrees,
                                      double flapsHandleIndex,
                                      double flapsPosition,
                                      double position,
                                      double dt) {
-  double flapsBias = fmax(0.0, fmin(1.0, (flapsPosition - FLAPS_ANGLE_REFERENCE) / FLAPS_ANGLE_REFERENCE));
-  droopBiasLeft = flapsBias * BIAS_DROOP_LEFT;
-  droopBiasRight = flapsBias * BIAS_DROOP_RIGHT;
+  // inhibit condition for anti-droop
+  if (!areGroundSpoilersActive && groundSpoilersActive && autopilotActive) {
+    antiDroopInhibited = true;
+  } else if (!groundSpoilersActive) {
+    antiDroopInhibited = false;
+  }
+  areGroundSpoilersActive = groundSpoilersActive;
 
-  if (groundSpoilersActive && !autopilotActive && (-pitchAttitudeDegrees) < PITCH_ATTITUDE_REFERENCE && flapsHandleIndex > 0) {
-    targetValueLeft = POSITION_ANTI_DROOP_LEFT;
-    targetValueRight = POSITION_ANTI_DROOP_RIGHT;
+  // anti-droop
+  if (groundSpoilersActive && !antiDroopInhibited && (-pitchAttitudeDegrees) < PITCH_ATTITUDE_REFERENCE && flapsHandleIndex > 0) {
+    rateLimiterAntiDroop.update(ANTI_DROOP_BIAS_ON, dt);
   } else {
-    targetValueLeft = fmax(-1.0, fmin(1.0, droopBiasLeft + position));
-    targetValueRight = fmax(-1.0, fmin(1.0, droopBiasRight + position));
+    rateLimiterAntiDroop.update(ANTI_DROOP_BIAS_OFF, dt);
   }
 
-  rateLimiterLeft.update(targetValueLeft, dt);
-  rateLimiterRight.update(targetValueRight, dt);
+  // droop
+  if ((lastFlapsPosition == 0 && flapsPosition > 0) || (lastFlapsPosition > 0 && flapsPosition == 0)) {
+    eventTime = simulationTime;
+  }
+  if (simulationTime - eventTime >= DROOP_TIME_SWITCH) {
+    if (flapsPosition > 0) {
+      targetValueDroop = DROOP_BIAS_ON;
+    } else {
+      targetValueDroop = DROOP_BIAS_OFF;
+    }
+  }
+  rateLimiterDroop.update(targetValueDroop, dt);
+  lastFlapsPosition = flapsPosition;
+
+  // set target position
+  rateLimiterLeft.update(fmax(-1.0, fmin(1.0, position + rateLimiterDroop.getValue() + rateLimiterAntiDroop.getValue())), dt);
+  rateLimiterRight.update(fmax(-1.0, fmin(1.0, position - rateLimiterDroop.getValue() - rateLimiterAntiDroop.getValue())), dt);
 }
 
 double AnimationAileronHandler::getPositionLeft() {

--- a/src/fbw/src/AnimationAileronHandler.cpp
+++ b/src/fbw/src/AnimationAileronHandler.cpp
@@ -2,8 +2,8 @@
 #include <cmath>
 
 AnimationAileronHandler::AnimationAileronHandler() {
-  rateLimiterLeft.setRate(RATE);
-  rateLimiterRight.setRate(RATE);
+  rateLimiterLeft.setRate(AILERON_RATE);
+  rateLimiterRight.setRate(AILERON_RATE);
   rateLimiterDroop.setRate(DROOP_RATE);
   rateLimiterAntiDroop.setRate(ANTI_DROOP_RATE);
 }
@@ -25,18 +25,20 @@ void AnimationAileronHandler::update(bool autopilotActive,
   areGroundSpoilersActive = groundSpoilersActive;
 
   // anti-droop
-  if (groundSpoilersActive && !antiDroopInhibited && (-pitchAttitudeDegrees) < PITCH_ATTITUDE_REFERENCE && flapsHandleIndex > 0) {
+  if (groundSpoilersActive && !antiDroopInhibited && (-pitchAttitudeDegrees) < ANTI_DROOP_PITCH_ATTITUDE_REFERENCE &&
+      flapsHandleIndex > 0) {
     rateLimiterAntiDroop.update(ANTI_DROOP_BIAS_ON, dt);
   } else {
     rateLimiterAntiDroop.update(ANTI_DROOP_BIAS_OFF, dt);
   }
 
   // droop
-  if ((lastFlapsPosition == 0 && flapsPosition > 0) || (lastFlapsPosition > 0 && flapsPosition == 0)) {
+  if ((lastFlapsPosition <= DROOP_MINIMUM_FLAPS_EXTENSION && flapsPosition > DROOP_MINIMUM_FLAPS_EXTENSION) ||
+      (lastFlapsPosition > DROOP_MINIMUM_FLAPS_EXTENSION && flapsPosition <= DROOP_MINIMUM_FLAPS_EXTENSION)) {
     eventTime = simulationTime;
   }
   if (simulationTime - eventTime >= DROOP_TIME_SWITCH) {
-    if (flapsPosition > 0) {
+    if (flapsPosition > DROOP_MINIMUM_FLAPS_EXTENSION) {
       targetValueDroop = DROOP_BIAS_ON;
     } else {
       targetValueDroop = DROOP_BIAS_OFF;

--- a/src/fbw/src/AnimationAileronHandler.h
+++ b/src/fbw/src/AnimationAileronHandler.h
@@ -6,11 +6,18 @@ class AnimationAileronHandler {
  public:
   AnimationAileronHandler();
 
-  void update(bool groundSpoilersActive, double flapsPosition, double position, double dt);
+  void update(bool autopilotActive,
+              bool groundSpoilersActive,
+              double pitchAttitudeDegrees,
+              double flapsHandleIndex,
+              double flapsPosition,
+              double position,
+              double dt);
   double getPositionLeft();
   double getPositionRight();
 
  private:
+  static constexpr double PITCH_ATTITUDE_REFERENCE = 2.5;
   static constexpr double FLAPS_ANGLE_REFERENCE = 5.0;
   static constexpr double BIAS_DROOP_LEFT = 0.2;
   static constexpr double BIAS_DROOP_RIGHT = -0.2;
@@ -18,7 +25,6 @@ class AnimationAileronHandler {
   static constexpr double POSITION_ANTI_DROOP_RIGHT = 1.0;
   static constexpr double RATE = 2.00;
 
-  bool isGroundSpoilersActive = false;
   double droopBiasLeft = 0;
   double droopBiasRight = 0;
   double targetValueLeft = 0;

--- a/src/fbw/src/AnimationAileronHandler.h
+++ b/src/fbw/src/AnimationAileronHandler.h
@@ -18,21 +18,16 @@ class AnimationAileronHandler {
   double getPositionRight();
 
  private:
-  static constexpr double PITCH_ATTITUDE_REFERENCE = 2.5;
-  static constexpr double FLAPS_ANGLE_REFERENCE = 5.0;
-  static constexpr double BIAS_DROOP_LEFT = 0.2;
-  static constexpr double BIAS_DROOP_RIGHT = -0.2;
-  static constexpr double POSITION_ANTI_DROOP_LEFT = -1.0;
-  static constexpr double POSITION_ANTI_DROOP_RIGHT = 1.0;
-  static constexpr double RATE = 2.00;
-
+  static constexpr double AILERON_RATE = 2.00;
   static constexpr double DROOP_RATE = 0.25;
   static constexpr double DROOP_TIME_SWITCH = 2.0;
   static constexpr double DROOP_BIAS_OFF = 0.0;
   static constexpr double DROOP_BIAS_ON = 0.2;
+  static constexpr double DROOP_MINIMUM_FLAPS_EXTENSION = 0.01;
   static constexpr double ANTI_DROOP_RATE = 1.0;
   static constexpr double ANTI_DROOP_BIAS_OFF = 0.0;
   static constexpr double ANTI_DROOP_BIAS_ON = -1.2;
+  static constexpr double ANTI_DROOP_PITCH_ATTITUDE_REFERENCE = 2.5;
 
   bool antiDroopInhibited = false;
   bool areGroundSpoilersActive = false;

--- a/src/fbw/src/AnimationAileronHandler.h
+++ b/src/fbw/src/AnimationAileronHandler.h
@@ -8,6 +8,7 @@ class AnimationAileronHandler {
 
   void update(bool autopilotActive,
               bool groundSpoilersActive,
+              double simulationTime,
               double pitchAttitudeDegrees,
               double flapsHandleIndex,
               double flapsPosition,
@@ -25,10 +26,24 @@ class AnimationAileronHandler {
   static constexpr double POSITION_ANTI_DROOP_RIGHT = 1.0;
   static constexpr double RATE = 2.00;
 
-  double droopBiasLeft = 0;
-  double droopBiasRight = 0;
-  double targetValueLeft = 0;
-  double targetValueRight = 0;
+  static constexpr double DROOP_RATE = 0.25;
+  static constexpr double DROOP_TIME_SWITCH = 2.0;
+  static constexpr double DROOP_BIAS_OFF = 0.0;
+  static constexpr double DROOP_BIAS_ON = 0.2;
+  static constexpr double ANTI_DROOP_RATE = 1.0;
+  static constexpr double ANTI_DROOP_BIAS_OFF = 0.0;
+  static constexpr double ANTI_DROOP_BIAS_ON = -1.2;
+
+  bool antiDroopInhibited = false;
+  bool areGroundSpoilersActive = false;
+
+  double eventTime = 0;
+
+  double lastFlapsPosition = 0;
+  double targetValueDroop = DROOP_BIAS_OFF;
+
   RateLimiter rateLimiterLeft;
   RateLimiter rateLimiterRight;
+  RateLimiter rateLimiterDroop;
+  RateLimiter rateLimiterAntiDroop;
 };

--- a/src/fbw/src/AnimationAileronHandler.h
+++ b/src/fbw/src/AnimationAileronHandler.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "RateLimiter.h"
+
+class AnimationAileronHandler {
+ public:
+  AnimationAileronHandler();
+
+  void update(bool groundSpoilersActive, double flapsPosition, double position, double dt);
+  double getPositionLeft();
+  double getPositionRight();
+
+ private:
+  static constexpr double FLAPS_ANGLE_REFERENCE = 5.0;
+  static constexpr double BIAS_DROOP_LEFT = 0.2;
+  static constexpr double BIAS_DROOP_RIGHT = -0.2;
+  static constexpr double POSITION_ANTI_DROOP_LEFT = -1.0;
+  static constexpr double POSITION_ANTI_DROOP_RIGHT = 1.0;
+  static constexpr double RATE = 2.00;
+
+  bool isGroundSpoilersActive = false;
+  double droopBiasLeft = 0;
+  double droopBiasRight = 0;
+  double targetValueLeft = 0;
+  double targetValueRight = 0;
+  RateLimiter rateLimiterLeft;
+  RateLimiter rateLimiterRight;
+};

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -22,6 +22,7 @@ bool FlyByWireInterface::connect() {
   spoilersHandler = make_shared<SpoilersHandler>();
   elevatorTrimHandler = make_shared<ElevatorTrimHandler>();
   rudderTrimHandler = make_shared<RudderTrimHandler>();
+  animationAileronHandler = make_shared<AnimationAileronHandler>();
 
   // initialize model
   autopilotStateMachine.initialize();
@@ -304,6 +305,9 @@ void FlyByWireInterface::setupLocalVariables() {
 
   idSpoilersArmed = make_unique<LocalVariable>("A32NX_SPOILERS_ARMED");
   idSpoilersHandlePosition = make_unique<LocalVariable>("A32NX_SPOILERS_HANDLE_POSITION");
+
+  idAileronPositionLeft = make_unique<LocalVariable>("A32NX_3D_AILERON_LEFT_DEFLECTION");
+  idAileronPositionRight = make_unique<LocalVariable>("A32NX_3D_AILERON_RIGHT_DEFLECTION");
 }
 
 bool FlyByWireInterface::readDataAndLocalVariables(double sampleTime) {
@@ -1038,6 +1042,12 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
   // update speeds
   idSpeedAlphaProtection->set(flyByWireOutput.sim.data_speeds_aoa.v_alpha_prot_kn);
   idSpeedAlphaMax->set(flyByWireOutput.sim.data_speeds_aoa.v_alpha_max_kn);
+
+  // update aileron positions
+  animationAileronHandler->update(spoilersHandler->getIsGroundSpoilersActive(), simData.flaps_position,
+                                  idExternalOverride->get() == 1 ? simData.xi_pos : flyByWireOutput.output.xi_pos, sampleTime);
+  idAileronPositionLeft->set(animationAileronHandler->getPositionLeft());
+  idAileronPositionRight->set(animationAileronHandler->getPositionRight());
 
   // success ----------------------------------------------------------------------------------------------------------
   return true;

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -1044,8 +1044,8 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
   idSpeedAlphaMax->set(flyByWireOutput.sim.data_speeds_aoa.v_alpha_max_kn);
 
   // update aileron positions
-  animationAileronHandler->update(idAutopilotActiveAny->get(), spoilersHandler->getIsGroundSpoilersActive(), simData.Theta_deg,
-                                  simData.flaps_handle_index, simData.flaps_position,
+  animationAileronHandler->update(idAutopilotActiveAny->get(), spoilersHandler->getIsGroundSpoilersActive(), simData.simulationTime,
+                                  simData.Theta_deg, simData.flaps_handle_index, simData.flaps_position,
                                   idExternalOverride->get() == 1 ? simData.xi_pos : flyByWireOutput.output.xi_pos, sampleTime);
   idAileronPositionLeft->set(animationAileronHandler->getPositionLeft());
   idAileronPositionRight->set(animationAileronHandler->getPositionRight());

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -1044,7 +1044,8 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
   idSpeedAlphaMax->set(flyByWireOutput.sim.data_speeds_aoa.v_alpha_max_kn);
 
   // update aileron positions
-  animationAileronHandler->update(spoilersHandler->getIsGroundSpoilersActive(), simData.flaps_position,
+  animationAileronHandler->update(idAutopilotActiveAny->get(), spoilersHandler->getIsGroundSpoilersActive(), simData.Theta_deg,
+                                  simData.flaps_handle_index, simData.flaps_position,
                                   idExternalOverride->get() == 1 ? simData.xi_pos : flyByWireOutput.output.xi_pos, sampleTime);
   idAileronPositionLeft->set(animationAileronHandler->getPositionLeft());
   idAileronPositionRight->set(animationAileronHandler->getPositionRight());

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -3,6 +3,7 @@
 #include <MSFS/Legacy/gauges.h>
 #include <SimConnect.h>
 
+#include "AnimationAileronHandler.h"
 #include "AutopilotLaws.h"
 #include "AutopilotStateMachine.h"
 #include "Autothrust.h"
@@ -211,6 +212,10 @@ class FlyByWireInterface {
 
   std::shared_ptr<ElevatorTrimHandler> elevatorTrimHandler;
   std::shared_ptr<RudderTrimHandler> rudderTrimHandler;
+
+  std::unique_ptr<LocalVariable> idAileronPositionLeft;
+  std::unique_ptr<LocalVariable> idAileronPositionRight;
+  std::shared_ptr<AnimationAileronHandler> animationAileronHandler;
 
   void loadConfiguration();
   void setupLocalVariables();

--- a/src/fbw/src/SpoilersHandler.cpp
+++ b/src/fbw/src/SpoilersHandler.cpp
@@ -14,6 +14,10 @@ bool SpoilersHandler::getIsArmed() const {
   return isArmed;
 }
 
+bool SpoilersHandler::getIsGroundSpoilersActive() const {
+  return isGroundSpoilersActive;
+}
+
 double SpoilersHandler::getHandlePosition() const {
   return handlePosition;
 }
@@ -128,6 +132,7 @@ void SpoilersHandler::update(double simulationTime_new,
       } else {
         simPosition = handlePosition_new;
       }
+      isGroundSpoilersActive = false;
     }
   }
 
@@ -181,6 +186,7 @@ void SpoilersHandler::update(double simulationTime_new,
   if (conditionTakeOff) {
     if ((isArmed && areThrustLeversAtOrBelowIdle) || isAtLeastOneInReverseAndOtherInIdle(thrustLeverAngle_1, thrustLeverAngle_2)) {
       simPosition = POSITION_FULL;
+      isGroundSpoilersActive = true;
     }
   }
 
@@ -198,6 +204,7 @@ void SpoilersHandler::update(double simulationTime_new,
         if (areThrustLeversAtOrBelowIdle || isAtLeastOneThrustLeverInReverseAndOtherBelowMct) {
           // full deployment
           simPosition = POSITION_FULL;
+          isGroundSpoilersActive = true;
         } else if (isArmed && areThrustLeversBelowClimb) {
           // partial deployment
           simPosition = POSITION_PARTIAL;
@@ -214,6 +221,7 @@ void SpoilersHandler::update(double simulationTime_new,
         if (numberOfMainLandingGearsOnGround == 2) {
           // full deployment
           simPosition = POSITION_FULL;
+          isGroundSpoilersActive = true;
         } else if (numberOfMainLandingGearsOnGround >= 1) {
           // partial deployment
           simPosition = POSITION_PARTIAL;
@@ -225,6 +233,7 @@ void SpoilersHandler::update(double simulationTime_new,
     if (numberOfMainLandingGearsOnGround > 0 &&
         (thrustLeverAngle_1 > TLA_CONDITION_TOUCH_GO || thrustLeverAngle_2 > TLA_CONDITION_TOUCH_GO)) {
       simPosition = fmax(handlePosition, POSITION_RETRACTED);
+      isGroundSpoilersActive = false;
     }
   }
 }

--- a/src/fbw/src/SpoilersHandler.h
+++ b/src/fbw/src/SpoilersHandler.h
@@ -6,6 +6,7 @@ class SpoilersHandler {
   bool getIsArmed() const;
   double getHandlePosition() const;
   double getSimPosition() const;
+  bool getIsGroundSpoilersActive() const;
 
   void setInitialPosition(double position);
   void setSimulationVariables(double simulationTime_new,
@@ -65,6 +66,8 @@ class SpoilersHandler {
   double landingGearCompression_2 = 0.0;
   double flapsHandleIndex = 0.0;
   bool isAngleOfAttackProtectionActive = false;
+
+  bool isGroundSpoilersActive = false;
 
   void update(bool isArmed_new, double handlePosition_new);
 

--- a/src/fbw/src/interface/SimConnectData.h
+++ b/src/fbw/src/interface/SimConnectData.h
@@ -37,6 +37,7 @@ struct SimData {
   double gear_animation_pos_1;
   double gear_animation_pos_2;
   double flaps_handle_index;
+  double flaps_position;
   double spoilers_handle_position;
   double spoilers_left_pos;
   double spoilers_right_pos;

--- a/src/fbw/src/interface/SimConnectInterface.cpp
+++ b/src/fbw/src/interface/SimConnectInterface.cpp
@@ -120,6 +120,7 @@ bool SimConnectInterface::prepareSimDataSimConnectDataDefinitions() {
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "GEAR ANIMATION POSITION:1", "NUMBER");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "GEAR ANIMATION POSITION:2", "NUMBER");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "FLAPS HANDLE INDEX", "NUMBER");
+  result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "TRAILING EDGE FLAPS LEFT ANGLE", "DEGREES");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "SPOILERS HANDLE POSITION", "POSITION");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "SPOILERS LEFT POSITION", "PERCENT OVER 100");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "SPOILERS RIGHT POSITION", "PERCENT OVER 100");

--- a/src/instruments/src/SD/Pages/Fctl/Fctl.tsx
+++ b/src/instruments/src/SD/Pages/Fctl/Fctl.tsx
@@ -85,8 +85,8 @@ export const FctlPage = () => {
 };
 
 const Spoilers = ({ x = 0, y = 0 }: ComponentPositionProps) => {
-    const [aileronLeftDeflectionState] = useSimVar('AILERON LEFT DEFLECTION PCT', 'percent over 100', 50);
-    const [aileronRightDeflectionState] = useSimVar('AILERON RIGHT DEFLECTION PCT', 'percent over 100', 50);
+    const [aileronLeftDeflectionState] = useSimVar('L:A32NX_3D_AILERON_LEFT_DEFLECTION', 'number', 50);
+    const [aileronRightDeflectionState] = useSimVar('L:A32NX_3D_AILERON_RIGHT_DEFLECTION', 'number', 50);
 
     const [leftSpoilerState] = useSimVar('SPOILERS LEFT POSITION', 'percent over 100', 50);
     const [rightSpoilerState] = useSimVar('SPOILERS RIGHT POSITION', 'percent over 100', 50);
@@ -267,7 +267,7 @@ const Stabilizer = ({ x, y }: ComponentPositionProps) => (
 const Aileron = ({ x, y, side, leftHydraulicSystem, rightHydraulicSystem }: ComponentPositionProps & ComponentSidePositionProps & HydraulicSystemPairProps) => {
     const textPositionX = side === 'left' ? -40 : 40;
 
-    const [aileronDeflection] = useSimVar(`AILERON ${side.toUpperCase()} DEFLECTION PCT`, 'percent over 100', 50);
+    const [aileronDeflection] = useSimVar(`L:A32NX_3D_AILERON_${side.toUpperCase()}_DEFLECTION`, 'number', 50);
     const aileronDeflectPctNormalized = aileronDeflection * 54;
     const cursorPath = `M${side === 'left' ? 1 : -1} ${side === 'left' ? 51 + aileronDeflectPctNormalized
         : 51 - aileronDeflectPctNormalized} l${side === 'right' ? '-' : ''}15 -7 l0 14Z`;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #4805

## Summary of Changes
This PR introduces **visual** aileron droop and anti-droop function:
- the ailerons are drooping 5° down on both sides when flaps are extended
- the ailerons are anti-drooping when ground spoilers are fully applied / deployed (not on partial deployment)

### What means visual?
Visual means that the droop and anti-droop of the ailerons is visible on the 3D model and on the FCTL SD page but it's not visible in simulation variables and also has no impact on the flight model.

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
https://www.youtube.com/watch?v=fEyOEUGiBi0
https://www.youtube.com/watch?v=CmHPzIs38sY

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- test if ailerons move properly in normal flight and with AP on and off
- test if ailerons droop with flaps (and only with flaps)
- test if ailerons anti-droop when **all** of the following conditions are true:
  - ground spoilers fully deployed (rejected take-off or on landing)
  - Autopilot off
  - Flaps/Slats deployed
  - pitch attitude < 2.5°

### Compatibility
It would be good to know how the custom animation of the ailerons is interacting with third party tools. Therefore please make a test with a replay tool if you have one and do a flight with a tool like YourControls if you have time and it's possible for you.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
