### PR TITLE
feat: init FCU with correct default values and improved flight / plane load for alpha protection

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -102,6 +102,7 @@
 1. [ATHR] Support flight director off take-off procedure - @aguther (Andreas Guther)
 1. [MCDU] Fixed tropo entry validation - @MisterChocker (Leon)
 1. [AP/FMGC] Improved managed speed and V2 validity - @aguther (Andreas Guther)
+1. [FBW] Inhibit alpha floor and protection law for 10 s after flight start / plane reload - @aguther (Andreas Guther)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -102,6 +102,7 @@
 1. [ATHR] Support flight director off take-off procedure - @aguther (Andreas Guther)
 1. [MCDU] Fixed tropo entry validation - @MisterChocker (Leon)
 1. [AP/FMGC] Improved managed speed and V2 validity - @aguther (Andreas Guther)
+1. [FCU] Init FCU with SPD 100 kn, HDG = 0° and ALT 100 ft - @aguther (Andreas Guther)
 1. [FBW] Inhibit alpha floor and protection law for 10 s after flight start / plane reload - @aguther (Andreas Guther)
 
 ## 0.6.0

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
@@ -170,6 +170,8 @@ class A320_Neo_FCU_Speed extends A320_Neo_FCU_Component {
         this._rotaryEncoderTimeout = 300;
         this._rotaryEncoderIncrement = 0.15;
         this._rotaryEncoderPreviousTimestamp = 0;
+
+        this.onPull();
     }
 
     init() {
@@ -523,10 +525,11 @@ class A320_Neo_FCU_Heading extends A320_Neo_FCU_Component {
         this.textTRK = this.getTextElement("TRK");
         this.textLAT = this.getTextElement("LAT");
         this.illuminator = this.getElement("circle", "Illuminator");
-        this.refresh(true, false, false, false, true, 0, false, true);
-        this.selectedValue = -1;
-        this.isSelectedValueActive = false;
+        this.currentValue = -1;
+        this.selectedValue = Simplane.getAltitudeAboveGround() > 1000 ? this.getCurrentHeading() : 0;
+        this.isSelectedValueActive = true;
         this.isPreselectionModeActive = false;
+        this.refresh(true, false, false, false, true, 0, false, true);
         this.onPull();
     }
 
@@ -828,13 +831,11 @@ class A320_Neo_FCU_Altitude extends A320_Neo_FCU_Component {
         this.isActive = false;
         this.isManaged = false;
         this.currentValue = 0;
-        let initValue = Simplane.getAltitude();
-        if (initValue <= 5000) {
-            initValue = 5000;
-        } else {
-            initValue = Math.round(initValue / 100) * 100;
+        let initValue = 100;
+        if (Simplane.getAltitudeAboveGround() > 1000) {
+            initValue = Math.min(49000, Math.max(100, Math.round(Simplane.getAltitude() / 100) * 100));
         }
-        Coherent.call("AP_ALT_VAR_SET_ENGLISH", 1, initValue, true);
+        Coherent.call("AP_ALT_VAR_SET_ENGLISH", 3, initValue, true);
         this.refresh(false, false, initValue, 0, true);
     }
     reboot() {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
@@ -190,6 +190,11 @@ class A320_Neo_FCU_Speed extends A320_Neo_FCU_Component {
         this.onPull();
     }
 
+    onFlightStart() {
+        super.onFlightStart();
+        this.init();
+    }
+
     update(_deltaTime) {
         const isManaged = Simplane.getAutoPilotAirspeedManaged() && this.isTargetManaged;
         const showSelectedSpeed = this.inSelection || !isManaged;
@@ -535,6 +540,7 @@ class A320_Neo_FCU_Heading extends A320_Neo_FCU_Component {
 
     onFlightStart() {
         super.onFlightStart();
+        this.init();
     }
 
     onRotate() {
@@ -838,9 +844,16 @@ class A320_Neo_FCU_Altitude extends A320_Neo_FCU_Component {
         Coherent.call("AP_ALT_VAR_SET_ENGLISH", 3, initValue, true);
         this.refresh(false, false, initValue, 0, true);
     }
+
+    onFlightStart() {
+        super.onFlightStart();
+        this.init();
+    }
+
     reboot() {
         this.init();
     }
+
     isManagedModeActiveOrArmed(_mode, _armed) {
         return (
             (_mode >= 20 && _mode <= 34)
@@ -851,6 +864,7 @@ class A320_Neo_FCU_Altitude extends A320_Neo_FCU_Component {
             )
         );
     }
+
     update(_deltaTime) {
         const verticalMode = SimVar.GetSimVarValue("L:A32NX_FMA_VERTICAL_MODE", "Number");
         const verticalArmed = SimVar.GetSimVarValue("L:A32NX_FMA_VERTICAL_ARMED", "Number");
@@ -858,6 +872,7 @@ class A320_Neo_FCU_Altitude extends A320_Neo_FCU_Component {
 
         this.refresh(Simplane.getAutoPilotActive(), isManaged, Simplane.getAutoPilotDisplayedAltitudeLockValue(Simplane.getAutoPilotAltitudeLockUnits()), SimVar.GetSimVarValue("L:A32NX_OVHD_INTLT_ANN", "number") == 0);
     }
+
     refresh(_isActive, _isManaged, _value, _lightsTest, _force = false) {
         if ((_isActive != this.isActive) || (_isManaged != this.isManaged) || (_value != this.currentValue) || (_lightsTest !== this.lightsTest) || _force) {
             this.isActive = _isActive;
@@ -874,6 +889,7 @@ class A320_Neo_FCU_Altitude extends A320_Neo_FCU_Component {
             this.setElementVisibility(this.illuminator, this.isManaged);
         }
     }
+
     onEvent(_event) {
         if (_event === "ALT_PUSH") {
             SimVar.SetSimVarValue("K:A32NX.FCU_ALT_PUSH", "number", 0);
@@ -922,6 +938,7 @@ class A320_Neo_FCU_VerticalSpeed extends A320_Neo_FCU_Component {
 
     onFlightStart() {
         super.onFlightStart();
+        this.init();
     }
 
     onPush() {

--- a/src/fbw/src/model/FlyByWire.cpp
+++ b/src/fbw/src/model/FlyByWire.cpp
@@ -335,7 +335,8 @@ void FlyByWireModelClass::step()
     FlyByWire_DWork.resetEventTime = FlyByWire_U.in.time.simulation_time;
   }
 
-  if ((rtb_on_ground == 0) && (FlyByWire_U.in.data.autopilot_custom_on == 0.0) && (rtb_Limiterxi1 > rtb_Switch)) {
+  if ((rtb_on_ground == 0) && (FlyByWire_U.in.data.autopilot_custom_on == 0.0) && (rtb_Limiterxi1 > rtb_Switch) &&
+      (FlyByWire_DWork.Delay_DSTATE > 10.0)) {
     FlyByWire_DWork.sProtActive_n = 1.0;
   }
 
@@ -430,7 +431,7 @@ void FlyByWireModelClass::step()
       rtb_Y_dd = 0.0;
     }
 
-    if (rtb_Limiterxi1 > rtb_Gain1_h + rtb_Y_dd) {
+    if ((rtb_Limiterxi1 > rtb_Gain1_h + rtb_Y_dd) && (FlyByWire_DWork.Delay_DSTATE > 10.0)) {
       FlyByWire_DWork.sAlphaFloor = 1.0;
     } else {
       guard1 = true;


### PR DESCRIPTION
## Summary of Changes
This PR is about FCU initialization and in flight start experience

### In flight start experience
The high alpha protection and alpha floor is now inhibited for 10s after flight start or plane reload. This allows the plane to settle values and filters and avoids unnecessary triggering of alpha floor and alpha protection law.

### On ground
- SPD = 100 kn
- HDG = 0°
- ALT = 100 ft

### In Flight
- SPD = current speed rounded to 1 kn
- HDG = current heading rounded to 1°
- ALT = current altitude rounded to 100 ft
- V/S = current V/S

Remark:
1. The V/S part showing +0000 is left out because it's unclear when and based on which condition on ground this changes to dashes. This will be fixed in an upcoming PR when this is clear.
2. When starting in flight, the speed sometimes changes quite fast without the user seeing it (bc the PFD is not yet shown), therefore the speed chosen in the FCU and the speed when the user sees it first might differ

## References
https://youtu.be/Mo7A3CuVb8g

## Testing instructions

### FCU
- spawn in cold & dark and power up plane, values as described for on ground
- spawn in on the runway, values as described for on ground
- spawn in flight, values  as described for in flight

### In flight experience
- spawn in flight and check if alpha protection of alpha floor is triggered

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
