### PR TITLE
ci: auto-merge bot config

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,58 @@
+# Configuration for probot-auto-merge - https://github.com/bobvanderlinden/probot-auto-merge
+
+# The minimum number of reviews from each association that approve the pull request before
+# doing an automatic merge. For more information about associations see:
+# https://developer.github.com/v4/enum/commentauthorassociation/
+minApprovals:
+  MEMBER: 1
+
+# Whether an out-of-date pull request is automatically updated.
+# It does so by merging its base on top of the head of the pull request.
+# This is the equivalent of clicking the 'Update branch' button.
+# This is useful for repositories where protected branches are used and the option
+# 'Require branches to be up to date before merging' is enabled.
+# Note: this only works when the branch of the pull request resides in the same repository as
+#       the pull request itself.
+updateBranch: true
+
+# Whether the pull request branch is automatically deleted.
+# This is the equivalent of clicking the 'Delete branch' button shown on merged pull requests.
+# Note: this only works when the branch of the pull request resides in the same repository as
+#       the pull request itself.
+deleteBranchAfterMerge: true
+
+# In what way a pull request needs to be merged. This can be:
+# * merge: creates a merge commit, combining the commits from the pull request on top of
+#   the base of the pull request (default)
+# * rebase: places the commits from the pull request individually on top of the base of the pull request
+# * squash: combines all changes from the pull request into a single commit and places the commit on top
+#   of the base of the pull request
+# For more information see https://help.github.com/articles/about-pull-request-merges/
+mergeMethod: squash
+
+# Optionally specify the merge commit message format. The following template
+# tags are supported:
+# * {title}: The pull request title at the moment it is merged
+# * {body}: The pull request body at the moment it is merged
+# * {number}: The pull request number
+# * {branch}: The name of the source branch
+# * {commits}: A list of merged commits
+# When this option is not set, the merge commit message is controlled by
+# GitHub and uses a combination of the title of the pull request when it was
+# opened (note that later changes to the title are ignored) and a list of
+# commits.
+# This settings is ignored when `mergeMethod` is set to `rebase`.
+mergeCommitMessage: |
+  {title} (#{number})
+
+  {commits}
+
+# Whenever required base branches are configured, pull requests will only be automatically merged whenever
+# their base branch (into which the PR would be merged) is matching any regular expression listed.
+requiredBaseBranches:
+- master
+
+# Whenever required labels are configured, pull requests will only be automatically merged whenever
+# all of these labels are attached to a pull request.
+requiredLabels:
+- Auto Merge


### PR DESCRIPTION
## Summary of Changes

Configures the auto-merge bot.

This will automatically merge PRs when they have at least one approval and the "Auto Merge" label.

This should only be used when one does not want to wait for a CI build to finish.

Discord username (if different from GitHub): someperson#4953

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
