### PR TITLE
feat: support FD off take-off procedure (#5016)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -99,6 +99,7 @@
 1. [AP] Improved disengage conditions for ROLL OUT and when excessive pitch or roll attitude - @aguther (Andreas Guther)
 1. [FBW] Improved ground spoiler logic - @aguther (Andreas Guther)
 1. [ATHR] Fixed incorrect THR LK activation when A/THR disconnect buttons have been used - @aguther (Andreas Guther)
+1. [ATHR] Support flight director off take-off procedure - @aguther (Andreas Guther)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/src/fbw/src/FlightDataRecorder.h
+++ b/src/fbw/src/FlightDataRecorder.h
@@ -12,7 +12,7 @@
 class FlightDataRecorder {
  public:
   // IMPORTANT: this constant needs to increased with every interface change
-  const uint64_t INTERFACE_VERSION = 5;
+  const uint64_t INTERFACE_VERSION = 6;
 
   void initialize();
 

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -513,7 +513,7 @@ bool FlyByWireInterface::updateAutopilotStateMachine(double sampleTime) {
     autopilotStateMachineInput.in.data.is_engine_operative_2 = simData.engine_combustion_2;
 
     // input ----------------------------------------------------------------------------------------------------------
-    autopilotStateMachineInput.in.input.FD_active = simData.ap_fd_1_active | simData.ap_fd_2_active;
+    autopilotStateMachineInput.in.input.FD_active = simData.ap_fd_1_active || simData.ap_fd_2_active;
     autopilotStateMachineInput.in.input.AP_ENGAGE_push = simInputAutopilot.AP_engage;
     autopilotStateMachineInput.in.input.AP_1_push = simInputAutopilot.AP_1_push;
     autopilotStateMachineInput.in.input.AP_2_push = simInputAutopilot.AP_2_push;
@@ -1176,6 +1176,7 @@ bool FlyByWireInterface::updateAutothrust(double sampleTime) {
     autoThrustInput.in.input.is_anti_ice_engine_2_active = simData.engineAntiIce_2 == 1;
     autoThrustInput.in.input.is_air_conditioning_1_active = idAirConditioningPack_1->get();
     autoThrustInput.in.input.is_air_conditioning_2_active = idAirConditioningPack_2->get();
+    autoThrustInput.in.input.FD_active = simData.ap_fd_1_active || simData.ap_fd_2_active;
 
     // step the model -------------------------------------------------------------------------------------------------
     autoThrust.setExternalInputs(&autoThrustInput);

--- a/src/fbw/src/model/Autothrust.cpp
+++ b/src/fbw/src/model/Autothrust.cpp
@@ -6,6 +6,21 @@
 
 const uint8_T Autothrust_IN_InAir = 1U;
 const uint8_T Autothrust_IN_OnGround = 2U;
+void AutothrustModelClass::Autothrust_TimeSinceCondition(real_T rtu_time, boolean_T rtu_condition, real_T *rty_y,
+  rtDW_TimeSinceCondition_Autothrust_T *localDW)
+{
+  if (!localDW->eventTime_not_empty) {
+    localDW->eventTime = rtu_time;
+    localDW->eventTime_not_empty = true;
+  }
+
+  if ((!rtu_condition) || (localDW->eventTime == 0.0)) {
+    localDW->eventTime = rtu_time;
+  }
+
+  *rty_y = rtu_time - localDW->eventTime;
+}
+
 void AutothrustModelClass::Autothrust_ThrustMode1(real_T rtu_u, real_T *rty_y)
 {
   if (rtu_u < 0.0) {
@@ -113,6 +128,7 @@ void AutothrustModelClass::step()
   real_T ca;
   real_T rtb_Gain2;
   real_T rtb_Gain3;
+  real_T rtb_Gain_f;
   real_T rtb_Saturation;
   real_T rtb_Sum_c;
   real_T rtb_Sum_g;
@@ -122,22 +138,22 @@ void AutothrustModelClass::step()
   real_T rtb_Switch_f_idx_0;
   real_T rtb_Switch_i_tmp;
   real_T rtb_Switch_m;
-  real_T rtb_y_i;
-  real_T rtb_y_jh;
+  real_T rtb_y_a;
+  real_T rtb_y_c;
   int32_T i;
   int32_T rtb_on_ground;
   boolean_T ATHR_ENGAGED_tmp;
   boolean_T ATHR_ENGAGED_tmp_0;
-  boolean_T ATHR_ENGAGED_tmp_1;
-  boolean_T cUseAutoThrustControl;
+  boolean_T ATHR_PB;
+  boolean_T ATHR_PB_tmp;
   boolean_T condition_AP_FD_ATHR_Specific;
-  boolean_T condition_THR_LK_tmp;
-  boolean_T pThrustMemoActive_tmp;
+  boolean_T condition_TOGA;
+  boolean_T flightDirectorOffTakeOff_tmp;
   boolean_T rtb_Compare_e;
   boolean_T rtb_NOT;
   boolean_T rtb_NOT1_m;
   boolean_T rtb_out;
-  boolean_T rtb_y_o;
+  boolean_T rtb_y_cs;
   athr_status rtb_status;
   rtb_Gain2 = Autothrust_P.Gain2_Gain * Autothrust_U.in.data.Theta_deg;
   rtb_Gain3 = Autothrust_P.Gain3_Gain * Autothrust_U.in.data.Phi_deg;
@@ -257,12 +273,12 @@ void AutothrustModelClass::step()
     rtb_Switch1_k = Autothrust_U.in.data.OAT_degC;
   }
 
-  rtb_y_i = look2_binlxpw(look2_binlxpw(Autothrust_U.in.data.H_ft, rtb_Switch1_k, Autothrust_P.Right_bp01Data,
+  rtb_y_c = look2_binlxpw(look2_binlxpw(Autothrust_U.in.data.H_ft, rtb_Switch1_k, Autothrust_P.Right_bp01Data,
     Autothrust_P.Right_bp02Data, Autothrust_P.Right_tableData, Autothrust_P.Right_maxIndex, 10U),
     Autothrust_U.in.data.TAT_degC, Autothrust_P.Left_bp01Data, Autothrust_P.Left_bp02Data, Autothrust_P.Left_tableData,
     Autothrust_P.Left_maxIndex, 2U) + rtb_Switch_m;
-  if (rtb_y_i <= rtb_Sum_g) {
-    rtb_y_i = rtb_Sum_g;
+  if (rtb_y_c <= rtb_Sum_g) {
+    rtb_y_c = rtb_Sum_g;
   }
 
   rtb_Switch2_k = look2_binlcpw(Autothrust_U.in.data.TAT_degC, Autothrust_U.in.data.H_ft,
@@ -281,7 +297,7 @@ void AutothrustModelClass::step()
                         Autothrust_P.AntiIceWing_tableData_a, Autothrust_P.AntiIceWing_maxIndex_d, 2U)) + rtb_Switch_m,
     Autothrust_P.RateLimiterVariableTs_up_i, Autothrust_P.RateLimiterVariableTs_lo_ns, Autothrust_U.in.time.dt,
     Autothrust_P.RateLimiterVariableTs_InitialCondition_bl, &rtb_Switch_m, &Autothrust_DWork.sf_RateLimiter_f);
-  rtb_y_jh = look2_binlxpw(Autothrust_U.in.data.TAT_degC, Autothrust_U.in.data.H_ft,
+  rtb_y_a = look2_binlxpw(Autothrust_U.in.data.TAT_degC, Autothrust_U.in.data.H_ft,
     Autothrust_P.MaximumContinuous_bp01Data, Autothrust_P.MaximumContinuous_bp02Data,
     Autothrust_P.MaximumContinuous_tableData, Autothrust_P.MaximumContinuous_maxIndex, 26U) + rtb_Switch_m;
   rtb_Switch_m = look2_binlcpw(Autothrust_U.in.data.TAT_degC, Autothrust_U.in.data.H_ft,
@@ -317,19 +333,11 @@ void AutothrustModelClass::step()
   rtb_Switch_m = look2_binlxpw(Autothrust_U.in.data.TAT_degC, Autothrust_U.in.data.H_ft,
     Autothrust_P.MaximumTakeOff_bp01Data, Autothrust_P.MaximumTakeOff_bp02Data, Autothrust_P.MaximumTakeOff_tableData,
     Autothrust_P.MaximumTakeOff_maxIndex, 36U) + rtb_Switch_dx;
-  if (!Autothrust_DWork.eventTime_not_empty_i) {
-    Autothrust_DWork.eventTime_h = Autothrust_U.in.time.simulation_time;
-    Autothrust_DWork.eventTime_not_empty_i = true;
-  }
-
-  rtb_NOT = !Autothrust_U.in.input.ATHR_disconnect;
-  if (rtb_NOT || (Autothrust_DWork.eventTime_h == 0.0)) {
-    Autothrust_DWork.eventTime_h = Autothrust_U.in.time.simulation_time;
-  }
-
-  Autothrust_DWork.Memory_PreviousInput = Autothrust_P.Logic_table[(((static_cast<uint32_T>
-    (Autothrust_U.in.time.simulation_time - Autothrust_DWork.eventTime_h >= Autothrust_P.CompareToConstant_const_k) << 1)
-    + false) << 1) + Autothrust_DWork.Memory_PreviousInput];
+  rtb_Switch1_k = rtb_Switch_m;
+  Autothrust_TimeSinceCondition(Autothrust_U.in.time.simulation_time, Autothrust_U.in.input.ATHR_disconnect,
+    &rtb_Switch_m, &Autothrust_DWork.sf_TimeSinceCondition_o);
+  Autothrust_DWork.Memory_PreviousInput = Autothrust_P.Logic_table[(((static_cast<uint32_T>(rtb_Switch_m >=
+    Autothrust_P.CompareToConstant_const_k) << 1) + false) << 1) + Autothrust_DWork.Memory_PreviousInput];
   if (!Autothrust_DWork.eventTime_not_empty_g) {
     Autothrust_DWork.eventTime_f = Autothrust_U.in.time.simulation_time;
     Autothrust_DWork.eventTime_not_empty_g = true;
@@ -359,10 +367,12 @@ void AutothrustModelClass::step()
   Autothrust_DWork.latch = (((!Autothrust_DWork.latch) || (((Autothrust_U.in.input.TLA_1_deg != 25.0) ||
     (Autothrust_U.in.input.TLA_2_deg != 25.0)) && ((Autothrust_U.in.input.TLA_1_deg != 45.0) ||
     (Autothrust_U.in.input.TLA_2_deg != 45.0)))) && Autothrust_DWork.latch);
-  rtb_y_o = ((rtb_Compare_e && (rtb_on_ground != 0)) || ((rtb_on_ground == 0) && Autothrust_DWork.latch));
+  rtb_y_cs = ((rtb_Compare_e && (rtb_on_ground != 0)) || ((rtb_on_ground == 0) && Autothrust_DWork.latch));
   Autothrust_DWork.Delay_DSTATE_a = (static_cast<int32_T>(Autothrust_U.in.input.ATHR_push) > static_cast<int32_T>
     (Autothrust_P.CompareToConstant_const_j));
   rtb_NOT1_m = (Autothrust_DWork.Delay_DSTATE_a && (!Autothrust_DWork.Memory_PreviousInput_m));
+  Autothrust_TimeSinceCondition(Autothrust_U.in.time.simulation_time, rtb_on_ground != 0, &rtb_Switch_m,
+    &Autothrust_DWork.sf_TimeSinceCondition1);
   rtb_BusAssignment_n.time = Autothrust_U.in.time;
   rtb_BusAssignment_n.data.nz_g = Autothrust_U.in.data.nz_g;
   rtb_BusAssignment_n.data.Theta_deg = rtb_Gain2;
@@ -403,9 +413,9 @@ void AutothrustModelClass::step()
   rtb_BusAssignment_n.input.thrust_limit_REV_percent = Autothrust_U.in.input.thrust_limit_REV_percent;
   rtb_BusAssignment_n.input.thrust_limit_IDLE_percent = rtb_Sum_c;
   rtb_BusAssignment_n.input.thrust_limit_CLB_percent = rtb_Sum_g;
-  rtb_BusAssignment_n.input.thrust_limit_MCT_percent = rtb_y_jh;
-  rtb_BusAssignment_n.input.thrust_limit_FLEX_percent = rtb_y_i;
-  rtb_BusAssignment_n.input.thrust_limit_TOGA_percent = rtb_Switch_m;
+  rtb_BusAssignment_n.input.thrust_limit_MCT_percent = rtb_y_a;
+  rtb_BusAssignment_n.input.thrust_limit_FLEX_percent = rtb_y_c;
+  rtb_BusAssignment_n.input.thrust_limit_TOGA_percent = rtb_Switch1_k;
   rtb_BusAssignment_n.input.flex_temperature_degC = Autothrust_U.in.input.flex_temperature_degC;
   rtb_BusAssignment_n.input.mode_requested = Autothrust_U.in.input.mode_requested;
   rtb_BusAssignment_n.input.is_mach_mode_active = Autothrust_U.in.input.is_mach_mode_active;
@@ -424,6 +434,7 @@ void AutothrustModelClass::step()
   rtb_BusAssignment_n.input.is_anti_ice_engine_2_active = Autothrust_U.in.input.is_anti_ice_engine_2_active;
   rtb_BusAssignment_n.input.is_air_conditioning_1_active = Autothrust_U.in.input.is_air_conditioning_1_active;
   rtb_BusAssignment_n.input.is_air_conditioning_2_active = Autothrust_U.in.input.is_air_conditioning_2_active;
+  rtb_BusAssignment_n.input.FD_active = Autothrust_U.in.input.FD_active;
   rtb_BusAssignment_n.output = Autothrust_P.athr_out_MATLABStruct.output;
   if (Autothrust_U.in.data.is_engine_operative_1 && Autothrust_U.in.data.is_engine_operative_2) {
     rtb_BusAssignment_n.data_computed.TLA_in_active_range = ((Autothrust_U.in.input.TLA_1_deg >= 0.0) &&
@@ -440,6 +451,7 @@ void AutothrustModelClass::step()
     Autothrust_DWork.latch));
   rtb_BusAssignment_n.data_computed.ATHR_push = rtb_NOT1_m;
   rtb_BusAssignment_n.data_computed.ATHR_disabled = Autothrust_DWork.Memory_PreviousInput;
+  rtb_BusAssignment_n.data_computed.time_since_touchdown = rtb_Switch_m;
   Autothrust_TLAComputation1(&rtb_BusAssignment_n, Autothrust_U.in.input.TLA_1_deg, &rtb_Switch_dx, &rtb_Compare_e);
   Autothrust_TLAComputation1(&rtb_BusAssignment_n, Autothrust_U.in.input.TLA_2_deg, &rtb_Switch_m, &rtb_NOT1_m);
   if (!Autothrust_DWork.prev_TLA_1_not_empty) {
@@ -453,17 +465,23 @@ void AutothrustModelClass::step()
   }
 
   condition_AP_FD_ATHR_Specific = !Autothrust_DWork.Memory_PreviousInput;
-  ATHR_ENGAGED_tmp = !Autothrust_DWork.ATHR_ENGAGED;
-  ATHR_ENGAGED_tmp_0 = ((Autothrust_DWork.prev_TLA_1 <= 0.0) || (Autothrust_U.in.input.TLA_1_deg != 0.0));
-  ATHR_ENGAGED_tmp_1 = ((Autothrust_DWork.prev_TLA_2 <= 0.0) || (Autothrust_U.in.input.TLA_2_deg != 0.0));
-  Autothrust_DWork.ATHR_ENGAGED = ((condition_AP_FD_ATHR_Specific && (((rtb_on_ground == 0) && ATHR_ENGAGED_tmp &&
-    rtb_BusAssignment_n.data_computed.ATHR_push) || (((Autothrust_U.in.input.TLA_1_deg == 45.0) &&
-    (Autothrust_U.in.input.TLA_2_deg == 45.0)) || (rtb_y_o && (Autothrust_U.in.input.TLA_1_deg >= 35.0) &&
-    (Autothrust_U.in.input.TLA_2_deg >= 35.0))) || Autothrust_U.in.input.alpha_floor_condition)) ||
-    (condition_AP_FD_ATHR_Specific && ((!rtb_BusAssignment_n.data_computed.ATHR_push) || ATHR_ENGAGED_tmp ||
-    Autothrust_U.in.input.is_LAND_mode_active) && rtb_NOT && ((ATHR_ENGAGED_tmp_0 || ATHR_ENGAGED_tmp_1) &&
-    (ATHR_ENGAGED_tmp_0 || (Autothrust_U.in.input.TLA_2_deg != 0.0)) && (ATHR_ENGAGED_tmp_1 ||
-    (Autothrust_U.in.input.TLA_1_deg != 0.0))) && Autothrust_DWork.ATHR_ENGAGED));
+  ATHR_PB_tmp = !Autothrust_DWork.ATHR_ENGAGED;
+  ATHR_PB = ((rtb_on_ground == 0) && ATHR_PB_tmp && rtb_BusAssignment_n.data_computed.ATHR_push);
+  condition_TOGA = (((Autothrust_U.in.input.TLA_1_deg == 45.0) && (Autothrust_U.in.input.TLA_2_deg == 45.0)) ||
+                    (rtb_y_cs && (Autothrust_U.in.input.TLA_1_deg >= 35.0) && (Autothrust_U.in.input.TLA_2_deg >= 35.0)));
+  flightDirectorOffTakeOff_tmp = !Autothrust_U.in.input.alpha_floor_condition;
+  Autothrust_DWork.flightDirectorOffTakeOff = (((!Autothrust_U.in.input.FD_active) && (rtb_on_ground != 0) &&
+    condition_TOGA && ((Autothrust_U.in.input.flight_phase <= 1.0) ||
+                       (rtb_BusAssignment_n.data_computed.time_since_touchdown >= 30.0))) || ((!ATHR_PB) && (!rtb_out) &&
+    flightDirectorOffTakeOff_tmp && Autothrust_DWork.flightDirectorOffTakeOff));
+  ATHR_ENGAGED_tmp = ((Autothrust_DWork.prev_TLA_1 <= 0.0) || (Autothrust_U.in.input.TLA_1_deg != 0.0));
+  ATHR_ENGAGED_tmp_0 = ((Autothrust_DWork.prev_TLA_2 <= 0.0) || (Autothrust_U.in.input.TLA_2_deg != 0.0));
+  rtb_NOT = !Autothrust_U.in.input.ATHR_disconnect;
+  Autothrust_DWork.ATHR_ENGAGED = ((condition_AP_FD_ATHR_Specific && (!Autothrust_DWork.flightDirectorOffTakeOff) &&
+    (ATHR_PB || condition_TOGA || Autothrust_U.in.input.alpha_floor_condition)) || (condition_AP_FD_ATHR_Specific &&
+    ((!rtb_BusAssignment_n.data_computed.ATHR_push) || ATHR_PB_tmp || Autothrust_U.in.input.is_LAND_mode_active) &&
+    rtb_NOT && ((ATHR_ENGAGED_tmp || ATHR_ENGAGED_tmp_0) && (ATHR_ENGAGED_tmp || (Autothrust_U.in.input.TLA_2_deg != 0.0))
+                && (ATHR_ENGAGED_tmp_0 || (Autothrust_U.in.input.TLA_1_deg != 0.0))) && Autothrust_DWork.ATHR_ENGAGED));
   condition_AP_FD_ATHR_Specific = (Autothrust_DWork.ATHR_ENGAGED && (rtb_out ||
     Autothrust_U.in.input.alpha_floor_condition));
   if (Autothrust_DWork.ATHR_ENGAGED && condition_AP_FD_ATHR_Specific) {
@@ -477,9 +495,9 @@ void AutothrustModelClass::step()
   Autothrust_DWork.prev_TLA_1 = Autothrust_U.in.input.TLA_1_deg;
   Autothrust_DWork.prev_TLA_2 = Autothrust_U.in.input.TLA_2_deg;
   if (Autothrust_U.in.input.TLA_1_deg > Autothrust_U.in.input.TLA_2_deg) {
-    rtb_Switch1_k = Autothrust_U.in.input.TLA_1_deg;
+    rtb_Switch_i_tmp = Autothrust_U.in.input.TLA_1_deg;
   } else {
-    rtb_Switch1_k = Autothrust_U.in.input.TLA_2_deg;
+    rtb_Switch_i_tmp = Autothrust_U.in.input.TLA_2_deg;
   }
 
   Autothrust_DWork.pConditionAlphaFloor = (Autothrust_U.in.input.alpha_floor_condition || ((!(rtb_status ==
@@ -488,38 +506,39 @@ void AutothrustModelClass::step()
     Autothrust_DWork.pMode = athr_mode_NONE;
   } else if (Autothrust_U.in.input.alpha_floor_condition) {
     Autothrust_DWork.pMode = athr_mode_A_FLOOR;
-  } else if ((!Autothrust_U.in.input.alpha_floor_condition) && Autothrust_DWork.pConditionAlphaFloor) {
+  } else if (flightDirectorOffTakeOff_tmp && Autothrust_DWork.pConditionAlphaFloor) {
     Autothrust_DWork.pMode = athr_mode_TOGA_LK;
   } else if ((rtb_status == athr_status_ENGAGED_ARMED) && ((Autothrust_U.in.input.TLA_1_deg == 45.0) ||
               (Autothrust_U.in.input.TLA_2_deg == 45.0))) {
     Autothrust_DWork.pMode = athr_mode_MAN_TOGA;
-  } else if ((rtb_status == athr_status_ENGAGED_ARMED) && rtb_y_o && (rtb_Switch1_k == 35.0)) {
+  } else if ((rtb_status == athr_status_ENGAGED_ARMED) && rtb_y_cs && (rtb_Switch_i_tmp == 35.0)) {
     Autothrust_DWork.pMode = athr_mode_MAN_FLEX;
   } else if ((rtb_status == athr_status_ENGAGED_ARMED) && ((Autothrust_U.in.input.TLA_1_deg == 35.0) ||
               (Autothrust_U.in.input.TLA_2_deg == 35.0))) {
     Autothrust_DWork.pMode = athr_mode_MAN_MCT;
   } else {
-    condition_AP_FD_ATHR_Specific = (Autothrust_U.in.data.is_engine_operative_1 &&
-      (!Autothrust_U.in.data.is_engine_operative_2));
-    ATHR_ENGAGED_tmp = (Autothrust_U.in.data.is_engine_operative_2 && (!Autothrust_U.in.data.is_engine_operative_1));
-    if ((rtb_status == athr_status_ENGAGED_ACTIVE) && (Autothrust_U.in.input.mode_requested == 3.0) &&
-        ((condition_AP_FD_ATHR_Specific && (Autothrust_U.in.input.TLA_1_deg == 35.0) && (Autothrust_U.in.input.TLA_2_deg
-           <= 35.0)) || (ATHR_ENGAGED_tmp && (Autothrust_U.in.input.TLA_2_deg == 35.0) &&
-                         (Autothrust_U.in.input.TLA_1_deg <= 35.0)))) {
+    ATHR_PB_tmp = (Autothrust_U.in.data.is_engine_operative_1 && (!Autothrust_U.in.data.is_engine_operative_2));
+    flightDirectorOffTakeOff_tmp = (Autothrust_U.in.data.is_engine_operative_2 &&
+      (!Autothrust_U.in.data.is_engine_operative_1));
+    if ((rtb_status == athr_status_ENGAGED_ACTIVE) && (Autothrust_U.in.input.mode_requested == 3.0) && ((ATHR_PB_tmp &&
+          (Autothrust_U.in.input.TLA_1_deg == 35.0) && (Autothrust_U.in.input.TLA_2_deg <= 35.0)) ||
+         (flightDirectorOffTakeOff_tmp && (Autothrust_U.in.input.TLA_2_deg == 35.0) && (Autothrust_U.in.input.TLA_1_deg <=
+           35.0)))) {
       Autothrust_DWork.pMode = athr_mode_THR_MCT;
     } else if ((rtb_status == athr_status_ENGAGED_ACTIVE) && (Autothrust_U.in.input.mode_requested == 3.0) &&
                Autothrust_U.in.data.is_engine_operative_1 && Autothrust_U.in.data.is_engine_operative_2 &&
-               (rtb_Switch1_k == 25.0)) {
+               (rtb_Switch_i_tmp == 25.0)) {
       Autothrust_DWork.pMode = athr_mode_THR_CLB;
     } else {
-      ATHR_ENGAGED_tmp_0 = (Autothrust_U.in.data.is_engine_operative_1 && Autothrust_U.in.data.is_engine_operative_2);
+      condition_AP_FD_ATHR_Specific = (Autothrust_U.in.data.is_engine_operative_1 &&
+        Autothrust_U.in.data.is_engine_operative_2);
       if ((rtb_status == athr_status_ENGAGED_ACTIVE) && (Autothrust_U.in.input.mode_requested == 3.0) &&
-          ((ATHR_ENGAGED_tmp_0 && (Autothrust_U.in.input.TLA_1_deg < 25.0) && (Autothrust_U.in.input.TLA_2_deg < 25.0)) ||
-           (condition_AP_FD_ATHR_Specific && (Autothrust_U.in.input.TLA_1_deg < 35.0)) || (ATHR_ENGAGED_tmp &&
-            (Autothrust_U.in.input.TLA_2_deg < 35.0)))) {
+          ((condition_AP_FD_ATHR_Specific && (Autothrust_U.in.input.TLA_1_deg < 25.0) &&
+            (Autothrust_U.in.input.TLA_2_deg < 25.0)) || (ATHR_PB_tmp && (Autothrust_U.in.input.TLA_1_deg < 35.0)) ||
+           (flightDirectorOffTakeOff_tmp && (Autothrust_U.in.input.TLA_2_deg < 35.0)))) {
         Autothrust_DWork.pMode = athr_mode_THR_LVR;
-      } else if ((rtb_status == athr_status_ENGAGED_ARMED) && ((ATHR_ENGAGED_tmp_0 && (rtb_Switch1_k > 25.0) &&
-                   (rtb_Switch1_k < 35.0)) || ((rtb_Switch1_k > 35.0) && (rtb_Switch1_k < 45.0)))) {
+      } else if ((rtb_status == athr_status_ENGAGED_ARMED) && ((condition_AP_FD_ATHR_Specific && (rtb_Switch_i_tmp >
+                    25.0) && (rtb_Switch_i_tmp < 35.0)) || ((rtb_Switch_i_tmp > 35.0) && (rtb_Switch_i_tmp < 45.0)))) {
         Autothrust_DWork.pMode = athr_mode_MAN_THR;
       } else if ((rtb_status == athr_status_ENGAGED_ACTIVE) && (Autothrust_U.in.input.mode_requested == 2.0)) {
         Autothrust_DWork.pMode = athr_mode_THR_IDLE;
@@ -541,15 +560,15 @@ void AutothrustModelClass::step()
     (!Autothrust_DWork.was_SRS_GA_active) && (Autothrust_U.in.data.H_ind_ft >
     Autothrust_U.in.input.thrust_reduction_altitude_go_around)) || ((Autothrust_U.in.input.is_SRS_TO_mode_active ||
     Autothrust_U.in.input.is_SRS_GA_mode_active) && Autothrust_DWork.inhibitAboveThrustReductionAltitude));
-  condition_AP_FD_ATHR_Specific = !Autothrust_U.in.data.is_engine_operative_1;
-  ATHR_ENGAGED_tmp = !Autothrust_U.in.data.is_engine_operative_2;
-  ATHR_ENGAGED_tmp_0 = (Autothrust_U.in.data.is_engine_operative_1 && Autothrust_U.in.data.is_engine_operative_2);
-  ATHR_ENGAGED_tmp_1 = (Autothrust_U.in.data.is_engine_operative_1 && ATHR_ENGAGED_tmp);
-  condition_THR_LK_tmp = (Autothrust_U.in.data.is_engine_operative_2 && condition_AP_FD_ATHR_Specific);
+  flightDirectorOffTakeOff_tmp = !Autothrust_U.in.data.is_engine_operative_1;
+  condition_AP_FD_ATHR_Specific = !Autothrust_U.in.data.is_engine_operative_2;
+  ATHR_PB_tmp = (Autothrust_U.in.data.is_engine_operative_1 && Autothrust_U.in.data.is_engine_operative_2);
+  ATHR_PB = (Autothrust_U.in.data.is_engine_operative_1 && condition_AP_FD_ATHR_Specific);
+  condition_TOGA = (Autothrust_U.in.data.is_engine_operative_2 && flightDirectorOffTakeOff_tmp);
   Autothrust_DWork.condition_THR_LK = (((rtb_status == athr_status_DISENGAGED) && (Autothrust_DWork.pStatus !=
-    athr_status_DISENGAGED) && rtb_NOT && ((ATHR_ENGAGED_tmp_0 && (Autothrust_U.in.input.TLA_1_deg == 25.0) &&
-    (Autothrust_U.in.input.TLA_2_deg == 25.0)) || (ATHR_ENGAGED_tmp_1 && (Autothrust_U.in.input.TLA_1_deg == 35.0) &&
-    (Autothrust_U.in.input.TLA_2_deg <= 35.0)) || (condition_THR_LK_tmp && (Autothrust_U.in.input.TLA_2_deg == 35.0) &&
+    athr_status_DISENGAGED) && rtb_NOT && ((ATHR_PB_tmp && (Autothrust_U.in.input.TLA_1_deg == 25.0) &&
+    (Autothrust_U.in.input.TLA_2_deg == 25.0)) || (ATHR_PB && (Autothrust_U.in.input.TLA_1_deg == 35.0) &&
+    (Autothrust_U.in.input.TLA_2_deg <= 35.0)) || (condition_TOGA && (Autothrust_U.in.input.TLA_2_deg == 35.0) &&
     (Autothrust_U.in.input.TLA_1_deg <= 35.0)))) || (((!Autothrust_DWork.condition_THR_LK) || ((!(rtb_status !=
     athr_status_DISENGAGED)) && ((Autothrust_U.in.input.TLA_1_deg == 25.0) || (Autothrust_U.in.input.TLA_2_deg == 25.0) ||
     (Autothrust_U.in.input.TLA_1_deg == 35.0) || (Autothrust_U.in.input.TLA_2_deg == 35.0)))) &&
@@ -557,40 +576,40 @@ void AutothrustModelClass::step()
   Autothrust_DWork.pStatus = rtb_status;
   Autothrust_DWork.was_SRS_TO_active = Autothrust_U.in.input.is_SRS_TO_mode_active;
   Autothrust_DWork.was_SRS_GA_active = Autothrust_U.in.input.is_SRS_GA_mode_active;
-  if ((rtb_on_ground == 0) || (condition_AP_FD_ATHR_Specific && ATHR_ENGAGED_tmp)) {
+  if ((rtb_on_ground == 0) || (flightDirectorOffTakeOff_tmp && condition_AP_FD_ATHR_Specific)) {
     if ((Autothrust_DWork.pMode == athr_mode_A_FLOOR) || (Autothrust_DWork.pMode == athr_mode_TOGA_LK)) {
       Autothrust_Y.out.output.thrust_limit_type = athr_thrust_limit_type_TOGA;
-      Autothrust_Y.out.output.thrust_limit_percent = rtb_BusAssignment_n.input.thrust_limit_TOGA_percent;
-    } else if (rtb_Switch1_k > 35.0) {
+      Autothrust_Y.out.output.thrust_limit_percent = rtb_Switch1_k;
+    } else if (rtb_Switch_i_tmp > 35.0) {
       Autothrust_Y.out.output.thrust_limit_type = athr_thrust_limit_type_TOGA;
-      Autothrust_Y.out.output.thrust_limit_percent = rtb_BusAssignment_n.input.thrust_limit_TOGA_percent;
-    } else if (rtb_Switch1_k > 25.0) {
-      if (!rtb_y_o) {
+      Autothrust_Y.out.output.thrust_limit_percent = rtb_Switch1_k;
+    } else if (rtb_Switch_i_tmp > 25.0) {
+      if (!rtb_y_cs) {
         Autothrust_Y.out.output.thrust_limit_type = athr_thrust_limit_type_MCT;
-        Autothrust_Y.out.output.thrust_limit_percent = rtb_y_jh;
+        Autothrust_Y.out.output.thrust_limit_percent = rtb_y_a;
       } else {
         Autothrust_Y.out.output.thrust_limit_type = athr_thrust_limit_type_FLEX;
-        Autothrust_Y.out.output.thrust_limit_percent = rtb_y_i;
+        Autothrust_Y.out.output.thrust_limit_percent = rtb_y_c;
       }
-    } else if (rtb_Switch1_k >= 0.0) {
+    } else if (rtb_Switch_i_tmp >= 0.0) {
       Autothrust_Y.out.output.thrust_limit_type = athr_thrust_limit_type_CLB;
       Autothrust_Y.out.output.thrust_limit_percent = rtb_Sum_g;
-    } else if (rtb_Switch1_k < 0.0) {
+    } else if (rtb_Switch_i_tmp < 0.0) {
       Autothrust_Y.out.output.thrust_limit_type = athr_thrust_limit_type_REVERSE;
       Autothrust_Y.out.output.thrust_limit_percent = Autothrust_U.in.input.thrust_limit_REV_percent;
     } else {
       Autothrust_Y.out.output.thrust_limit_type = athr_thrust_limit_type_NONE;
       Autothrust_Y.out.output.thrust_limit_percent = 0.0;
     }
-  } else if (rtb_Switch1_k >= 0.0) {
-    if ((!rtb_y_o) || (rtb_Switch1_k > 35.0)) {
+  } else if (rtb_Switch_i_tmp >= 0.0) {
+    if ((!rtb_y_cs) || (rtb_Switch_i_tmp > 35.0)) {
       Autothrust_Y.out.output.thrust_limit_type = athr_thrust_limit_type_TOGA;
-      Autothrust_Y.out.output.thrust_limit_percent = rtb_BusAssignment_n.input.thrust_limit_TOGA_percent;
+      Autothrust_Y.out.output.thrust_limit_percent = rtb_Switch1_k;
     } else {
       Autothrust_Y.out.output.thrust_limit_type = athr_thrust_limit_type_FLEX;
-      Autothrust_Y.out.output.thrust_limit_percent = rtb_y_i;
+      Autothrust_Y.out.output.thrust_limit_percent = rtb_y_c;
     }
-  } else if (rtb_Switch1_k < 0.0) {
+  } else if (rtb_Switch_i_tmp < 0.0) {
     Autothrust_Y.out.output.thrust_limit_type = athr_thrust_limit_type_REVERSE;
     Autothrust_Y.out.output.thrust_limit_percent = Autothrust_U.in.input.thrust_limit_REV_percent;
   } else {
@@ -598,30 +617,30 @@ void AutothrustModelClass::step()
     Autothrust_Y.out.output.thrust_limit_percent = 0.0;
   }
 
-  rtb_Switch1_k = rtb_Switch_dx;
-  rtb_Switch_i_tmp = rtb_Switch_m;
-  cUseAutoThrustControl = ((rtb_status == athr_status_ENGAGED_ACTIVE) && (((Autothrust_U.in.input.TLA_1_deg <= 35.0) &&
+  rtb_Switch_i_tmp = rtb_Switch_dx;
+  rtb_Switch2_k = rtb_Switch_m;
+  ATHR_ENGAGED_tmp = ((rtb_status == athr_status_ENGAGED_ACTIVE) && (((Autothrust_U.in.input.TLA_1_deg <= 35.0) &&
     (Autothrust_U.in.input.TLA_2_deg <= 35.0)) || Autothrust_U.in.input.alpha_floor_condition));
-  pThrustMemoActive_tmp = !cUseAutoThrustControl;
+  ATHR_ENGAGED_tmp_0 = !ATHR_ENGAGED_tmp;
   Autothrust_DWork.pThrustMemoActive = ((((Autothrust_U.in.input.ATHR_push && (rtb_status != athr_status_DISENGAGED)) ||
-    (pThrustMemoActive_tmp && Autothrust_DWork.pUseAutoThrustControl && rtb_NOT)) && ((ATHR_ENGAGED_tmp_0 &&
-    (Autothrust_U.in.input.TLA_1_deg == 25.0) && (Autothrust_U.in.input.TLA_2_deg == 25.0)) || (ATHR_ENGAGED_tmp_1 &&
-    (Autothrust_U.in.input.TLA_1_deg == 35.0) && (Autothrust_U.in.input.TLA_2_deg <= 35.0)) || (condition_THR_LK_tmp &&
-    (Autothrust_U.in.input.TLA_2_deg == 35.0) && (Autothrust_U.in.input.TLA_1_deg <= 35.0)))) || (pThrustMemoActive_tmp &&
+    (ATHR_ENGAGED_tmp_0 && Autothrust_DWork.pUseAutoThrustControl && rtb_NOT)) && ((ATHR_PB_tmp &&
+    (Autothrust_U.in.input.TLA_1_deg == 25.0) && (Autothrust_U.in.input.TLA_2_deg == 25.0)) || (ATHR_PB &&
+    (Autothrust_U.in.input.TLA_1_deg == 35.0) && (Autothrust_U.in.input.TLA_2_deg <= 35.0)) || (condition_TOGA &&
+    (Autothrust_U.in.input.TLA_2_deg == 35.0) && (Autothrust_U.in.input.TLA_1_deg <= 35.0)))) || (ATHR_ENGAGED_tmp_0 &&
     ((Autothrust_U.in.input.TLA_1_deg == 25.0) || (Autothrust_U.in.input.TLA_1_deg == 35.0) ||
      (Autothrust_U.in.input.TLA_2_deg == 25.0) || (Autothrust_U.in.input.TLA_2_deg == 35.0)) &&
     Autothrust_DWork.pThrustMemoActive));
-  Autothrust_DWork.pUseAutoThrustControl = cUseAutoThrustControl;
+  Autothrust_DWork.pUseAutoThrustControl = ATHR_ENGAGED_tmp;
   rtb_NOT = ((!(rtb_status == Autothrust_P.CompareToConstant_const_d)) || ((Autothrust_DWork.pMode ==
     Autothrust_P.CompareToConstant2_const_c) || (Autothrust_DWork.pMode == Autothrust_P.CompareToConstant3_const_k)));
   if (Autothrust_U.in.data.is_engine_operative_1 && Autothrust_U.in.data.is_engine_operative_2) {
     rtb_Switch_m = rtb_Sum_g;
   } else {
-    rtb_Switch_m = rtb_y_jh;
+    rtb_Switch_m = rtb_y_a;
   }
 
   rtb_Switch_dx = Autothrust_P.Gain1_Gain_c * Autothrust_U.in.data.alpha_deg;
-  rtb_y_i = result[2] * std::sin(rtb_Switch_dx);
+  rtb_y_c = result[2] * std::sin(rtb_Switch_dx);
   rtb_Switch_dx = std::cos(rtb_Switch_dx);
   rtb_Switch_dx *= result[0];
   x[0] = Autothrust_U.in.input.V_LS_kn;
@@ -643,31 +662,31 @@ void AutothrustModelClass::step()
     i = 1;
   }
 
-  rtb_y_jh = x[i] - Autothrust_U.in.data.V_ias_kn;
-  rtb_Switch_dx = (rtb_y_i + rtb_Switch_dx) * Autothrust_P.Gain_Gain_h * Autothrust_P.Gain_Gain_b * look1_binlxpw(
+  rtb_y_a = x[i] - Autothrust_U.in.data.V_ias_kn;
+  rtb_Switch_dx = (rtb_y_c + rtb_Switch_dx) * Autothrust_P.Gain_Gain_h * Autothrust_P.Gain_Gain_b * look1_binlxpw(
     static_cast<real_T>(Autothrust_U.in.input.is_approach_mode_active),
-    Autothrust_P.ScheduledGain2_BreakpointsForDimension1, Autothrust_P.ScheduledGain2_Table, 1U) + rtb_y_jh;
-  rtb_Switch2_k = Autothrust_P.DiscreteDerivativeVariableTs_Gain * rtb_Switch_dx;
-  rtb_y_i = (rtb_Switch2_k - Autothrust_DWork.Delay_DSTATE) / Autothrust_U.in.time.dt;
+    Autothrust_P.ScheduledGain2_BreakpointsForDimension1, Autothrust_P.ScheduledGain2_Table, 1U) + rtb_y_a;
+  rtb_Gain_f = Autothrust_P.DiscreteDerivativeVariableTs_Gain * rtb_Switch_dx;
+  rtb_y_c = (rtb_Gain_f - Autothrust_DWork.Delay_DSTATE) / Autothrust_U.in.time.dt;
   if ((!Autothrust_DWork.pY_not_empty) || (!Autothrust_DWork.pU_not_empty)) {
-    Autothrust_DWork.pU = rtb_y_i;
+    Autothrust_DWork.pU = rtb_y_c;
     Autothrust_DWork.pU_not_empty = true;
-    Autothrust_DWork.pY = rtb_y_i;
+    Autothrust_DWork.pY = rtb_y_c;
     Autothrust_DWork.pY_not_empty = true;
   }
 
   rtb_Switch_f_idx_0 = Autothrust_U.in.time.dt * Autothrust_P.LagFilter_C1;
   ca = rtb_Switch_f_idx_0 / (rtb_Switch_f_idx_0 + 2.0);
-  Autothrust_DWork.pY = (2.0 - rtb_Switch_f_idx_0) / (rtb_Switch_f_idx_0 + 2.0) * Autothrust_DWork.pY + (rtb_y_i * ca +
+  Autothrust_DWork.pY = (2.0 - rtb_Switch_f_idx_0) / (rtb_Switch_f_idx_0 + 2.0) * Autothrust_DWork.pY + (rtb_y_c * ca +
     Autothrust_DWork.pU * ca);
-  Autothrust_DWork.pU = rtb_y_i;
+  Autothrust_DWork.pU = rtb_y_c;
   if (!Autothrust_DWork.eventTime_not_empty) {
     Autothrust_DWork.eventTime = Autothrust_U.in.time.simulation_time;
     Autothrust_DWork.eventTime_not_empty = true;
   }
 
-  rtb_y_i = std::abs(rtb_y_jh);
-  if (rtb_y_i > 5.0) {
+  rtb_y_c = std::abs(rtb_y_a);
+  if (rtb_y_c > 5.0) {
     Autothrust_DWork.eventTime = Autothrust_U.in.time.simulation_time;
   } else {
     if (Autothrust_DWork.eventTime == 0.0) {
@@ -689,8 +708,8 @@ void AutothrustModelClass::step()
     break;
 
    case 1:
-    if (10.0 < rtb_y_i) {
-      rtb_y_i = 10.0;
+    if (10.0 < rtb_y_c) {
+      rtb_y_c = 10.0;
     }
 
     rtb_Switch_f_idx_0 = Autothrust_U.in.time.simulation_time - Autothrust_DWork.eventTime;
@@ -698,16 +717,16 @@ void AutothrustModelClass::step()
       rtb_Switch_f_idx_0 = 0.0;
     }
 
-    if (1.0 > rtb_y_i) {
-      rtb_y_i = 1.0;
+    if (1.0 > rtb_y_c) {
+      rtb_y_c = 1.0;
     }
 
     if (15.0 < rtb_Switch_f_idx_0) {
       rtb_Switch_f_idx_0 = 15.0;
     }
 
-    rtb_Switch_dx = ((1.0 - (rtb_y_i - 1.0) * 0.1111111111111111) * 0.5 * (0.066666666666666666 * rtb_Switch_f_idx_0) *
-                     rtb_y_jh + (Autothrust_DWork.pY * look1_binlxpw(static_cast<real_T>
+    rtb_Switch_dx = ((1.0 - (rtb_y_c - 1.0) * 0.1111111111111111) * 0.5 * (0.066666666666666666 * rtb_Switch_f_idx_0) *
+                     rtb_y_a + (Autothrust_DWork.pY * look1_binlxpw(static_cast<real_T>
       (Autothrust_U.in.input.is_approach_mode_active), Autothrust_P.ScheduledGain1_BreakpointsForDimension1,
       Autothrust_P.ScheduledGain1_Table, 1U) + rtb_Switch_dx * look1_binlxpw(static_cast<real_T>
       (Autothrust_U.in.input.is_approach_mode_active), Autothrust_P.ScheduledGain_BreakpointsForDimension1,
@@ -718,22 +737,22 @@ void AutothrustModelClass::step()
 
    case 2:
     if (Phi_rad > Theta_rad) {
-      rtb_y_i = Phi_rad;
+      rtb_y_c = Phi_rad;
     } else {
-      rtb_y_i = Theta_rad;
+      rtb_y_c = Theta_rad;
     }
 
-    rtb_Switch_dx = (rtb_Sum_c - rtb_y_i) * Autothrust_P.Gain_Gain;
+    rtb_Switch_dx = (rtb_Sum_c - rtb_y_c) * Autothrust_P.Gain_Gain;
     break;
 
    default:
     if (Phi_rad > Theta_rad) {
-      rtb_y_i = Phi_rad;
+      rtb_y_c = Phi_rad;
     } else {
-      rtb_y_i = Theta_rad;
+      rtb_y_c = Theta_rad;
     }
 
-    rtb_Switch_dx = (rtb_Sum_g - rtb_y_i) * Autothrust_P.Gain_Gain_m;
+    rtb_Switch_dx = (rtb_Sum_g - rtb_y_c) * Autothrust_P.Gain_Gain_m;
     break;
   }
 
@@ -745,12 +764,12 @@ void AutothrustModelClass::step()
 
   if (Autothrust_DWork.icLoad != 0) {
     if (Phi_rad > Theta_rad) {
-      rtb_y_i = Phi_rad;
+      rtb_y_c = Phi_rad;
     } else {
-      rtb_y_i = Theta_rad;
+      rtb_y_c = Theta_rad;
     }
 
-    Autothrust_DWork.Delay_DSTATE_k = rtb_y_i - rtb_Switch_dx;
+    Autothrust_DWork.Delay_DSTATE_k = rtb_y_c - rtb_Switch_dx;
   }
 
   Autothrust_DWork.Delay_DSTATE_k += rtb_Switch_dx;
@@ -771,42 +790,42 @@ void AutothrustModelClass::step()
   }
 
   rtb_Switch_m = Autothrust_DWork.Delay_DSTATE_k - Autothrust_DWork.Delay_DSTATE_j;
-  rtb_y_i = Autothrust_P.Constant2_Value * Autothrust_U.in.time.dt;
-  if (rtb_Switch_m < rtb_y_i) {
-    rtb_y_i = rtb_Switch_m;
+  rtb_y_c = Autothrust_P.Constant2_Value * Autothrust_U.in.time.dt;
+  if (rtb_Switch_m < rtb_y_c) {
+    rtb_y_c = rtb_Switch_m;
   }
 
   rtb_Switch_f_idx_0 = Autothrust_U.in.time.dt * Autothrust_P.Constant3_Value;
-  if (rtb_y_i > rtb_Switch_f_idx_0) {
-    rtb_Switch_f_idx_0 = rtb_y_i;
+  if (rtb_y_c > rtb_Switch_f_idx_0) {
+    rtb_Switch_f_idx_0 = rtb_y_c;
   }
 
   Autothrust_DWork.Delay_DSTATE_j += rtb_Switch_f_idx_0;
   if (Autothrust_DWork.pUseAutoThrustControl) {
     if ((Autothrust_DWork.pMode == Autothrust_P.CompareToConstant2_const_h) || (Autothrust_DWork.pMode ==
          Autothrust_P.CompareToConstant3_const)) {
-      if (rtb_BusAssignment_n.input.thrust_limit_TOGA_percent < rtb_Switch1_k) {
-        rtb_Switch_f_idx_0 = rtb_Switch1_k;
+      if (rtb_Switch1_k < rtb_Switch_i_tmp) {
+        rtb_Switch_f_idx_0 = rtb_Switch_i_tmp;
       } else {
-        rtb_Switch_f_idx_0 = rtb_BusAssignment_n.input.thrust_limit_TOGA_percent;
+        rtb_Switch_f_idx_0 = rtb_Switch1_k;
       }
 
-      if (rtb_BusAssignment_n.input.thrust_limit_TOGA_percent < rtb_Switch_i_tmp) {
-        ca = rtb_Switch_i_tmp;
+      if (rtb_Switch1_k < rtb_Switch2_k) {
+        ca = rtb_Switch2_k;
       } else {
-        ca = rtb_BusAssignment_n.input.thrust_limit_TOGA_percent;
+        ca = rtb_Switch1_k;
       }
     } else {
-      if (Autothrust_DWork.Delay_DSTATE_j > rtb_Switch1_k) {
-        rtb_Switch_f_idx_0 = rtb_Switch1_k;
+      if (Autothrust_DWork.Delay_DSTATE_j > rtb_Switch_i_tmp) {
+        rtb_Switch_f_idx_0 = rtb_Switch_i_tmp;
       } else if (Autothrust_DWork.Delay_DSTATE_j < rtb_Sum_c) {
         rtb_Switch_f_idx_0 = rtb_Sum_c;
       } else {
         rtb_Switch_f_idx_0 = Autothrust_DWork.Delay_DSTATE_j;
       }
 
-      if (Autothrust_DWork.Delay_DSTATE_j > rtb_Switch_i_tmp) {
-        ca = rtb_Switch_i_tmp;
+      if (Autothrust_DWork.Delay_DSTATE_j > rtb_Switch2_k) {
+        ca = rtb_Switch2_k;
       } else if (Autothrust_DWork.Delay_DSTATE_j < rtb_Sum_c) {
         ca = rtb_Sum_c;
       } else {
@@ -817,8 +836,8 @@ void AutothrustModelClass::step()
     rtb_Switch_f_idx_0 = Phi_rad;
     ca = Theta_rad;
   } else {
-    rtb_Switch_f_idx_0 = rtb_Switch1_k;
-    ca = rtb_Switch_i_tmp;
+    rtb_Switch_f_idx_0 = rtb_Switch_i_tmp;
+    ca = rtb_Switch2_k;
   }
 
   rtb_Switch_m = rtb_Switch_f_idx_0 - Phi_rad;
@@ -850,20 +869,20 @@ void AutothrustModelClass::step()
     }
   }
 
-  Autothrust_ThrustMode1(Autothrust_U.in.input.TLA_1_deg, &rtb_y_jh);
+  Autothrust_ThrustMode1(Autothrust_U.in.input.TLA_1_deg, &rtb_y_a);
   rtb_Switch_dx = ca - Theta_rad;
   if (rtb_NOT1_m) {
     Autothrust_DWork.Delay_DSTATE_lz = Autothrust_P.DiscreteTimeIntegratorVariableTs_InitialCondition_n;
   }
 
-  rtb_y_i = Autothrust_P.Gain_Gain_bf * rtb_Switch_dx * Autothrust_P.DiscreteTimeIntegratorVariableTs_Gain_k *
+  rtb_y_c = Autothrust_P.Gain_Gain_bf * rtb_Switch_dx * Autothrust_P.DiscreteTimeIntegratorVariableTs_Gain_k *
     Autothrust_U.in.time.dt + Autothrust_DWork.Delay_DSTATE_lz;
-  if (rtb_y_i > Autothrust_P.DiscreteTimeIntegratorVariableTs_UpperLimit_p) {
+  if (rtb_y_c > Autothrust_P.DiscreteTimeIntegratorVariableTs_UpperLimit_p) {
     Autothrust_DWork.Delay_DSTATE_lz = Autothrust_P.DiscreteTimeIntegratorVariableTs_UpperLimit_p;
-  } else if (rtb_y_i < Autothrust_P.DiscreteTimeIntegratorVariableTs_LowerLimit_e) {
+  } else if (rtb_y_c < Autothrust_P.DiscreteTimeIntegratorVariableTs_LowerLimit_e) {
     Autothrust_DWork.Delay_DSTATE_lz = Autothrust_P.DiscreteTimeIntegratorVariableTs_LowerLimit_e;
   } else {
-    Autothrust_DWork.Delay_DSTATE_lz = rtb_y_i;
+    Autothrust_DWork.Delay_DSTATE_lz = rtb_y_c;
   }
 
   if (!rtb_NOT1_m) {
@@ -880,7 +899,7 @@ void AutothrustModelClass::step()
     }
   }
 
-  Autothrust_ThrustMode1(Autothrust_U.in.input.TLA_2_deg, &rtb_y_i);
+  Autothrust_ThrustMode1(Autothrust_U.in.input.TLA_2_deg, &rtb_y_c);
   Autothrust_Y.out.time = Autothrust_U.in.time;
   Autothrust_Y.out.data.nz_g = Autothrust_U.in.data.nz_g;
   Autothrust_Y.out.data.Theta_deg = rtb_Gain2;
@@ -912,9 +931,10 @@ void AutothrustModelClass::step()
   Autothrust_Y.out.data.OAT_degC = Autothrust_U.in.data.OAT_degC;
   Autothrust_Y.out.data.ISA_degC = rtb_Saturation;
   Autothrust_Y.out.data_computed.TLA_in_active_range = rtb_out;
-  Autothrust_Y.out.data_computed.is_FLX_active = rtb_y_o;
+  Autothrust_Y.out.data_computed.is_FLX_active = rtb_y_cs;
   Autothrust_Y.out.data_computed.ATHR_push = rtb_BusAssignment_n.data_computed.ATHR_push;
   Autothrust_Y.out.data_computed.ATHR_disabled = Autothrust_DWork.Memory_PreviousInput;
+  Autothrust_Y.out.data_computed.time_since_touchdown = rtb_BusAssignment_n.data_computed.time_since_touchdown;
   Autothrust_Y.out.input.ATHR_push = Autothrust_U.in.input.ATHR_push;
   Autothrust_Y.out.input.ATHR_disconnect = Autothrust_U.in.input.ATHR_disconnect;
   Autothrust_Y.out.input.TLA_1_deg = Autothrust_U.in.input.TLA_1_deg;
@@ -927,7 +947,7 @@ void AutothrustModelClass::step()
   Autothrust_Y.out.input.thrust_limit_CLB_percent = rtb_Sum_g;
   Autothrust_Y.out.input.thrust_limit_MCT_percent = rtb_BusAssignment_n.input.thrust_limit_MCT_percent;
   Autothrust_Y.out.input.thrust_limit_FLEX_percent = rtb_BusAssignment_n.input.thrust_limit_FLEX_percent;
-  Autothrust_Y.out.input.thrust_limit_TOGA_percent = rtb_BusAssignment_n.input.thrust_limit_TOGA_percent;
+  Autothrust_Y.out.input.thrust_limit_TOGA_percent = rtb_Switch1_k;
   Autothrust_Y.out.input.flex_temperature_degC = Autothrust_U.in.input.flex_temperature_degC;
   Autothrust_Y.out.input.mode_requested = Autothrust_U.in.input.mode_requested;
   Autothrust_Y.out.input.is_mach_mode_active = Autothrust_U.in.input.is_mach_mode_active;
@@ -945,6 +965,7 @@ void AutothrustModelClass::step()
   Autothrust_Y.out.input.is_anti_ice_engine_2_active = Autothrust_U.in.input.is_anti_ice_engine_2_active;
   Autothrust_Y.out.input.is_air_conditioning_1_active = Autothrust_U.in.input.is_air_conditioning_1_active;
   Autothrust_Y.out.input.is_air_conditioning_2_active = Autothrust_U.in.input.is_air_conditioning_2_active;
+  Autothrust_Y.out.input.FD_active = Autothrust_U.in.input.FD_active;
   if (!rtb_Compare_e) {
     Autothrust_Y.out.output.sim_throttle_lever_1_pos = Autothrust_DWork.Delay_DSTATE_n;
   } else {
@@ -957,30 +978,30 @@ void AutothrustModelClass::step()
     Autothrust_Y.out.output.sim_throttle_lever_2_pos = Autothrust_DWork.Delay_DSTATE_h;
   }
 
-  Autothrust_Y.out.output.sim_thrust_mode_1 = rtb_y_jh;
-  Autothrust_Y.out.output.sim_thrust_mode_2 = rtb_y_i;
-  Autothrust_Y.out.output.N1_TLA_1_percent = rtb_Switch1_k;
-  Autothrust_Y.out.output.N1_TLA_2_percent = rtb_Switch_i_tmp;
+  Autothrust_Y.out.output.sim_thrust_mode_1 = rtb_y_a;
+  Autothrust_Y.out.output.sim_thrust_mode_2 = rtb_y_c;
+  Autothrust_Y.out.output.N1_TLA_1_percent = rtb_Switch_i_tmp;
+  Autothrust_Y.out.output.N1_TLA_2_percent = rtb_Switch2_k;
   Autothrust_Y.out.output.is_in_reverse_1 = rtb_Compare_e;
   Autothrust_Y.out.output.is_in_reverse_2 = rtb_NOT1_m;
   Autothrust_Y.out.output.N1_c_1_percent = rtb_Switch_f_idx_0;
   Autothrust_Y.out.output.N1_c_2_percent = ca;
   Autothrust_Y.out.output.status = rtb_status;
   Autothrust_Y.out.output.mode = Autothrust_DWork.pMode;
-  rtb_NOT = (((!Autothrust_U.in.input.is_SRS_TO_mode_active) || ((Autothrust_U.in.data.H_ind_ft >=
+  ATHR_PB_tmp = (((!Autothrust_U.in.input.is_SRS_TO_mode_active) || ((Autothrust_U.in.data.H_ind_ft >=
     Autothrust_U.in.input.thrust_reduction_altitude) && (!Autothrust_DWork.inhibitAboveThrustReductionAltitude))) &&
-             ((!Autothrust_U.in.input.is_SRS_GA_mode_active) || ((Autothrust_U.in.data.H_ind_ft >=
+                 ((!Autothrust_U.in.input.is_SRS_GA_mode_active) || ((Autothrust_U.in.data.H_ind_ft >=
     Autothrust_U.in.input.thrust_reduction_altitude_go_around) && (!Autothrust_DWork.inhibitAboveThrustReductionAltitude))));
   if ((rtb_status != athr_status_DISENGAGED) && (Autothrust_DWork.pMode != athr_mode_A_FLOOR) && (Autothrust_DWork.pMode
-       != athr_mode_TOGA_LK) && (rtb_on_ground == 0) && rtb_NOT && Autothrust_U.in.data.is_engine_operative_1 &&
+       != athr_mode_TOGA_LK) && (rtb_on_ground == 0) && ATHR_PB_tmp && Autothrust_U.in.data.is_engine_operative_1 &&
       Autothrust_U.in.data.is_engine_operative_2 && (((Autothrust_U.in.input.TLA_1_deg < 25.0) &&
         (Autothrust_U.in.input.TLA_2_deg < 25.0)) || (Autothrust_U.in.input.TLA_1_deg > 25.0) ||
        (Autothrust_U.in.input.TLA_2_deg > 25.0))) {
     Autothrust_Y.out.output.mode_message = athr_mode_message_LVR_CLB;
   } else if ((rtb_status != athr_status_DISENGAGED) && (Autothrust_DWork.pMode != athr_mode_A_FLOOR) &&
-             (Autothrust_DWork.pMode != athr_mode_TOGA_LK) && (rtb_on_ground == 0) && rtb_NOT &&
-             (condition_AP_FD_ATHR_Specific || ATHR_ENGAGED_tmp) && (Autothrust_U.in.input.TLA_1_deg != 35.0) &&
-             (Autothrust_U.in.input.TLA_2_deg != 35.0)) {
+             (Autothrust_DWork.pMode != athr_mode_TOGA_LK) && (rtb_on_ground == 0) && ATHR_PB_tmp &&
+             (flightDirectorOffTakeOff_tmp || condition_AP_FD_ATHR_Specific) && (Autothrust_U.in.input.TLA_1_deg != 35.0)
+             && (Autothrust_U.in.input.TLA_2_deg != 35.0)) {
     Autothrust_Y.out.output.mode_message = athr_mode_message_LVR_MCT;
   } else if ((rtb_status == athr_status_ENGAGED_ACTIVE) && Autothrust_U.in.data.is_engine_operative_1 &&
              Autothrust_U.in.data.is_engine_operative_2 && (((Autothrust_U.in.input.TLA_1_deg == 25.0) &&
@@ -993,7 +1014,7 @@ void AutothrustModelClass::step()
     Autothrust_Y.out.output.mode_message = athr_mode_message_NONE;
   }
 
-  Autothrust_DWork.Delay_DSTATE = rtb_Switch2_k;
+  Autothrust_DWork.Delay_DSTATE = rtb_Gain_f;
   Autothrust_DWork.icLoad = 0U;
   Autothrust_DWork.icLoad_c = 0U;
 }

--- a/src/fbw/src/model/Autothrust.h
+++ b/src/fbw/src/model/Autothrust.h
@@ -7,6 +7,11 @@
 class AutothrustModelClass {
  public:
   typedef struct {
+    real_T eventTime;
+    boolean_T eventTime_not_empty;
+  } rtDW_TimeSinceCondition_Autothrust_T;
+
+  typedef struct {
     real_T pY;
     boolean_T pY_not_empty;
   } rtDW_RateLimiter_Autothrust_T;
@@ -24,7 +29,6 @@ class AutothrustModelClass {
     real_T pY;
     real_T pU;
     real_T eventTime;
-    real_T eventTime_h;
     real_T eventTime_f;
     athr_mode pMode;
     athr_status pStatus;
@@ -38,6 +42,7 @@ class AutothrustModelClass {
     boolean_T ATHR_ENGAGED;
     boolean_T prev_TLA_1_not_empty;
     boolean_T prev_TLA_2_not_empty;
+    boolean_T flightDirectorOffTakeOff;
     boolean_T pConditionAlphaFloor;
     boolean_T was_SRS_TO_active;
     boolean_T was_SRS_GA_active;
@@ -49,13 +54,14 @@ class AutothrustModelClass {
     boolean_T pU_not_empty;
     boolean_T eventTime_not_empty;
     boolean_T latch;
-    boolean_T eventTime_not_empty_i;
     boolean_T eventTime_not_empty_g;
     rtDW_RateLimiter_Autothrust_T sf_RateLimiter_p;
     rtDW_RateLimiter_Autothrust_T sf_RateLimiter_f;
     rtDW_RateLimiter_Autothrust_T sf_RateLimiter_b;
     rtDW_RateLimiter_Autothrust_T sf_RateLimiter_k;
     rtDW_RateLimiter_Autothrust_T sf_RateLimiter;
+    rtDW_TimeSinceCondition_Autothrust_T sf_TimeSinceCondition1;
+    rtDW_TimeSinceCondition_Autothrust_T sf_TimeSinceCondition_o;
   } D_Work_Autothrust_T;
 
   typedef struct {
@@ -261,6 +267,8 @@ class AutothrustModelClass {
   D_Work_Autothrust_T Autothrust_DWork;
   ExternalInputs_Autothrust_T Autothrust_U;
   ExternalOutputs_Autothrust_T Autothrust_Y;
+  static void Autothrust_TimeSinceCondition(real_T rtu_time, boolean_T rtu_condition, real_T *rty_y,
+    rtDW_TimeSinceCondition_Autothrust_T *localDW);
   static void Autothrust_ThrustMode1(real_T rtu_u, real_T *rty_y);
   static void Autothrust_TLAComputation1(const athr_out *rtu_in, real_T rtu_TLA, real_T *rty_N1c, boolean_T
     *rty_inReverse);

--- a/src/fbw/src/model/Autothrust_data.cpp
+++ b/src/fbw/src/model/Autothrust_data.cpp
@@ -44,7 +44,8 @@ AutothrustModelClass::Parameters_Autothrust_T AutothrustModelClass::Autothrust_P
       false,
       false,
       false,
-      false
+      false,
+      0.0
     },
 
     {
@@ -72,6 +73,7 @@ AutothrustModelClass::Parameters_Autothrust_T AutothrustModelClass::Autothrust_P
       0.0,
       0.0,
       0.0,
+      false,
       false,
       false,
       false,

--- a/src/fbw/src/model/Autothrust_types.h
+++ b/src/fbw/src/model/Autothrust_types.h
@@ -116,6 +116,7 @@ typedef struct {
   boolean_T is_anti_ice_engine_2_active;
   boolean_T is_air_conditioning_1_active;
   boolean_T is_air_conditioning_2_active;
+  boolean_T FD_active;
 } athr_input;
 
 #endif
@@ -204,6 +205,7 @@ typedef struct {
   boolean_T is_FLX_active;
   boolean_T ATHR_push;
   boolean_T ATHR_disabled;
+  real_T time_since_touchdown;
 } athr_data_computed;
 
 #endif

--- a/src/fdr2csv/src/FlightDataRecorderConverter.cpp
+++ b/src/fdr2csv/src/FlightDataRecorderConverter.cpp
@@ -241,6 +241,7 @@ void FlightDataRecorderConverter::writeHeader(ofstream& out, const string& delim
   out << "athr.data_computed.is_FLX_active" << delimiter;
   out << "athr.data_computed.ATHR_push" << delimiter;
   out << "athr.data_computed.ATHR_disabled" << delimiter;
+  out << "athr.data_computed.time_since_touchdown" << delimiter;
   out << "athr.input.ATHR_push" << delimiter;
   out << "athr.input.ATHR_disconnect" << delimiter;
   out << "athr.input.TLA_1_deg" << delimiter;
@@ -268,6 +269,7 @@ void FlightDataRecorderConverter::writeHeader(ofstream& out, const string& delim
   out << "athr.input.is_anti_ice_engine_2_active" << delimiter;
   out << "athr.input.is_air_conditioning_1_active" << delimiter;
   out << "athr.input.is_air_conditioning_2_active" << delimiter;
+  out << "athr.input.FD_active" << delimiter;
   out << "athr.output.sim_throttle_lever_1_pos" << delimiter;
   out << "athr.output.sim_throttle_lever_2_pos" << delimiter;
   out << "athr.output.sim_thrust_mode_1" << delimiter;
@@ -700,6 +702,7 @@ void FlightDataRecorderConverter::writeStruct(ofstream& out,
   out << static_cast<unsigned int>(athr.data_computed.is_FLX_active) << delimiter;
   out << static_cast<unsigned int>(athr.data_computed.ATHR_push) << delimiter;
   out << static_cast<unsigned int>(athr.data_computed.ATHR_disabled) << delimiter;
+  out << athr.data_computed.time_since_touchdown << delimiter;
   out << static_cast<unsigned int>(athr.input.ATHR_push) << delimiter;
   out << static_cast<unsigned int>(athr.input.ATHR_disconnect) << delimiter;
   out << athr.input.TLA_1_deg << delimiter;
@@ -727,6 +730,7 @@ void FlightDataRecorderConverter::writeStruct(ofstream& out,
   out << static_cast<unsigned int>(athr.input.is_anti_ice_engine_2_active) << delimiter;
   out << static_cast<unsigned int>(athr.input.is_air_conditioning_1_active) << delimiter;
   out << static_cast<unsigned int>(athr.input.is_air_conditioning_2_active) << delimiter;
+  out << static_cast<unsigned int>(athr.input.FD_active) << delimiter;
   out << athr.output.sim_throttle_lever_1_pos << delimiter;
   out << athr.output.sim_throttle_lever_2_pos << delimiter;
   out << athr.output.sim_thrust_mode_1 << delimiter;

--- a/src/fdr2csv/src/main.cpp
+++ b/src/fdr2csv/src/main.cpp
@@ -14,7 +14,7 @@
 using namespace std;
 
 // IMPORTANT: this constant needs to increased with every interface change
-const uint64_t INTERFACE_VERSION = 5;
+const uint64_t INTERFACE_VERSION = 6;
 
 int main(int argc, char* argv[]) {
   // variables for command line parameters


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #5016

## Summary of Changes
This PR introduces support for the normal procedure *NO FLIGHT DIRECTOR TAKEOFF*.

**Remark:**
This PR only covers the area of A/THR logic and nothing related to managed/selected speed management.

## References
FCOM PRO-NOR-SRP-01-30

## Testing instructions

### Take-Off

#### Part 1
For the following checks no actual take-off is needed

- on ground, FMGC flight phase 0, disable both FD, set levers to TOGA: no FMA indication, thrust limit TOGA applied
- on ground, FMGC flight phase 0, disable both FD, set valid FLX temperature, set levers to FLX: no FMA indication, thrust limit FLX applied
- on ground, FMGC flight phase 0, both FD enabled, set levers to TOGA: FMA indication, thrust limit TOGA applied
- on ground, FMGC flight phase 0, both FD enabled, set valid FLX temperature, levers to FLX: FMA indication, thrust limit FLX applied

#### Part 2
This part needs an actual take-off

- set speed to 150 kn on FCU (selected)
- on ground, FMGC flight phase 0, disable both FD, set levers to TOGA: no FMA indication, thrust limit TOGA applied
- take-off, establish initial climb with ~ 15° pitch attitude
- around 1500 ft AGL:
  - set thrust levers to CL detent: no FMA indication
  - activate A/THR using FCU pushbutton: FMA shows SPEED and ATHR in white
  - turn on FDs: basic modes engage (HDG + VS with current rate of climb or respective TRACK + FPA)

### Go Around
- in FMGC approach phase, land with both FD off and ATHR off, within 30s after touchdown apply TOGA: FDs engage, TOGA and ATHR blue is shown and SRS and GA TRK engages

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
