### PR TITLE
fix: wiped flight plan when approach begins

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -8,6 +8,7 @@ const Markers = {
 
 class CDUFlightPlanPage {
     static ShowPage(mcdu, offset = 0) {
+
         //mcdu.flightPlanManager.updateWaypointDistances(false /* approach */);
         //mcdu.flightPlanManager.updateWaypointDistances(true /* approach */);
         mcdu.clearDisplay();
@@ -153,13 +154,9 @@ class CDUFlightPlanPage {
         }
         const waypointsWithDiscontinuities = [];
         const routeFirstWaypointIndex = 1 + fpm.getDepartureWaypointsCount();
-        const routeLastWaypointIndex = fpm.getWaypointsCount() - 2 - fpm.getArrivalWaypointsCount();
-        let first = 0;
-        if (fpm.isActiveApproach()) {
-            first = fpm.getWaypointsCount() - 1;
-        } else {
-            first = Math.max(0, fpm.getActiveWaypointIndex() - 1);
-        }
+        const routeLastWaypointIndex = fpm.getLastIndexBeforeApproach();
+        let first = Math.max(0, fpm.getActiveWaypointIndex() - 1);
+
         if (mcdu.currentFlightPhase <= FmgcFlightPhases.TAKEOFF) {
             first = 0;
         }
@@ -167,7 +164,7 @@ class CDUFlightPlanPage {
             const prev = waypointsWithDiscontinuities[waypointsWithDiscontinuities.length - 1];
             const wp = fpm.getWaypoint(i);
             if (!prev || (prev.wp && prev.wp.ident != wp.ident)) {
-                waypointsWithDiscontinuities.push({ wp: fpm.getWaypoint(i), fpIndex: i });
+                waypointsWithDiscontinuities.push({ wp: fpm.getWaypoint(i) });
             }
         }
         const destination = waypointsWithDiscontinuities.pop();
@@ -264,13 +261,11 @@ class CDUFlightPlanPage {
 
                 let prevWaypoint;
                 let waypoint;
-                let fpIndex = 0;
                 if (waypointsWithDiscontinuities[wpIndex]) {
                     waypoint = waypointsWithDiscontinuities[wpIndex].wp;
                     if (waypointsWithDiscontinuities[wpIndex - 1]) {
                         prevWaypoint = waypointsWithDiscontinuities[wpIndex - 1].wp;
                     }
-                    fpIndex = waypointsWithDiscontinuities[wpIndex].fpIndex;
                 }
                 if (!waypoint) {
                     console.error("Should not reach.");
@@ -285,15 +280,15 @@ class CDUFlightPlanPage {
                             timeCell = FMCMainDisplay.secondsTohhmm(wpIndex >= activeIndex || waypoint.ident === "(DECEL)" ? stats.get(statIndex).timeFromPpos : 0) + "[s-text]";
                         }
                     }
-                    if (fpIndex > fpm.getDepartureWaypointsCount()) {
-                        if (fpIndex < fpm.getWaypointsCount() - fpm.getArrivalWaypointsCount()) {
-                            if (waypoint.infos.airwayIdentInFP === "") {
-                                const prevWaypointWithDiscontinuity = waypointsWithDiscontinuities[wpIndex - 1];
-                                if (prevWaypointWithDiscontinuity) {
-                                    prevWaypoint = prevWaypointWithDiscontinuity.wp;
-                                }
+
+                    if (wpIndex < fpm.getLastIndexBeforeApproach()) {
+                        if (waypoint.infos.airwayIdentInFP === "") {
+                            const prevWaypointWithDiscontinuity = waypointsWithDiscontinuities[wpIndex - 1];
+                            if (prevWaypointWithDiscontinuity) {
+                                prevWaypoint = prevWaypointWithDiscontinuity.wp;
                             }
                         }
+
                     }
 
                     const maxLineCount = rowsCount - discontinuityCount;
@@ -436,14 +431,14 @@ class CDUFlightPlanPage {
                         }, (value) => {
                             if (value === "") {
                                 if (waypoint) {
-                                    CDULateralRevisionPage.ShowPage(mcdu, waypoint, fpIndex);
+                                    CDULateralRevisionPage.ShowPage(mcdu, waypoint, wpIndex);
                                 }
                             } else if (value === FMCMainDisplay.clrValue) {
-                                mcdu.removeWaypoint(fpIndex, () => {
+                                mcdu.removeWaypoint(wpIndex, () => {
                                     CDUFlightPlanPage.ShowPage(mcdu, offset);
                                 }, true);
                             } else if (value.length > 0) {
-                                mcdu.insertWaypoint(value, fpIndex, () => {
+                                mcdu.insertWaypoint(value, wpIndex, () => {
                                     CDUFlightPlanPage.ShowPage(mcdu, offset);
                                 }, true);
                             }
@@ -506,16 +501,6 @@ class CDUFlightPlanPage {
         }
         mcdu.currentFlightPlanWaypointIndex = offset + first;
         SimVar.SetSimVarValue("L:A32NX_SELECTED_WAYPOINT", "number", offset + first);
-
-        const wpCount = fpm.getWaypointsCount();
-        if (wpCount > 0) {
-            while (mcdu.currentFlightPlanWaypointIndex < 0) {
-                mcdu.currentFlightPlanWaypointIndex += wpCount;
-            }
-            while (mcdu.currentFlightPlanWaypointIndex >= wpCount) {
-                mcdu.currentFlightPlanWaypointIndex -= wpCount;
-            }
-        }
 
         // Remove excess lines
         while (rows.length >= 13) {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
