### PR TITLE
fix: FCU LED display power

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -133,6 +133,7 @@
 1. [HYD] Switched hydraulics to new engine model simvars - @Crocket63 (crocket)
 1. [LIGHTS] New potentiometer for lights, emissives and screens. - @bouveng (Johan Bouveng)
 1. [SOUND] Improved engine startup sound and added wiper sounds - @hotshotp (Boris)
+1. [FCU] Fix FCU DISPLAY AC1 BUS power. - @bouveng (Johan Bouveng)
 
 
 ## 0.6.0

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -179,6 +179,7 @@
             <UseTemplate Name="ASOBO_LIGHTING_Potentiometer_Emissive_Template">
                 <NODE_ID>SCREEN_AUTOPILOT</NODE_ID>
                 <POTENTIOMETER>87</POTENTIOMETER>
+                <EMISSIVE_CODE>(L:A32NX_ELEC_AC_1_BUS_IS_POWERED, Bool)</EMISSIVE_CODE>
             </UseTemplate>
             <CameraTitle>PA</CameraTitle>
 


### PR DESCRIPTION
Fixes #5275

## Summary of Changes
Adds `AC1 BUS` to `FCU LED DISPLAY` so its backlight is off and unlit when aircraft it unpowered.

## References
Correct bus verified by Joeri [Z+2] (engineer) @ #pilot-feedback

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): bouveng 

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Spawn C/D
2. Verify that the `FCU LED DISPLAY` backlight not is controllable by potentiometer.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
