### PR TITLE
feat(displays): Add pixelated screens

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -143,6 +143,7 @@
 1. [SOUND] Improved engine startup, idle sounds, and cabin wind - @hotshotp (Boris)
 1. [MODEL] Swap EFIS WPT and VOR D buttons - @tracernz (Mike)
 1. [MODEL] Fix no-smoking/no-PED switch animation - @tracernz (Mike)
+1. [DISPLAYS] Add pixelated screens - @bouveng (Johan Bouveng)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -198,18 +198,6 @@
             </UseTemplate>
         </Component>
 
-        <!-- G1000 ###################################### -->
-
-        <Component ID="Screen_emissive" Node="DYN_SCREEN">
-            <Material>
-                <EmissiveFactor>
-                    <Parameter>
-                        <Code>0.5</Code>
-                    </Parameter>
-                </EmissiveFactor>
-            </Material>
-        </Component>
-
         <Component ID="Pedestal_Fwd">
             <UseTemplate Name="FBW_ENGINE_Lever_Throttle_Template">
                 <NODE_ID>LEVER_THROTTLE_1</NODE_ID>
@@ -513,6 +501,15 @@
                     <POTENTIOMETER>88</POTENTIOMETER>
                 </UseTemplate>
 
+                <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
+                    <NODE_ID>SCREEN_PFD_L</NODE_ID>
+                    <POTENTIOMETER>88</POTENTIOMETER>
+                    <PART_ID>SCREEN_PFD1</PART_ID>
+                    <CAMERA_TITLE>PFD</CAMERA_TITLE>
+                    <!-- Pixelated screens needs more light -->
+                    <EMISSIVE_CODE>2</EMISSIVE_CODE>
+                </UseTemplate>
+
                 <UseTemplate Name="FBW_Airbus_Push_EFIS_GPWS">
                     <NODE_ID>PUSH_EFIS_CS_GPWS</NODE_ID>
                     <ANIM_NAME>PUSH_EFIS_CS_GPWS</ANIM_NAME>
@@ -587,13 +584,6 @@
                     <NODE_ID>PRINT_TORN</NODE_ID>
                 </UseTemplate>
 
-                <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
-                    <NODE_ID>SCREEN_PFD_L</NODE_ID>
-                    <POTENTIOMETER>88</POTENTIOMETER>
-                    <PART_ID>SCREEN_PFD1</PART_ID>
-                    <CAMERA_TITLE>PFD</CAMERA_TITLE>
-                </UseTemplate>
-
                 <!-- CPT ND SCREEN -->
                 <UseTemplate Name="FBW_Stepless_Potentiometer">
                     <NODE_ID>KNOB_EFIS_CS_ND_SMALL</NODE_ID>
@@ -617,14 +607,17 @@
                     <POTENTIOMETER>89</POTENTIOMETER>
                     <PART_ID>SCREEN_MFD1</PART_ID>
                     <CAMERA_TITLE>MFD</CAMERA_TITLE>
+                    <!-- Pixelated screens needs more light -->
+                    <EMISSIVE_CODE>2</EMISSIVE_CODE>
                 </UseTemplate>
 
                 <!-- DCDU -->
                 <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
                     <NODE_ID>SCREEN_COM_L</NODE_ID>
+                    <!-- Pixelated screens needs more light -->
                     <EMISSIVE_CODE>
                         (L:A32NX_ELEC_DC_1_BUS_IS_POWERED, Bool) if{
-                            (L:#PLANE_NAME#_PANEL_DCDU_L_BRIGHTNESS, percent over 100)
+                            2 (L:#PLANE_NAME#_PANEL_DCDU_L_BRIGHTNESS, percent over 100) *
                         } els{
                             0
                         }
@@ -639,7 +632,7 @@
                     <PLANE_NAME>A32NX</PLANE_NAME>
                 </DefaultTemplateParameters>
 
-                <!-- F/O PDF SCREEN -->
+                <!-- F/O PFD SCREEN -->
                 <UseTemplate Name="FBW_Stepless_Potentiometer">
                     <NODE_ID>KNOB_EFIS_FO_PFD</NODE_ID>
                     <PART_ID>PFD_Brightness_FO</PART_ID>
@@ -658,6 +651,8 @@
                     <NODE_ID>SCREEN_PFD_R</NODE_ID>
                     <POTENTIOMETER>90</POTENTIOMETER>
                     <PART_ID>SCREEN_PFD2</PART_ID>
+                    <!-- Pixelated screens needs more light -->
+                    <EMISSIVE_CODE>2</EMISSIVE_CODE>
                 </UseTemplate>
 
                 <!-- F/O ND SCREEN -->
@@ -669,6 +664,14 @@
                     <POTENTIOMETER>91</POTENTIOMETER>
                 </UseTemplate>
 
+                <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
+                    <NODE_ID>SCREEN_MFD_R</NODE_ID>
+                    <POTENTIOMETER>91</POTENTIOMETER>
+                    <PART_ID>SCREEN_MFD2</PART_ID>
+                    <!-- Pixelated screens needs more light -->
+                    <EMISSIVE_CODE>2</EMISSIVE_CODE>
+                </UseTemplate>
+
                 <!-- F/O WX SCREEN -->
                 <UseTemplate Name="FBW_Stepless_Potentiometer">
                     <NODE_ID>KNOB_EFIS_FO_ND</NODE_ID>
@@ -678,18 +681,13 @@
                     <POTENTIOMETER>95</POTENTIOMETER>
                 </UseTemplate>
 
-                <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
-                    <NODE_ID>SCREEN_MFD_R</NODE_ID>
-                    <POTENTIOMETER>91</POTENTIOMETER>
-                    <PART_ID>SCREEN_MFD2</PART_ID>
-                </UseTemplate>
-
                 <!-- DCDU -->
                 <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
                     <NODE_ID>SCREEN_COM_R</NODE_ID>
+                    <!-- Pixelated screens needs more light -->
                     <EMISSIVE_CODE>
                         (L:A32NX_ELEC_DC_2_BUS_IS_POWERED, Bool) if{
-                            (L:#PLANE_NAME#_PANEL_DCDU_R_BRIGHTNESS, percent over 100)
+                            2 (L:#PLANE_NAME#_PANEL_DCDU_R_BRIGHTNESS, percent over 100) *
                         } els{
                             0
                         }
@@ -792,12 +790,13 @@
             </UseTemplate>
 
             <Component ID="Standby_Indicator">
-                <!-- TODO: Model change required to not affect brake/clock - Uncomment when this is done -->
-                <!--
+                <!-- TODO: SAI/ISIS/CLOCK/BAT/ATC/RUD TRIM is sharing the same emissive/mesh. Model change needed to split these. So we control the individual emissives with css opacity. -->
+                <!-- SAI/ISIS & CLOCK SCREENS -->
                 <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
                     <NODE_ID>DYN_SCREEN</NODE_ID>
-                    <EMISSIVE_CODE>(L:A32NX_BARO_BRIGHTNESS, Percent over 100)</EMISSIVE_CODE>
-                </UseTemplate> -->
+                    <!-- Pixelated screens needs more light -->
+                    <EMISSIVE_CODE>2</EMISSIVE_CODE>
+                </UseTemplate>
 
                 <UseTemplate Name="ASOBO_AUTOPILOT_Knob_Baro_Template">
                     <ANIM_NAME>AUTOPILOT_Knob_Baro</ANIM_NAME>
@@ -882,6 +881,8 @@
                     <POTENTIOMETER>92</POTENTIOMETER>
                     <PART_ID>SCREEN_EICAS1</PART_ID>
                     <CAMERA_TITLE>ECAM</CAMERA_TITLE>
+                    <!-- Pixelated screens needs more light -->
+                    <EMISSIVE_CODE>2</EMISSIVE_CODE>
                 </UseTemplate>
 
                 <!-- LOWER ECAM SCREEN -->
@@ -897,6 +898,8 @@
                     <POTENTIOMETER>93</POTENTIOMETER>
                     <PART_ID>SCREEN_EICAS2</PART_ID>
                     <CAMERA_TITLE>ECAM</CAMERA_TITLE>
+                    <!-- Pixelated screens needs more light -->
+                    <EMISSIVE_CODE>2</EMISSIVE_CODE>
                 </UseTemplate>
             </Component>
 

--- a/flybywire-aircraft-a320-neo/html_ui/CSS/A32NX_Display_Common.css
+++ b/flybywire-aircraft-a320-neo/html_ui/CSS/A32NX_Display_Common.css
@@ -46,6 +46,28 @@ text {
   fill: none;
 }
 
+/* LCD pixel effect for screens */
+#panel:after {
+  content: '';
+  width: 100%;
+  height: 100%;
+  z-index: 999;
+  position: absolute;
+  /* custom svg */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M0 0 V10 Z H10 Z' stroke='%23000' stroke-width='3' fill='none'/%3E%3C/svg%3E");
+  background-size: 2px;
+  opacity: 0.75;
+  /* subtle tint and edge bleed */
+  background-color:rgba(0, 0, 255, 0.025);
+  box-shadow: inset 0px 0px 30px 10px rgba(0, 75, 255, 0.04);
+  border-radius: 30px;
+  /*
+    TODO: This rule collectively affects CPT/FO ND, MCDU and ECAM screens
+    These screens should use the pixels.scss impl. some day, ideally.
+    Original impl. in /src/instruments/src/Common/pixels.scss
+  */
+}
+
 /* change from PageTitle */
 .PageTitle {
   fill: var(--displayWhite);

--- a/flybywire-aircraft-a320-neo/html_ui/CSS/A32NX_Display_Common.css
+++ b/flybywire-aircraft-a320-neo/html_ui/CSS/A32NX_Display_Common.css
@@ -58,7 +58,7 @@ text {
   background-size: 2px;
   opacity: 0.75;
   /* subtle tint and edge bleed */
-  background-color:rgba(0, 0, 255, 0.025);
+  background-color: rgba(0, 0, 255, 0.025);
   box-shadow: inset 0px 0px 30px 10px rgba(0, 75, 255, 0.04);
   border-radius: 30px;
   /*

--- a/src/behavior/src/A32NX_Interior_MCDU.xml
+++ b/src/behavior/src/A32NX_Interior_MCDU.xml
@@ -444,10 +444,11 @@
         <Component ID="#NODE_ID_SCREEN#" Node="#NODE_ID_SCREEN#">
             <UseTemplate Name="ASOBO_GT_Emissive_Gauge">
                 <DONT_OVERRIDE_BASE_EMISSIVE>False</DONT_OVERRIDE_BASE_EMISSIVE>
+                <!-- Pixelated screens needs more light -->
                 <EMISSIVE_CODE>
                     #DISPLAY_POWERED# sp0
                     l0 if{
-                        (L:A32NX_MCDU_#SIDE#_BRIGHTNESS, number)
+                        2 (L:A32NX_MCDU_#SIDE#_BRIGHTNESS, number) *
                     } els{
                         0
                     }

--- a/src/instruments/src/ATC/style.scss
+++ b/src/instruments/src/ATC/style.scss
@@ -12,6 +12,8 @@ $colour-main: hsl(31, 69%, 35%);
   height: 100%;
   width: 100%;
   left: 0;
+  /* TODO: Remove opacity when SAI/ISIS/CLOCK/BAT/ATC/RMP/RUD TRIM is split and not share the same emissive/mesh */
+  opacity: 0.5;
 }
 
 text {

--- a/src/instruments/src/BAT/style.scss
+++ b/src/instruments/src/BAT/style.scss
@@ -10,6 +10,8 @@
   height: 100%;
   width: 100%;
   left: 0;
+  /* TODO: Remove opacity when SAI/ISIS/CLOCK/BAT/ATC/RMP/RUD TRIM is split and not share the same emissive/mesh */
+  opacity: 0.5;
 }
 
 text {

--- a/src/instruments/src/Clock/style.scss
+++ b/src/instruments/src/Clock/style.scss
@@ -20,6 +20,8 @@ svg {
   width: 256px;
   height: 256px;
   background: rgba(5, 40, 80, 0.01);
+  /* TODO: Remove opacity when SAI/ISIS/CLOCK/BAT/ATC/RMP/RUD TRIM is split and not share the same emissive/mesh */
+  opacity: 0.5;
 }
 
 text {

--- a/src/instruments/src/Common/pixels.scss
+++ b/src/instruments/src/Common/pixels.scss
@@ -1,0 +1,24 @@
+/* LCD pixel effect for screens */
+@mixin pixels($density: 2, $spacing: 3, $bleed: true, $checkered: false) {
+  content: '';
+  width: 100%;
+  height: 100%;
+  z-index: 999;
+  position: absolute;
+  background-size: $density * 1px;
+  opacity: 0.75;
+
+  @if $checkered {
+    background-image: url("data:image/svg+xml,%3Csvg width='2' height='2' xmlns='http://www.w3.org/2000/svg'%3E%3Crect height='1' width='1' y='0' x='0' /%3E%3Crect height='1' width='1' y='1' x='1' /%3E%3C/svg%3E");
+    background-position: 1px 0;
+    background-color: rgba(80, 80, 80, 0.2);
+  } @else {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M0 0 V10 Z H10 Z' stroke='%23000' stroke-width='#{$spacing}' fill='none'/%3E%3C/svg%3E");
+    @if $bleed {
+      /* subtle tint, bleed and edge bleed */
+      background-color:rgba(0, 0, 255, 0.025);
+      box-shadow: inset 0px 0px 30px 10px rgba(0, 75, 255, 0.04);
+    }
+  }
+
+}

--- a/src/instruments/src/Common/pixels.scss
+++ b/src/instruments/src/Common/pixels.scss
@@ -16,7 +16,7 @@
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M0 0 V10 Z H10 Z' stroke='%23000' stroke-width='#{$spacing}' fill='none'/%3E%3C/svg%3E");
     @if $bleed {
       /* subtle tint, bleed and edge bleed */
-      background-color:rgba(0, 0, 255, 0.025);
+      background-color: rgba(0, 0, 255, 0.025);
       box-shadow: inset 0px 0px 30px 10px rgba(0, 75, 255, 0.04);
     }
   }

--- a/src/instruments/src/DCDU/style.scss
+++ b/src/instruments/src/DCDU/style.scss
@@ -12,6 +12,12 @@
   font-style: normal;
 }
 
+/* pixels for screen */
+@import "../Common/pixels";
+#panel:after {
+  @include pixels($checkered: true);
+}
+
 .dcdu-lines {
   position: absolute;
   left: 10px !important;

--- a/src/instruments/src/PFD/style.scss
+++ b/src/instruments/src/PFD/style.scss
@@ -1,6 +1,12 @@
 @import "../Common/definitions";
 @import "animations";
 
+/* pixels for screen */
+@import "../Common/pixels";
+#panel:after {
+  @include pixels;
+}
+
 @font-face {
   font-family: "Ecam";
   //noinspection CssUnknownTarget
@@ -13,9 +19,7 @@
   position: absolute;
   width: 1280px;
   height: 1280px;
-
   background: $display-background;
-
   font-family: "Ecam", monospace !important;
 }
 

--- a/src/instruments/src/RMP/style.scss
+++ b/src/instruments/src/RMP/style.scss
@@ -27,6 +27,8 @@ $colour-main: hsl(31, 69%, 35%);
 
 .rmp-svg {
   background-color: hsl(31, 69%, 6%);
+  /* TODO: Remove opacity when SAI/ISIS/CLOCK/BAT/ATC/RMP/RUD TRIM is split and not share the same emissive/mesh */
+  opacity: 0.5;
 }
 
 text {

--- a/src/instruments/src/RTPI/style.scss
+++ b/src/instruments/src/RTPI/style.scss
@@ -12,6 +12,8 @@ $colour-main: hsl(32, 100%, 69%);
   position: absolute;
   width: 105%;
   height: 100%;
+  /* TODO: Remove opacity when SAI/ISIS/CLOCK/BAT/ATC/RMP/RUD TRIM is split and not share the same emissive/mesh */
+  opacity: 0.5;
 }
 
 text {


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/433429/126842655-9a42c7db-a73f-4319-9877-aac9961e6d0f.jpg" width="50%"/><img src="https://user-images.githubusercontent.com/433429/126843027-c773c057-3821-4c92-8a09-f2861e1583a9.jpg" width="50%"/><p align="right" style="font-size:10px;"><i>Screens with different pixel density. DCDU checkered pixel pattern.<br/>(watch images at 100% to see effect properly)</i></p>

## Summary of Changes
:closed_book::green_book::blue_book:

This PR adds **pixels** to the following screens:

- `PFD` - pixels, tint and subtle backlight bleed
- `ND` - pixels, tint and subtle backlight bleed
- `EICAS 1 + 2` - pixels, tint and subtle backlight bleed
- `DCDU 1 + 2` - pixels (checkered), tint
- `SAI/ISIS` - pixels, tint
- `FCU/MCDU` - pixels, tint

Large screens have a subtle blue tint and a small backlight bleed that can be seen in the dark in a favorable setting (dark and high intensity setting).
DCDU screens have a light white tint and a checkered large pixel pattern.

## Screenshots
<img src="https://user-images.githubusercontent.com/433429/126843304-fa557adc-428f-4c21-a406-8d5889f827d2.jpg" width="50%" /><img src="https://user-images.githubusercontent.com/433429/126842926-780e78b2-34f0-4eec-9aeb-044d44a47343.jpg" width="50%" />
<img src="https://user-images.githubusercontent.com/433429/126844721-ed2a469a-a012-4a8b-a737-8c5439eeee19.jpg" width="50%" /><img src="https://user-images.githubusercontent.com/433429/126844745-d1ec051f-7538-46b6-a89a-d38d63b70bbd.jpg" width="50%" />
<p align="right"><i>MCDU, SAI/ISIS, letters and WX.<br/>(watch images at 100% to see effect properly)</i></p>

![Microsoft Flight Simulator 2021-07-23 23_35_53](https://user-images.githubusercontent.com/433429/126843985-db6e6ed1-c33d-446d-a821-88decaccbd3b.png)
<p align="right"><i>Subtle small backlight bleed can be seen on the large screens in favorable settings (dark and high intensity setting)<br/>(watch image at 100% to see effect properly)</i></p>

![Microsoft Flight Simulator 2021-07-24 00_00_30](https://user-images.githubusercontent.com/433429/126845616-53f0c35d-be46-4904-86e5-0cbb79ea2b05.jpg)
<p align="right"><i>Dust and scratches are still visible.<br/>(watch image at 100% to see effect properly)</i></p>

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
<img src="https://user-images.githubusercontent.com/433429/126845161-9b6ee999-3b0f-4d52-8481-bf6e746425dd.png" width="50%" /><img src="https://user-images.githubusercontent.com/433429/126845247-f2ff7a55-6914-4e4b-a7ba-0eba7a337e08.png" width="50%" /><img src="https://user-images.githubusercontent.com/433429/126845189-364d7fe6-5b7e-4257-b18e-1fcbac58fa44.jpg" width="50%" /><img src="https://user-images.githubusercontent.com/433429/126845274-a1b2d8b3-b6ac-44e9-bcb2-2f3ec10a56f5.jpg" width="50%" />
<p align="right"><i>Note the DCDU's checkered pixel pattern</i></p>

## Known behaviors
At some zoom levels and angles, a very minor unavoidable [moiré effect](https://en.wikipedia.org/wiki/Moir%C3%A9_pattern) can be observed.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username: @bouveng

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1, Spawn on runway
2, Observe screens at different zoom levels and under various lighting conditions.<br/>(_you need to be somewhat close to see the pixels at all_)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
