### PR TITLE
feat(mcdu): clear whole scratchpad when CLR held

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -91,6 +91,7 @@
 1. [OVHD] Correct EVAC button behaviours - @tracernz (Mike)
 1. [OVHD] Fix invisible fault emissive decal on centre fuel pump 2 - @tracernz (Mike)
 1. [VFX] Add APU exhaust heat blur effect - @wpine215 (Iceman)
+1. [MCDU] Clear scratchpad when CLR held down - @tracernz (Mike)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -100,6 +100,12 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             }
             this.tryShowMessage();
         };
+        this.onClrHeld = () => {
+            if (this.inOut !== "" && this.inOut !== FMCMainDisplay.clrValue) {
+                this.inOut = "";
+                this.tryShowMessage();
+            }
+        };
 
         this.PageTimeout = {
             Prog: 2000,
@@ -996,6 +1002,8 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
                 setTimeout(() => {
                     this.onClr();
                 }, this.getDelaySwitchPage());
+            } else if (input === "CLR_Held") {
+                this.onClrHeld();
             } else if (input === "DIV") {
                 setTimeout(() => {
                     this.onDiv();

--- a/src/behavior/src/A32NX_Interior_MCDU.xml
+++ b/src/behavior/src/A32NX_Interior_MCDU.xml
@@ -312,8 +312,9 @@
             <BASE_NAME>OVFY</BASE_NAME>
         </UseTemplate>
 
-        <UseTemplate Name="FBW_MCDU_BUTTON_Template">
+        <UseTemplate Name="FBW_MCDU_Holdable_BUTTON_Template">
             <BASE_NAME>CLR</BASE_NAME>
+            <MIN_HELD_DURATION>1</MIN_HELD_DURATION>
         </UseTemplate>
     </Template>
 
@@ -336,6 +337,45 @@
                 <SEQ1_EMISSIVE_DRIVES_VISIBILITY>False</SEQ1_EMISSIVE_DRIVES_VISIBILITY>
                 <LEFT_SINGLE_CODE>(&gt;H:A320_Neo_CDU_#SIDE_NUMERIC#_BTN_#LEFT_SINGLE_CODE_BTN_NAME#)</LEFT_SINGLE_CODE>
             </UseTemplate>
+        </Component>
+    </Template>
+
+    <Template Name="FBW_MCDU_Holdable_BUTTON_Template">
+        <DefaultTemplateParameters>
+            <NODE_ID>PUSH_MCDU#SIDE#_#BASE_NAME#</NODE_ID>
+            <LEFT_SINGLE_CODE_BTN_NAME>#BASE_NAME#</LEFT_SINGLE_CODE_BTN_NAME>
+            <MIN_HELD_DURATION>2</MIN_HELD_DURATION>
+        </DefaultTemplateParameters>
+
+        <Component ID="#NODE_ID#" Node="#NODE_ID#">
+            <UseTemplate Name="ASOBO_GT_Push_Button_Airliner">
+                <NO_SEQ2/>
+                <ANIM_NAME>#NODE_ID#</ANIM_NAME>
+                <WWISE_EVENT_1>mcdubuttons</WWISE_EVENT_1>
+                <WWISE_EVENT_2>mcdubuttons</WWISE_EVENT_2>
+                <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
+                <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
+                <DONT_OVERRIDE_BASE_EMISSIVE>True</DONT_OVERRIDE_BASE_EMISSIVE>
+                <SEQ1_EMISSIVE_CODE>#BUTTON_LIGHTS_POWERED#</SEQ1_EMISSIVE_CODE>
+                <SEQ1_EMISSIVE_DRIVES_VISIBILITY>False</SEQ1_EMISSIVE_DRIVES_VISIBILITY>
+                <LEFT_SINGLE_CODE>
+                    (E:SIMULATION TIME, seconds) #MIN_HELD_DURATION# + (&gt;L:A32NX_MCDU_#BASE_NAME#_MinReleaseTime)
+                    1 (&gt;L:A32NX_MCDU_#BASE_NAME#_Pressed)
+                    (&gt;H:A320_Neo_CDU_#SIDE_NUMERIC#_BTN_#LEFT_SINGLE_CODE_BTN_NAME#)
+                </LEFT_SINGLE_CODE>
+                <LEFT_LEAVE_CODE>
+                    0 (&gt;L:A32NX_MCDU_#BASE_NAME#_Pressed)
+                </LEFT_LEAVE_CODE>
+            </UseTemplate>
+
+            <Update Frequency="0.5" InteractionModel="All">
+                (L:A32NX_MCDU_#BASE_NAME#_Pressed) if{
+                    (E:SIMULATION TIME, seconds) (L:A32NX_MCDU_#BASE_NAME#_MinReleaseTime) &gt; if{
+                        (&gt;H:A320_Neo_CDU_#SIDE_NUMERIC#_BTN_#LEFT_SINGLE_CODE_BTN_NAME#_Held)
+                        0 (&gt;L:A32NX_MCDU_#BASE_NAME#_Pressed)
+                    }
+                }
+            </Update>
         </Component>
     </Template>
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
When the CLR button on the MCDU is held down for a period of time, the whole scratchpad is cleared. ~~Awaiting pilot feedback on what that period is before this goes out of draft...~~ The scratchpad clears when the button has been held for approx. 1 second, thanks to Capt. Chaos.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
Unfortunately had to use Lvars rather than Ovars to hold the state because the ASOBO_GT_Push_Button_Airliner template creates a sub-component, putting the LEFT_SINGLE_CODE in a different scope to the update.


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
Try the CLR button with the scratchpad in various states (messages up, empty, with one character, with multiple characters, empty, etc...).


## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
