### PR TITLE
fix: Fix falsy SimVar values not being persisted properly

### DIFF
--- a/src/instruments/src/Common/persistence.tsx
+++ b/src/instruments/src/Common/persistence.tsx
@@ -72,7 +72,7 @@ export const useSimVarSyncedPersistentProperty: SimVarSyncedPersistentPropertyTy
     const [simVarValue, setSimVarValue] = useSimVar(simVarName, simVarUnit, 1_000);
 
     useEffect(() => {
-        if (simVarValue) {
+        if (simVarValue || simVarValue === 0) {
             setPropertyValue((simVarValue as number).toString());
         }
     }, [simVarValue]);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #5110

## Summary of Changes
This addresses an issue where the value 0 would not be saved to persistent storage because it is considered falsy in JS. Consequently, when the refuel rate was set to "Real" on the EFB, this was encoded as a 0 and not saved properly, so when the plane was reloaded, the incorrect refuel rate was selected. Additionally, I noticed that the "PTU audible in cockpit" setting was also not saved properly due to the same issue. This has now been fixed.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BlueberryKing#6641

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Load up the airplane anywhere (cold & dark or not)
2. Set the refuel rate on the EFB to **something other than "Real"** and turn "PTU audible in cockpit" **on**.
3. Restart the flight and make sure both values were as you set them before reloading.
4. Now, set the refuel rate to **"Real"** and "PTU audible in cockpit" to **off**.
3. Restart the flight and make sure both values were as you set them before reloading.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
