### PR TITLE
feat: improved managed speed validity + VS speed protection and LOC/GS arm fix

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -101,6 +101,7 @@
 1. [ATHR] Fixed incorrect THR LK activation when A/THR disconnect buttons have been used - @aguther (Andreas Guther)
 1. [ATHR] Support flight director off take-off procedure - @aguther (Andreas Guther)
 1. [MCDU] Fixed tropo entry validation - @MisterChocker (Leon)
+1. [AP/FMGC] Improved managed speed and V2 validity - @aguther (Andreas Guther)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -627,17 +627,14 @@ class FMCMainDisplay extends BaseAirliners {
             this.managedSpeedTargetIsMach = isMach;
         }
 
-        if (!this.isAirspeedManaged()) {
-            return;
-        }
-
         // Overspeed protection
         const Vtap = Math.min(this.managedSpeedTarget, SimVar.GetSimVarValue("L:A32NX_SPEEDS_VMAX", "number"));
-
         SimVar.SetSimVarValue("L:A32NX_SPEEDS_MANAGED_PFD", "knots", vPfd);
         SimVar.SetSimVarValue("L:A32NX_SPEEDS_MANAGED_ATHR", "knots", Vtap);
 
-        Coherent.call("AP_SPD_VAR_SET", 0, Vtap);
+        if (this.isAirspeedManaged()) {
+            Coherent.call("AP_SPD_VAR_SET", 0, Vtap);
+        }
     }
 
     activatePreSelSpeedMach(preSel) {


### PR DESCRIPTION
## Summary of Changes
This PR improves managed speed and V2 validity.

### Managed Speed
The managed speed validity is improved. This leads to managed speed in cold and dark or spawning on the runway without an entered V2 to selected speed with default 100 kn. Managed speed cannot be engaged until a V2 is entered. This has no impact on the availability in flight when AP is engaged or when in approach phase.

As outlined, when a flight without V2 entered is performed, the managed speed can be used in FMGC approach phase, but when FMGC changes in done phase, the managed speed reverts to selected speed (below 100 kn it will be 100 kn).

### V2
The V2 is now assumed valid when equal or greater than 90 kn.

### VS speed protection
The FMA speed protection for V/S or FPA mode is only shown blinking in amber and a triple click when the AP is engaged. When manually flying, the FD vertical bar guides the pilot for speed protection (e.g. guides nose down) but the FMA stays normal and no triple click appears.

### LOC/GS arm fix
It was possible to arm LOC and GS when both flight directors and autopilot have been off. It was not shown, but as soon as one FD or AP was engaged it was suddenly armed. This has been fixed. Disconnecting both FDs and APs results in those modes to disarm.

## References
https://youtu.be/Mo7A3CuVb8g

DSC-22_30-75
> Note: When flying with FD bars only (AP OFF), the FMGS adjusts the pitch bar so that VLS is
maintained. However, no triple click is generated and the V/S target display on the FMA
remains unchanged

> Note: When flying with FD bars only (AP OFF), the FMGS adjusts the pitch bar so that VMAX
is maintained. However, no triple click is generated and the V/S target display on the
FMA remains unchanged.

## Testing instructions

### Cold & Dark
- start cold & dark on gate
- power up the plane
- speed is in selected mode with 100 kn
- managed speed cannot be engaged
- enter a V2
- managed speed engages

### Spawn on runway
- speed is in selected mode with 100 kn
- ensure no V2 is set
- managed speed cannot be engaged
- take-off, SRS does **not** engage
- circle to land, ensure FMGC is in approach phase
- push SPD to engage managed speed
- land the plane and bring it to stop
- 30 s after touchdown the FMGC will revert to selected speed with 100 kn set

### V/S speed protection

#### Manual Flight
- take-off or spawn in flight
- fly manually
- set V/S of e.g. 2000 fpm
- set thrust and pitch so that you slowly loose speed towards VLS
- observe the vertical FD bar
- it will guide you nose down when approaching VLS
- FMA remains unchanged and no triple click appears
- exit this condition

#### Autopilot
- take-off or spawn in flight
- engage AP without A/THR
- set V/S of e.g. 2000 fpm
- set thrust so that you slowly loose speed towards VLS
- observe the vertical FD bar
- it will guide the AP nose down when approaching VLS
- shortly before reaching VLS, the FMA will show a blinking amber box with pulsing VS target and a triple click is played
- disengage the AP
- the FMA will revert to normal condition, FD vertical bar is still guiding for speed protection

### LOC/GS arm fix
- fly in the vicinity of an airport where you are able to receive a valid ILS signal
- tune the ILS signal, verify it by engaging the LS button
- arm LOC
- disable both FDs
- engage one FD : no APPR and LOC is armed
- arm APPR
- disable both FDs
- engage one FD : no APPR and LOC is armed
- disable both FDs
- push LOC
- engage one FD : no APPR and LOC is armed
- disable both FDs
- push APPR
- engage one FD : no APPR and LOC is armed

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
