### PR TITLE
feat: added lvar if ground spoilers are active

### DIFF
--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -947,6 +947,14 @@
       0 | Retracted
       1 | Full extension
 
+- A32NX_SPOILERS_GROUND_SPOILERS_ACTIVE
+    - Bool
+    - Indicates if the ground spoilers are active (fully deployed)
+      Value | Position
+      --- | ---
+      0 | Inactive
+      1 | Active
+
 - A32NX_PERFORMANCE_WARNING_ACTIVE
     - Bool
     - Indicates if performance warning is active

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -307,6 +307,7 @@ void FlyByWireInterface::setupLocalVariables() {
 
   idSpoilersArmed = make_unique<LocalVariable>("A32NX_SPOILERS_ARMED");
   idSpoilersHandlePosition = make_unique<LocalVariable>("A32NX_SPOILERS_HANDLE_POSITION");
+  idSpoilersGroundSpoilersActive = make_unique<LocalVariable>("A32NX_SPOILERS_GROUND_SPOILERS_ACTIVE");
 
   idAileronPositionLeft = make_unique<LocalVariable>("A32NX_3D_AILERON_LEFT_DEFLECTION");
   idAileronPositionRight = make_unique<LocalVariable>("A32NX_3D_AILERON_RIGHT_DEFLECTION");
@@ -1282,6 +1283,7 @@ bool FlyByWireInterface::updateFlapsSpoilers(double sampleTime) {
   // set 3D handle position
   idSpoilersArmed->set(spoilersHandler->getIsArmed() ? 1 : 0);
   idSpoilersHandlePosition->set(spoilersHandler->getHandlePosition());
+  idSpoilersGroundSpoilersActive->set(spoilersHandler->getIsGroundSpoilersActive() ? 1 : 0);
 
   // result
   return true;

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -210,6 +210,7 @@ class FlyByWireInterface {
 
   std::unique_ptr<LocalVariable> idSpoilersArmed;
   std::unique_ptr<LocalVariable> idSpoilersHandlePosition;
+  std::unique_ptr<LocalVariable> idSpoilersGroundSpoilersActive;
   std::shared_ptr<SpoilersHandler> spoilersHandler;
 
   std::shared_ptr<ElevatorTrimHandler> elevatorTrimHandler;


### PR DESCRIPTION
## Summary of Changes
This PR adds a local variable to tell if ground spoilers are active/fully deployed. This information is needed for the upcoming work of custom auto brake implementation.

This is by intention not added to changelog because it's implementation details and a non-visible feature to the user.

## Testing instructions
- test if variable `A32NX_SPOILERS_GROUND_SPOILERS_ACTIVE` goes to 1 when ground spoilers are fully deployed.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
