### PR TITLE
chore(readme): updated known issues to be more up-to-date with latest dev progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,19 +93,16 @@ If the above methods do not work:
 
 If you would like to contribute to the project, see [Contributing.md](.github/Contributing.md)
 
-## Known Issues (Please note that most issues are being worked on and some of them may even be fixed in the master branch)
+## Known Issues
 
-- Captain's PFD may occasionally turn off during flight
-- No Smoking switch doesn't use a full range of motion.
-- Automatic ECAM page switching has minor bugs.
-- AP not following the flight plan (leaking input values affect, but don't disconnect the AP) [Workaround: Set dead-zones for your input device higher]
+- AP not following the flight plan (leaking input values affect, but don't disconnect the AP) [Workaround: Set dead-zones for your input device higher - start from 10% deadzone]
 - Autopilot goes direct to RWY on APP (same with the default A320) [Workaround: Use DIR to a waypoint or selected heading]
 - Upper ECAM displays wrong THR levers position / N1 rating.
-- Newly added ASOBO A320 liveries are incompatible with the A32NX mod.
-- Rudder keybindings not working (you have to set your keybinding to rudder axis right and left)
-- Wing dips on landing (due to bad transition to direct law in flare, same with the default A320)  [Workaround use minimal aileron input on landing]
 - Black screens/unable to start (conflict with another mod/livery or incorrect installation of the A32NX mod, use the [installer](https://api.flybywiresim.com/installer))
-- Invisible plane, no sounds? Reinstall A32NX, delete any old version from your `Community` folder.
+- No Smoking switch doesn't use a full range of motion.
+- Invisible plane or no sounds - Reinstall A32NX, delete any old version from your `Community` folder.
+
+See the [Issues](https://github.com/flybywiresim/a32nx/issues) page for a more complete breakdown of issues that have been discovered and which are being worked on by the development team.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -95,27 +95,7 @@ If you would like to contribute to the project, see [Contributing.md](.github/Co
 
 ## Known Issues
 
-- Black screens/THALES maintenance screens/unable to start.
-  - Caused by: Outdated sim version, conflict with another mod/livery or incorrect installation of the A32NX mod
-  - Update Sim, clean up your community folder of outdated and conflicting addons and use the [installer](https://api.flybywiresim.com/installer) to install A32NX.
-- Invisible plane or no sounds.
-  - Caused by:  installing multiple conflicting versions of A32NX.
-  - Delete any old version from your `Community` folder, or remove all and reinstall A32NX.
-- AP not following the flight plan.
-  - Caused by: Leaking input from peripherals affecting values but not disconnecting the AP.
-  - Set dead-zones for your input device higher - start from 10% dead-zone
-- Autopilot goes direct to RWY on APP.
-   - Caused by: Default Asobo flight plan manager
-   - Use DIR to a waypoint or selected heading
-- THR CLB flashing symbol on PFD when thrust levers already set to climb.
-  - Caused by: Missing or incorrect throttle calibration
-  - Calibrate your throttles using the EFB (flyPad), setting enough dead-zone for this message to not appear.
-- No Smoking switch doesn't use a full range of motion.
-- No Smoking switch will sometimes not be switched to ON when spawning on the runway.
-
-See the [Issues](https://github.com/flybywiresim/a32nx/issues) page for a more complete breakdown of issues which have been discovered and are being worked on by the development team.
-
-See the [Issues](https://github.com/flybywiresim/a32nx/issues) page for a more complete breakdown of issues which have been discovered and are being worked on by the development team.
+[List of most commonly reported and known issues](https://docs.flybywiresim.com/start/reported-issues/). To request a new feature or report a new issue, please see our [Issues](https://github.com/flybywiresim/a32nx/issues) tracker.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -95,13 +95,25 @@ If you would like to contribute to the project, see [Contributing.md](.github/Co
 
 ## Known Issues
 
-- Black screens/THALES maintenance screens/unable to start. Causes: Outdated sim version, conflict with another mod/livery or incorrect installation of the A32NX mod - Update Sim, clean up your community folder of outdated and conflicting addons and use the [installer](https://api.flybywiresim.com/installer) to install A32NX.
-- Invisible plane or no sounds. Caused by installing multiple conflicting versions of A32NX. - Delete any old version from your `Community` folder, or remove all and reinstall A32NX.
-- AP not following the flight plan. Caused by leaking input affecting values but not disconnecting the AP. - Workaround: Set dead-zones for your input device higher - start from 10% dead-zone
-- Autopilot goes direct to RWY on APP. Caused by the default Asobo flight plan manager - Workaround: Use DIR to a waypoint or selected heading
-- THR CLB flashing symbol on PFD when thrust levers already set to climb. Caused by missing or incorrect throttle calibration - Calibrate your throttles using the EFB (flyPad).
+- Black screens/THALES maintenance screens/unable to start.
+  - Caused by: Outdated sim version, conflict with another mod/livery or incorrect installation of the A32NX mod
+  - Update Sim, clean up your community folder of outdated and conflicting addons and use the [installer](https://api.flybywiresim.com/installer) to install A32NX.
+- Invisible plane or no sounds.
+  - Caused by:  installing multiple conflicting versions of A32NX.
+  - Delete any old version from your `Community` folder, or remove all and reinstall A32NX.
+- AP not following the flight plan.
+  - Caused by: Leaking input from peripherals affecting values but not disconnecting the AP.
+  - Set dead-zones for your input device higher - start from 10% dead-zone
+- Autopilot goes direct to RWY on APP.
+   - Caused by: Default Asobo flight plan manager
+   - Use DIR to a waypoint or selected heading
+- THR CLB flashing symbol on PFD when thrust levers already set to climb.
+  - Caused by: Missing or incorrect throttle calibration
+  - Calibrate your throttles using the EFB (flyPad), setting enough dead-zone for this message to not appear.
 - No Smoking switch doesn't use a full range of motion.
 - No Smoking switch will sometimes not be switched to ON when spawning on the runway.
+
+See the [Issues](https://github.com/flybywiresim/a32nx/issues) page for a more complete breakdown of issues which have been discovered and are being worked on by the development team.
 
 See the [Issues](https://github.com/flybywiresim/a32nx/issues) page for a more complete breakdown of issues which have been discovered and are being worked on by the development team.
 

--- a/README.md
+++ b/README.md
@@ -95,15 +95,15 @@ If you would like to contribute to the project, see [Contributing.md](.github/Co
 
 ## Known Issues
 
-- Black screens/THALES maintenance screens/unable to start (Outdated sim version, conflict with another mod/livery or incorrect installation of the A32NX mod, use the [installer](https://api.flybywiresim.com/installer))
-- Invisible plane or no sounds - Reinstall A32NX, delete any old version from your `Community` folder.
-- AP not following the flight plan (leaking input values affect, but don't disconnect the AP) [Workaround: Set dead-zones for your input device higher - start from 10% deadzone]
-- Autopilot goes direct to RWY on APP (same with the default A320) [Workaround: Use DIR to a waypoint or selected heading]
-- Upper ECAM displays wrong THR levers position / N1 rating.
-- THR CLB flashing symbol on PFD - Calibrate your throttles using the EFB (flyPad - Click on the settings gear icon).
+- Black screens/THALES maintenance screens/unable to start. Causes: Outdated sim version, conflict with another mod/livery or incorrect installation of the A32NX mod - Update Sim, clean up your community folder of outdated and conflicting addons and use the [installer](https://api.flybywiresim.com/installer) to install A32NX.
+- Invisible plane or no sounds. Caused by installing multiple conflicting versions of A32NX. - Delete any old version from your `Community` folder, or remove all and reinstall A32NX.
+- AP not following the flight plan. Caused by leaking input affecting values but not disconnecting the AP. - Workaround: Set dead-zones for your input device higher - start from 10% dead-zone
+- Autopilot goes direct to RWY on APP. Caused by the default Asobo flight plan manager - Workaround: Use DIR to a waypoint or selected heading
+- THR CLB flashing symbol on PFD when thrust levers already set to climb. Caused by missing or incorrect throttle calibration - Calibrate your throttles using the EFB (flyPad).
 - No Smoking switch doesn't use a full range of motion.
+- No Smoking switch will sometimes not be switched to ON when spawning on the runway.
 
-See the [Issues](https://github.com/flybywiresim/a32nx/issues) page for a more complete breakdown of issues that have been discovered and which are being worked on by the development team.
+See the [Issues](https://github.com/flybywiresim/a32nx/issues) page for a more complete breakdown of issues which have been discovered and are being worked on by the development team.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -95,12 +95,13 @@ If you would like to contribute to the project, see [Contributing.md](.github/Co
 
 ## Known Issues
 
+- Black screens/THALES maintenance screens/unable to start (Outdated sim version, conflict with another mod/livery or incorrect installation of the A32NX mod, use the [installer](https://api.flybywiresim.com/installer))
+- Invisible plane or no sounds - Reinstall A32NX, delete any old version from your `Community` folder.
 - AP not following the flight plan (leaking input values affect, but don't disconnect the AP) [Workaround: Set dead-zones for your input device higher - start from 10% deadzone]
 - Autopilot goes direct to RWY on APP (same with the default A320) [Workaround: Use DIR to a waypoint or selected heading]
 - Upper ECAM displays wrong THR levers position / N1 rating.
-- Black screens/unable to start (conflict with another mod/livery or incorrect installation of the A32NX mod, use the [installer](https://api.flybywiresim.com/installer))
+- THR CLB flashing symbol on PFD - Calibrate your throttles using the EFB (flyPad - Click on the settings gear icon).
 - No Smoking switch doesn't use a full range of motion.
-- Invisible plane or no sounds - Reinstall A32NX, delete any old version from your `Community` folder.
 
 See the [Issues](https://github.com/flybywiresim/a32nx/issues) page for a more complete breakdown of issues that have been discovered and which are being worked on by the development team.
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

Updated Known Issues text to be more relevant.

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Removes old already fixed known issues (i.e. #974), updates this to the more frequent known issues/support requests and links to the github issues page. 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## OLD:

### Known Issues (Please note that most issues are being worked on and some of them may even be fixed in the master branch)

- Captain's PFD may occasionally turn off during flight
- No Smoking switch doesn't use a full range of motion.
- Automatic ECAM page switching has minor bugs.
- AP not following the flight plan (leaking input values affect, but don't disconnect the AP) [Workaround: Set dead-zones for your input device higher]
- Autopilot goes direct to RWY on APP (same with the default A320) [Workaround: Use DIR to a waypoint or selected heading]
- Upper ECAM displays wrong THR levers position / N1 rating.
- Newly added ASOBO A320 liveries are incompatible with the A32NX mod.
- Rudder keybindings not working (you have to set your keybinding to rudder axis right and left)
- Wing dips on landing (due to bad transition to direct law in flare, same with the default A320)  [Workaround use minimal aileron input on landing]
- Black screens/unable to start (conflict with another mod/livery or incorrect installation of the A32NX mod, use the [installer](https://api.flybywiresim.com/installer))
- Invisible plane, no sounds? Reinstall A32NX, delete any old version from your `Community` folder.

## NEW:

## Known Issues

[List of most commonly reported and known issues](https://docs.flybywiresim.com/start/reported-issues/). To request a new feature or report a new issue, please see our [Issues](https://github.com/flybywiresim/a32nx/issues) tracker.

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
This PR has no need for testing for obvious reasons. Expedite. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
