### PR TITLE
fix(efb): Fix for missing icons in EFB Map

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@flybywiresim/api-client": "~0.7.0",
-    "@flybywiresim/map": "~0.5.2",
+    "@flybywiresim/react-components": "^0.2.7",
     "@tabler/icons": "^1.38.0",
     "@tailwindcss/postcss7-compat": "^2.0.2",
     "aewx-metar-parser": "~0.10.1",

--- a/src/instruments/src/EFB/Dashboard/Dashboard.tsx
+++ b/src/instruments/src/EFB/Dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CurrentFlight, Map } from '@flybywiresim/map';
+import { CurrentFlight, Map } from '@flybywiresim/react-components';
 import FlightWidget from './Widgets/FlightWidget';
 import WeatherWidget from './Widgets/WeatherWidget';
 import { useSimVar } from '../../Common/simVars';

--- a/src/instruments/src/EFB/Dispatch/Pages/FuelPage.tsx
+++ b/src/instruments/src/EFB/Dispatch/Pages/FuelPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { round } from 'lodash';
 import { IconPlayerPlay, IconHandStop } from '@tabler/icons';
-import { Slider } from '../../Components/Form/Slider';
+import { Slider } from '@flybywiresim/react-components';
 import { SelectGroup, SelectItem } from '../../Components/Form/Select';
 import { ProgressBar } from '../../Components/Progress/Progress';
 import Button, { BUTTON_TYPE } from '../../Components/Button/Button';

--- a/src/instruments/src/EFB/Settings/Settings.tsx
+++ b/src/instruments/src/EFB/Settings/Settings.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
-import { Toggle } from '../Components/Form/Toggle';
+import { Slider, Toggle } from '@flybywiresim/react-components';
 import { Select, SelectGroup, SelectItem } from '../Components/Form/Select';
-import { Slider } from '../Components/Form/Slider';
 import { useSimVarSyncedPersistentProperty } from '../../Common/persistence';
 import Button from '../Components/Button/Button';
 import ThrottleConfig from './ThrottleConfig/ThrottleConfig';

--- a/src/instruments/src/EFB/Settings/ThrottleConfig/ThrottleConfig.tsx
+++ b/src/instruments/src/EFB/Settings/ThrottleConfig/ThrottleConfig.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
+import { Toggle } from '@flybywiresim/react-components';
 import { usePersistentPropertyWithDefault } from '../../../Common/persistence';
 import { useSimVar } from '../../../Common/simVars';
 import Button, { BUTTON_TYPE } from '../../Components/Button/Button';
 import { SelectItem, VerticalSelectGroup } from '../../Components/Form/Select';
-import { Toggle } from '../../Components/Form/Toggle';
 
 import BaseThrottleConfig from './BaseThrottleConfig';
 import { ThrottleSimvar } from './ThrottleSimVar';


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #4761

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
PR is to address the missing icons in the EFB Map. This has been done with the introduction of @flybywiresim/react-components, as well as this I've updated the Slider and Toggle components which were also migrated across to the component library.

* Added @flybywiresim/react-components
* Swapped and removed @flybywiresim/map for @flybywiresim/react-components in EFB Dashboard
* Replaced Slider and Toggle components with @flybywiresim/react-components

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/5309174/120816762-a421d380-c583-11eb-9ea5-48c2e94a0837.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Open the EFB, view the map, make sure that the icons are in the control panel in the bottom right of the map.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
