### PR TITLE
fix: unit for vertical speed

### DIFF
--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -12,7 +12,7 @@ use uom::si::{
     f64::*,
     length::foot,
     thermodynamic_temperature::degree_celsius,
-    velocity::{foot_per_minute, knot, foot_per_second},
+    velocity::{foot_per_minute, foot_per_second, knot},
 };
 
 pub struct AirDataInertialReferenceSystemOverheadPanel {
@@ -1058,7 +1058,7 @@ mod tests {
         fn vertical_speed_of(mut self, velocity: Velocity) -> Self {
             self.write(
                 AdirsSimulatorData::VERTICAL_SPEED,
-                velocity.get::<foot_per_minute>(),
+                velocity.get::<foot_per_second>(),
             );
             self
         }

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -12,7 +12,7 @@ use uom::si::{
     f64::*,
     length::foot,
     thermodynamic_temperature::degree_celsius,
-    velocity::{foot_per_minute, knot},
+    velocity::{foot_per_minute, knot, foot_per_second},
 };
 
 pub struct AirDataInertialReferenceSystemOverheadPanel {
@@ -215,7 +215,7 @@ impl SimulationElement for AdirsSimulatorData {
         // To reduce reads, we only read these values once and then share it with the underlying ADRs and IRs.
         self.mach = reader.read(Self::MACH);
         let vertical_speed: f64 = reader.read(Self::VERTICAL_SPEED);
-        self.vertical_speed = Velocity::new::<foot_per_minute>(vertical_speed);
+        self.vertical_speed = Velocity::new::<foot_per_second>(vertical_speed);
         self.true_airspeed = reader.read(Self::TRUE_AIRSPEED);
         self.latitude = reader.read(Self::LATITUDE);
         self.longitude = reader.read(Self::LONGITUDE);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #5395

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The sim provides the variable `VELOCITY WORLD Y` in` feet per second`, whereas `feet per minute` was assumed. This causes e.g. the PFD VS indication to show wrong values. 
I replaced `foot per minute` with `foot per second` to mitigate this. 
Feel free to close this PR if the solution is not satisfying.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/19493808/126885279-8a5b95f0-1549-424f-bf30-16a1f5e99930.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
