### PR TITLE
fix: PFD and ND tooltip

### DIFF
--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -511,8 +511,8 @@
                     <PART_ID>PFD_Brightness</PART_ID>
                     <ANIM_NAME>KNOB_EFIS_CS_PFD</ANIM_NAME>
                     <MIN_VALUE>0</MIN_VALUE>
-                    <ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_L_PFD_DECREASE</ANIMTIP_0>
-                    <ANIMTIP_1>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_L_PFD_INCREASE</ANIMTIP_1>
+                    <ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_PFD_DECREASE</ANIMTIP_0>
+                    <ANIMTIP_1>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_PFD_INCREASE</ANIMTIP_1>
                 </UseTemplate>
 
                 <UseTemplate Name="FBW_Airbus_Push_EFIS_GPWS">
@@ -602,8 +602,8 @@
                     <PART_ID>ND_Brightness</PART_ID>
                     <ANIM_NAME>KNOB_EFIS_CS_ND_SMALL</ANIM_NAME>
                     <MIN_VALUE>0</MIN_VALUE>
-                    <ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_L_ND_DECREASE</ANIMTIP_0>
-                    <ANIMTIP_1>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_L_ND_INCREASE</ANIMTIP_1>
+                    <ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_ND_DECREASE</ANIMTIP_0>
+                    <ANIMTIP_1>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_ND_INCREASE</ANIMTIP_1>
                 </UseTemplate>
 
                 <UseTemplate Name="ASOBO_LIGHTING_Knob_Potentiometer_Template">
@@ -649,8 +649,8 @@
                     <PART_ID>PFD_Brightness_FO</PART_ID>
                     <ANIM_NAME>KNOB_EFIS_FO_PFD</ANIM_NAME>
                     <MIN_VALUE>0</MIN_VALUE>
-                    <ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_R_PFD_DECREASE</ANIMTIP_0>
-                    <ANIMTIP_1>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_R_PFD_INCREASE</ANIMTIP_1>
+                    <ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_PFD_DECREASE</ANIMTIP_0>
+                    <ANIMTIP_1>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_PFD_INCREASE</ANIMTIP_1>
                 </UseTemplate>
 
                 <UseTemplate Name="FBW_Airbus_Push_EFIS_GPWS">
@@ -671,8 +671,8 @@
                     <PART_ID>ND_Brightness_FO</PART_ID>
                     <ANIM_NAME>KNOB_EFIS_FO_ND_SMALL</ANIM_NAME>
                     <MIN_VALUE>0</MIN_VALUE>
-                    <ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_R_ND_DECREASE</ANIMTIP_0>
-                    <ANIMTIP_1>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_R_ND_INCREASE</ANIMTIP_1>
+                    <ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_ND_DECREASE</ANIMTIP_0>
+                    <ANIMTIP_1>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_ND_INCREASE</ANIMTIP_1>
                 </UseTemplate>
 
                 <UseTemplate Name="ASOBO_LIGHTING_Knob_Potentiometer_Template">


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #5231

## Summary of Changes
The FO's PFD brightness increase used to say "left" even though it was on the right so all the left and rights have been removed from the tooltips as they are mostly not needed (for the PFD and ND to keep it all the same)
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
Before: 
![image](https://user-images.githubusercontent.com/70103461/123698447-140b3d00-d856-11eb-8785-c2956372e39c.png)
After: Will be added soon
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
None needed
<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Check that the PFD and ND tooltips are still working and that they do not reference any specific side.
- Make sure nothing else is broken

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
