### PR TITLE
feat: improved ROLLOUT and AP disengage conditions + improved ground spoiler logic

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -97,6 +97,7 @@
 1. [AP] Automatically arm NAV on ground when flight plan becomes available - @aguther (Andreas Guther)
 1. [FCU] Automatically connect flight directors when FCU is powered on - @aguther (Andreas Guther)
 1. [AP] Improved disengage conditions for ROLL OUT and when excessive pitch or roll attitude - @aguther (Andreas Guther)
+1. [FBW] Improved ground spoiler logic - @aguther (Andreas Guther)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -96,6 +96,7 @@
 1. [AP+PFD] Added triple click and FMA mode reversion logic - @aguther (Andreas Guther)
 1. [AP] Automatically arm NAV on ground when flight plan becomes available - @aguther (Andreas Guther)
 1. [FCU] Automatically connect flight directors when FCU is powered on - @aguther (Andreas Guther)
+1. [AP] Improved disengage conditions for ROLL OUT and when excessive pitch or roll attitude - @aguther (Andreas Guther)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -1270,8 +1270,8 @@ bool FlyByWireInterface::updateFlapsSpoilers(double sampleTime) {
 
   // update simulation variables
   spoilersHandler->setSimulationVariables(
-      simData.simulationTime, autopilotStateMachineOutput.enabled_AP1 == 1 || autopilotStateMachineOutput.enabled_AP1 == 1,
-      simData.V_ias_kn, thrustLeverAngle_1->get(), thrustLeverAngle_2->get(), simData.gear_animation_pos_1, simData.gear_animation_pos_2,
+      simData.simulationTime, autopilotStateMachineOutput.enabled_AP1 == 1 || autopilotStateMachineOutput.enabled_AP2 == 1,
+      simData.V_gnd_kn, thrustLeverAngle_1->get(), thrustLeverAngle_2->get(), simData.gear_animation_pos_1, simData.gear_animation_pos_2,
       simData.flaps_handle_index, flyByWireOutput.sim.data_computed.high_aoa_prot_active == 1);
 
   // check state of spoilers and adapt if necessary

--- a/src/fbw/src/SpoilersHandler.h
+++ b/src/fbw/src/SpoilersHandler.h
@@ -11,7 +11,7 @@ class SpoilersHandler {
   void setInitialPosition(double position);
   void setSimulationVariables(double simulationTime_new,
                               bool isAutopilotEngaged_new,
-                              double airspeed_new,
+                              double groundSpeed_new,
                               double thrustLeverAngle_1_new,
                               double thrustLeverAngle_2_new,
                               double landingGearCompression_1_new,
@@ -37,7 +37,7 @@ class SpoilersHandler {
   static constexpr double POSITION_FULL = 1.0;
 
   static constexpr double MINIMUM_AIRBORNE_TIME = 5.0;
-  static constexpr double CONDITION_AIRSPEED = 72.0;
+  static constexpr double CONDITION_GROUND_SPEED = 72.0;
 
   static constexpr double TLA_IDLE = 0.0;
   static constexpr double TLA_CLB = 25.0;
@@ -59,7 +59,7 @@ class SpoilersHandler {
   double simulationTime = 0.0;
   double timeAirborne = 0.0;
   bool isAutopilotEngaged = false;
-  double airspeed = 0.0;
+  double groundSpeed = 0.0;
   double thrustLeverAngle_1 = 0.0;
   double thrustLeverAngle_2 = 0.0;
   double landingGearCompression_1 = 0.0;
@@ -75,7 +75,7 @@ class SpoilersHandler {
               bool isArmed_new,
               double handlePosition_new,
               bool isAutopilotEngaged_new,
-              double airspeed_new,
+              double groundSpeed_new,
               double thrustLeverAngle_1_new,
               double thrustLeverAngle_2_new,
               double landingGearCompression_1_new,
@@ -95,7 +95,7 @@ class SpoilersHandler {
 
   static bool areAboveMct(double thrustLeverAngle_1, double thrustLeverAngle_2);
 
-  static bool isAtLeastOneInReverseAndOtherInIdle(double thrustLeverAngle_1, double thrustLeverAngle_2);
+  static bool isAtLeastOneInReverseAndOtherAtOrBelowIdle(double thrustLeverAngle_1, double thrustLeverAngle_2);
 
   static bool isAtLeastOneInReverseAndOtherBelowMct(double thrustLeverAngle_1, double thrustLeverAngle_2);
 };

--- a/src/fbw/src/model/AutopilotStateMachine.h
+++ b/src/fbw/src/model/AutopilotStateMachine.h
@@ -54,6 +54,7 @@ class AutopilotStateMachineModelClass {
     real_T timeDeltaSpeed4;
     real_T timeDeltaSpeed10;
     real_T timeConditionSoftAlt;
+    real_T runwayHeadingStored;
     real_T eventTime_a;
     real_T eventTime_iz;
     real_T eventTime_c;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
This PR improves:
- the `AP` and `ROLL OUT` mode disengage / disconnect conditions
- the ground spoiler logic

### Autopilot
- disconnect when Pitch attitude > 25°
- disconnect when Pitch attitude < -13°
- disconnect when Bank angle > 45°

### ROLL OUT
- disengage when flight phase `DONE`
- disengage when on ground more than 10s and `APPR` is pushed on FCU
- disengage when runway heading from ILS to aircraft track is > 7° (remark: on slow speed aircraft heading is used due to unreliable track info from the sim)

### GROUND SPOILERS
- ground spoilers are now also deploying when they are not armed and both levers in reverse
- the logic now uses ground speed and not CAS

## References
This PR uses information from FCOM.

## Additional context
<!-- Add any other context about the pull request here. -->
If AP and ROLL OUT mode is disconnected in flight phase done is not fully clear (no documentation found), but looking at YouTube videos this is probably the case.

## Testing instructions

### ROLL OUT & AP

Important:
ROLL OUT will only engage when LAND was previously engaged. LAND engaged when LOC and G/S was engaged and you’re a certain time below 400 ft.

#### Manual Flight
- Perform Landing with AP **off**: ROLL OUT should disengage after 30 s on ground (flight phase DONE)
- Perform Landing with AP **off**: ROLL OUT should disengage when APPR button is pressed after 10 s after touchdown
- Perform Landing with AP **off**: ROLL OUT should disengage when runway heading vs. plane track is > 7°
- Perform Landing with AP **off**: ROLL OUT should disengage when LOC bearing changes during ROLL OUT (e.g. EDNY with add-on)

#### Autopilot
- Perform Autoland: ROLL OUT should **not disengage** when APPR button is pressed after 10 s after touchdown
- Perform Autoland in crosswind: ROLL OUT should not disengage during normal operation

In general be sure that you're in FMGC flight phase 5 before you do a landing, otherwise the ROLL OUT might disconnect on landing.

### GROUND SPOILERS

#### Rejected Take-Off
- perform rejected take off with spoilers **not** armed and use only one reverse the other lever at idle: spoilers
- perform rejected take off with spoilers **not** armed and use only one reverse the other lever above idle: no spoilers
- perform rejected take off with spoilers **not** armed and use both reverse: spoilers
- perform rejected take off with spoilers armed and both levers to idle: spoilers
- perform rejected take off with spoilers armed and both levers to reverse: spoilers

#### Landing
- perform landing with spoilers armed and both levers to idle: spoilers
- perform landing with spoilers **not** armed and one in reverse and the other below MCT: spoilers

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
