### PR TITLE
feat: Add autopilot simvars for FCU hardware use

### DIFF
--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -1197,6 +1197,54 @@
     - Indicates the selected heading on the FCU, instantly updated
     - In case of managed heading mode, the value is -1
 
+- A32NX_FCU_SPD_MANAGED
+  - Boolean
+  - Indicates if managed speed/mach mode is active (dashes and dot)
+    State | Value
+      --- | ---
+      SELECTED | 0
+      MANAGED | 1
+
+- A32NX_FCU_HDG_MANAGED_DASHES
+  - Boolean
+  - Indicates if managed heading mode is active
+    State | Value
+      --- | ---
+      SELECTED | 0
+      MANAGED | 1
+
+- A32NX_FCU_HDG_MANAGED_DOT
+  - Boolean
+  - Indicates if managed heading mode is active or armed
+    State | Value
+      --- | ---
+      SELECTED | 0
+      MANAGED/ARMED | 1
+
+- A32NX_FCU_ALT_MANAGED
+  - Boolean
+  - Indicates if managed altitude mode is active (dot)
+    State | Value
+      --- | ---
+      SELECTED | 0
+      MANAGED | 1
+
+- A32NX_FCU_VS_MANAGED
+  - Boolean
+  - Indicates if managed VS/FPA mode is active
+    State | Value
+      --- | ---
+      SELECTED | 0
+      MANAGED | 1
+
+- A32NX_FCU_VS_POSITIVE
+  - Boolean
+  - Indicates if vertical speed/FPA is a nonnegative value
+    State | Value
+      --- | ---
+      NEGATIVE | 0
+      ZERO OR POSITIVE | 1
+
 - A32NX_FCU_LOC_MODE_ACTIVE
     - Boolean
     - Indicates if LOC button on the FCU is illuminated

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -1237,14 +1237,6 @@
       SELECTED | 0
       MANAGED | 1
 
-- A32NX_FCU_VS_POSITIVE
-  - Boolean
-  - Indicates if vertical speed/FPA is a nonnegative value
-    State | Value
-      --- | ---
-      NEGATIVE | 0
-      ZERO OR POSITIVE | 1
-
 - A32NX_FCU_LOC_MODE_ACTIVE
     - Boolean
     - Indicates if LOC button on the FCU is illuminated

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -1197,9 +1197,17 @@
     - Indicates the selected heading on the FCU, instantly updated
     - In case of managed heading mode, the value is -1
 
-- A32NX_FCU_SPD_MANAGED
+- A32NX_FCU_SPD_MANAGED_DASHES
   - Boolean
-  - Indicates if managed speed/mach mode is active (dashes and dot)
+  - Indicates if managed speed/mach mode is active and a numerical value is not displayed
+    State | Value
+      --- | ---
+      SELECTED | 0
+      MANAGED | 1
+      
+- A32NX_FCU_SPD_MANAGED_DOT
+  - Boolean
+  - Indicates if managed speed/mach mode is active
     State | Value
       --- | ---
       SELECTED | 0
@@ -1207,7 +1215,7 @@
 
 - A32NX_FCU_HDG_MANAGED_DASHES
   - Boolean
-  - Indicates if managed heading mode is active
+  - Indicates if managed heading mode is active and a numerical value is not displayed
     State | Value
       --- | ---
       SELECTED | 0

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
@@ -303,6 +303,7 @@ class A320_Neo_FCU_Speed extends A320_Neo_FCU_Component {
                 console.warn("reset due to _isManaged == true");
             }
             this.isManaged = _isManaged;
+            SimVar.SetSimVarValue("L:A32NX_FCU_SPD_MANAGED", "boolean", this.isManaged);
             if (_showSelectedSpeed !== this.showSelectedSpeed && !_showSelectedSpeed) {
                 this.inSelection = false;
                 this.isSelectedValueActive = false;
@@ -341,8 +342,6 @@ class A320_Neo_FCU_Speed extends A320_Neo_FCU_Component {
                 }
             }
             this.setElementVisibility(this.illuminator, this.isManaged);
-
-            SimVar.SetSimVarValue("L:A32NX_FCU_SPD_MANAGED", "boolean", this.isManaged);
         }
     }
 
@@ -1118,11 +1117,9 @@ class A320_Neo_FCU_VerticalSpeed extends A320_Neo_FCU_Component {
                     }
                 }
                 SimVar.SetSimVarValue("L:A32NX_FCU_VS_MANAGED", "boolean", false);
-                SimVar.SetSimVarValue("L:A32NX_FCU_VS_POSITIVE", "boolean", this.currentValue >= 0);
             } else {
                 this.textValueContent = "~----";
                 SimVar.SetSimVarValue("L:A32NX_FCU_VS_MANAGED", "boolean", true);
-                SimVar.SetSimVarValue("L:A32NX_FCU_VS_POSITIVE", "boolean", false);
             }
         }
     }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
@@ -303,7 +303,7 @@ class A320_Neo_FCU_Speed extends A320_Neo_FCU_Component {
                 console.warn("reset due to _isManaged == true");
             }
             this.isManaged = _isManaged;
-            SimVar.SetSimVarValue("L:A32NX_FCU_SPD_MANAGED", "boolean", this.isManaged);
+            SimVar.SetSimVarValue("L:A32NX_FCU_SPD_MANAGED_DOT", "boolean", this.isManaged);
             if (_showSelectedSpeed !== this.showSelectedSpeed && !_showSelectedSpeed) {
                 this.inSelection = false;
                 this.isSelectedValueActive = false;
@@ -311,6 +311,7 @@ class A320_Neo_FCU_Speed extends A320_Neo_FCU_Component {
                 console.warn("reset due to _showSelectedSpeed == false");
             }
             this.showSelectedSpeed = _showSelectedSpeed;
+            SimVar.SetSimVarValue("L:A32NX_FCU_SPD_MANAGED_DASHES", "boolean", this.isManaged && !this.showSelectedSpeed);
             this.currentValue = _machActive ? _value * 100 : _value;
             this.isMachActive = _machActive;
             this.setTextElementActive(this.textSPD, !_machActive);

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
@@ -341,6 +341,8 @@ class A320_Neo_FCU_Speed extends A320_Neo_FCU_Component {
                 }
             }
             this.setElementVisibility(this.illuminator, this.isManaged);
+
+            SimVar.SetSimVarValue("L:A32NX_FCU_SPD_MANAGED", "boolean", this.isManaged);
         }
     }
 
@@ -693,6 +695,18 @@ class A320_Neo_FCU_Heading extends A320_Neo_FCU_Component {
                 var value = Math.round(Math.max(this.currentValue, 0)) % 360;
                 this.textValueContent = value.toString().padStart(3, "0");
             }
+
+            SimVar.SetSimVarValue(
+                "L:A32NX_FCU_HDG_MANAGED_DASHES",
+                "boolean",
+                (this.isManagedArmed || this.isManagedActive) && !this.showSelectedHeading
+            );
+            SimVar.SetSimVarValue(
+                "L:A32NX_FCU_HDG_MANAGED_DOT",
+                "boolean",
+                this.isManagedArmed || this.isManagedActive
+            );
+
             this.setElementVisibility(this.illuminator, this.isManagedArmed || this.isManagedActive);
         }
     }
@@ -887,6 +901,7 @@ class A320_Neo_FCU_Altitude extends A320_Neo_FCU_Component {
             const value = Math.floor(Math.max(this.currentValue, 100));
             this.textValueContent = value.toString().padStart(5, "0");
             this.setElementVisibility(this.illuminator, this.isManaged);
+            SimVar.SetSimVarValue("L:A32NX_FCU_ALT_MANAGED", "boolean", this.isManaged);
         }
     }
 
@@ -1102,8 +1117,12 @@ class A320_Neo_FCU_VerticalSpeed extends A320_Neo_FCU_Component {
                         this.textValueContent = sign + (Math.floor(value * 0.01).toString().padStart(2, "0")) + "oo";
                     }
                 }
+                SimVar.SetSimVarValue("L:A32NX_FCU_VS_MANAGED", "boolean", false);
+                SimVar.SetSimVarValue("L:A32NX_FCU_VS_POSITIVE", "boolean", this.currentValue >= 0);
             } else {
                 this.textValueContent = "~----";
+                SimVar.SetSimVarValue("L:A32NX_FCU_VS_MANAGED", "boolean", true);
+                SimVar.SetSimVarValue("L:A32NX_FCU_VS_POSITIVE", "boolean", false);
             }
         }
     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Added 5 simvars which reflect the state of FCU indicators, primarily those for managed modes. This applies to managed speed/mach, managed heading (with separate variables for managed and managed OR armed), managed altitude, and managed vertical speed/FPA.

These simvar calls occur in the `refresh` method of the FCU classes, which are only called when the value changes, so the simvar is only changed when the value updates (rather than every frame). Therefore, there is no effect on performance.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
N/A

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Iceman#5540

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
No QA testing is necessary.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
