### PR TITLE
feat: added FMA triple click mode reversion logic + automatic NAV arm on ground + connect FDs on FCU power on

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -94,6 +94,7 @@
 1. [MCDU] Improve robustness of Lat/Lon & P-B/P-B input parsing - @tracernz (Mike)
 1. [RTPI] Add separate RTPI font file - @sidnov (Sid)
 1. [AP+PFD] Added triple click and FMA mode reversion logic - @aguther (Andreas Guther)
+1. [AP] Automatically arm NAV on ground when flight plan becomes available - @aguther (Andreas Guther)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -95,6 +95,7 @@
 1. [RTPI] Add separate RTPI font file - @sidnov (Sid)
 1. [AP+PFD] Added triple click and FMA mode reversion logic - @aguther (Andreas Guther)
 1. [AP] Automatically arm NAV on ground when flight plan becomes available - @aguther (Andreas Guther)
+1. [FCU] Automatically connect flight directors when FCU is powered on - @aguther (Andreas Guther)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -93,6 +93,7 @@
 1. [VFX] Add APU exhaust heat blur effect - @wpine215 (Iceman)
 1. [MCDU] Improve robustness of Lat/Lon & P-B/P-B input parsing - @tracernz (Mike)
 1. [RTPI] Add separate RTPI font file - @sidnov (Sid)
+1. [AP+PFD] Added triple click and FMA mode reversion logic - @aguther (Andreas Guther)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/sound/sound.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/sound/sound.xml
@@ -1535,6 +1535,13 @@
             </Requires>
         </Sound>
 
+        <Sound WwiseEvent="3click" WwiseData="true" NodeName="PEDALS_LEFT" LocalVar="A32NX_FMA_TRIPLE_CLICK" Continuous="false">
+            <Range LowerBound="1"/>
+            <Requires SimVar="ELECTRICAL MAIN BUS VOLTAGE" Units="VOLTS" Index="1">
+                <Range LowerBound="28" />
+            </Requires>
+        </Sound>
+
     </SimVarSounds>
 
     <!-- AvionicSounds ========================================================================================== -->

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
@@ -619,6 +619,7 @@ class A320_Neo_FCU_Heading extends A320_Neo_FCU_Component {
                 this.selectedValue = _value;
                 this.isSelectedValueActive = false;
                 this.isPreselectionModeActive = false;
+                SimVar.SetSimVarValue("K:HEADING_SLOT_INDEX_SET", "number", 2);
             }
             if (_isManagedActive !== this.isManagedActive) {
                 if (_isManagedActive) {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
@@ -30,8 +30,17 @@ class A320_Neo_FCU extends BaseAirliners {
     onUpdate(_deltaTime) {
         super.onUpdate(_deltaTime);
 
-        this.electricity.style.display = SimVar.GetSimVarValue("L:A32NX_ELEC_DC_ESS_BUS_IS_POWERED", "Bool") ||
+        const newStyle = SimVar.GetSimVarValue("L:A32NX_ELEC_DC_ESS_BUS_IS_POWERED", "Bool") ||
             SimVar.GetSimVarValue("L:A32NX_ELEC_DC_2_BUS_IS_POWERED", "Bool") ? "block" : "none";
+        if (newStyle === "block" && newStyle !== this.electricity.style.display) {
+            if (!SimVar.GetSimVarValue("AUTOPILOT FLIGHT DIRECTOR ACTIVE:1", "bool")) {
+                SimVar.SetSimVarValue("K:TOGGLE_FLIGHT_DIRECTOR", "number", 1);
+            }
+            if (!SimVar.GetSimVarValue("AUTOPILOT FLIGHT DIRECTOR ACTIVE:2", "bool")) {
+                SimVar.SetSimVarValue("K:TOGGLE_FLIGHT_DIRECTOR", "number", 2);
+            }
+        }
+        this.electricity.style.display = newStyle;
     }
     onEvent(_event) {
     }

--- a/src/fbw/src/FlightDataRecorder.h
+++ b/src/fbw/src/FlightDataRecorder.h
@@ -12,7 +12,7 @@
 class FlightDataRecorder {
  public:
   // IMPORTANT: this constant needs to increased with every interface change
-  const uint64_t INTERFACE_VERSION = 4;
+  const uint64_t INTERFACE_VERSION = 5;
 
   void initialize();
 

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -207,6 +207,8 @@ void FlyByWireInterface::setupLocalVariables() {
   idFmaSoftAltModeActive = make_unique<LocalVariable>("A32NX_FMA_SOFT_ALT_MODE");
   idFmaCruiseAltModeActive = make_unique<LocalVariable>("A32NX_FMA_CRUISE_ALT_MODE");
   idFmaApproachCapability = make_unique<LocalVariable>("A32NX_ApproachCapability");
+  idFmaTripleClick = make_unique<LocalVariable>("A32NX_FMA_TRIPLE_CLICK");
+  idFmaModeReversion = make_unique<LocalVariable>("A32NX_FMA_MODE_REVERSION");
 
   // register L variable for flight director
   idFlightDirectorBank = make_unique<LocalVariable>("A32NX_FLIGHT_DIRECTOR_BANK");
@@ -560,6 +562,8 @@ bool FlyByWireInterface::updateAutopilotStateMachine(double sampleTime) {
     autopilotStateMachineOutput.mode_reversion_lateral = clientData.mode_reversion_lateral;
     autopilotStateMachineOutput.mode_reversion_vertical = clientData.mode_reversion_vertical;
     autopilotStateMachineOutput.mode_reversion_TRK_FPA = clientData.mode_reversion_TRK_FPA;
+    autopilotStateMachineOutput.mode_reversion_triple_click = clientData.mode_reversion_triple_click;
+    autopilotStateMachineOutput.mode_reversion_fma = clientData.mode_reversion_fma;
     autopilotStateMachineOutput.speed_protection_mode = clientData.speed_protection_mode;
     autopilotStateMachineOutput.autothrust_mode = clientData.autothrust_mode;
     autopilotStateMachineOutput.Psi_c_deg = clientData.Psi_c_deg;
@@ -729,6 +733,10 @@ bool FlyByWireInterface::updateAutopilotStateMachine(double sampleTime) {
       idAutopilotAutolandWarning->set(1);
     }
   }
+
+  // FMA triple click and mode reversion ------------------------------------------------------------------------------
+  idFmaTripleClick->set(autopilotStateMachineOutput.mode_reversion_triple_click);
+  idFmaModeReversion->set(autopilotStateMachineOutput.mode_reversion_fma);
 
   // return result ----------------------------------------------------------------------------------------------------
   return true;

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -117,6 +117,8 @@ class FlyByWireInterface {
   std::unique_ptr<LocalVariable> idFmaExpediteModeActive;
   std::unique_ptr<LocalVariable> idFmaSpeedProtectionActive;
   std::unique_ptr<LocalVariable> idFmaApproachCapability;
+  std::unique_ptr<LocalVariable> idFmaTripleClick;
+  std::unique_ptr<LocalVariable> idFmaModeReversion;
 
   std::unique_ptr<LocalVariable> idFlightDirectorBank;
   std::unique_ptr<LocalVariable> idFlightDirectorPitch;

--- a/src/fbw/src/interface/SimConnectData.h
+++ b/src/fbw/src/interface/SimConnectData.h
@@ -193,6 +193,8 @@ struct ClientDataAutopilotStateMachine {
   double mode_reversion_lateral;
   double mode_reversion_vertical;
   double mode_reversion_TRK_FPA;
+  double mode_reversion_triple_click;
+  double mode_reversion_fma;
   double speed_protection_mode;
   double autothrust_mode;
   double Psi_c_deg;

--- a/src/fbw/src/interface/SimConnectInterface.cpp
+++ b/src/fbw/src/interface/SimConnectInterface.cpp
@@ -451,6 +451,10 @@ bool SimConnectInterface::prepareClientDataDefinitions() {
                                                  SIMCONNECT_CLIENTDATATYPE_FLOAT64);
   result &= SimConnect_AddToClientDataDefinition(hSimConnect, ClientData::AUTOPILOT_STATE_MACHINE, SIMCONNECT_CLIENTDATAOFFSET_AUTO,
                                                  SIMCONNECT_CLIENTDATATYPE_FLOAT64);
+  result &= SimConnect_AddToClientDataDefinition(hSimConnect, ClientData::AUTOPILOT_STATE_MACHINE, SIMCONNECT_CLIENTDATAOFFSET_AUTO,
+                                                 SIMCONNECT_CLIENTDATATYPE_FLOAT64);
+  result &= SimConnect_AddToClientDataDefinition(hSimConnect, ClientData::AUTOPILOT_STATE_MACHINE, SIMCONNECT_CLIENTDATAOFFSET_AUTO,
+                                                 SIMCONNECT_CLIENTDATATYPE_FLOAT64);
 
   // request data to be updated when set
   result &= SimConnect_RequestClientData(hSimConnect, ClientData::AUTOPILOT_STATE_MACHINE, ClientData::AUTOPILOT_STATE_MACHINE,

--- a/src/fbw/src/model/AutopilotLaws_data.cpp
+++ b/src/fbw/src/model/AutopilotLaws_data.cpp
@@ -81,6 +81,8 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
       0.0,
       false,
       false,
+      false,
+      false,
       0.0,
       0.0,
       0.0,

--- a/src/fbw/src/model/AutopilotLaws_types.h
+++ b/src/fbw/src/model/AutopilotLaws_types.h
@@ -89,6 +89,8 @@ typedef struct {
   real_T mode_reversion_lateral;
   real_T mode_reversion_vertical;
   boolean_T mode_reversion_TRK_FPA;
+  boolean_T mode_reversion_triple_click;
+  boolean_T mode_reversion_fma;
   boolean_T speed_protection_mode;
   real_T autothrust_mode;
   real_T Psi_c_deg;

--- a/src/fbw/src/model/AutopilotStateMachine.cpp
+++ b/src/fbw/src/model/AutopilotStateMachine.cpp
@@ -1391,6 +1391,19 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_DES(void)
   }
 }
 
+void AutopilotStateMachineModelClass::AutopilotStateMachine_FLARE_during(void)
+{
+  AutopilotStateMachine_B.out.mode = vertical_mode_FLARE;
+  AutopilotStateMachine_B.out.law = vertical_law_FLARE;
+  if ((AutopilotStateMachine_B.BusAssignment_g.data.H_radio_ft <= 30.0) &&
+      ((AutopilotStateMachine_B.BusAssignment_g.output.enabled_AP1 != 0.0) ||
+       (AutopilotStateMachine_B.BusAssignment_g.output.enabled_AP2 != 0.0))) {
+    AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_IDLE;
+  } else {
+    AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_SPEED;
+  }
+}
+
 void AutopilotStateMachineModelClass::AutopilotStateMachine_ROLL_OUT_entry_o(void)
 {
   AutopilotStateMachine_B.out.mode = vertical_mode_ROLL_OUT;
@@ -1440,14 +1453,8 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_LAND_entry_i(void)
 void AutopilotStateMachineModelClass::AutopilotStateMachine_FLARE_entry_g(void)
 {
   AutopilotStateMachine_B.out.mode = vertical_mode_FLARE;
-  if ((AutopilotStateMachine_B.BusAssignment_g.output.enabled_AP1 != 0.0) ||
-      (AutopilotStateMachine_B.BusAssignment_g.output.enabled_AP2 != 0.0)) {
-    AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_IDLE;
-  } else {
-    AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_SPEED;
-  }
-
   AutopilotStateMachine_B.out.law = vertical_law_FLARE;
+  AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_SPEED;
 }
 
 void AutopilotStateMachineModelClass::AutopilotStateMachine_GS(void)
@@ -1463,6 +1470,8 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_GS(void)
     if (AutopilotStateMachine_B.BusAssignment_g.vertical.condition.ROLL_OUT) {
       AutopilotStateMachine_DWork.is_GS = AutopilotStateMachine_IN_ROLL_OUT;
       AutopilotStateMachine_ROLL_OUT_entry_o();
+    } else {
+      AutopilotStateMachine_FLARE_during();
     }
     break;
 
@@ -1925,6 +1934,7 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_ON_l(void)
           AutopilotStateMachine_B.out.mode_reversion = true;
           guard1 = true;
         } else if ((!AutopilotStateMachine_B.BusAssignment_g.vertical.condition.CLB) && (tmp > 50.0)) {
+          AutopilotStateMachine_B.out.mode_reversion = true;
           if (tmp > 50.0) {
             guard3 = true;
           } else if (tmp < -50.0) {
@@ -3034,6 +3044,10 @@ void AutopilotStateMachineModelClass::step()
     AutopilotStateMachine_P.ap_sm_output_MATLABStruct.output.mode_reversion_vertical;
   AutopilotStateMachine_B.BusAssignment_g.output.mode_reversion_TRK_FPA =
     AutopilotStateMachine_P.ap_sm_output_MATLABStruct.output.mode_reversion_TRK_FPA;
+  AutopilotStateMachine_B.BusAssignment_g.output.mode_reversion_triple_click =
+    AutopilotStateMachine_P.ap_sm_output_MATLABStruct.output.mode_reversion_triple_click;
+  AutopilotStateMachine_B.BusAssignment_g.output.mode_reversion_fma =
+    AutopilotStateMachine_P.ap_sm_output_MATLABStruct.output.mode_reversion_fma;
   AutopilotStateMachine_B.BusAssignment_g.output.speed_protection_mode =
     AutopilotStateMachine_P.ap_sm_output_MATLABStruct.output.speed_protection_mode;
   AutopilotStateMachine_B.BusAssignment_g.output.autothrust_mode =
@@ -3407,6 +3421,126 @@ void AutopilotStateMachineModelClass::step()
   AutopilotStateMachine_DWork.Delay_DSTATE_e += rtb_GainTheta1;
   AutopilotStateMachine_DWork.DelayInput1_DSTATE_o = (AutopilotStateMachine_DWork.Delay_DSTATE_e !=
     AutopilotStateMachine_P.CompareToConstant_const_da);
+  if (!AutopilotStateMachine_DWork.eventTimeTC_not_empty) {
+    AutopilotStateMachine_DWork.eventTimeTC = AutopilotStateMachine_B.BusAssignment_g.time.simulation_time;
+    AutopilotStateMachine_DWork.eventTimeTC_not_empty = true;
+  }
+
+  if (!AutopilotStateMachine_DWork.eventTimeMR_not_empty) {
+    AutopilotStateMachine_DWork.eventTimeMR = AutopilotStateMachine_B.BusAssignment_g.time.simulation_time;
+    AutopilotStateMachine_DWork.eventTimeMR_not_empty = true;
+  }
+
+  engageCondition = !AutopilotStateMachine_B.BusAssignment_g.input.VS_pull;
+  if (AutopilotStateMachine_B.out.mode_reversion &&
+      (((AutopilotStateMachine_B.BusAssignment_g.vertical_previous.output.mode == vertical_mode_CLB) &&
+        (AutopilotStateMachine_B.out.mode == vertical_mode_OP_CLB)) ||
+       ((AutopilotStateMachine_B.BusAssignment_g.vertical_previous.output.mode == vertical_mode_DES) &&
+        (AutopilotStateMachine_B.out.mode == vertical_mode_VS))) &&
+      (!AutopilotStateMachine_B.BusAssignment_g.input.ALT_pull) && engageCondition) {
+    AutopilotStateMachine_DWork.warningArmedNAV = true;
+    AutopilotStateMachine_DWork.warningArmedVS = false;
+    AutopilotStateMachine_DWork.eventTimeTC = AutopilotStateMachine_B.BusAssignment_g.time.simulation_time;
+    AutopilotStateMachine_DWork.modeReversionFMA = false;
+    AutopilotStateMachine_DWork.eventTimeMR = AutopilotStateMachine_B.BusAssignment_g.time.simulation_time;
+  } else {
+    if (AutopilotStateMachine_DWork.warningArmedNAV && (AutopilotStateMachine_B.BusAssignment_g.input.VS_push ||
+         AutopilotStateMachine_B.BusAssignment_g.input.VS_pull ||
+         AutopilotStateMachine_B.BusAssignment_g.data_computed.H_fcu_in_selection)) {
+      AutopilotStateMachine_DWork.warningArmedNAV = false;
+      AutopilotStateMachine_DWork.modeReversionFMA = false;
+    }
+  }
+
+  if (AutopilotStateMachine_B.BusAssignment_g.input.TRK_FPA_mode) {
+    rtb_GainTheta = AutopilotStateMachine_B.BusAssignment_g.input.FPA_fcu_deg;
+  } else {
+    rtb_GainTheta = AutopilotStateMachine_B.BusAssignment_g.input.H_dot_fcu_fpm;
+  }
+
+  if (!AutopilotStateMachine_DWork.lastVsTarget_not_empty) {
+    AutopilotStateMachine_DWork.lastVsTarget = rtb_GainTheta;
+    AutopilotStateMachine_DWork.lastVsTarget_not_empty = true;
+  }
+
+  if (AutopilotStateMachine_B.out.mode_reversion && (AutopilotStateMachine_B.out.mode == vertical_mode_VS) &&
+      ((AutopilotStateMachine_B.BusAssignment_g.vertical_previous.output.mode == vertical_mode_OP_CLB) ||
+       (AutopilotStateMachine_B.BusAssignment_g.vertical_previous.output.mode == vertical_mode_OP_DES) ||
+       (AutopilotStateMachine_B.BusAssignment_g.vertical_previous.output.mode == vertical_mode_ALT_CPT)) &&
+      (!AutopilotStateMachine_B.BusAssignment_g.input.VS_push) && engageCondition) {
+    AutopilotStateMachine_DWork.warningArmedVS = true;
+    AutopilotStateMachine_DWork.warningArmedNAV = false;
+    AutopilotStateMachine_DWork.eventTimeTC = AutopilotStateMachine_B.BusAssignment_g.time.simulation_time;
+    AutopilotStateMachine_DWork.modeReversionFMA = false;
+    AutopilotStateMachine_DWork.eventTimeMR = AutopilotStateMachine_B.BusAssignment_g.time.simulation_time;
+  } else {
+    if (AutopilotStateMachine_DWork.warningArmedVS && (AutopilotStateMachine_B.BusAssignment_g.input.ALT_pull ||
+         AutopilotStateMachine_B.BusAssignment_g.input.VS_push || ((AutopilotStateMachine_DWork.lastVsTarget != 0.0) &&
+          (rtb_GainTheta != AutopilotStateMachine_DWork.lastVsTarget)))) {
+      AutopilotStateMachine_DWork.modeReversionFMA = false;
+      AutopilotStateMachine_DWork.warningArmedVS = false;
+    }
+  }
+
+  AutopilotStateMachine_DWork.lastVsTarget = rtb_GainTheta;
+  if ((AutopilotStateMachine_B.BusAssignment_g.output.enabled_AP1 == 0.0) &&
+      (AutopilotStateMachine_B.BusAssignment_g.output.enabled_AP2 == 0.0) && AutopilotStateMachine_B.out.FD_disconnect &&
+      ((AutopilotStateMachine_B.BusAssignment_g.vertical_previous.output.mode == vertical_mode_OP_CLB) ||
+       (AutopilotStateMachine_B.BusAssignment_g.vertical_previous.output.mode == vertical_mode_OP_DES))) {
+    AutopilotStateMachine_DWork.modeReversionFMA = false;
+    rtb_on_ground = 1;
+    AutopilotStateMachine_Y.out.output.mode_reversion_fma = AutopilotStateMachine_DWork.modeReversionFMA;
+  } else if (AutopilotStateMachine_B.out.speed_protection_mode &&
+             (!AutopilotStateMachine_B.BusAssignment_g.vertical_previous.output.speed_protection_mode)) {
+    AutopilotStateMachine_DWork.modeReversionFMA = false;
+    rtb_on_ground = 1;
+    AutopilotStateMachine_Y.out.output.mode_reversion_fma = AutopilotStateMachine_DWork.modeReversionFMA;
+  } else {
+    if ((!AutopilotStateMachine_B.out.mode_reversion) &&
+        (AutopilotStateMachine_B.BusAssignment_g.vertical_previous.output.mode != AutopilotStateMachine_B.out.mode)) {
+      AutopilotStateMachine_DWork.warningArmedNAV = false;
+      AutopilotStateMachine_DWork.warningArmedVS = false;
+      AutopilotStateMachine_DWork.modeReversionFMA = false;
+    }
+
+    if (((!AutopilotStateMachine_DWork.warningArmedNAV) && (!AutopilotStateMachine_DWork.warningArmedVS)) ||
+        (AutopilotStateMachine_DWork.eventTimeTC == 0.0)) {
+      AutopilotStateMachine_DWork.eventTimeTC = AutopilotStateMachine_B.BusAssignment_g.time.simulation_time;
+    }
+
+    if ((!AutopilotStateMachine_DWork.modeReversionFMA) || (AutopilotStateMachine_DWork.eventTimeMR == 0.0)) {
+      AutopilotStateMachine_DWork.eventTimeMR = AutopilotStateMachine_B.BusAssignment_g.time.simulation_time;
+    }
+
+    if (AutopilotStateMachine_B.BusAssignment_g.time.simulation_time - AutopilotStateMachine_DWork.eventTimeTC >= 5.0) {
+      rtb_on_ground = 1;
+      AutopilotStateMachine_DWork.modeReversionFMA = true;
+      AutopilotStateMachine_DWork.warningArmedNAV = false;
+      AutopilotStateMachine_DWork.warningArmedVS = false;
+    } else {
+      rtb_on_ground = 0;
+    }
+
+    AutopilotStateMachine_DWork.modeReversionFMA = ((AutopilotStateMachine_B.BusAssignment_g.time.simulation_time -
+      AutopilotStateMachine_DWork.eventTimeMR < 10.0) && AutopilotStateMachine_DWork.modeReversionFMA);
+    AutopilotStateMachine_Y.out.output.mode_reversion_fma = AutopilotStateMachine_DWork.modeReversionFMA;
+  }
+
+  rtb_GainTheta1 = static_cast<real_T>(rtb_on_ground) - AutopilotStateMachine_DWork.Delay_DSTATE_n;
+  rtb_GainTheta = AutopilotStateMachine_P.Raising_Value_a * AutopilotStateMachine_B.BusAssignment_g.time.dt;
+  if (rtb_GainTheta1 < rtb_GainTheta) {
+    rtb_GainTheta = rtb_GainTheta1;
+  }
+
+  rtb_GainTheta1 = AutopilotStateMachine_P.Falling_Value_k / AutopilotStateMachine_P.Debounce1_Value *
+    AutopilotStateMachine_B.BusAssignment_g.time.dt;
+  if (rtb_GainTheta > rtb_GainTheta1) {
+    rtb_GainTheta1 = rtb_GainTheta;
+  }
+
+  AutopilotStateMachine_DWork.Delay_DSTATE_n += rtb_GainTheta1;
+  AutopilotStateMachine_DWork.DelayInput1_DSTATE_h = (AutopilotStateMachine_DWork.Delay_DSTATE_n !=
+    AutopilotStateMachine_P.CompareToConstant_const_n);
   AutopilotStateMachine_Y.out.time = AutopilotStateMachine_B.BusAssignment_g.time;
   AutopilotStateMachine_Y.out.data = AutopilotStateMachine_B.BusAssignment_g.data;
   AutopilotStateMachine_Y.out.data_computed = AutopilotStateMachine_B.BusAssignment_g.data_computed;
@@ -3424,6 +3558,7 @@ void AutopilotStateMachineModelClass::step()
   AutopilotStateMachine_Y.out.output.vertical_law = static_cast<int32_T>(AutopilotStateMachine_B.out.law);
   AutopilotStateMachine_Y.out.output.vertical_mode = static_cast<int32_T>(AutopilotStateMachine_B.out.mode);
   AutopilotStateMachine_Y.out.output.mode_reversion_TRK_FPA = AutopilotStateMachine_DWork.DelayInput1_DSTATE_o;
+  AutopilotStateMachine_Y.out.output.mode_reversion_triple_click = AutopilotStateMachine_DWork.DelayInput1_DSTATE_h;
   AutopilotStateMachine_Y.out.output.speed_protection_mode = AutopilotStateMachine_B.out.speed_protection_mode;
   AutopilotStateMachine_Y.out.output.autothrust_mode = static_cast<int32_T>(AutopilotStateMachine_B.out.mode_autothrust);
   AutopilotStateMachine_Y.out.output.Psi_c_deg = AutopilotStateMachine_B.BusAssignment_g.lateral.output.Psi_c_deg;
@@ -3496,6 +3631,7 @@ void AutopilotStateMachineModelClass::initialize()
     AutopilotStateMachine_DWork.Delay_DSTATE_f = AutopilotStateMachine_P.RateLimiterDynamicVariableTs_InitialCondition;
     AutopilotStateMachine_DWork.Delay_DSTATE_l = AutopilotStateMachine_P.RateLimiterDynamicVariableTs_InitialCondition_d;
     AutopilotStateMachine_DWork.Delay_DSTATE_e = AutopilotStateMachine_P.RateLimiterDynamicVariableTs_InitialCondition_g;
+    AutopilotStateMachine_DWork.Delay_DSTATE_n = AutopilotStateMachine_P.RateLimiterDynamicVariableTs_InitialCondition_h;
   }
 }
 

--- a/src/fbw/src/model/AutopilotStateMachine.cpp
+++ b/src/fbw/src/model/AutopilotStateMachine.cpp
@@ -2472,20 +2472,27 @@ void AutopilotStateMachineModelClass::step()
   AutopilotStateMachine_DWork.sLandModeArmedOrActive = speedTargetChanged;
   AutopilotStateMachine_DWork.sRollOutActive = conditionSoftAlt;
   AutopilotStateMachine_DWork.sGoAroundModeActive = rtb_cLAND;
-  AutopilotStateMachine_DWork.state_h = ((AutopilotStateMachine_U.in.data.is_flight_plan_available &&
-    (!AutopilotStateMachine_DWork.Delay_DSTATE.condition.NAV) && AutopilotStateMachine_DWork.DelayInput1_DSTATE_e &&
-    (AutopilotStateMachine_DWork.Delay_DSTATE.output.mode != lateral_mode_NAV) &&
-    (AutopilotStateMachine_DWork.Delay_DSTATE.output.mode != lateral_mode_LOC_CPT) &&
+  if (!AutopilotStateMachine_DWork.wasFlightPlanAvailable_not_empty) {
+    AutopilotStateMachine_DWork.wasFlightPlanAvailable = AutopilotStateMachine_U.in.data.is_flight_plan_available;
+    AutopilotStateMachine_DWork.wasFlightPlanAvailable_not_empty = true;
+  }
+
+  AutopilotStateMachine_DWork.state_d = ((AutopilotStateMachine_U.in.data.is_flight_plan_available &&
+    (!AutopilotStateMachine_DWork.Delay_DSTATE.condition.NAV) && (AutopilotStateMachine_DWork.DelayInput1_DSTATE_e ||
+    ((rtb_on_ground != 0) && (!AutopilotStateMachine_DWork.wasFlightPlanAvailable) &&
+     AutopilotStateMachine_U.in.data.is_flight_plan_available)) && (AutopilotStateMachine_DWork.Delay_DSTATE.output.mode
+    != lateral_mode_NAV) && (AutopilotStateMachine_DWork.Delay_DSTATE.output.mode != lateral_mode_LOC_CPT) &&
     (AutopilotStateMachine_DWork.Delay_DSTATE.output.mode != lateral_mode_LOC_TRACK) &&
     (AutopilotStateMachine_DWork.Delay_DSTATE.output.mode != lateral_mode_LAND) &&
-    (AutopilotStateMachine_DWork.Delay_DSTATE.output.mode != lateral_mode_FLARE)) || AutopilotStateMachine_DWork.state_h);
+    (AutopilotStateMachine_DWork.Delay_DSTATE.output.mode != lateral_mode_FLARE)) || AutopilotStateMachine_DWork.state_d);
   engageCondition = !AutopilotStateMachine_DWork.Delay_DSTATE.armed.LOC;
-  AutopilotStateMachine_DWork.state_h = ((!AutopilotStateMachine_DWork.DelayInput1_DSTATE_g) &&
+  AutopilotStateMachine_DWork.state_d = ((!AutopilotStateMachine_DWork.DelayInput1_DSTATE_g) &&
     ((AutopilotStateMachine_U.in.data.H_radio_ft >= 30.0) || (!rtb_AND)) && engageCondition &&
     (!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode == lateral_mode_NAV)) &&
     (!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode == lateral_mode_LAND)) &&
     (!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode == lateral_mode_FLARE)) &&
-    AutopilotStateMachine_DWork.state_h);
+    AutopilotStateMachine_DWork.state_d);
+  AutopilotStateMachine_DWork.wasFlightPlanAvailable = AutopilotStateMachine_U.in.data.is_flight_plan_available;
   rtb_cLAND = (AutopilotStateMachine_DWork.Delay1_DSTATE.armed.GS ||
                (AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode == vertical_mode_GS_CPT) ||
                (AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode == vertical_mode_GS_TRACK) ||
@@ -2496,16 +2503,16 @@ void AutopilotStateMachineModelClass::step()
              (!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode == lateral_mode_LOC_TRACK)) &&
              (!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode == lateral_mode_LAND)) &&
              (!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode == lateral_mode_FLARE)));
-  AutopilotStateMachine_DWork.state_d = (((AutopilotStateMachine_U.in.data.H_radio_ft > 400.0) &&
+  AutopilotStateMachine_DWork.state_dg = (((AutopilotStateMachine_U.in.data.H_radio_ft > 400.0) &&
     AutopilotStateMachine_U.in.data.nav_valid && (AutopilotStateMachine_U.in.data.throttle_lever_1_pos < 45.0) &&
     (AutopilotStateMachine_U.in.data.throttle_lever_2_pos < 45.0) && (rtb_BusAssignment1_input_LOC_push ||
-    rtb_BusAssignment1_input_APPR_push) && rtb_cGA && rtb_cFLARE) || AutopilotStateMachine_DWork.state_d);
+    rtb_BusAssignment1_input_APPR_push) && rtb_cGA && rtb_cFLARE) || AutopilotStateMachine_DWork.state_dg);
   speedTargetChanged = !rtb_BusAssignment1_input_APPR_push;
   conditionSoftAlt = !rtb_BusAssignment1_input_LOC_push;
-  AutopilotStateMachine_DWork.state_d = ((conditionSoftAlt || engageCondition || rtb_cLAND) && (speedTargetChanged ||
+  AutopilotStateMachine_DWork.state_dg = ((conditionSoftAlt || engageCondition || rtb_cLAND) && (speedTargetChanged ||
     rtb_cFLARE) && (!AutopilotStateMachine_DWork.Delay_DSTATE.armed.NAV) && rtb_cGA &&
     (AutopilotStateMachine_U.in.data.throttle_lever_1_pos != 45.0) &&
-    (AutopilotStateMachine_U.in.data.throttle_lever_2_pos != 45.0) && AutopilotStateMachine_DWork.state_d);
+    (AutopilotStateMachine_U.in.data.throttle_lever_2_pos != 45.0) && AutopilotStateMachine_DWork.state_dg);
   rtb_y_m = (AutopilotStateMachine_U.in.data.Psi_magnetic_deg - (AutopilotStateMachine_U.in.data.nav_loc_deg + 360.0)) +
     360.0;
   if (rtb_y_m == 0.0) {
@@ -3072,8 +3079,8 @@ void AutopilotStateMachineModelClass::step()
     AutopilotStateMachine_P.ap_sm_output_MATLABStruct.output.FD_disconnect;
   AutopilotStateMachine_B.BusAssignment_g.output.FD_connect =
     AutopilotStateMachine_P.ap_sm_output_MATLABStruct.output.FD_connect;
-  AutopilotStateMachine_B.BusAssignment_g.lateral.armed.NAV = AutopilotStateMachine_DWork.state_h;
-  AutopilotStateMachine_B.BusAssignment_g.lateral.armed.LOC = AutopilotStateMachine_DWork.state_d;
+  AutopilotStateMachine_B.BusAssignment_g.lateral.armed.NAV = AutopilotStateMachine_DWork.state_d;
+  AutopilotStateMachine_B.BusAssignment_g.lateral.armed.LOC = AutopilotStateMachine_DWork.state_dg;
   AutopilotStateMachine_B.BusAssignment_g.lateral.condition.NAV = ((AutopilotStateMachine_U.in.data.H_radio_ft >= 30.0) &&
     AutopilotStateMachine_U.in.data.is_flight_plan_available && (AutopilotStateMachine_U.in.data.flight_guidance_xtk_nmi
     < 10.0));

--- a/src/fbw/src/model/AutopilotStateMachine.h
+++ b/src/fbw/src/model/AutopilotStateMachine.h
@@ -113,8 +113,10 @@ class AutopilotStateMachineModelClass {
     boolean_T eventTime_not_empty_i;
     boolean_T eventTime_not_empty_e;
     boolean_T sThrottleCondition;
-    boolean_T state_h;
+    boolean_T wasFlightPlanAvailable;
+    boolean_T wasFlightPlanAvailable_not_empty;
     boolean_T state_d;
+    boolean_T state_dg;
     boolean_T state_j;
     boolean_T sDES;
     boolean_T sCLB;

--- a/src/fbw/src/model/AutopilotStateMachine.h
+++ b/src/fbw/src/model/AutopilotStateMachine.h
@@ -39,9 +39,13 @@ class AutopilotStateMachineModelClass {
     real_T Delay_DSTATE_f;
     real_T Delay_DSTATE_l;
     real_T Delay_DSTATE_e;
+    real_T Delay_DSTATE_n;
     real_T local_H_fcu_ft;
     real_T local_H_constraint_ft;
     real_T local_H_GA_init_ft;
+    real_T eventTimeTC;
+    real_T eventTimeMR;
+    real_T lastVsTarget;
     real_T eventTime;
     real_T eventTime_n;
     real_T eventTime_i;
@@ -83,6 +87,12 @@ class AutopilotStateMachineModelClass {
     boolean_T wereAllEnginesOperative_d;
     boolean_T wereAllEnginesOperative_not_empty_a;
     boolean_T verticalSpeedCancelMode;
+    boolean_T eventTimeTC_not_empty;
+    boolean_T eventTimeMR_not_empty;
+    boolean_T warningArmedNAV;
+    boolean_T warningArmedVS;
+    boolean_T modeReversionFMA;
+    boolean_T lastVsTarget_not_empty;
     boolean_T sAP1;
     boolean_T sAP2;
     boolean_T sLandModeArmedOrActive;
@@ -135,14 +145,17 @@ class AutopilotStateMachineModelClass {
     real_T RateLimiterDynamicVariableTs_InitialCondition;
     real_T RateLimiterDynamicVariableTs_InitialCondition_d;
     real_T RateLimiterDynamicVariableTs_InitialCondition_g;
+    real_T RateLimiterDynamicVariableTs_InitialCondition_h;
     real_T Debounce_Value;
     real_T Debounce_Value_a;
     real_T Debounce_Value_j;
+    real_T Debounce1_Value;
     real_T CompareToConstant_const;
     real_T CompareToConstant_const_l;
     real_T CompareToConstant_const_d;
     real_T CompareToConstant_const_j;
     real_T CompareToConstant_const_da;
+    real_T CompareToConstant_const_n;
     real_T DetectDecrease_vinit;
     boolean_T DetectIncrease12_vinit;
     boolean_T DetectIncrease_vinit;
@@ -191,6 +204,8 @@ class AutopilotStateMachineModelClass {
     real_T Falling_Value_b;
     real_T Raising_Value_c;
     real_T Falling_Value_a;
+    real_T Raising_Value_a;
+    real_T Falling_Value_k;
   };
 
   void initialize();
@@ -275,6 +290,7 @@ class AutopilotStateMachineModelClass {
   void AutopilotStateMachine_ALT_CST_CPT_entry(void);
   void AutopilotStateMachine_DES_during(void);
   void AutopilotStateMachine_DES(void);
+  void AutopilotStateMachine_FLARE_during(void);
   void AutopilotStateMachine_ROLL_OUT_entry_o(void);
   boolean_T AutopilotStateMachine_GS_TO_X(void);
   boolean_T AutopilotStateMachine_GS_TO_X_MR(void);

--- a/src/fbw/src/model/AutopilotStateMachine_data.cpp
+++ b/src/fbw/src/model/AutopilotStateMachine_data.cpp
@@ -267,6 +267,8 @@ AutopilotStateMachineModelClass::Parameters_AutopilotStateMachine_T AutopilotSta
       0.0,
       false,
       false,
+      false,
+      false,
       0.0,
       0.0,
       0.0,
@@ -301,6 +303,10 @@ AutopilotStateMachineModelClass::Parameters_AutopilotStateMachine_T AutopilotSta
 
   0.0,
 
+  0.0,
+
+  1.0,
+
   1.0,
 
   1.0,
@@ -310,6 +316,8 @@ AutopilotStateMachineModelClass::Parameters_AutopilotStateMachine_T AutopilotSta
   -1.0,
 
   -1.0,
+
+  0.0,
 
   0.0,
 
@@ -468,6 +476,10 @@ AutopilotStateMachineModelClass::Parameters_AutopilotStateMachine_T AutopilotSta
   0.5,
 
   0.0,
+
+  1000.0,
+
+  -1.0,
 
   1000.0,
 

--- a/src/fbw/src/model/AutopilotStateMachine_types.h
+++ b/src/fbw/src/model/AutopilotStateMachine_types.h
@@ -427,6 +427,8 @@ typedef struct {
   real_T mode_reversion_lateral;
   real_T mode_reversion_vertical;
   boolean_T mode_reversion_TRK_FPA;
+  boolean_T mode_reversion_triple_click;
+  boolean_T mode_reversion_fma;
   boolean_T speed_protection_mode;
   real_T autothrust_mode;
   real_T Psi_c_deg;

--- a/src/fdr2csv/src/FlightDataRecorderConverter.cpp
+++ b/src/fdr2csv/src/FlightDataRecorderConverter.cpp
@@ -189,6 +189,8 @@ void FlightDataRecorderConverter::writeHeader(ofstream& out, const string& delim
   out << "ap_sm.output.mode_reversion_lateral" << delimiter;
   out << "ap_sm.output.mode_reversion_vertical" << delimiter;
   out << "ap_sm.output.mode_reversion_TRK_FPA" << delimiter;
+  out << "ap_sm.output.mode_reversion_triple_click" << delimiter;
+  out << "ap_sm.output.mode_reversion_fma" << delimiter;
   out << "ap_sm.output.speed_protection_mode" << delimiter;
   out << "ap_sm.output.autothrust_mode" << delimiter;
   out << "ap_sm.output.Psi_c_deg" << delimiter;
@@ -646,6 +648,8 @@ void FlightDataRecorderConverter::writeStruct(ofstream& out,
   out << ap_sm.output.mode_reversion_lateral << delimiter;
   out << ap_sm.output.mode_reversion_vertical << delimiter;
   out << static_cast<unsigned int>(ap_sm.output.mode_reversion_TRK_FPA) << delimiter;
+  out << static_cast<unsigned int>(ap_sm.output.mode_reversion_triple_click) << delimiter;
+  out << static_cast<unsigned int>(ap_sm.output.mode_reversion_fma) << delimiter;
   out << static_cast<unsigned int>(ap_sm.output.speed_protection_mode) << delimiter;
   out << ap_sm.output.autothrust_mode << delimiter;
   out << ap_sm.output.Psi_c_deg << delimiter;

--- a/src/fdr2csv/src/main.cpp
+++ b/src/fdr2csv/src/main.cpp
@@ -14,7 +14,7 @@
 using namespace std;
 
 // IMPORTANT: this constant needs to increased with every interface change
-const uint64_t INTERFACE_VERSION = 4;
+const uint64_t INTERFACE_VERSION = 5;
 
 int main(int argc, char* argv[]) {
   // variables for command line parameters

--- a/src/instruments/src/PFD/FMA.jsx
+++ b/src/instruments/src/PFD/FMA.jsx
@@ -338,13 +338,16 @@ const B1Cell = () => {
         return null;
     }
 
+    const inSpeedProtection = inProtection && (activeVerticalMode === 14 || activeVerticalMode === 15);
+    const inModeReversion = getSimVar('L:A32NX_FMA_MODE_REVERSION', 'bool');
+
     return (
         <g>
             <ShowForSeconds timer={10} id={activeVerticalMode}>
-                <path className="NormalStroke White" d="m34.656 1.8143h29.918v6.0476h-29.918z" />
+                <path className={`${(inSpeedProtection || inModeReversion) ? 'NormalStroke None' : 'NormalStroke White'}`} d="m34.656 1.8143h29.918v6.0476h-29.918z" />
             </ShowForSeconds>
-            {inProtection && (activeVerticalMode === 14 || activeVerticalMode === 15)
-            && <path className="NormalStroke Amber BlinkInfinite" d="m34.656 1.8143h29.918v6.0476h-29.918z" />}
+            {inSpeedProtection && <path className="NormalStroke Amber BlinkInfinite" d="m34.656 1.8143h29.918v6.0476h-29.918z" />}
+            {inModeReversion && <path className="NormalStroke White BlinkInfinite" d="m34.656 1.8143h29.918v6.0476h-29.918z" />}
             <text className="FontMedium MiddleAlign Green" x="49.498924" y="6.8785663" xmlSpace="preserve">{text}</text>
         </g>
     );

--- a/src/instruments/src/PFD/style.scss
+++ b/src/instruments/src/PFD/style.scss
@@ -138,6 +138,11 @@ tspan.Cyan {
   stroke: none;
 }
 
+.None {
+  fill: none;
+  stroke: none;
+}
+
 .White {
   fill: none;
   stroke: $display-white;


### PR DESCRIPTION
## Summary of Changes
This PR adds:
- triple click and blinking of white box on FMA due to mode reversions
- automatic arm of NAV when on ground and flight plan becomes available
- automatic connection of flight directors on FCU power-on (no simulation of FCU startup-procedure)

## References
According to FCOM the following cases need to be considered.

### NAV disengage

#### `NAV` + `CLB`
- `NAV` is lost (manual or automatic): reverts to `OP CLB`
- when not confirmed within 5s with
  - FCU ALT change
  - V/S push
  - V/S pull
  - engage of another vertical mode
- triple click and white box blinking for 10s

#### `NAV` + `DES`
- `NAV` is lost (manual or automatic): reverts to `V/S`
- when not confirmed within 5s with
  - FCU ALT change
  - V/S push
  - V/S pull
  - engage of another vertical mode
- triple click and white box blinking for 10s

### Revert to V/S
- in `OP CLB` and FCU altitude is changed below current altitude
- in `OP DES` and FCU altitude is changed above current altitude
- in `ALT*` and FCU altitude is changed more than `250 ft`
- when not confirmed within 5s with
  - ALT pull
  - V/S push
  - change V/S (FPA) target
  - engage of another vertical mode
- triple click and white box blinking for 10s

### OPEN CLB/DES speed protection
- no autopilot engaged
- `OP CLB` and thrust mode `THR CLB` and VMAX is reached
- `OP DES` and thrust mode `THR IDLE` and VLS is reached
- both FD disconnect and triple click is played

### V/S speed protection
- V/S cannot be hold due to performance (either VMAX or VLS is reached)
- V/S target is abandoned, triple click is played and amber blinking box on FMA

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
- test conditions described in references. Focus on triple click sound and blinking of white box around FMA mode.
- test if NAV automatically arms when on ground and flight plan becomes available
- test if on FCU power on the flight directors are automatically connected

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
