### PR TITLE
fix(fmgc): flight phase initialization

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/FMGC/A32NX_FlightPhaseManager.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/FMGC/A32NX_FlightPhaseManager.js
@@ -102,6 +102,7 @@ class A32NX_FlightPhaseManager {
     }
 
     init() {
+        console.log("FMGC Flight Phase: " + this.fmc.currentFlightPhase);
         this.activeFlightPhase.init(this.fmc);
     }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/FMGC/A32NX_FlightPhaseManager.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/FMGC/A32NX_FlightPhaseManager.js
@@ -96,12 +96,13 @@ class A32NX_FlightPhaseManager {
             [FmgcFlightPhases.DONE]: new A32NX_FlightPhase_Done()
         };
 
-        const initialFlightPhase = SimVar.GetSimVarValue("L:A32NX_INITIAL_FLIGHT_PHASE", "number") || FmgcFlightPhases.PREFLIGHT;
-        this.activeFlightPhase = this.flightPhases[initialFlightPhase];
+        this.activeFlightPhase = this.flightPhases[this.fmc.currentFlightPhase];
 
-        SimVar.SetSimVarValue("L:A32NX_FMGC_FLIGHT_PHASE", "number", initialFlightPhase);
+        SimVar.SetSimVarValue("L:A32NX_FMGC_FLIGHT_PHASE", "number", this.fmc.currentFlightPhase);
+    }
 
-        this.activeFlightPhase.init(_fmc);
+    init() {
+        this.activeFlightPhase.init(this.fmc);
     }
 
     checkFlightPhase(_deltaTime) {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -55,6 +55,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             mainFrame = this;
         }
         this.generateHTMLLayout(mainFrame);
+        this.initKeyboardScratchpad();
         this._titleLeftElement = this.getChildById("title-left");
         this._titleElement = this.getChildById("title");
         this._pageCurrentElement = this.getChildById("page-current");
@@ -76,8 +77,6 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this._inOutElement = this.getChildById("in-out");
         this._inOutElement.style.removeProperty("color");
         this._inOutElement.className = "white";
-
-        this.initKeyboardScratchpad();
 
         this.setTimeout = (func) => {
             setTimeout(() => {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -55,7 +55,6 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             mainFrame = this;
         }
         this.generateHTMLLayout(mainFrame);
-        this.initKeyboardScratchpad();
         this._titleLeftElement = this.getChildById("title-left");
         this._titleElement = this.getChildById("title");
         this._pageCurrentElement = this.getChildById("page-current");
@@ -77,6 +76,8 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this._inOutElement = this.getChildById("in-out");
         this._inOutElement.style.removeProperty("color");
         this._inOutElement.className = "white";
+
+        this.initKeyboardScratchpad();
 
         this.setTimeout = (func) => {
             setTimeout(() => {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -24,6 +24,64 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this.clrStop = false;
         this.aocAirportList = new CDUAocAirportList;
         this.initB = false;
+        this.PageTimeout = {
+            Prog: 2000,
+            Dyn: 1500
+        };
+        this.page = {
+            SelfPtr: false,
+            Current: 0,
+            Clear: 0,
+            AirportsMonitor: 1,
+            AirwaysFromWaypointPage: 2,
+            // AirwaysFromWaypointPageGetAllRows: 3,
+            AvailableArrivalsPage: 4,
+            AvailableArrivalsPageVias: 5,
+            AvailableDeparturesPage: 6,
+            AvailableFlightPlanPage: 7,
+            DataIndexPage1: 8,
+            DataIndexPage2: 9,
+            DirectToPage: 10,
+            FlightPlanPage: 11,
+            FuelPredPage: 12,
+            GPSMonitor: 13,
+            HoldAtPage: 14,
+            IdentPage: 15,
+            InitPageA: 16,
+            InitPageB: 17,
+            IRSInit: 18,
+            IRSMonitor: 19,
+            IRSStatus: 20,
+            IRSStatusFrozen: 21,
+            LateralRevisionPage: 22,
+            MenuPage: 23,
+            NavaidPage: 24,
+            NavRadioPage: 25,
+            NewWaypoint: 26,
+            PerformancePageTakeoff: 27,
+            PerformancePageClb: 28,
+            PerformancePageCrz: 29,
+            PerformancePageDes: 30,
+            PerformancePageAppr: 31,
+            PerformancePageGoAround: 32,
+            PilotsWaypoint: 33,
+            PosFrozen: 34,
+            PositionMonitorPage: 35,
+            ProgressPage: 36,
+            ProgressPageReport: 37,
+            ProgressPagePredictiveGPS: 38,
+            SelectedNavaids: 39,
+            SelectWptPage: 40,
+            VerticalRevisionPage: 41,
+            WaypointPage: 42,
+            AOCInit: 43,
+            AOCInit2: 44,
+            AOCOfpData: 45,
+            AOCOfpData2: 46,
+            ClimbWind: 47,
+            CruiseWind: 48,
+            DescentWind: 49,
+        };
     }
     get templateID() {
         return "A320_Neo_CDU";
@@ -50,11 +108,8 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
     Init() {
         super.Init();
         Coherent.trigger('UNFOCUS_INPUT_FIELD');// note: without this, resetting mcdu kills camera
-        let mainFrame = this.getChildById("Mainframe");
-        if (mainFrame == null) {
-            mainFrame = this;
-        }
-        this.generateHTMLLayout(mainFrame);
+
+        this.generateHTMLLayout(this.getChildById("Mainframe") || this);
         this.initKeyboardScratchpad();
         this._titleLeftElement = this.getChildById("title-left");
         this._titleElement = this.getChildById("title");
@@ -170,65 +225,6 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
                     }, this.rightInputDelay[f] ? this.rightInputDelay[f]() : this.getDelayBasic());
                 }
             }
-        };
-
-        this.PageTimeout = {
-            Prog: 2000,
-            Dyn: 1500
-        };
-        this.page = {
-            SelfPtr: false,
-            Current: 0,
-            Clear: 0,
-            AirportsMonitor: 1,
-            AirwaysFromWaypointPage: 2,
-            // AirwaysFromWaypointPageGetAllRows: 3,
-            AvailableArrivalsPage: 4,
-            AvailableArrivalsPageVias: 5,
-            AvailableDeparturesPage: 6,
-            AvailableFlightPlanPage: 7,
-            DataIndexPage1: 8,
-            DataIndexPage2: 9,
-            DirectToPage: 10,
-            FlightPlanPage: 11,
-            FuelPredPage: 12,
-            GPSMonitor: 13,
-            HoldAtPage: 14,
-            IdentPage: 15,
-            InitPageA: 16,
-            InitPageB: 17,
-            IRSInit: 18,
-            IRSMonitor: 19,
-            IRSStatus: 20,
-            IRSStatusFrozen: 21,
-            LateralRevisionPage: 22,
-            MenuPage: 23,
-            NavaidPage: 24,
-            NavRadioPage: 25,
-            NewWaypoint: 26,
-            PerformancePageTakeoff: 27,
-            PerformancePageClb: 28,
-            PerformancePageCrz: 29,
-            PerformancePageDes: 30,
-            PerformancePageAppr: 31,
-            PerformancePageGoAround: 32,
-            PilotsWaypoint: 33,
-            PosFrozen: 34,
-            PositionMonitorPage: 35,
-            ProgressPage: 36,
-            ProgressPageReport: 37,
-            ProgressPagePredictiveGPS: 38,
-            SelectedNavaids: 39,
-            SelectWptPage: 40,
-            VerticalRevisionPage: 41,
-            WaypointPage: 42,
-            AOCInit: 43,
-            AOCInit2: 44,
-            AOCOfpData: 45,
-            AOCOfpData2: 46,
-            ClimbWind: 47,
-            CruiseWind: 48,
-            DescentWind: 49,
         };
 
         const flightNo = SimVar.GetSimVarValue("ATC FLIGHT NUMBER", "string");

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -6,7 +6,8 @@ class FMCMainDisplay extends BaseAirliners {
         this.fmsUpdateThrottler = new UpdateThrottler(250);
         this._progBrgDistUpdateThrottler = new UpdateThrottler(2000);
         this.ilsUpdateThrottler = new UpdateThrottler(5000);
-        this.currentFlightPhase = FmgcFlightPhases.PREFLIGHT;
+        this.currentFlightPhase = SimVar.GetSimVarValue("L:A32NX_INITIAL_FLIGHT_PHASE", "number") || FmgcFlightPhases.PREFLIGHT;
+        this.flightPhaseManager = new A32NX_FlightPhaseManager(this);
         this._apCooldown = 500;
         this._radioNavOn = false;
         this._vhf1Frequency = 0;
@@ -183,8 +184,6 @@ class FMCMainDisplay extends BaseAirliners {
 
         this.dataManager = new FMCDataManager(this);
 
-        this.flightPhaseManager = new A32NX_FlightPhaseManager(this);
-
         this.tempCurve = new Avionics.Curve();
         this.tempCurve.interpolationFunction = Avionics.CurveTool.NumberInterpolation;
         this.tempCurve.add(-10 * 3.28084, 21.50);
@@ -242,6 +241,8 @@ class FMCMainDisplay extends BaseAirliners {
         CDUPerformancePage.UpdateThrRedAccFromOrigin(this, true, true);
         CDUPerformancePage.UpdateEngOutAccFromOrigin(this);
         SimVar.SetSimVarValue("L:AIRLINER_THR_RED_ALT", "Number", this.thrustReductionAltitude);
+
+        this.flightPhaseManager.init();
 
         /** It takes some time until origin and destination are known, placing this inside callback of the flight plan loader doesn't work */
         setTimeout(() => {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -210,6 +210,7 @@ class FMCMainDisplay extends BaseAirliners {
 
         this.cruiseFlightLevel = SimVar.GetGameVarValue("AIRCRAFT CRUISE ALTITUDE", "feet");
         this.cruiseFlightLevel /= 100;
+        this._cruiseFlightLevel = this.cruiseFlightLevel;
 
         this.flightPlanManager.onCurrentGameFlightLoaded(() => {
             this.flightPlanManager.updateFlightPlan(() => {
@@ -224,6 +225,7 @@ class FMCMainDisplay extends BaseAirliners {
                     console.log("FlightPlan Cruise Override. Cruising at FL" + cruiseAlt + " instead of default FL" + this.cruiseFlightLevel);
                     if (cruiseAlt > 0) {
                         this.cruiseFlightLevel = cruiseAlt;
+                        this._cruiseFlightLevel = cruiseAlt;
                     }
                 };
                 const arrivalIndex = this.flightPlanManager.getArrivalProcIndex();


### PR DESCRIPTION
<!-- Signed-off-by: Leon Beeser <leon.beeser@yahoo.de>

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #5226

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Improved initialization of the flight phase manager.

- `A32NX_FlightPhaseManager` get constructed immediately and updates the flight phase based on flt state or defaults to preflight if not defined (this has not been changed)
- `A32NX_FlightPhaseManager` now has it's own init to initialize the initial flight phase which may need additional fmgc data which has not been processed, therefore the `flightPhaseManager.init()` is placed at the bottom of the fmgc initialization.

<!-- ## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

<!-- ## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): DerL30N#3751

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Spawn on apron, runway, mid flight and approach and check for correct flight phases. (use the Prog and perf pages)
And also ensure that everything is working as normal.

- apron and runway: observe prog page shows TO and take off page is not green,
- mid flight: observe cruise phase is the current fmgc flight phase,
- approach: observe approach phase is the current fmgc flight phase.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
