### PR TITLE
fix: vertical speed indication seems locked at 0 feet per minute

### DIFF
--- a/src/systems/a320_systems_wasm/src/lib.rs
+++ b/src/systems/a320_systems_wasm/src/lib.rs
@@ -71,7 +71,6 @@ fn create_aircraft_variable_reader(
     reader.add("INDICATED ALTITUDE", "Feet", 0)?;
     reader.add("AMBIENT PRESSURE", "inHg", 0)?;
     reader.add("SEA LEVEL PRESSURE", "Millibars", 0)?;
-    reader.add("VELOCITY WORLD Y", "Feet per Second", 0)?;
     reader.add("SIM ON GROUND", "Bool", 0)?;
     reader.add("GENERAL ENG STARTER ACTIVE", "Bool", 1)?;
     reader.add("GENERAL ENG STARTER ACTIVE", "Bool", 2)?;

--- a/src/systems/systems/src/simulation/test.rs
+++ b/src/systems/systems/src/simulation/test.rs
@@ -6,7 +6,7 @@ use uom::si::{
     length::foot,
     pressure::inch_of_mercury,
     thermodynamic_temperature::degree_celsius,
-    velocity::{foot_per_minute, foot_per_second, knot},
+    velocity::{foot_per_minute, knot},
 };
 
 use crate::electrical::{Electricity, Potential};
@@ -234,7 +234,7 @@ impl<T: Aircraft> SimulationTestBed<T> {
     fn set_vertical_speed(&mut self, vertical_speed: Velocity) {
         self.write(
             UpdateContext::VERTICAL_SPEED_KEY,
-            vertical_speed.get::<foot_per_second>(),
+            vertical_speed.get::<foot_per_minute>(),
         );
     }
 

--- a/src/systems/systems/src/simulation/update_context.rs
+++ b/src/systems/systems/src/simulation/update_context.rs
@@ -1,5 +1,5 @@
 use std::time::Duration;
-use uom::si::{f64::*, pressure::inch_of_mercury, time::second, velocity::foot_per_second};
+use uom::si::{f64::*, pressure::inch_of_mercury, time::second, velocity::foot_per_minute};
 
 use super::{Read, SimulatorReader};
 
@@ -41,7 +41,7 @@ impl UpdateContext {
             ambient_temperature,
             ambient_pressure: Pressure::new::<inch_of_mercury>(29.92),
             is_on_ground,
-            vertical_speed: Velocity::new::<foot_per_second>(0.),
+            vertical_speed: Velocity::new::<foot_per_minute>(0.),
             longitudinal_acceleration,
         }
     }
@@ -56,7 +56,7 @@ impl UpdateContext {
             ambient_pressure: Pressure::new::<inch_of_mercury>(
                 reader.read(UpdateContext::AMBIENT_PRESSURE_KEY),
             ),
-            vertical_speed: Velocity::new::<foot_per_second>(
+            vertical_speed: Velocity::new::<foot_per_minute>(
                 reader.read(UpdateContext::VERTICAL_SPEED_KEY),
             ),
             delta: delta_time,


### PR DESCRIPTION
Fixes #5395

## Summary of Changes
In `a320_systems_wasm/src/lib.rs` #5242 added (merged yesterday 10:49Z):
```rust
reader.add("VELOCITY WORLD Y", "feet per minute", 0)?;
```
and #5159 added below it (merged yesterday 20:08Z):
```rust
reader.add("VELOCITY WORLD Y", "Feet per Second", 0)?;
```

Thus `feet per second` is read, whereas #5242 assumes `feet per minute`.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
