### PR TITLE
build: update to dev-env with SDK 0.13

### DIFF
--- a/scripts/dev-env/run.cmd
+++ b/scripts/dev-env/run.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set image="ghcr.io/flybywiresim/dev-env@sha256:0bf0844b914cbd45a8a0a866a71c7a07fa09308f48cb961708be479f0d63aa0f"
+set image="ghcr.io/flybywiresim/dev-env@sha256:9e1cad0d8122187c530d0f5027b6440982e7c72dca3f04d8cbf6010baca8ac83"
 
 docker image inspect %image% 1> nul || docker system prune --filter label=flybywiresim=true -f
 docker run --rm -it -v "%cd%:/external" %image% %*

--- a/scripts/dev-env/run.sh
+++ b/scripts/dev-env/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE="ghcr.io/flybywiresim/dev-env@sha256:0bf0844b914cbd45a8a0a866a71c7a07fa09308f48cb961708be479f0d63aa0f"
+IMAGE="ghcr.io/flybywiresim/dev-env@sha256:9e1cad0d8122187c530d0f5027b6440982e7c72dca3f04d8cbf6010baca8ac83"
 
 # only set `-it` if there is a tty
 if [ -t 0 ] && [ -t 1 ];


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
This PR updates the dev-env to use SDK 0.13 for compilation instead of 0.9.

## Testing instructions
Fly the plane as usual, expectation is no difference to current development version.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
