### PR TITLE
feat(build): multi-platform file path support

### DIFF
--- a/src/instruments/README.md
+++ b/src/instruments/README.md
@@ -1,5 +1,7 @@
 # Instruments
 
+## How to create a new instrument
+
 To create a new instrument, create a folder in `/src/instruments/src`, with a `config.json` file, for example:
 
 ```json
@@ -24,4 +26,12 @@ renderTarget.style.backgroundColor = 'red';
 ReactDOM.render(<MyAwesomeThing/>, renderTarget);
 
 // or something else!
+```
+
+## How to build in watch mode
+
+After running `npm install`, from the root folder, run:
+
+```
+rollup -wc .\src\instruments\buildSrc\simulatorBuild.mjs
 ```

--- a/src/instruments/buildSrc/browserBuild.mjs
+++ b/src/instruments/buildSrc/browserBuild.mjs
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { join } from 'path';
 import serve from 'rollup-plugin-serve';
 import liveReload from 'rollup-plugin-livereload';
 import { baseCompile } from './plugins.mjs';
@@ -7,8 +8,8 @@ import { Directories } from './directories.mjs';
 process.chdir(Directories.src);
 
 function getInputs() {
-    const baseInstruments = fs.readdirSync(`${Directories.instruments}/src`, { withFileTypes: true })
-        .filter((d) => d.isDirectory() && fs.existsSync(`${Directories.instruments}/src/${d.name}/config.json`));
+    const baseInstruments = fs.readdirSync(join(Directories.instruments, 'src', { withFileTypes: true })
+        .filter((d) => d.isDirectory() && fs.existsSync(join(Directories.instruments, 'src', d.name, 'config.json')));
 
     return [
         ...baseInstruments.map(({ name }) => ({

--- a/src/instruments/buildSrc/browserBuild.mjs
+++ b/src/instruments/buildSrc/browserBuild.mjs
@@ -8,7 +8,7 @@ import { Directories } from './directories.mjs';
 process.chdir(Directories.src);
 
 function getInputs() {
-    const baseInstruments = fs.readdirSync(join(Directories.instruments, 'src', { withFileTypes: true })
+    const baseInstruments = fs.readdirSync(join(Directories.instruments, 'src'), { withFileTypes: true })
         .filter((d) => d.isDirectory() && fs.existsSync(join(Directories.instruments, 'src', d.name, 'config.json')));
 
     return [
@@ -21,13 +21,13 @@ function getInputs() {
 
 const builds = getInputs()
     .map(({ path }) => {
-        const config = JSON.parse(fs.readFileSync(`${Directories.instruments}/src/${path}/config.json`));
+        const config = JSON.parse(fs.readFileSync(join(Directories.instruments, 'src', path, 'config.json')));
 
         return {
             watch: true,
-            input: `${Directories.instruments}/src/${path}/${config.index}`,
+            input: join(Directories.instruments, 'src', path, config.index),
             output: {
-                file: `${Directories.instruments}/devServer/bundles/${path}/bundle.js`,
+                file: join(Directories.instruments, 'devServer/bundles', path, 'bundle.js'),
                 format: 'iife',
             },
             plugins: [
@@ -40,6 +40,6 @@ const builds = getInputs()
 
 const instruments = getInputs().map(({ path }) => path);
 
-fs.writeFileSync(`${Directories.instruments}/devServer/instruments.json`, JSON.stringify(instruments));
+fs.writeFileSync(join(Directories.instruments, 'devServer/instruments.json'), JSON.stringify(instruments));
 
 export default builds;

--- a/src/instruments/buildSrc/directories.mjs
+++ b/src/instruments/buildSrc/directories.mjs
@@ -6,8 +6,8 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const Directories = {
-    temp: path.join(os.tmpdir(), '/instruments-build'),
+    temp: path.join(os.tmpdir(), 'instruments-build'),
     instruments: path.join(__dirname, '/..'),
-    src: path.join(__dirname, '/../..'),
-    root: path.join(__dirname, '/../../..'),
+    src: path.join(__dirname, '../..'),
+    root: path.join(__dirname, '../../..'),
 };

--- a/src/instruments/buildSrc/directories.mjs
+++ b/src/instruments/buildSrc/directories.mjs
@@ -1,11 +1,13 @@
 import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 // eslint-disable-next-line no-underscore-dangle
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const Directories = {
-    temp: `${os.tmpdir()}/instruments-build`,
-    instruments: `${__dirname}..`,
-    src: `${__dirname}../..`,
-    root: `${__dirname}../../..`,
+    temp: path.join(os.tmpdir(), '/instruments-build'),
+    instruments: path.join(__dirname, '/..'),
+    src: path.join(__dirname, '/../..'),
+    root: path.join(__dirname, '/../../..'),
 };

--- a/src/instruments/buildSrc/igniter/tasks.mjs
+++ b/src/instruments/buildSrc/igniter/tasks.mjs
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { join } from 'path';
 import { ExecTask } from '@flybywiresim/igniter';
 import { Directories } from '../directories.mjs';
 
@@ -30,19 +31,19 @@ const ecamPages = [
 ];
 
 function getInputs() {
-    const baseInstruments = fs.readdirSync(`${Directories.instruments}/src`, { withFileTypes: true })
-        .filter((d) => d.isDirectory() && fs.existsSync(`${Directories.instruments}/src/${d.name}/config.json`));
+    const baseInstruments = fs.readdirSync(join(Directories.instruments, 'src'), { withFileTypes: true })
+        .filter((d) => d.isDirectory() && fs.existsSync(join(Directories.instruments, 'src', d.name, 'config.json')));
 
     return [
         ...baseInstruments.map(({ name }) => new ExecTask(
             name,
             `node src/instruments/buildSrc/igniter/worker.mjs ${name}`,
-            [`src/instruments/src/${name}`, `flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/A32NX/${name}`],
+            [join('src/instruments/src', name), join('flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/A32NX', name)],
         )),
         ...ecamPages.map(({ name, path }) => new ExecTask(
             name,
             `node src/instruments/buildSrc/igniter/worker.mjs ${name}`,
-            [`src/instruments/src/${path}`, `flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/A32NX/EcamPages/${name}`],
+            [join('src/instruments/src', path), join('flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/A32NX/EcamPages', name)],
         )),
     ];
 }

--- a/src/instruments/buildSrc/plugins.mjs
+++ b/src/instruments/buildSrc/plugins.mjs
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { join } from 'path';
 import image from '@rollup/plugin-image';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
@@ -28,10 +29,10 @@ function babel() {
     });
 }
 
-function postCss(instrumentName, instrumentFolder) {
+function postCss(_, instrumentFolder) {
     let plugins;
 
-    const tailwindConfigPath = `${Directories.instruments}/src/${instrumentFolder}/tailwind.config.js`;
+    const tailwindConfigPath = join(Directories.instruments, 'src', instrumentFolder, 'tailwind.config.js');
 
     if (fs.existsSync(tailwindConfigPath)) {
         plugins = [
@@ -57,7 +58,7 @@ export function baseCompile(instrumentName, instrumentFolder) {
         commonjs({ include: /node_modules/ }),
         babel(),
         typescriptPaths({
-            tsConfigPath: `${Directories.src}/tsconfig.json`,
+            tsConfigPath: join(Directories.src, 'tsconfig.json'),
             preserveExtensions: true,
         }),
         replace({ 'process.env.NODE_ENV': '"production"' }),

--- a/src/instruments/buildSrc/simulatorBuild.mjs
+++ b/src/instruments/buildSrc/simulatorBuild.mjs
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { join } from 'path';
 import { baseCompile } from './plugins.mjs';
 import { getTemplatePlugin } from './templatePlugins.mjs';
 import { Directories } from './directories.mjs';
@@ -33,8 +34,8 @@ const ecamPages = [
 ];
 
 function getInputs() {
-    const baseInstruments = fs.readdirSync(`${Directories.instruments}/src`, { withFileTypes: true })
-        .filter((d) => d.isDirectory() && fs.existsSync(`${Directories.instruments}/src/${d.name}/config.json`));
+    const baseInstruments = fs.readdirSync(join(Directories.instruments, 'src'), { withFileTypes: true })
+        .filter((d) => d.isDirectory() && fs.existsSync(join(Directories.instruments, 'src', d.name, 'config.json')));
 
     return [
         ...baseInstruments.map(({ name }) => ({ path: name, name, isInstrument: true })),
@@ -44,14 +45,14 @@ function getInputs() {
 
 export default getInputs()
     .map(({ path, name, isInstrument }) => {
-        const config = JSON.parse(fs.readFileSync(`${Directories.instruments}/src/${path}/config.json`));
+        const config = JSON.parse(fs.readFileSync(join(Directories.instruments, 'src', path, 'config.json')));
 
         return {
             watch: true,
             name,
-            input: `${Directories.instruments}/src/${path}/${config.index}`,
+            input: join(Directories.instruments, 'src', path, config.index),
             output: {
-                file: `${Directories.temp}/bundle.js`,
+                file: join(Directories.temp, 'bundle.js'),
                 format: 'iife',
             },
             plugins: [

--- a/src/instruments/buildSrc/templatePlugins.mjs
+++ b/src/instruments/buildSrc/templatePlugins.mjs
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import instrumentTemplate from '@flybywiresim/rollup-plugin-msfs';
 import ecamPageTemplate from '../ecam-page-template/rollup.js';
 import { Directories } from './directories.mjs';
@@ -9,11 +10,11 @@ export function getTemplatePlugin({ name, config, imports = [], isInstrument }) 
             elementName: `a32nx-${name.toLowerCase()}`,
             config,
             imports,
-            outputDir: `${Directories.root}/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/A32NX`,
+            outputDir: join(Directories.root, 'flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/A32NX'),
         });
     }
     return ecamPageTemplate({
         name,
-        outputDir: `${Directories.root}/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/A32NX/EcamPages/`,
+        outputDir: join(Directories.root, 'flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/A32NX/EcamPages'),
     });
 }

--- a/src/instruments/ecam-page-template/rollup.js
+++ b/src/instruments/ecam-page-template/rollup.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const fs = require('fs');
 
 // The bundle code contains `$`, which is a special character
@@ -8,8 +9,8 @@ function replaceButSad(s, search, replace) {
     return s.split(search).join(replace);
 }
 
-const TEMPLATE_HTML = fs.readFileSync(`${__dirname}/template.html`, 'utf8');
-const TEMPLATE_JS = fs.readFileSync(`${__dirname}/template.js`, 'utf8');
+const TEMPLATE_HTML = fs.readFileSync(path.join(__dirname, 'template.html'), 'utf8');
+const TEMPLATE_JS = fs.readFileSync(path.join(__dirname, 'template.js'), 'utf8');
 
 module.exports = ({ name, outputDir }) => ({
     name: 'template',
@@ -33,8 +34,8 @@ module.exports = ({ name, outputDir }) => ({
         const templateHtml = process(TEMPLATE_HTML);
         const templateJs = process(TEMPLATE_JS);
 
-        fs.mkdirSync(`${outputDir}/${name}`, { recursive: true });
-        fs.writeFileSync(`${outputDir}/${name}/template.html`, templateHtml);
-        fs.writeFileSync(`${outputDir}/${name}/template.js`, templateJs);
+        fs.mkdirSync(path.join(outputDir, name), { recursive: true });
+        fs.writeFileSync(path.join(outputDir, name, 'template.html'), templateHtml);
+        fs.writeFileSync(path.join(outputDir, name, 'template.js'), templateJs);
     },
 });


### PR DESCRIPTION
## Summary of Changes
Couldn't build instruments in watch mode on Windows using the changes introduced in  #4750. This PR enables multi-platform file path support.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

## Testing instructions
No need to test by QA. Maybe a developer can test on their non-Windows environment if it still work as expected 😀.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
