### PR TITLE
feat(fpm, lnav): refactoring of flight path building / rendering. add support for VM legs

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -82,12 +82,12 @@ class CDUFlightPlanPage {
             waypointsAndMarkers.push({ wp: fpm.getWaypoint(i), fpIndex: i});
 
             if (wp.endsInDiscontinuity) {
-                waypointsAndMarkers.push({ marker: Markers.FPLN_DISCONTINUITY, clr: wp.discontinuityCanBeCleared, fpIndex: i});
+                waypointsAndMarkers.push({ marker: Markers.FPLN_DISCONTINUITY, fpIndex: i});
             }
             if (i === fpm.getWaypointsCount() - 1) {
-                waypointsAndMarkers.push({ marker: Markers.END_OF_FPLN, clr: false, fpIndex: i});
+                waypointsAndMarkers.push({ marker: Markers.END_OF_FPLN, fpIndex: i});
                 // TODO: Rewrite once alt fpln exists
-                waypointsAndMarkers.push({ marker: Markers.NO_ALTN_FPLN, clr: false, fpIndex: i});
+                waypointsAndMarkers.push({ marker: Markers.NO_ALTN_FPLN, fpIndex: i});
             }
         }
         // TODO: Alt F-PLAN
@@ -328,11 +328,11 @@ class CDUFlightPlanPage {
                         } else if (value === FMCMainDisplay.clrValue) {
                             mcdu.removeWaypoint(waypointsAndMarkers[winI].fpIndex, () => {
                                 CDUFlightPlanPage.ShowPage(mcdu, offset);
-                            }, true);
+                            }, !fpm.isCurrentFlightPlanTemporary());
                         } else if (value.length > 0) {
                             mcdu.insertWaypoint(value, waypointsAndMarkers[winI].fpIndex, () => {
                                 CDUFlightPlanPage.ShowPage(mcdu, offset);
-                            }, true);
+                            }, !fpm.isCurrentFlightPlanTemporary());
                         }
                     });
                 } else {
@@ -361,17 +361,15 @@ class CDUFlightPlanPage {
                 scrollWindow[rowI] = waypointsAndMarkers[winI];
                 addLskAt(rowI, 0, (value) => {
                     if (value === FMCMainDisplay.clrValue) {
-                        if (waypointsAndMarkers[winI].clr) {
-                            mcdu.clearDiscontinuity(waypointsAndMarkers[winI].fpIndex, () => {
-                                CDUFlightPlanPage.ShowPage(mcdu, offset);
-                            }, true);
-                        }
+                        mcdu.clearDiscontinuity(waypointsAndMarkers[winI].fpIndex, () => {
+                            CDUFlightPlanPage.ShowPage(mcdu, offset);
+                        }, !fpm.isCurrentFlightPlanTemporary());
                         return;
                     }
 
                     mcdu.insertWaypoint(value, waypointsAndMarkers[winI].fpIndex + 1, () => {
                         CDUFlightPlanPage.ShowPage(mcdu, offset);
-                    }, true);
+                    }, !fpm.isCurrentFlightPlanTemporary());
                 });
             }
         }
@@ -551,7 +549,7 @@ function renderFixContent(rowObj, spdRepeat = false, altRepeat = false) {
 
     return [
         `${rowObj.ident}[color]${rowObj.color}`,
-        `{${rowObj.spdColor}}${spdRepeat ? "\xa0\"\xa0" : rowObj.speedConstraint}{end}{${rowObj.altColor}}/${altRepeat ? "\xa0\xa0\"\xa0\xa0" : rowObj.altitudeConstraint.altPrefix + rowObj.altitudeConstraint.alt}{end}[s-text]`,
+        `{${rowObj.spdColor}}${spdRepeat ? "\xa0\"\xa0" : rowObj.speedConstraint}{end}{${rowObj.altColor}}/${altRepeat ? "\xa0\xa0\xa0\"\xa0\xa0" : rowObj.altitudeConstraint.altPrefix + rowObj.altitudeConstraint.alt}{end}[s-text]`,
         `${rowObj.timeCell}{sp}{sp}[color]${rowObj.timeColor}`
     ];
 }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -2042,11 +2042,17 @@ class FMCMainDisplay extends BaseAirliners {
                 this.addNewMessage(NXSystemMessages.notAllowed);
                 return callback(false);
             }
-            this.flightPlanManager.clearDiscontinuity(index);
+            if (!this.flightPlanManager.clearDiscontinuity(index)) {
+                this.addNewMessage(NXSystemMessages.notAllowed);
+                return callback(false);
+            }
             callback();
         } else {
             this.ensureCurrentFlightPlanIsTemporary(() => {
-                this.flightPlanManager.clearDiscontinuity(index);
+                if (!this.flightPlanManager.clearDiscontinuity(index)) {
+                    this.addNewMessage(NXSystemMessages.notAllowed);
+                    return callback(false);
+                }
                 callback();
             });
         }

--- a/src/fmgc/src/flightplanning/FlightPlanManager.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanManager.ts
@@ -499,6 +499,7 @@ export class FlightPlanManager {
                         wp.legAltitudeDescription = approach.finalLegs[i].altDesc;
                         wp.legAltitude1 = approach.finalLegs[i].altitude1 * 3.28084;
                         wp.legAltitude2 = approach.finalLegs[i].altitude2 * 3.28084;
+                        wp.speedConstraint = approach.finalLegs[i].speedRestriction;
                         approachWaypoints.push(wp);
                     }
                 }
@@ -510,6 +511,7 @@ export class FlightPlanManager {
                         wp.legAltitudeDescription = approachTransition.legs[i].altDesc;
                         wp.legAltitude1 = approachTransition.legs[i].altitude1 * 3.28084;
                         wp.legAltitude2 = approachTransition.legs[i].altitude2 * 3.28084;
+                        wp.speedConstraint = approach.finalLegs[i].speedRestriction;
                         approachWaypoints.push(wp);
                     }
                 }

--- a/src/fmgc/src/flightplanning/FlightPlanManager.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanManager.ts
@@ -1104,15 +1104,18 @@ export class FlightPlanManager {
      * Clears a discontinuity from the end of a waypoint.
      * @param index
      */
-    public clearDiscontinuity(index: number): void {
+    public clearDiscontinuity(index: number): boolean {
         const currentFlightPlan = this._flightPlans[this._currentFlightPlanIndex];
         const waypoint = currentFlightPlan.getWaypoint(index);
 
-        if (waypoint !== undefined) {
+        if (waypoint !== undefined && waypoint.discontinuityCanBeCleared) {
             waypoint.endsInDiscontinuity = false;
+            this._updateFlightPlanVersion();
+            return true;
         }
 
         this._updateFlightPlanVersion();
+        return false;
     }
 
     /**

--- a/src/fmgc/src/flightplanning/LegsProcedure.ts
+++ b/src/fmgc/src/flightplanning/LegsProcedure.ts
@@ -379,6 +379,10 @@ export class LegsProcedure {
       waypoint.isVectors = true;
       waypoint.endsInDiscontinuity = true;
       waypoint.discontinuityCanBeCleared = false;
+      if (!waypoint.additionalData) {
+          waypoint.additionalData = {};
+      }
+      waypoint.additionalData.vectorsCourse = leg.course;
 
       return waypoint;
   }

--- a/src/fmgc/src/flightplanning/LegsProcedure.ts
+++ b/src/fmgc/src/flightplanning/LegsProcedure.ts
@@ -372,8 +372,8 @@ export class LegsProcedure {
    * @returns The mapped leg.
    */
   public mapVectors(leg: ProcedureLeg, prevLeg: WayPoint) {
-      const course = leg.course + GeoMath.getMagvar(prevLeg.infos.coordinates.lat, prevLeg.infos.coordinates.long);
-      const coordinates = GeoMath.relativeBearingDistanceToCoords(course, 5, prevLeg.infos.coordinates);
+      const course = leg.trueDegrees ? leg.course : A32NX_Util.magneticToTrue(leg.course, Facilities.getMagVar(prevLeg.infos.coordinates));
+      const coordinates = GeoMath.relativeBearingDistanceToCoords(course, 381, prevLeg.infos.coordinates);
 
       const waypoint = this.buildWaypoint(FixNamingScheme.vector(), coordinates);
       waypoint.isVectors = true;
@@ -382,7 +382,7 @@ export class LegsProcedure {
       if (!waypoint.additionalData) {
           waypoint.additionalData = {};
       }
-      waypoint.additionalData.vectorsCourse = leg.course;
+      waypoint.additionalData.vectorsCourse = course;
 
       return waypoint;
   }

--- a/src/fmgc/src/flightplanning/LegsProcedure.ts
+++ b/src/fmgc/src/flightplanning/LegsProcedure.ts
@@ -386,6 +386,7 @@ export class LegsProcedure {
       }
       waypoint.additionalData.vectorsCourse = course;
       waypoint.additionalData.vectorsHeading = heading;
+      waypoint.additionalData.legType = leg.type;
 
       return waypoint;
   }

--- a/src/fmgc/src/flightplanning/LegsProcedure.ts
+++ b/src/fmgc/src/flightplanning/LegsProcedure.ts
@@ -372,7 +372,9 @@ export class LegsProcedure {
    * @returns The mapped leg.
    */
   public mapVectors(leg: ProcedureLeg, prevLeg: WayPoint) {
-      const course = leg.trueDegrees ? leg.course : A32NX_Util.magneticToTrue(leg.course, Facilities.getMagVar(prevLeg.infos.coordinates));
+      const magVar = Facilities.getMagVar(prevLeg.infos.coordinates);
+      const course = leg.trueDegrees ? leg.course : A32NX_Util.magneticToTrue(leg.course, magVar);
+      const heading = leg.trueDegrees ? A32NX_Util.trueToMagnetic(leg.course, magVar) : leg.course;
       const coordinates = GeoMath.relativeBearingDistanceToCoords(course, 381, prevLeg.infos.coordinates);
 
       const waypoint = this.buildWaypoint(FixNamingScheme.vector(), coordinates);
@@ -383,6 +385,7 @@ export class LegsProcedure {
           waypoint.additionalData = {};
       }
       waypoint.additionalData.vectorsCourse = course;
+      waypoint.additionalData.vectorsHeading = heading;
 
       return waypoint;
   }

--- a/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
+++ b/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
@@ -149,6 +149,7 @@ export class ManagedFlightPlan {
             distanceFromPpos,
             timeFromPpos,
             etaFromPpos,
+            magneticVariation: GeoMath.getMagvar(this.activeWaypoint.infos.coordinates.lat, this.activeWaypoint.infos.coordinates.long),
         };
     }
 

--- a/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
+++ b/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
@@ -748,6 +748,7 @@ export class ManagedFlightPlan {
                     const coordinates = GeoMath.relativeBearingDistanceToCoords(course, distanceInNM, runway.endCoordinates);
 
                     const faLeg = procedure.buildWaypoint(`${Math.round(altitudeFeet)}`, coordinates);
+                    // TODO should this check for unclr discont? (probs not)
                     faLeg.endsInDiscontinuity = true;
                     faLeg.discontinuityCanBeCleared = true;
 
@@ -854,8 +855,10 @@ export class ManagedFlightPlan {
                 const prevWaypointIndex = segment.offset - 1;
                 if (prevWaypointIndex > 0) {
                     const prevWaypoint = this.getWaypoint(segment.offset - 1);
-                    prevWaypoint.endsInDiscontinuity = true;
-                    prevWaypoint.discontinuityCanBeCleared = true;
+                    if (!prevWaypoint.endsInDiscontinuity) {
+                        prevWaypoint.endsInDiscontinuity = true;
+                        prevWaypoint.discontinuityCanBeCleared = true;
+                    }
                 }
             }
 

--- a/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
+++ b/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
@@ -566,6 +566,7 @@ export class ManagedFlightPlan {
             legAltitudeDescription: waypoint.legAltitudeDescription,
             legAltitude1: waypoint.legAltitude1,
             legAltitude2: waypoint.legAltitude2,
+            speedConstraint: waypoint.speedConstraint,
             isVectors: waypoint.isVectors,
             endsInDiscontinuity: waypoint.endsInDiscontinuity,
             discontinuityCanBeCleared: waypoint.discontinuityCanBeCleared,

--- a/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
+++ b/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
@@ -571,6 +571,7 @@ export class ManagedFlightPlan {
             distanceInFP: waypoint.distanceInFP,
             cumulativeDistanceInFP: waypoint.cumulativeDistanceInFP,
             isRunway: waypoint.isRunway,
+            additionalData: waypoint.additionalData,
             infos: {
                 icao: waypoint.infos.icao,
                 ident: waypoint.infos.ident,

--- a/src/fmgc/src/flightplanning/data/flightplan.ts
+++ b/src/fmgc/src/flightplanning/data/flightplan.ts
@@ -28,6 +28,11 @@ export interface WaypointStats {
      * Predicted ETA from PPOS in seconds
      */
     etaFromPpos: number;
+
+    /**
+     * Magnetic variation in degrees
+     */
+    magneticVariation: number;
 }
 
 export interface ApproachStats {

--- a/src/fmgc/src/guidance/ControlLaws.ts
+++ b/src/fmgc/src/guidance/ControlLaws.ts
@@ -1,7 +1,7 @@
 /**
  * This enum represents a Control Law selected by the guidance system.
  */
-import { Degrees, NauticalMiles } from '../../../../typings/types';
+import { Degrees, NauticalMiles } from '@typings/types';
 
 export enum ControlLaw {
     /**

--- a/src/fmgc/src/guidance/Geometry.ts
+++ b/src/fmgc/src/guidance/Geometry.ts
@@ -1,164 +1,20 @@
 import { Degrees, NauticalMiles } from '@typings/types';
 import { MathUtils } from '@shared/MathUtils';
+import { TFLeg } from '@fmgc/guidance/lnav/legs/Tf';
+import { VMLeg } from '@fmgc/guidance/lnav/legs/VM';
+import { Transition } from '@fmgc/guidance/lnav/transitions';
+import { Leg } from '@fmgc/guidance/lnav/legs';
 import { LatLongData } from '@typings/fs-base-ui/html_ui/JS/Types';
 import { ControlLaw, GuidanceParameters } from './ControlLaws';
 
 export const EARTH_RADIUS_NM = 3440.1;
+
 const mod = (x: number, n: number) => x - Math.floor(x / n) * n;
 
 export interface Guidable {
-    getGuidanceParameters(ppos: LatLongAlt, trueTrack: number): GuidanceParameters | null;
-    getDistanceToGo(ppos: LatLong | LatLongAlt): NauticalMiles;
-    isAbeam(ppos: LatLongAlt): boolean;
-}
-
-export abstract class Leg implements Guidable {
-    abstract getGuidanceParameters(ppos, trueTrack);
-
-    /**
-     * Calculates directed DTG parameter
-     *
-     * @param ppos {LatLong} the current position of the aircraft
-     */
-    abstract getDistanceToGo(ppos: LatLong): NauticalMiles;
-
-    abstract isAbeam(ppos);
-}
-
-export class TFLeg extends Leg {
-    public from: WayPoint;
-
-    public to: WayPoint;
-
-    constructor(from: WayPoint, to: WayPoint) {
-        super();
-        this.from = from;
-        this.to = to;
-    }
-
-    get bearing(): Degrees {
-        return Avionics.Utils.computeGreatCircleHeading(
-            this.from.infos.coordinates,
-            this.to.infos.coordinates,
-        );
-    }
-
-    getGuidanceParameters(ppos, trueTrack): GuidanceParameters | null {
-        const fromLatLongAlt = this.from.infos.coordinates;
-
-        const desiredTrack = this.bearing;
-        const trackAngleError = mod(desiredTrack - trueTrack + 180, 360) - 180;
-
-        // crosstrack error
-        const bearingAC = Avionics.Utils.computeGreatCircleHeading(fromLatLongAlt, ppos);
-        const bearingAB = desiredTrack;
-        const distanceAC = Avionics.Utils.computeDistance(fromLatLongAlt, ppos);
-
-        const desiredOffset = 0;
-        const actualOffset = (
-            Math.asin(
-                Math.sin(Avionics.Utils.DEG2RAD * (distanceAC / EARTH_RADIUS_NM))
-                * Math.sin(Avionics.Utils.DEG2RAD * (bearingAC - bearingAB)),
-            ) / Avionics.Utils.DEG2RAD
-        ) * EARTH_RADIUS_NM;
-        const crossTrackError = desiredOffset - actualOffset;
-
-        return {
-            law: ControlLaw.LATERAL_PATH,
-            trackAngleError,
-            crossTrackError,
-            phiCommand: 0,
-        };
-    }
-
-    /**
-     * Calculates the angle between the leg and the aircraft PPOS.
-     *
-     * This effectively returns the angle ABC in the figure shown below:
-     *
-     * ```
-     * * A
-     * |
-     * * B (TO)
-     * |\
-     * | \
-     * |  \
-     * |   \
-     * |    \
-     * |     \
-     * |      \
-     * * FROM  * C (PPOS)
-     * ```
-     *
-     * @param ppos {LatLong} the current position of the aircraft
-     */
-    getAircraftToLegBearing(ppos: LatLongData): number {
-        const aircraftToTerminationBearing = Avionics.Utils.computeGreatCircleHeading(ppos, this.to.infos.coordinates);
-
-        // Rotate frame of reference to 0deg
-        let correctedLegBearing = this.bearing - aircraftToTerminationBearing;
-        if (correctedLegBearing < 0) {
-            correctedLegBearing = 360 + correctedLegBearing;
-        }
-
-        let aircraftToLegBearing = 180 - correctedLegBearing;
-        if (aircraftToLegBearing < 0) {
-            // if correctedLegBearing was greater than 180 degrees, then its supplementary angle is negative.
-            // In this case, we can subtract it from 360 degrees to obtain the bearing.
-
-            aircraftToLegBearing = 360 + aircraftToLegBearing;
-        }
-
-        return aircraftToLegBearing;
-    }
-
-    getDistanceToGo(ppos: LatLongData): NauticalMiles {
-        const aircraftLegBearing = this.getAircraftToLegBearing(ppos);
-
-        const absDtg = Avionics.Utils.computeGreatCircleDistance(ppos, this.to.infos.coordinates);
-
-        // @todo should be abeam distance
-        if (aircraftLegBearing >= 90 && aircraftLegBearing <= 270) {
-            // Since a line perpendicular to the leg is formed by two 90 degree angles, an aircraftLegBearing outside
-            // (North - 90) and (North + 90) is in the lower quadrants of a plane centered at the TO fix. This means
-            // the aircraft is NOT past the TO fix, and DTG must be positive.
-
-            return absDtg;
-        }
-
-        return -absDtg;
-    }
-
-    get distance(): NauticalMiles {
-        return Avionics.Utils.computeGreatCircleDistance(this.from.infos.coordinates, this.to.infos.coordinates);
-    }
-
-    isAbeam(ppos: LatLongAlt): boolean {
-        const bearingAC = Avionics.Utils.computeGreatCircleHeading(this.from.infos.coordinates, ppos);
-        const headingAC = Math.abs(MathUtils.diffAngle(this.bearing, bearingAC));
-        if (headingAC > 90) {
-            // if we're even not abeam of the starting point
-            return false;
-        }
-        const distanceAC = Avionics.Utils.computeDistance(this.from.infos.coordinates, ppos);
-        const distanceAX = Math.cos(headingAC * Avionics.Utils.DEG2RAD) * distanceAC;
-        // if we're too far away from the starting point to be still abeam of the ending point
-        return distanceAX <= this.distance;
-    }
-
-    toString(): string {
-        return `<TFLeg from=${this.from} to=${this.to}>`;
-    }
-}
-
-export abstract class Transition implements Guidable {
-    abstract isAbeam(ppos: LatLongAlt): boolean;
-
-    abstract getGuidanceParameters(ppos, trueTrack);
-
-    abstract getDistanceToGo(ppos);
-
-    abstract getTrackDistanceToTerminationPoint(ppos: LatLongAlt): NauticalMiles;
+    getGuidanceParameters(ppos: LatLongData, trueTrack: Degrees): GuidanceParameters | null;
+    getDistanceToGo(ppos: LatLongData): NauticalMiles;
+    isAbeam(ppos: LatLongData): boolean;
 }
 
 /**
@@ -167,7 +23,7 @@ export abstract class Transition implements Guidable {
 export class Type1Transition extends Transition {
     public previousLeg: TFLeg;
 
-    public nextLeg: TFLeg;
+    public nextLeg: TFLeg | VMLeg;
 
     public radius: NauticalMiles;
 
@@ -175,7 +31,7 @@ export class Type1Transition extends Transition {
 
     constructor(
         previousLeg: TFLeg,
-        nextLeg: TFLeg,
+        nextLeg: TFLeg | VMLeg, // FIXME this cannot happen, but what are you gonna do about it ?,
         radius: NauticalMiles,
         clockwise: boolean,
     ) {
@@ -316,17 +172,13 @@ export class Type1Transition extends Transition {
 export class Geometry {
     /**
      * The list of transitions between legs.
-     * - entry 1: transition before first leg
-     * - entry 2: transition after first leg
-     * - entry n: transition after leg n - 1
+     * - entry n: transition after leg n
      */
     public transitions: Map<number, Transition>;
 
     /**
      * The list of legs in this geometry, possibly connected through transitions:
-     * - entry 1: first leg, after transition 1
-     * - entry 2: second leg, after transition 2
-     * - entry n: nth leg, after transition n
+     * - entry n: nth leg, before transition n
      */
     public legs: Map<number, Leg>;
 
@@ -377,13 +229,22 @@ export class Geometry {
     }
 
     shouldSequenceLeg(ppos: LatLongAlt): boolean {
+        const activeLeg = this.legs.get(1);
+
+        // VM legs do not connect to anything and do not have a transition after them - we never sequence them
+        if (activeLeg instanceof VMLeg) {
+            return false;
+        }
+
+        // FIXME I don't think this works since getActiveLegGeometry doesn't put a transition at n = 2
         const terminatingTransition = this.transitions.get(2);
+
         if (terminatingTransition) {
             const tdttp = terminatingTransition.getTrackDistanceToTerminationPoint(ppos);
+
             return tdttp < 0.001;
         }
 
-        const activeLeg = this.legs.get(1);
         if (activeLeg) {
             return activeLeg.getDistanceToGo(ppos) < 0.001;
         }

--- a/src/fmgc/src/guidance/Geometry.ts
+++ b/src/fmgc/src/guidance/Geometry.ts
@@ -1,6 +1,6 @@
 import { Degrees, NauticalMiles } from '@typings/types';
 import { MathUtils } from '@shared/MathUtils';
-import { TFLeg } from '@fmgc/guidance/lnav/legs/Tf';
+import { TFLeg } from '@fmgc/guidance/lnav/legs/TF';
 import { VMLeg } from '@fmgc/guidance/lnav/legs/VM';
 import { Transition } from '@fmgc/guidance/lnav/transitions';
 import { Leg } from '@fmgc/guidance/lnav/legs';

--- a/src/fmgc/src/guidance/GuidanceManager.ts
+++ b/src/fmgc/src/guidance/GuidanceManager.ts
@@ -1,5 +1,11 @@
+import { TFLeg } from '@fmgc/guidance/lnav/legs/Tf';
+import { WayPoint } from '@fmgc/types/fstypes/FSTypes';
+import { Degrees } from '@typings/types';
+import { VMLeg } from '@fmgc/guidance/lnav/legs/VM';
+import { Leg } from '@fmgc/guidance/lnav/legs';
+import { Transition } from '@fmgc/guidance/lnav/transitions';
 import { FlightPlanManager } from '../flightplanning/FlightPlanManager';
-import { Leg, Geometry, TFLeg, Type1Transition, Transition } from './Geometry';
+import { Geometry, Type1Transition } from './Geometry';
 
 const mod = (x: number, n: number) => x - Math.floor(x / n) * n;
 
@@ -16,11 +22,7 @@ export class GuidanceManager {
         this.flightPlanManager = flightPlanManager;
     }
 
-    getActiveLeg(): TFLeg | null {
-        const activeIndex = this.flightPlanManager.getActiveWaypointIndex();
-        const from = this.flightPlanManager.getWaypoint(activeIndex - 1);
-        const to = this.flightPlanManager.getWaypoint(activeIndex);
-
+    private static tfBetween(from: WayPoint, to: WayPoint) {
         if (!from || !to) {
             return null;
         }
@@ -32,26 +34,40 @@ export class GuidanceManager {
         return new TFLeg(from, to);
     }
 
-    getNextLeg(): TFLeg | null {
-        const activeIndex = this.flightPlanManager.getActiveWaypointIndex();
-        const from = this.flightPlanManager.getWaypoint(activeIndex);
+    private static vmWithHeading(heading: Degrees) {
+        return new VMLeg(heading);
+    }
 
+    getActiveLeg(): TFLeg | VMLeg | null {
+        const activeIndex = this.flightPlanManager.getActiveWaypointIndex();
+
+        const from = this.flightPlanManager.getWaypoint(activeIndex - 1);
+        const to = this.flightPlanManager.getWaypoint(activeIndex);
+
+        if (from.isVectors) {
+            return GuidanceManager.vmWithHeading(from.additionalData.vectorsCourse);
+        }
+
+        return GuidanceManager.tfBetween(from, to);
+    }
+
+    getNextLeg(): TFLeg | VMLeg | null {
+        const activeIndex = this.flightPlanManager.getActiveWaypointIndex();
+
+        const from = this.flightPlanManager.getWaypoint(activeIndex);
         const to = this.flightPlanManager.getWaypoint(activeIndex + 1);
 
-        if (!from || !to) {
-            return null;
+        if (from.isVectors) {
+            return GuidanceManager.vmWithHeading(from.additionalData.vectorsCourse);
         }
 
-        if (from.endsInDiscontinuity) {
-            return null;
-        }
-
-        return new TFLeg(from, to);
+        return GuidanceManager.tfBetween(from, to);
     }
 
     /**
      * The active leg path geometry, used for immediate autoflight.
      */
+    // TODO Extract leg and transition building
     getActiveLegPathGeometry(): Geometry | null {
         const activeLeg = this.getActiveLeg();
         const nextLeg = this.getNextLeg();
@@ -63,7 +79,7 @@ export class GuidanceManager {
         const legs = new Map<number, Leg>([[1, activeLeg]]);
         const transitions = new Map<number, Transition>();
 
-        if (nextLeg) {
+        if (nextLeg && activeLeg instanceof TFLeg) {
             legs.set(2, nextLeg);
 
             const kts = Math.max(SimVar.GetSimVarValue('AIRSPEED TRUE', 'knots'), 150); // knots, i.e. nautical miles per hour
@@ -96,68 +112,71 @@ export class GuidanceManager {
 
     /**
      * The full leg path geometry, used for the ND and predictions on the F-PLN page.
-     *
-     * @param onlyFirstContinuousSegment if set to `true`, only the first segment before any discontinuities will be returned. If set to `false`,
-     *                                   all segments will be return, regardless of discontinuities
      */
-    getMultipleLegGeometry(onlyFirstContinuousSegment = true): Geometry | null {
-        const activeLeg = this.getActiveLeg();
-        const nextLeg = this.getNextLeg();
-
-        if (!activeLeg) {
-            return null;
-        }
-
-        const legs = new Map<number, Leg>([[1, activeLeg]]);
+    // TODO Extract leg and transition building
+    getMultipleLegGeometry(): Geometry | null {
+        const activeIdx = this.flightPlanManager.getCurrentFlightPlan().activeWaypointIndex;
+        const legs = new Map<number, Leg>();
         const transitions = new Map<number, Transition>();
 
-        if (nextLeg) {
-            legs.set(2, nextLeg);
-
-            const kts = Math.max(SimVar.GetSimVarValue('AIRSPEED TRUE', 'knots'), 150); // knots, i.e. nautical miles per hour
-
-            // bank angle limits, always assume limit 2 for now @ 25 degrees between 150 and 300 knots
-            let bankAngleLimit = 25;
-            if (kts < 150) {
-                bankAngleLimit = 15 + Math.min(kts / 150, 1) * (25 - 15);
-            } else if (kts > 300) {
-                bankAngleLimit = 25 - Math.min((kts - 300) / 150, 1) * (25 - 19);
-            }
-
-            // turn radius
-            const xKr = (kts ** 2 / (9.81 * Math.tan(bankAngleLimit * Avionics.Utils.DEG2RAD))) / 6080.2;
-
-            // turn direction
-            const courseChange = mod(nextLeg.bearing - activeLeg.bearing + 180, 360) - 180;
-            const cw = courseChange >= 0;
-
-            transitions.set(2, new Type1Transition(
-                activeLeg,
-                nextLeg,
-                xKr,
-                cw,
-            ));
-        }
-
-        const activeIndex = this.flightPlanManager.getActiveWaypointIndex();
+        // We go in reverse order here, since transitions often need info about the next leg
         const wpCount = this.flightPlanManager.getCurrentFlightPlan().length;
-        for (let i = activeIndex + 1; i < wpCount; i++) {
-            const from = this.flightPlanManager.getWaypoint(i);
-            const to = this.flightPlanManager.getWaypoint(i + 1);
+        for (let i = wpCount - 1; (i >= activeIdx - 1); i--) {
+            const nextLeg = legs.get(i + 1);
 
+            const from = this.flightPlanManager.getWaypoint(i - 1);
+            const to = this.flightPlanManager.getWaypoint(i);
+
+            // Reached the end or start of the flight plan
             if (!from || !to) {
                 continue;
             }
 
-            if (from.endsInDiscontinuity) {
-                if (onlyFirstContinuousSegment) {
-                    break;
-                } else {
-                    continue;
-                }
+            // If TO is a MANUAL leg, make a VM(FROM -> TO)
+            if (to.isVectors) {
+                const currentLeg = GuidanceManager.vmWithHeading(46);
+                legs.set(i, currentLeg);
+
+                continue;
             }
 
-            legs.set(legs.size + 1, new TFLeg(from, to));
+            // If FROM ends in a discontinuity there is no leg "FROM -> TO"
+            if (from.endsInDiscontinuity) {
+                continue;
+            }
+
+            // Leg (hard-coded to TF for now)
+            const currentLeg = new TFLeg(from, to);
+            legs.set(i, currentLeg);
+
+            // Transition (hard-coded to Type 1 for now)
+            if (nextLeg && nextLeg instanceof TFLeg || nextLeg instanceof VMLeg) { // FIXME this cannot happen, but what are you gonna do about it ?
+                const kts = Math.max(SimVar.GetSimVarValue('AIRSPEED TRUE', 'knots'), 150); // knots, i.e. nautical miles per hour
+
+                // Bank angle limits, always assume limit 2 for now @ 25 degrees between 150 and 300 knots
+                let bankAngleLimit = 25;
+                if (kts < 150) {
+                    bankAngleLimit = 15 + Math.min(kts / 150, 1) * (25 - 15);
+                } else if (kts > 300) {
+                    bankAngleLimit = 25 - Math.min((kts - 300) / 150, 1) * (25 - 19);
+                }
+
+                // Turn radius
+                const xKr = (kts ** 2 / (9.81 * Math.tan(bankAngleLimit * Avionics.Utils.DEG2RAD))) / 6080.2;
+
+                // Turn direction
+                const courseChange = mod(nextLeg.bearing - currentLeg.bearing + 180, 360) - 180;
+                const cw = courseChange >= 0;
+
+                const transition = new Type1Transition(
+                    currentLeg,
+                    nextLeg,
+                    xKr,
+                    cw,
+                );
+
+                transitions.set(i, transition);
+            }
         }
 
         return new Geometry(transitions, legs);

--- a/src/fmgc/src/guidance/GuidanceManager.ts
+++ b/src/fmgc/src/guidance/GuidanceManager.ts
@@ -26,8 +26,8 @@ export class GuidanceManager {
         return new TFLeg(from, to);
     }
 
-    private static vmWithHeading(heading: Degrees) {
-        return new VMLeg(heading);
+    private static vmWithHeading(heading: Degrees, initialCourse: Degrees) {
+        return new VMLeg(heading, initialCourse);
     }
 
     getActiveLeg(): TFLeg | VMLeg | null {
@@ -45,7 +45,7 @@ export class GuidanceManager {
         }
 
         if (to.isVectors) {
-            return GuidanceManager.vmWithHeading(to.additionalData.vectorsCourse);
+            return GuidanceManager.vmWithHeading(to.additionalData.vectorsHeading, to.additionalData.vectorsCourse);
         }
 
         return GuidanceManager.tfBetween(from, to);
@@ -66,7 +66,7 @@ export class GuidanceManager {
         }
 
         if (to.isVectors) {
-            return GuidanceManager.vmWithHeading(to.additionalData.vectorsCourse);
+            return GuidanceManager.vmWithHeading(to.additionalData.vectorsHeading, to.additionalData.vectorsCourse);
         }
 
         return GuidanceManager.tfBetween(from, to);
@@ -142,7 +142,7 @@ export class GuidanceManager {
 
             // If TO is a MANUAL leg, make a VM(FROM -> TO)
             if (to.isVectors) {
-                const currentLeg = GuidanceManager.vmWithHeading(to.additionalData.vectorsCourse);
+                const currentLeg = GuidanceManager.vmWithHeading(to.additionalData.vectorsHeading, to.additionalData.vectorsCourse);
                 legs.set(i, currentLeg);
 
                 continue;

--- a/src/fmgc/src/guidance/GuidanceManager.ts
+++ b/src/fmgc/src/guidance/GuidanceManager.ts
@@ -1,4 +1,4 @@
-import { TFLeg } from '@fmgc/guidance/lnav/legs/Tf';
+import { TFLeg } from '@fmgc/guidance/lnav/legs/TF';
 import { WayPoint } from '@fmgc/types/fstypes/FSTypes';
 import { Degrees } from '@typings/types';
 import { VMLeg } from '@fmgc/guidance/lnav/legs/VM';

--- a/src/fmgc/src/guidance/GuidanceManager.ts
+++ b/src/fmgc/src/guidance/GuidanceManager.ts
@@ -23,14 +23,6 @@ export class GuidanceManager {
     }
 
     private static tfBetween(from: WayPoint, to: WayPoint) {
-        if (!from || !to) {
-            return null;
-        }
-
-        if (from.endsInDiscontinuity) {
-            return null;
-        }
-
         return new TFLeg(from, to);
     }
 
@@ -44,8 +36,16 @@ export class GuidanceManager {
         const from = this.flightPlanManager.getWaypoint(activeIndex - 1);
         const to = this.flightPlanManager.getWaypoint(activeIndex);
 
-        if (from.isVectors) {
-            return GuidanceManager.vmWithHeading(from.additionalData.vectorsCourse);
+        if (!from || !to) {
+            return null;
+        }
+
+        if (from.endsInDiscontinuity) {
+            return null;
+        }
+
+        if (to.isVectors) {
+            return GuidanceManager.vmWithHeading(to.additionalData.vectorsCourse);
         }
 
         return GuidanceManager.tfBetween(from, to);
@@ -57,8 +57,16 @@ export class GuidanceManager {
         const from = this.flightPlanManager.getWaypoint(activeIndex);
         const to = this.flightPlanManager.getWaypoint(activeIndex + 1);
 
-        if (from.isVectors) {
-            return GuidanceManager.vmWithHeading(from.additionalData.vectorsCourse);
+        if (!from || !to) {
+            return null;
+        }
+
+        if (from.endsInDiscontinuity) {
+            return null;
+        }
+
+        if (to.isVectors) {
+            return GuidanceManager.vmWithHeading(to.additionalData.vectorsCourse);
         }
 
         return GuidanceManager.tfBetween(from, to);

--- a/src/fmgc/src/guidance/GuidanceManager.ts
+++ b/src/fmgc/src/guidance/GuidanceManager.ts
@@ -134,7 +134,7 @@ export class GuidanceManager {
 
             // If TO is a MANUAL leg, make a VM(FROM -> TO)
             if (to.isVectors) {
-                const currentLeg = GuidanceManager.vmWithHeading(46);
+                const currentLeg = GuidanceManager.vmWithHeading(to.additionalData.vectorsCourse);
                 legs.set(i, currentLeg);
 
                 continue;

--- a/src/fmgc/src/guidance/lnav/LnavDriver.ts
+++ b/src/fmgc/src/guidance/lnav/LnavDriver.ts
@@ -122,8 +122,12 @@ export class LnavDriver implements GuidanceComponent {
 
             if (geometry.shouldSequenceLeg(this.ppos)) {
                 const currentLeg = geometry.legs.get(1);
+                const nextLeg = geometry.legs.get(2);
 
-                if (currentLeg instanceof TFLeg && currentLeg.to.endsInDiscontinuity) {
+                // FIXME we should stop relying on discos in the wpt objects, but for now it's fiiiiiine
+                // Hard-coded check for TF leg after the disco for now - only case where we don't wanna
+                // sequence this way is VM
+                if (currentLeg instanceof TFLeg && currentLeg.to.endsInDiscontinuity && nextLeg instanceof TFLeg) {
                     this.sequenceDiscontinuity(currentLeg);
                 } else {
                     this.sequenceLeg(currentLeg);

--- a/src/fmgc/src/guidance/lnav/LnavDriver.ts
+++ b/src/fmgc/src/guidance/lnav/LnavDriver.ts
@@ -1,7 +1,9 @@
 import { LateralMode, VerticalMode } from '@shared/autopilot';
+import { TFLeg } from '@fmgc/guidance/lnav/legs/Tf';
+import { Leg } from '@fmgc/guidance/lnav/legs';
+import { MathUtils } from '@shared/MathUtils';
 import { GuidanceComponent } from '../GuidanceComponent';
 import { ControlLaw } from '../ControlLaws';
-import { Leg, TFLeg } from '../Geometry';
 import { GuidanceController } from '../GuidanceController';
 
 export class LnavDriver implements GuidanceComponent {
@@ -61,22 +63,55 @@ export class LnavDriver implements GuidanceComponent {
                         trackAngleError,
                         phiCommand,
                     } = params;
+
                     if (!this.lastAvail) {
                         SimVar.SetSimVarValue('L:A32NX_FG_AVAIL', 'Bool', true);
                         this.lastAvail = true;
                     }
+
                     if (crossTrackError !== this.lastXTE) {
                         SimVar.SetSimVarValue('L:A32NX_FG_CROSS_TRACK_ERROR', 'nautical miles', crossTrackError);
                         this.lastXTE = crossTrackError;
                     }
+
                     if (trackAngleError !== this.lastTAE) {
                         SimVar.SetSimVarValue('L:A32NX_FG_TRACK_ANGLE_ERROR', 'degree', trackAngleError);
                         this.lastTAE = trackAngleError;
                     }
+
                     if (phiCommand !== this.lastPhi) {
                         SimVar.SetSimVarValue('L:A32NX_FG_PHI_COMMAND', 'degree', phiCommand);
                         this.lastPhi = phiCommand;
                     }
+
+                    break;
+                case ControlLaw.HEADING:
+                    const { heading } = params;
+
+                    if (!this.lastAvail) {
+                        SimVar.SetSimVarValue('L:A32NX_FG_AVAIL', 'Bool', true);
+                        this.lastAvail = true;
+                    }
+
+                    if (this.lastXTE !== 0) {
+                        SimVar.SetSimVarValue('L:A32NX_FG_CROSS_TRACK_ERROR', 'nautical miles', 0);
+                        this.lastXTE = 0;
+                    }
+
+                    // Track Angle Error
+                    const currentHeading = SimVar.GetSimVarValue('PLANE HEADING DEGREES MAGNETIC', 'Degrees');
+                    const deltaHeading = MathUtils.diffAngle(currentHeading, heading);
+
+                    if (deltaHeading !== this.lastTAE) {
+                        SimVar.SetSimVarValue('L:A32NX_FG_TRACK_ANGLE_ERROR', 'degree', deltaHeading);
+                        this.lastTAE = deltaHeading;
+                    }
+
+                    if (this.lastPhi !== 0) {
+                        SimVar.SetSimVarValue('L:A32NX_FG_PHI_COMMAND', 'degree', 0);
+                        this.lastPhi = 0;
+                    }
+
                     break;
                 default:
                     throw new Error(`Invalid control law: ${params.law}`);

--- a/src/fmgc/src/guidance/lnav/LnavDriver.ts
+++ b/src/fmgc/src/guidance/lnav/LnavDriver.ts
@@ -1,5 +1,5 @@
 import { LateralMode, VerticalMode } from '@shared/autopilot';
-import { TFLeg } from '@fmgc/guidance/lnav/legs/Tf';
+import { TFLeg } from '@fmgc/guidance/lnav/legs/TF';
 import { Leg } from '@fmgc/guidance/lnav/legs';
 import { MathUtils } from '@shared/MathUtils';
 import { GuidanceComponent } from '../GuidanceComponent';

--- a/src/fmgc/src/guidance/lnav/legs/TF.ts
+++ b/src/fmgc/src/guidance/lnav/legs/TF.ts
@@ -1,0 +1,131 @@
+import { Degrees, NauticalMiles } from '@typings/types';
+import { ControlLaw, GuidanceParameters } from '@fmgc/guidance/ControlLaws';
+import { LatLongData } from '@typings/fs-base-ui/html_ui/JS/Types';
+import { MathUtils } from '@shared/MathUtils';
+import { EARTH_RADIUS_NM } from '@fmgc/guidance/Geometry';
+import { Leg } from '@fmgc/guidance/lnav/legs';
+
+export class TFLeg implements Leg {
+    public from: WayPoint;
+
+    public to: WayPoint;
+
+    constructor(from: WayPoint, to: WayPoint) {
+        this.from = from;
+        this.to = to;
+    }
+
+    get bearing(): Degrees {
+        return Avionics.Utils.computeGreatCircleHeading(
+            this.from.infos.coordinates,
+            this.to.infos.coordinates,
+        );
+    }
+
+    getGuidanceParameters(ppos: LatLongData, trueTrack: Degrees): GuidanceParameters | null {
+        const fromLatLongAlt = this.from.infos.coordinates;
+
+        const desiredTrack = this.bearing;
+        const trackAngleError = MathUtils.mod(desiredTrack - trueTrack + 180, 360) - 180;
+
+        // crosstrack error
+        const bearingAC = Avionics.Utils.computeGreatCircleHeading(fromLatLongAlt, ppos);
+        const bearingAB = desiredTrack;
+        const distanceAC = Avionics.Utils.computeDistance(fromLatLongAlt, ppos);
+
+        const desiredOffset = 0;
+        const actualOffset = (
+            Math.asin(
+                Math.sin(Avionics.Utils.DEG2RAD * (distanceAC / EARTH_RADIUS_NM))
+                * Math.sin(Avionics.Utils.DEG2RAD * (bearingAC - bearingAB)),
+            ) / Avionics.Utils.DEG2RAD
+        ) * EARTH_RADIUS_NM;
+        const crossTrackError = desiredOffset - actualOffset;
+
+        return {
+            law: ControlLaw.LATERAL_PATH,
+            trackAngleError,
+            crossTrackError,
+            phiCommand: 0,
+        };
+    }
+
+    /**
+     * Calculates the angle between the leg and the aircraft PPOS.
+     *
+     * This effectively returns the angle ABC in the figure shown below:
+     *
+     * ```
+     * * A
+     * |
+     * * B (TO)
+     * |\
+     * | \
+     * |  \
+     * |   \
+     * |    \
+     * |     \
+     * |      \
+     * * FROM  * C (PPOS)
+     * ```
+     *
+     * @param ppos {LatLong} the current position of the aircraft
+     */
+    getAircraftToLegBearing(ppos: LatLongData): number {
+        const aircraftToTerminationBearing = Avionics.Utils.computeGreatCircleHeading(ppos, this.to.infos.coordinates);
+
+        // Rotate frame of reference to 0deg
+        let correctedLegBearing = this.bearing - aircraftToTerminationBearing;
+        if (correctedLegBearing < 0) {
+            correctedLegBearing = 360 + correctedLegBearing;
+        }
+
+        let aircraftToLegBearing = 180 - correctedLegBearing;
+        if (aircraftToLegBearing < 0) {
+            // if correctedLegBearing was greater than 180 degrees, then its supplementary angle is negative.
+            // In this case, we can subtract it from 360 degrees to obtain the bearing.
+
+            aircraftToLegBearing = 360 + aircraftToLegBearing;
+        }
+
+        return aircraftToLegBearing;
+    }
+
+    getDistanceToGo(ppos: LatLongData): NauticalMiles {
+        const aircraftLegBearing = this.getAircraftToLegBearing(ppos);
+
+        const absDtg = Avionics.Utils.computeGreatCircleDistance(ppos, this.to.infos.coordinates);
+
+        // @todo should be abeam distance
+        if (aircraftLegBearing >= 90 && aircraftLegBearing <= 270) {
+            // Since a line perpendicular to the leg is formed by two 90 degree angles, an aircraftLegBearing outside
+            // (North - 90) and (North + 90) is in the lower quadrants of a plane centered at the TO fix. This means
+            // the aircraft is NOT past the TO fix, and DTG must be positive.
+
+            return absDtg;
+        }
+
+        return -absDtg;
+    }
+
+    get distance(): NauticalMiles {
+        return Avionics.Utils.computeGreatCircleDistance(this.from.infos.coordinates, this.to.infos.coordinates);
+    }
+
+    isAbeam(ppos: LatLongAlt): boolean {
+        const bearingAC = Avionics.Utils.computeGreatCircleHeading(this.from.infos.coordinates, ppos);
+        const headingAC = Math.abs(MathUtils.diffAngle(this.bearing, bearingAC));
+        if (headingAC > 90) {
+            // if we're even not abeam of the starting point
+            return false;
+        }
+        const distanceAC = Avionics.Utils.computeDistance(this.from.infos.coordinates, ppos);
+        const distanceAX = Math.cos(headingAC * Avionics.Utils.DEG2RAD) * distanceAC;
+        // if we're too far away from the starting point to be still abeam of the ending point
+        return distanceAX <= this.distance;
+    }
+
+    toString(): string {
+        return `<TFLeg from=${this.from} to=${this.to}>`;
+    }
+}

--- a/src/fmgc/src/guidance/lnav/legs/VM.ts
+++ b/src/fmgc/src/guidance/lnav/legs/VM.ts
@@ -1,0 +1,39 @@
+import { Degrees, NauticalMiles } from '@typings/types';
+import { ControlLaw, GuidanceParameters } from '@fmgc/guidance/ControlLaws';
+import { LatLongData } from '@typings/fs-base-ui/html_ui/JS/Types';
+import { Leg } from '@fmgc/guidance/lnav/legs';
+
+export class VMLeg implements Leg {
+    public heading: Degrees;
+
+    constructor(heading: Degrees) {
+        this.heading = heading;
+    }
+
+    get bearing(): Degrees {
+        return this.heading;
+    }
+
+    getGuidanceParameters(_ppos: LatLongData, _trueTrack): GuidanceParameters | null {
+        return {
+            law: ControlLaw.HEADING,
+            heading: this.heading,
+        };
+    }
+
+    getDistanceToGo(_ppos: LatLongData): NauticalMiles {
+        return 1;
+    }
+
+    get distance(): NauticalMiles {
+        return 1;
+    }
+
+    isAbeam(_ppos: LatLongAlt): boolean {
+        return true;
+    }
+
+    toString(): string {
+        return `<VMLeg course=${this.heading}>`;
+    }
+}

--- a/src/fmgc/src/guidance/lnav/legs/VM.ts
+++ b/src/fmgc/src/guidance/lnav/legs/VM.ts
@@ -3,15 +3,18 @@ import { ControlLaw, GuidanceParameters } from '@fmgc/guidance/ControlLaws';
 import { LatLongData } from '@typings/fs-base-ui/html_ui/JS/Types';
 import { Leg } from '@fmgc/guidance/lnav/legs';
 
+// TODO needs updated with wind prediction, and maybe local magvar if following for longer distances
 export class VMLeg implements Leg {
     public heading: Degrees;
+    public initialCourse: Degrees;
 
-    constructor(heading: Degrees) {
+    constructor(heading: Degrees, initialCourse: Degrees) {
         this.heading = heading;
+        this.initialCourse = initialCourse;
     }
 
     get bearing(): Degrees {
-        return this.heading;
+        return this.initialCourse;
     }
 
     getGuidanceParameters(_ppos: LatLongData, _trueTrack): GuidanceParameters | null {

--- a/src/fmgc/src/guidance/lnav/legs/index.ts
+++ b/src/fmgc/src/guidance/lnav/legs/index.ts
@@ -1,0 +1,18 @@
+import { Degrees, NauticalMiles } from '@typings/types';
+import { Guidable } from '@fmgc/guidance/Geometry';
+import { LatLongData } from '@typings/fs-base-ui/html_ui/JS/Types';
+
+export interface Leg extends Guidable {
+    get bearing(): Degrees;
+
+    getGuidanceParameters(ppos: LatLongAlt, trueTrack: Degrees);
+
+    /**
+     * Calculates directed DTG parameter
+     *
+     * @param ppos {LatLong} the current position of the aircraft
+     */
+    getDistanceToGo(ppos: LatLongData): NauticalMiles;
+
+    isAbeam(ppos);
+}

--- a/src/fmgc/src/guidance/lnav/transitions.ts
+++ b/src/fmgc/src/guidance/lnav/transitions.ts
@@ -1,0 +1,12 @@
+import { Guidable } from '@fmgc/guidance/Geometry';
+import { NauticalMiles } from '@typings/types';
+
+export abstract class Transition implements Guidable {
+    abstract isAbeam(ppos: LatLongAlt): boolean;
+
+    abstract getGuidanceParameters(ppos, trueTrack);
+
+    abstract getDistanceToGo(ppos);
+
+    abstract getTrackDistanceToTerminationPoint(ppos: LatLongAlt): NauticalMiles;
+}

--- a/src/fmgc/src/types/fstypes/FSTypes.d.ts
+++ b/src/fmgc/src/types/fstypes/FSTypes.d.ts
@@ -303,7 +303,7 @@ declare interface RawVor extends RawFacility {
     type: VorType;
     vorClass: VorClass;
     weatherBroadcast: number;
-    //[0, 360)
+    // [0, 360)
     magneticVariation?: number;
     __Type: 'JS_FacilityVOR';
 }
@@ -332,10 +332,10 @@ declare interface RawNdb extends RawFacility {
     freqMHz: number;
     type: NdbType;
     weatherBroadcast: number;
-    //[0, 360)
+    // [0, 360)
     magneticVariation?: number;
     __Type: 'JS_FacilityNDB';
-};
+}
 
 declare enum NdbType {
     Unknown = 0,

--- a/src/fmgc/tsconfig.json
+++ b/src/fmgc/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "moduleResolution": "node",
     "target": "ESNext",
     "noEmit": true,
     "typeRoots": ["../../typings"]

--- a/src/instruments/src/ND/elements/FlightPlan.tsx
+++ b/src/instruments/src/ND/elements/FlightPlan.tsx
@@ -5,6 +5,7 @@ import { GuidanceManager } from '@fmgc/guidance/GuidanceManager';
 import { MathUtils } from '@shared/MathUtils';
 import { Layer } from '@instruments/common/utils';
 import { useSimVar } from '@instruments/common/simVars';
+import useInterval from '@instruments/common/useInterval';
 import { FlightPlanManager } from '@fmgc/flightplanning/FlightPlanManager';
 import { WayPoint } from '@fmgc/types/fstypes/FSTypes';
 import { TFLeg } from '@fmgc/guidance/lnav/legs/TF';
@@ -28,9 +29,9 @@ export const FlightPlan: FC<FlightPathProps> = ({ x = 0, y = 0, flightPlanManage
 
     const [geometry, setGeometry] = useState(() => guidanceManager.getMultipleLegGeometry());
 
-    useEffect(() => {
+    useInterval(() => {
         setGeometry(guidanceManager.getMultipleLegGeometry());
-    }, [flightPlan]);
+    }, 2_000);
 
     if (geometry) {
         return (

--- a/src/instruments/src/ND/elements/FlightPlan.tsx
+++ b/src/instruments/src/ND/elements/FlightPlan.tsx
@@ -7,7 +7,7 @@ import { Layer } from '@instruments/common/utils';
 import { useSimVar } from '@instruments/common/simVars';
 import { FlightPlanManager } from '@fmgc/flightplanning/FlightPlanManager';
 import { WayPoint } from '@fmgc/types/fstypes/FSTypes';
-import { TFLeg } from '@fmgc/guidance/lnav/legs/Tf';
+import { TFLeg } from '@fmgc/guidance/lnav/legs/TF';
 import { VMLeg } from '@fmgc/guidance/lnav/legs/VM';
 import { Leg } from '@fmgc/guidance/lnav/legs';
 import { Transition } from '@fmgc/guidance/lnav/transitions';
@@ -35,12 +35,14 @@ export const FlightPlan: FC<FlightPathProps> = ({ x = 0, y = 0, flightPlanManage
     if (geometry) {
         return (
             <Layer x={x} y={y}>
-                {flightPlan.visibleWaypoints.map((waypoint, index) => {
-                    if (!waypoint.isVectors) {
-                        return <Waypoint key={waypoint.ident} waypoint={waypoint} index={index} mapParams={mapParams} debug={debug} />;
-                    }
-                    return null;
-                })}
+                <g clipPath={clipPath}>
+                    {flightPlan.visibleWaypoints.map((waypoint, index) => {
+                        if (!waypoint.isVectors) {
+                            return <Waypoint key={waypoint.ident} waypoint={waypoint} index={index} mapParams={mapParams} debug={debug} />;
+                        }
+                        return null;
+                    })}
+                </g>
                 <path d={makePathFromGeometry(geometry, mapParams)} stroke="#00ff00" strokeWidth={2} fill="none" clipPath={clipPath} />
                 {debug && (
                     <>
@@ -69,7 +71,7 @@ const Waypoint: FC<{ waypoint: WayPoint, index: number, mapParams: MapParameters
 
     return (
         <Layer x={x} y={y}>
-            <rect x={-6} y={0} width={8} height={8} stroke="#00ff00" strokeWidth={2} transform="rotate(45 4 4)" />
+            <rect x={-4} y={-4} width={8} height={8} stroke="#00ff00" strokeWidth={2} transform="rotate(45 0 0)" />
 
             <text x={15} y={10} fontSize={20} fill="#00ff00">
                 {waypoint.ident}

--- a/src/instruments/src/ND/elements/FlightPlan.tsx
+++ b/src/instruments/src/ND/elements/FlightPlan.tsx
@@ -74,6 +74,8 @@ const Waypoint: FC<{ waypoint: WayPoint, index: number, isActive: boolean, mapPa
     // TODO FL
     //debugger;
 
+    // TODO VNAV to provide met/missed prediction => magenta if met, amber if missed
+    const constrainedAltitudeClass = waypoint.legAltitudeDescription > 0 ? "White" : null;
     let constraintY = -6;
     let constraintText: string[] = [];
     if (constraints) {
@@ -108,9 +110,12 @@ const Waypoint: FC<{ waypoint: WayPoint, index: number, isActive: boolean, mapPa
                 {debug && `(${index})`}
             </text>
             { constraints && (
-                constraintText.map(t => {
-                    return <text x={15} y={constraintY += 20} className="Magenta" fontSize={20}>{t}</text>
-                })
+                constraintText.map(t => (
+                    <text x={15} y={constraintY += 20} className="Magenta" fontSize={20}>{t}</text>
+                ))
+            )}
+            { constrainedAltitudeClass && (
+                <circle r={12} className={constrainedAltitudeClass} strokeWidth={2} />
             )}
         </Layer>
     );

--- a/src/instruments/src/ND/elements/FlightPlan.tsx
+++ b/src/instruments/src/ND/elements/FlightPlan.tsx
@@ -1,12 +1,16 @@
 import React, { FC, useEffect, useState } from 'react';
 import { useCurrentFlightPlan } from '@instruments/common/flightplan';
-import { Geometry, Leg, TFLeg, Type1Transition } from '@fmgc/guidance/Geometry';
+import { Geometry, Type1Transition } from '@fmgc/guidance/Geometry';
 import { GuidanceManager } from '@fmgc/guidance/GuidanceManager';
 import { MathUtils } from '@shared/MathUtils';
 import { Layer } from '@instruments/common/utils';
-import { GeoMath } from '@fmgc/flightplanning/GeoMath';
 import { useSimVar } from '@instruments/common/simVars';
 import { FlightPlanManager } from '@fmgc/flightplanning/FlightPlanManager';
+import { WayPoint } from '@fmgc/types/fstypes/FSTypes';
+import { TFLeg } from '@fmgc/guidance/lnav/legs/Tf';
+import { VMLeg } from '@fmgc/guidance/lnav/legs/VM';
+import { Leg } from '@fmgc/guidance/lnav/legs';
+import { Transition } from '@fmgc/guidance/lnav/transitions';
 import { MapParameters } from '../utils/MapParameters';
 
 export type FlightPathProps = {
@@ -22,28 +26,36 @@ export const FlightPlan: FC<FlightPathProps> = ({ x = 0, y = 0, flightPlanManage
     const [guidanceManager] = useState(() => new GuidanceManager(flightPlanManager));
     const flightPlan = useCurrentFlightPlan();
 
-    const [geometry, setGeometry] = useState(() => guidanceManager.getMultipleLegGeometry(false));
+    const [geometry, setGeometry] = useState(() => guidanceManager.getMultipleLegGeometry());
 
     useEffect(() => {
-        setGeometry(guidanceManager.getMultipleLegGeometry(false));
+        setGeometry(guidanceManager.getMultipleLegGeometry());
     }, [flightPlan]);
 
     if (geometry) {
         return (
             <Layer x={x} y={y}>
-                <g clipPath={clipPath}>
-                    {flightPlan.visibleWaypoints.map((waypoint) => {
-                        if (!waypoint.isVectors) {
-                            return <Waypoint key={waypoint.ident} waypoint={waypoint} mapParams={mapParams} />;
-                        }
-                        return null;
-                    })}
-                </g>
+                {flightPlan.visibleWaypoints.map((waypoint, index) => {
+                    if (!waypoint.isVectors) {
+                        return <Waypoint key={waypoint.ident} waypoint={waypoint} index={index} mapParams={mapParams} debug={debug} />;
+                    }
+                    return null;
+                })}
                 <path d={makePathFromGeometry(geometry, mapParams)} stroke="#00ff00" strokeWidth={2} fill="none" clipPath={clipPath} />
                 {debug && (
-                    Array.from(geometry.legs.values()).map((leg) => (
-                        <DebugLeg leg={leg} mapParams={mapParams} />
-                    ))
+                    <>
+                        {
+                            Array.from(geometry.legs.values()).map((leg) => (
+                                <DebugLeg leg={leg} mapParams={mapParams} />
+                            ))
+                        }
+                        {
+                            Array.from(geometry.transitions.values()).map((transition) => (
+                                <DebugTransition transition={transition} mapParams={mapParams} />
+                            ))
+                        }
+                    </>
+
                 )}
             </Layer>
         );
@@ -52,28 +64,37 @@ export const FlightPlan: FC<FlightPathProps> = ({ x = 0, y = 0, flightPlanManage
     return null;
 };
 
-const Waypoint: FC<{ waypoint: WayPoint, mapParams: MapParameters }> = ({ waypoint, mapParams }) => {
+const Waypoint: FC<{ waypoint: WayPoint, index: number, mapParams: MapParameters, debug: boolean }> = ({ waypoint, index, mapParams, debug = false }) => {
     const [x, y] = mapParams.coordinatesToXYy(waypoint.infos.coordinates);
 
     return (
         <Layer x={x} y={y}>
-            <rect x={-4} y={-4} width={8} height={8} stroke="#00ff00" strokeWidth={2} transform="rotate(45 0 0)" />
+            <rect x={-6} y={0} width={8} height={8} stroke="#00ff00" strokeWidth={2} transform="rotate(45 4 4)" />
 
-            <text x={15} y={10} fontSize={20} fill="#00ff00">{waypoint.ident}</text>
+            <text x={15} y={10} fontSize={20} fill="#00ff00">
+                {waypoint.ident}
+                {debug && `(${index})`}
+            </text>
         </Layer>
     );
 };
 
-export type DebugLegProps = {
-    leg: Leg,
+export type DebugLegProps<TLeg extends Leg> = {
+    leg: TLeg,
     mapParams: MapParameters,
 }
 
-const DebugLeg: FC<DebugLegProps> = ({ leg, mapParams }) => {
-    if (!(leg instanceof TFLeg)) {
-        return null;
+const DebugLeg: FC<DebugLegProps<Leg>> = ({ leg, mapParams }) => {
+    if (leg instanceof TFLeg) {
+        return <DebugTFLeg leg={leg} mapParams={mapParams} />;
+    } if (leg instanceof VMLeg) {
+        return <DebugVMLeg leg={leg} mapParams={mapParams} />;
     }
 
+    return null;
+};
+
+const DebugTFLeg: FC<DebugLegProps<TFLeg>> = ({ leg, mapParams }) => {
     const legType = 'TF';
 
     const [lat] = useSimVar('PLANE LATITUDE', 'degrees', 250);
@@ -102,7 +123,7 @@ const DebugLeg: FC<DebugLegProps> = ({ leg, mapParams }) => {
                 {' '}
                 {MathUtils.fastToFixed(leg.bearing, 1)}
             </text>
-            <text fill="#ff4444" x={infoX + 120} y={infoY + 40} fontSize={16}>
+            <text fill="#ff4444" x={infoX + 100} y={infoY + 40} fontSize={16}>
                 tA:
                 {' '}
                 {MathUtils.fastToFixed(leg.getAircraftToLegBearing({ lat, long }), 1)}
@@ -110,7 +131,63 @@ const DebugLeg: FC<DebugLegProps> = ({ leg, mapParams }) => {
             <text fill="#ff4444" x={infoX} y={infoY + 60} fontSize={16}>
                 DTG:
                 {' '}
-                {leg.getDistanceToGo({ lat, long })}
+                {MathUtils.fastToFixed(leg.getDistanceToGo({ lat, long }), 3)}
+            </text>
+        </>
+    );
+};
+
+const DebugVMLeg: FC<DebugLegProps<VMLeg>> = ({ leg, mapParams }) => {
+    const legType = 'VM';
+
+    const [lat] = useSimVar('PLANE LATITUDE', 'degrees', 250);
+    const [long] = useSimVar('PLANE LONGITUDE', 'degrees', 250);
+
+    const [fromX, fromY] = mapParams.coordinatesToXYy({ lat, long });
+
+    const [infoX, infoY] = [fromX, fromY - 150];
+
+    return (
+        <>
+            <text fill="#ff4444" x={infoX} y={infoY} fontSize={16}>
+                {leg.heading}
+                &deg;
+            </text>
+            <text fill="#ff4444" x={infoX} y={infoY + 20} fontSize={16}>{legType}</text>
+        </>
+    );
+};
+
+export type DebugTransitionProps = {
+    transition: Transition,
+    mapParams: MapParameters,
+}
+
+const DebugTransition: FC<DebugTransitionProps> = ({ transition, mapParams }) => {
+    if (!(transition instanceof Type1Transition)) {
+        return null;
+    }
+
+    const inbound = transition.getTurningPoints()[0];
+    const outbound = transition.getTurningPoints()[1];
+
+    const [fromX, fromY] = mapParams.coordinatesToXYy(inbound);
+    const [toX, toY] = mapParams.coordinatesToXYy(outbound);
+
+    const [infoX, infoY] = [
+        Math.round(Math.min(fromX, toX) + (Math.abs(toX - fromX) / 2) + 5),
+        Math.round(Math.min(fromY, toY) + (Math.abs(toY - fromY) / 2)),
+    ];
+
+    let transitionType;
+    if (transition instanceof Type1Transition) {
+        transitionType = 'Type 1';
+    }
+
+    return (
+        <>
+            <text fill="yellow" x={infoX} y={infoY} fontSize={16}>
+                {transitionType}
             </text>
         </>
     );
@@ -124,132 +201,99 @@ const DebugLeg: FC<DebugLegProps> = ({ leg, mapParams }) => {
 function makePathFromGeometry(geometry: Geometry, mapParams: MapParameters): string {
     const path: string[] = [];
 
-    let x: string | null = null;
-    let y: string | null = null;
-
-    const firstLeg = geometry.legs.get(1) as TFLeg;
-
-    // initial transition
-    if (geometry.transitions.has(1)) {
-        // draw the initial transition fully
-        const transition = geometry.transitions.get(1) as Type1Transition;
-
-        const [inbound, outbound] = transition.getTurningPoints();
-
-        const [inbndX, inbndY] = mapParams.coordinatesToXYy(inbound);
-        x = MathUtils.fastToFixed(inbndX, 1);
-        y = MathUtils.fastToFixed(inbndY, 1);
-
-        // move to starting point of transition
-        path.push(`M ${x} ${y}`);
-
-        // draw first transition
-        const r = MathUtils.fastToFixed(transition.radius * mapParams.nmToPx, 0);
-        const [outbndX, outbndY] = mapParams.coordinatesToXYy(outbound);
-
-        x = MathUtils.fastToFixed(outbndX, 1);
-        y = MathUtils.fastToFixed(outbndY, 1);
-        const cw = transition.clockwise;
-
-        path.push(`A ${r} ${r} 0 0 ${cw ? 1 : 0} ${x} ${y}`);
-    } else if (geometry.legs.has(1)) {
-        // Move to the starting point of the first leg
-        const [toX, toY] = mapParams.coordinatesToXYy(firstLeg.from.infos.coordinates);
-        x = MathUtils.fastToFixed(toX, 1);
-        y = MathUtils.fastToFixed(toY, 1);
-
-        path.push(`M ${x} ${y}`);
-
-        // If the "to" waypoint ends in a discontinuity, we won't draw a line there later, so do it now
-        if (firstLeg.to.endsInDiscontinuity) {
-            if (firstLeg.to.isVectors) {
-                const farAwayCoords = GeoMath.relativeBearingDistanceToCoords(firstLeg.bearing, 70, firstLeg.to.infos.coordinates);
-
-                const [toX, toY] = mapParams.coordinatesToXYy(farAwayCoords);
-
-                x = MathUtils.fastToFixed(toX, 1);
-                y = MathUtils.fastToFixed(toY, 1);
-
-                path.push(`L ${x} ${y}`);
-            } else {
-                const [toX, toY] = mapParams.coordinatesToXYy(firstLeg.to.infos.coordinates);
-
-                x = MathUtils.fastToFixed(toX, 1);
-                y = MathUtils.fastToFixed(toY, 1);
-
-                path.push(`L ${x} ${y}`);
-            }
-        }
-    }
-
-    let finalLeg = firstLeg;
-    for (let i = 2; i <= geometry.legs.size; i++) {
-        const [prevLeg, leg] = [geometry.legs.get(i - 1), geometry.legs.get(i) as Leg];
+    for (const [i, leg] of geometry.legs.entries()) {
+        const transitionBefore = geometry.transitions.get(i - 1);
         const transition = geometry.transitions.get(i);
 
+        let x;
+        let y;
+
         if (leg instanceof TFLeg) {
-            if (transition && transition instanceof Type1Transition) {
-                // draw line to start of transition
-                const [inbound, outbound] = transition.getTurningPoints();
+            if (transition) {
+                // This is the transition after this leg - so since we are going in reverse order, draw it first
+                if (transition instanceof Type1Transition) {
+                    const [inLla, outLla] = transition.getTurningPoints();
 
-                const [inbndX, inbndY] = mapParams.coordinatesToXYy(inbound);
-                x = MathUtils.fastToFixed(inbndX, 1);
-                y = MathUtils.fastToFixed(inbndY, 1);
-                path.push(`${path.length ? 'L' : 'M'} ${x} ${y}`);
+                    // Move to inbound point
+                    const [inX, inY] = mapParams.coordinatesToXYy(inLla);
+                    x = MathUtils.fastToFixed(inX, 1);
+                    y = MathUtils.fastToFixed(inY, 1);
 
-                // draw transition itself to end of transition
-                const r = MathUtils.fastToFixed(transition.radius * mapParams.nmToPx, 0);
-                const [outbndX, outbndY] = mapParams.coordinatesToXYy(outbound);
+                    path.push(`M ${x} ${y}`);
 
-                x = MathUtils.fastToFixed(outbndX, 1);
-                y = MathUtils.fastToFixed(outbndY, 1);
-                const cw = transition.clockwise;
+                    const r = MathUtils.fastToFixed(transition.radius * mapParams.nmToPx, 0);
 
-                path.push(`A ${r} ${r} 0 0 ${cw ? 1 : 0} ${x} ${y}`);
+                    // Draw arc to outbound point
+                    const [outX, outY] = mapParams.coordinatesToXYy(outLla);
+                    x = MathUtils.fastToFixed(outX, 1);
+                    y = MathUtils.fastToFixed(outY, 1);
+                    const cw = transition.clockwise;
 
-                /* const [cX, cY] = map.coordinatesToXY(transition.center);
-                const pcx = MathUtils.fastToFixed(cX, 1);
-                const pcy = MathUtils.fastToFixed(cY, 1); */
-            }
-
-            // If there was no transition but the leg exists, we M or L to the from waypoint
-            if (!transition && leg) {
-                // draw line to start of next leg
-                const [fromX, fromY] = mapParams.coordinatesToXYy(leg.from.infos.coordinates);
-                x = MathUtils.fastToFixed(fromX, 1);
-                y = MathUtils.fastToFixed(fromY, 1);
-
-                // If the previous leg ended in a discontinuity OR this is the fist leg, we use an M command
-                let lineCommand;
-                if (prevLeg && prevLeg instanceof TFLeg && prevLeg.to.endsInDiscontinuity) {
-                    lineCommand = 'M';
-                } else {
-                    lineCommand = path.length > 0 ? 'L' : 'M';
+                    path.push(`A ${r} ${r} 0 0 ${cw ? 1 : 0} ${x} ${y}`);
                 }
-
-                path.push(`${lineCommand} ${x} ${y}`);
             }
 
-            // If the to waypoint ends in a discontinuity, we will not L to it for the next leg - do that now
-            if (leg && leg.to.endsInDiscontinuity) {
-                // draw line to end of leg
-                const [fromX, fromY] = mapParams.coordinatesToXYy(leg.to.infos.coordinates);
+            // Draw the orthodromic path of the TF leg
+
+            // If we have a transition *before*, we need to go to the inbound turning point of it, not to the TO fix
+            let fromLla;
+            if (transitionBefore) {
+                if (transitionBefore instanceof Type1Transition) {
+                    fromLla = transitionBefore.getTurningPoints()[1];
+                }
+            } else {
+                fromLla = leg.from.infos.coordinates;
+            }
+
+            const [fromX, fromY] = mapParams.coordinatesToXYy(fromLla);
+
+            x = MathUtils.fastToFixed(fromX, 1);
+            y = MathUtils.fastToFixed(fromY, 1);
+
+            path.push(`M ${x} ${y}`);
+
+            // If we have a transition *after*, we need to go to the inbound turning point of it, not to the TO fix
+            let toLla;
+            if (transition) {
+                if (transition instanceof Type1Transition) {
+                    toLla = transition.getTurningPoints()[0];
+                }
+            } else {
+                toLla = leg.to.infos.coordinates;
+            }
+
+            const [toX, toY] = mapParams.coordinatesToXYy(toLla);
+            x = MathUtils.fastToFixed(toX, 1);
+            y = MathUtils.fastToFixed(toY, 1);
+
+            path.push(`L ${x} ${y}`);
+        } else if (leg instanceof VMLeg) {
+            if (transitionBefore && transitionBefore instanceof Type1Transition) {
+                const fromLla = transitionBefore.getTurningPoints()[1];
+
+                const [fromX, fromY] = mapParams.coordinatesToXYy(fromLla);
+
                 x = MathUtils.fastToFixed(fromX, 1);
                 y = MathUtils.fastToFixed(fromY, 1);
+
+                path.push(`M ${x} ${y}`);
+
+                const farAway = mapParams.nmRadius + 2;
+                const farAwayPoint = Avionics.Utils.bearingDistanceToCoordinates(
+                    leg.bearing,
+                    farAway,
+                    fromLla.lat,
+                    fromLla.long,
+                );
+
+                const [toX, toY] = mapParams.coordinatesToXYy(farAwayPoint);
+
+                x = MathUtils.fastToFixed(toX, 1);
+                y = MathUtils.fastToFixed(toY, 1);
 
                 path.push(`L ${x} ${y}`);
             }
-
-            finalLeg = leg;
         }
-    }
-
-    // draw to final leg
-    if (finalLeg) {
-        const [fromX, fromY] = mapParams.coordinatesToXYy(finalLeg.to.infos.coordinates);
-        x = MathUtils.fastToFixed(fromX, 1);
-        y = MathUtils.fastToFixed(fromY, 1);
-        path.push(`${path.length ? 'L' : 'M'} ${x} ${y}`);
     }
 
     return path.join(' ');

--- a/src/instruments/src/ND/elements/FlightPlan.tsx
+++ b/src/instruments/src/ND/elements/FlightPlan.tsx
@@ -232,7 +232,7 @@ function makePathFromGeometry(geometry: Geometry, mapParams: MapParameters): str
                     y = MathUtils.fastToFixed(outY, 1);
                     const cw = transition.clockwise;
 
-                    path.push(`A ${r} ${r} 0 0 ${cw ? 1 : 0} ${x} ${y}`);
+                    path.push(`A ${r} ${r} 0 ${transition.angle >= 180 ? 1 : 0} ${cw ? 1 : 0} ${x} ${y}`);
                 }
             }
 

--- a/src/instruments/src/ND/elements/ToWaypointIndicator.tsx
+++ b/src/instruments/src/ND/elements/ToWaypointIndicator.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo } from 'react';
 import { Layer } from '@instruments/common/utils';
 import { WaypointStats } from '@fmgc/flightplanning/data/flightplan';
+import { GeoMath } from '@fmgc/flightplanning/GeoMath';
 
 export type ToWaypointIndicatorProps = {
     info?: WaypointStats,
@@ -36,12 +37,14 @@ export const ToWaypointIndicator: FC<ToWaypointIndicatorProps> = memo(({ info })
         timeText = '--:--';
     }
 
+    const heading = GeoMath.correctMagvar(info.bearingInFp, info.magneticVariation);
+
     return (
         <Layer x={690} y={28}>
             {/* EIS2 can only display 9 characters for this ident */}
             <text x={-9} y={0} fontSize={25} className="White" textAnchor="end">{info.ident.substring(0, 8)}</text>
 
-            <text x={54} y={0} fontSize={25} className="Green" textAnchor="end">{(Math.round(info.bearingInFp)).toString().padStart(3, '0')}</text>
+            <text x={54} y={0} fontSize={25} className="Green" textAnchor="end">{(Math.round(heading)).toString().padStart(3, '0')}</text>
             <text x={73} y={2} fontSize={25} className="Cyan" textAnchor="end">&deg;</text>
 
             {info.distanceFromPpos < 20 ? (

--- a/src/instruments/src/ND/elements/WindIndicator.tsx
+++ b/src/instruments/src/ND/elements/WindIndicator.tsx
@@ -16,7 +16,7 @@ export const WindIndicator: FC<AdirsTasDrivenIndicatorProps> = ({ adirsState, ta
         <Layer x={17} y={56}>
             <text x={25} y={0} fontSize={22} textAnchor="end" className="Green">
                 {windInfoShown ? (
-                    Math.round(windDirection).toString().padStart(3, '0')
+                    (Math.round(windDirection) % 360).toString().padStart(3, '0')
                 ) : (
                     '---'
                 )}

--- a/src/instruments/src/ND/index.tsx
+++ b/src/instruments/src/ND/index.tsx
@@ -29,6 +29,15 @@ export enum Mode {
 
 export type EfisSide = 'L' | 'R'
 
+export enum EfisOption {
+    None = 0,
+    Constraints = 1,
+    VorDmes = 2,
+    Waypoints = 3,
+    Ndbs = 4,
+    Airports = 5,
+}
+
 const NavigationDisplay: React.FC = () => {
     const [displayIndex] = useState(() => {
         const url = document.getElementsByTagName('a32nx-nd')[0].getAttribute('url');
@@ -37,6 +46,8 @@ const NavigationDisplay: React.FC = () => {
     });
 
     const side = displayIndex === 1 ? 'L' : 'R';
+
+    const [efisOption] = useSimVar(`L:A32NX_EFIS_${side}_OPTION`, 'enum', 500);
 
     const [lat] = useSimVar('PLANE LATITUDE', 'degree latitude');
     const [long] = useSimVar('PLANE LONGITUDE', 'degree longitude');
@@ -59,9 +70,9 @@ const NavigationDisplay: React.FC = () => {
                     <SpeedIndicator adirsState={adirsState} tas={tas} />
                     <WindIndicator adirsState={adirsState} tas={tas} />
 
-                    {modeIndex === Mode.PLAN && <PlanMode rangeSetting={rangeSettings[rangeIndex]} ppos={ppos} />}
-                    {modeIndex === Mode.ARC && <ArcMode rangeSetting={rangeSettings[rangeIndex]} side={side} ppos={ppos} />}
-                    {(modeIndex === Mode.ROSE_ILS || modeIndex === Mode.ROSE_VOR || modeIndex === Mode.ROSE_NAV) && <RoseMode rangeSetting={rangeSettings[rangeIndex]} side={side} ppos={ppos} mode={modeIndex} />}
+                    {modeIndex === Mode.PLAN && <PlanMode rangeSetting={rangeSettings[rangeIndex]} ppos={ppos} efisOption={efisOption} />}
+                    {modeIndex === Mode.ARC && <ArcMode rangeSetting={rangeSettings[rangeIndex]} side={side} ppos={ppos} efisOption={efisOption} />}
+                    {(modeIndex === Mode.ROSE_ILS || modeIndex === Mode.ROSE_VOR || modeIndex === Mode.ROSE_NAV) && <RoseMode rangeSetting={rangeSettings[rangeIndex]} side={side} ppos={ppos} mode={modeIndex} efisOption={efisOption} />}
 
                     <Chrono side={side} />
 

--- a/src/instruments/src/ND/pages/ArcMode.tsx
+++ b/src/instruments/src/ND/pages/ArcMode.tsx
@@ -455,7 +455,7 @@ const Overlay: React.FC<OverlayProps> = memo(({ heading, track, rangeSetting, si
 
             <TrackBug heading={heading} track={track} />
             { lsDisplayed && <IlsCourseBug heading={heading} ilsCourse={ilsCourse} /> }
-            <SelectedHeadingBug heading={heading} selected={selectedHeading} />
+            <SelectedHeadingBug heading={Math.round(heading)} selected={selectedHeading} />
         </g>
 
         <RadioNeedle index={1} side={side} displayMode={Mode.ARC} centreHeight={620} />

--- a/src/instruments/src/ND/pages/ArcMode.tsx
+++ b/src/instruments/src/ND/pages/ArcMode.tsx
@@ -8,16 +8,17 @@ import { FlightPlan } from '../elements/FlightPlan';
 import { MapParameters } from '../utils/MapParameters';
 import { RadioNeedle } from '../elements/RadioNeedles';
 import { ToWaypointIndicator } from '../elements/ToWaypointIndicator';
-import { EfisSide, Mode } from '../index';
+import { EfisSide, EfisOption, Mode } from '../index';
 import { ApproachMessage } from '../elements/ApproachMessage';
 
 export interface ArcModeProps {
     rangeSetting: number,
     side: EfisSide,
     ppos: LatLongData,
+    efisOption: EfisOption,
 }
 
-export const ArcMode: React.FC<ArcModeProps> = ({ rangeSetting, side, ppos }) => {
+export const ArcMode: React.FC<ArcModeProps> = ({ rangeSetting, side, ppos, efisOption }) => {
     const flightPlanManager = useFlightPlanManager();
 
     const [magHeading] = useSimVar('PLANE HEADING DEGREES MAGNETIC', 'degrees');
@@ -28,7 +29,6 @@ export const ArcMode: React.FC<ArcModeProps> = ({ rangeSetting, side, ppos }) =>
     const [selectedHeading] = useSimVar('L:A32NX_AUTOPILOT_HEADING_SELECTED', 'degrees');
     const [ilsCourse] = useSimVar('NAV LOCALIZER:3', 'degrees');
     const [lsDisplayed] = useSimVar(`L:BTN_LS_${side === 'L' ? 1 : 2}_FILTER_ACTIVE`, 'bool'); // TODO rename simvar
-    const [efisOption] = useSimVar(`L:A32NX_EFIS_${side}_OPTION`, 'enum', 500);
 
     const [mapParams] = useState(() => {
         const params = new MapParameters();
@@ -49,6 +49,7 @@ export const ArcMode: React.FC<ArcModeProps> = ({ rangeSetting, side, ppos }) =>
                 flightPlanManager={flightPlanManager}
                 mapParams={mapParams}
                 clipPath="url(#arc-mode-map-clip)"
+                constraints={efisOption === EfisOption.Constraints}
                 debug={false}
             />
 

--- a/src/instruments/src/ND/pages/ArcMode.tsx
+++ b/src/instruments/src/ND/pages/ArcMode.tsx
@@ -48,7 +48,7 @@ export const ArcMode: React.FC<ArcModeProps> = ({ rangeSetting, side, ppos }) =>
                 y={620}
                 flightPlanManager={flightPlanManager}
                 mapParams={mapParams}
-                clipPath="url(#arc-mode-flight-plan-clip)"
+                clipPath="url(#arc-mode-map-clip)"
                 debug={false}
             />
 
@@ -83,8 +83,8 @@ interface OverlayProps {
 
 const Overlay: React.FC<OverlayProps> = memo(({ heading, track, rangeSetting, side, tcasMode, selectedHeading, ilsCourse, lsDisplayed }) => (
     <>
-        <clipPath id="arc-mode-flight-plan-clip">
-            <circle cx={0} cy={0} r={490.5} />
+        <clipPath id="arc-mode-map-clip">
+            <path d="M-384,-308 a492,492 0 0 1 768,0 L384,-58 L264,-58 L207,5 L207,148 L-210,148 L-210,63 L-262,5 L-384,5 L-384,-308" />
         </clipPath>
         <clipPath id="arc-mode-overlay-clip-4">
             <path d="m 6 0 h 756 v 768 h -756 z" />

--- a/src/instruments/src/ND/pages/PlanMode.tsx
+++ b/src/instruments/src/ND/pages/PlanMode.tsx
@@ -6,13 +6,15 @@ import { useSimVar } from '@instruments/common/simVars';
 import { ToWaypointIndicator } from '../elements/ToWaypointIndicator';
 import { FlightPlan } from '../elements/FlightPlan';
 import { MapParameters } from '../utils/MapParameters';
+import { EfisOption } from '../index';
 
 export interface PlanModeProps {
     rangeSetting: number,
     ppos: LatLongData,
+    efisOption: EfisOption,
 }
 
-export const PlanMode: FC<PlanModeProps> = ({ rangeSetting, ppos }) => {
+export const PlanMode: FC<PlanModeProps> = ({ rangeSetting, ppos, efisOption }) => {
     const flightPlanManager = useFlightPlanManager();
 
     const [selectedWaypointIndex] = useSimVar('L:A32NX_SELECTED_WAYPOINT', 'number', 50);
@@ -43,6 +45,7 @@ export const PlanMode: FC<PlanModeProps> = ({ rangeSetting, ppos }) => {
                 flightPlanManager={flightPlanManager}
                 mapParams={mapParams}
                 clipPath="url(#plan-mode-map-clip)"
+                constraints={efisOption === EfisOption.Constraints}
                 debug={false}
             />
 

--- a/src/instruments/src/ND/pages/PlanMode.tsx
+++ b/src/instruments/src/ND/pages/PlanMode.tsx
@@ -42,7 +42,7 @@ export const PlanMode: FC<PlanModeProps> = ({ rangeSetting, ppos }) => {
                 y={384}
                 flightPlanManager={flightPlanManager}
                 mapParams={mapParams}
-                clipPath="url(#plan-mode-flight-plan-clip)"
+                clipPath="url(#plan-mode-map-clip)"
                 debug={false}
             />
 
@@ -59,8 +59,8 @@ interface OverlayProps {
 
 const Overlay: FC<OverlayProps> = ({ rangeSetting }) => (
     <>
-        <clipPath id="plan-mode-flight-plan-clip">
-            <circle cx={0} cy={0} r={248.5} />
+        <clipPath id="plan-mode-map-clip">
+            <polygon points="-339,-272 -244,-272 -104,-328 104,-328 244,-272 339,-272 339,336 -270,336 -270,249 -339,249" />
         </clipPath>
         <g className="White" strokeWidth={3}>
             <circle cx={384} cy={384} r={250} />

--- a/src/instruments/src/ND/pages/RoseMode.tsx
+++ b/src/instruments/src/ND/pages/RoseMode.tsx
@@ -8,7 +8,7 @@ import { TuningMode } from '@fmgc/radionav';
 import { ToWaypointIndicator } from '../elements/ToWaypointIndicator';
 import { FlightPlan } from '../elements/FlightPlan';
 import { MapParameters } from '../utils/MapParameters';
-import { EfisSide, Mode } from '../index';
+import { EfisOption, EfisSide, Mode } from '../index';
 import { RadioNeedle } from '../elements/RadioNeedles';
 import { ApproachMessage } from '../elements/ApproachMessage';
 
@@ -17,9 +17,10 @@ export interface RoseModeProps {
     mode: Mode.ROSE_ILS | Mode.ROSE_VOR | Mode.ROSE_NAV,
     side: EfisSide,
     ppos: LatLongData,
+    efisOption: EfisOption,
 }
 
-export const RoseMode: FC<RoseModeProps> = ({ rangeSetting, mode, side, ppos }) => {
+export const RoseMode: FC<RoseModeProps> = ({ rangeSetting, mode, side, ppos, efisOption }) => {
     const flightPlanManager = useFlightPlanManager();
 
     const [magHeading] = useSimVar('PLANE HEADING DEGREES MAGNETIC', 'degrees');
@@ -30,7 +31,6 @@ export const RoseMode: FC<RoseModeProps> = ({ rangeSetting, mode, side, ppos }) 
     const [selectedHeading] = useSimVar('L:A32NX_AUTOPILOT_HEADING_SELECTED', 'degrees');
     const [ilsCourse] = useSimVar('NAV LOCALIZER:3', 'degrees');
     const [lsDisplayed] = useSimVar(`L:BTN_LS_${side === 'L' ? 1 : 2}_FILTER_ACTIVE`, 'bool'); // TODO rename simvar
-    const [efisOption] = useSimVar(`L:A32NX_EFIS_${side}_OPTION`, 'enum', 500);
 
     const [mapParams] = useState(() => {
         const params = new MapParameters();
@@ -51,6 +51,7 @@ export const RoseMode: FC<RoseModeProps> = ({ rangeSetting, mode, side, ppos }) 
                 flightPlanManager={flightPlanManager}
                 mapParams={mapParams}
                 clipPath="url(#rose-mode-map-clip)"
+                constraints={efisOption === EfisOption.Constraints}
                 debug={false}
             />)}
 

--- a/src/instruments/src/ND/pages/RoseMode.tsx
+++ b/src/instruments/src/ND/pages/RoseMode.tsx
@@ -50,7 +50,7 @@ export const RoseMode: FC<RoseModeProps> = ({ rangeSetting, mode, side, ppos }) 
                 y={384}
                 flightPlanManager={flightPlanManager}
                 mapParams={mapParams}
-                clipPath="url(#rose-mode-flight-plan-clip)"
+                clipPath="url(#rose-mode-map-clip)"
                 debug={false}
             />)}
 
@@ -93,8 +93,8 @@ interface OverlayProps {
 
 const Overlay: FC<OverlayProps> = ({ heading, track, rangeSetting, side, tcasMode, displayMode, selectedHeading, ilsCourse, lsDisplayed }) => (
     <>
-        <clipPath id="rose-mode-flight-plan-clip">
-            <circle cx={0} cy={0} r={248.5} />
+        <clipPath id="rose-mode-map-clip">
+            <path d="M-339,-229 L-102,-229 a250,250 0 0 1 204,0 L339,-229 L339,178 L264,178 L207,241 L207,384 L-210,384 L-210,299 L-262,241 L-339,241 L-339,-229" />
         </clipPath>
 
         {/* C = 384,384 */}

--- a/src/instruments/src/ND/pages/RoseMode.tsx
+++ b/src/instruments/src/ND/pages/RoseMode.tsx
@@ -468,7 +468,7 @@ const Overlay: FC<OverlayProps> = ({ heading, track, rangeSetting, side, tcasMod
 
             <TrackBug heading={heading} track={track} />
             { displayMode === Mode.ROSE_NAV && lsDisplayed && <IlsCourseBug heading={heading} ilsCourse={ilsCourse} /> }
-            <SelectedHeadingBug heading={heading} selected={selectedHeading} />
+            <SelectedHeadingBug heading={Math.round(heading)} selected={selectedHeading} />
         </g>
 
         <RadioNeedle index={1} side={side} displayMode={displayMode} centreHeight={384} />

--- a/src/instruments/src/ND/utils/MapParameters.ts
+++ b/src/instruments/src/ND/utils/MapParameters.ts
@@ -1,8 +1,14 @@
 import { Coordinates, Xy } from '@fmgc/flightplanning/data/geo';
+
 export class MapParameters {
     public centerCoordinates: Coordinates;
+
     public mapUpTrueDeg: number;
+
     public nmToPx: number;
+
+    public nmRadius: number;
+
     public version = 0;
 
     compute(centerCoordinates: Coordinates, nmRadius: number, pxRadius: number, mapUpTrueDeg: number): void {
@@ -11,6 +17,7 @@ export class MapParameters {
         this.mapUpTrueDeg = mapUpTrueDeg;
         this.centerCoordinates = centerCoordinates;
         this.nmToPx = pxRadius / nmRadius;
+        this.nmRadius = nmRadius;
     }
 
     coordinatesToXYy(coordinates: Coordinates): Xy {

--- a/src/instruments/tsconfig.json
+++ b/src/instruments/tsconfig.json
@@ -6,6 +6,7 @@
     "jsx": "react",
     "moduleResolution": "node",
     "skipLibCheck": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "downlevelIteration": true,
   }
 }

--- a/src/shared/src/MathUtils.ts
+++ b/src/shared/src/MathUtils.ts
@@ -29,4 +29,8 @@ export class MathUtils {
        }
        return diff;
    }
+
+   public static mod(x: number, n: number): number {
+       return x - Math.floor(x / n) * n;
+   }
 }

--- a/typings/fs-base-ui/html_ui/JS/simvar.d.ts
+++ b/typings/fs-base-ui/html_ui/JS/simvar.d.ts
@@ -4,7 +4,7 @@
 
 type NumberVarUnit = ("number" | "Number") | "position 32k" | ("SINT32") | ("bool" | "Bool" | "Boolean" | "boolean") | "Enum" | "lbs" | "kg" | ("Degrees" | "degree" | "Radians")
     | "radians" | ("Percent" | "percent") | ("Feet" | "feet" | "feets" | "Feets") | "Volts" | "Amperes" | "Hertz" | "PSI" | "celsius" | "degree latitude"
-    | "degree longitude" | "Meters per second" | "Position" | ("Knots" | "knots") | "Seconds" | "seconds" | "kilograms per second" | "nautical miles" | "degrees"
+    | "degree longitude" | "meters per second" | "Meters per second" | "Position" | ("Knots" | "knots") | "Seconds" | "seconds" | "kilograms per second" | "nautical miles" | "degrees"
 
 type TextVarUnit = "Text" | "string"
 


### PR DESCRIPTION
## Summary of Changes

This is an initial refactoring of leg building and flight path rendering.

* Legs are now declared in `guidance/lnav/legs`.
* Multiple leg geometry now generates transitions (still hard-coded to Type I) for all legs in the flight plan.
* This allows us to use a simple reverse-iteration instead of having different / repeated logic for different legs or transitions.
* Leg and transition indices in Geometry are now different. Transition at index n is now the transition after leg at index n.
* The flight plan rendering code has been cleaned up to match the reverse iteration for geometry generation, and not contain special edge cases for first / second leg / transition.

Additionally, the following changes have been introduced to help the refactor:

* VM legs are now generated from waypoints for which `isVectors = true`.
  * [x] Rendering
  * [x] Giodamce

* [x] Use correct heading for VM legs
* [x] Fix rendering of active VM legs 

In the future, the plans are to introduce lower-level path primitives to use for both guidance and drawing. This will introduce proper vectorization.

Discord username (if different from GitHub): someperson#4953

## Testing Instructions

* Load in a SID containing a MANUAL leg (for example, CYYZ06R AVSEP6)
* Make sure NAV mode keeps infinite line heading without sequencing leg until DIR TO
* Perform DIR TO to downstream waypoint
* Observe correct sequencing

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
