### PR TITLE
build: remove legacy deps and peer deps 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/react-router-dom": "~5.1.6",
     "@typescript-eslint/eslint-plugin": "~4.14.2",
     "@typescript-eslint/parser": "~4.14.2",
-    "awesome-typescript-loader": "^5.2.1",
+    "ts-loader": "^9.2.2",
     "css-loader": "^5.0.1",
     "eslint": "7.21.0",
     "file-loader": "^6.2.0",
@@ -55,7 +55,7 @@
     "rollup-plugin-typescript-paths": "^1.3.0",
     "sass-loader": "^10.1.0",
     "style-loader": "^2.0.0",
-    "typescript": "~4.1.2",
+    "typescript": "^4.3.2",
     "webpack": "^5.12.2",
     "webpack-cli": "^4.3.1",
     "webpack-dev-server": "^3.11.1"
@@ -63,7 +63,7 @@
   "dependencies": {
     "@flybywiresim/api-client": "~0.7.0",
     "@flybywiresim/map": "~0.5.2",
-    "@tabler/icons": "^1.38.0",
+    "@tabler/icons": "^1.41.2",
     "@tailwindcss/postcss7-compat": "^2.0.2",
     "aewx-metar-parser": "~0.10.1",
     "byte-data": "^19.0.1",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,4 +4,4 @@ set -ex
 
 rm -f package-lock.json
 rm -rf node_modules
-npm install --no-optional --legacy-peer-deps
+npm install --no-optional

--- a/src/instruments/src/EFB/webpack.development.config.js
+++ b/src/instruments/src/EFB/webpack.development.config.js
@@ -13,7 +13,7 @@ module.exports = {
         rules: [
             {
                 test: /\.tsx?$/,
-                loader: 'awesome-typescript-loader',
+                loader: 'ts-loader',
             },
             {
                 test: /\.s?[ac]ss$/i,

--- a/src/instruments/src/EFB/webpack.msfs.config.js
+++ b/src/instruments/src/EFB/webpack.msfs.config.js
@@ -13,7 +13,7 @@ module.exports = {
         rules: [
             {
                 test: /\.tsx?$/,
-                loader: 'awesome-typescript-loader',
+                loader: 'ts-loader',
             },
             {
                 test: /\.s?[ac]ss$/i,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Removes `--legacy-peer-deps ` from `setup.sh`.  Fixes peer dep errors with tabler-icons.
Removes and replaces `awesome-typescript-loader` with `ts-loader`. This was done since `awesome-typescript-loader` is now marked legacy.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): blurpyx#2092

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Make sure everything works fine, especially the EFB.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
