### PR TITLE
fix: discontinuities/waypoints not clearing

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -420,6 +420,7 @@ class CDUFlightPlanPage {
                         printRow(renderFixContent(waypoint.ident, color, spdColor, speedConstraint, altColor, altPrefix, altitudeConstraint, timeCell));
 
                         // Setup fix LSK and RSk
+                        const wpIndexOffset = wpIndex + first;
 
                         addLsk((value) => {
                             if (value === "") {
@@ -434,11 +435,11 @@ class CDUFlightPlanPage {
                                     CDULateralRevisionPage.ShowPage(mcdu, waypoint, wpIndex);
                                 }
                             } else if (value === FMCMainDisplay.clrValue) {
-                                mcdu.removeWaypoint(wpIndex, () => {
+                                mcdu.removeWaypoint(wpIndexOffset, () => {
                                     CDUFlightPlanPage.ShowPage(mcdu, offset);
                                 }, true);
                             } else if (value.length > 0) {
-                                mcdu.insertWaypoint(value, wpIndex, () => {
+                                mcdu.insertWaypoint(value, wpIndexOffset, () => {
                                     CDUFlightPlanPage.ShowPage(mcdu, offset);
                                 }, true);
                             }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -456,17 +456,22 @@ class CDUFlightPlanPage {
                             printRow([""]);
                             printRow(Markers.FPLN_DISCONTINUITY);
 
+                            // waypointsWithDiscontinuities can include the origin airport but the position in the FPM
+                            // visibleWaypoints list never does, so detect when we've included it in the earlier index
+                            // math and fix the off-by-one here.
+                            const fpmIndex = (first == 0) ? (wpIndex - 1) : wpIndex;
+
                             addLsk(0, (value) => {
                                 if (value === FMCMainDisplay.clrValue) {
                                     if (waypoint.discontinuityCanBeCleared) {
-                                        mcdu.clearDiscontinuity(wpIndex, () => {
+                                        mcdu.clearDiscontinuity(fpmIndex, () => {
                                             CDUFlightPlanPage.ShowPage(mcdu, offset);
                                         }, true);
                                     }
                                     return;
                                 }
 
-                                mcdu.insertWaypoint(value, wpIndex + 1, () => {
+                                mcdu.insertWaypoint(value, fpmIndex + 1, () => {
                                     CDUFlightPlanPage.ShowPage(mcdu, offset);
                                 }, true);
                             });


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
Fixes various waypoint indexing weirdness in the flight plan page causing waypoint/discontinuity deletion to fail.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
