### PR TITLE
fix(displays): Fix potentiometer bug - adjust pixel intensity

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/CSS/A32NX_Display_Common.css
+++ b/flybywire-aircraft-a320-neo/html_ui/CSS/A32NX_Display_Common.css
@@ -56,7 +56,7 @@ text {
   /* custom svg */
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M0 0 V10 Z H10 Z' stroke='%23000' stroke-width='3' fill='none'/%3E%3C/svg%3E");
   background-size: 2px;
-  opacity: 0.75;
+  opacity: 0.35;
   /* subtle tint and edge bleed */
   background-color: rgba(0, 0, 255, 0.025);
   box-shadow: inset 0px 0px 30px 10px rgba(0, 75, 255, 0.04);

--- a/src/instruments/src/Common/displayUnit.tsx
+++ b/src/instruments/src/Common/displayUnit.tsx
@@ -26,8 +26,6 @@ export const DisplayUnit: React.FC<DisplayUnitProps> = (props) => {
     const [electricityState] = useSimVar(props.electricitySimvar, 'bool', 200);
 
     useUpdate((deltaTime) => {
-        console.log(`Updated ${deltaTime} ${new Date().getTime()}`);
-        console.log(state);
         if (timer !== null) {
             if (timer > 0) {
                 setTimer(timer - (deltaTime / 1000));

--- a/src/instruments/src/Common/pixels.scss
+++ b/src/instruments/src/Common/pixels.scss
@@ -6,7 +6,7 @@
   z-index: 999;
   position: absolute;
   background-size: $density * 1px;
-  opacity: 0.75;
+  opacity: 0.35;
 
   @if $checkered {
     background-image: url("data:image/svg+xml,%3Csvg width='2' height='2' xmlns='http://www.w3.org/2000/svg'%3E%3Crect height='1' width='1' y='0' x='0' /%3E%3Crect height='1' width='1' y='1' x='1' /%3E%3C/svg%3E");

--- a/src/instruments/src/PFD/index.jsx
+++ b/src/instruments/src/PFD/index.jsx
@@ -180,7 +180,7 @@ class PFD extends Component {
         return (
             <DisplayUnit
                 electricitySimvar={this.isCaptainSide() ? 'L:A32NX_ELEC_AC_ESS_BUS_IS_POWERED' : 'L:A32NX_ELEC_AC_2_BUS_IS_POWERED'}
-                potentiometerIndex={this.isCaptainSide() === 1 ? 88 : 90}
+                potentiometerIndex={this.isCaptainSide() ? 88 : 90}
             >
                 <svg className="pfd-svg" version="1.1" viewBox="0 0 158.75 158.75" xmlns="http://www.w3.org/2000/svg">
                     <Horizon pitch={pitch} roll={roll} heading={heading} FDActive={FDActive} selectedHeading={selectedHeading} isOnGround={isOnGround} radioAlt={radioAlt} decisionHeight={decisionHeight} isAttExcessive={this.isAttExcessive} deltaTime={this.deltaTime} />


### PR DESCRIPTION
Fixes #5390 #5397

## Summary of Changes
Fixed a bug where `CPT PFD` was turned **off** by `F/O PFD` potentiometer.
Lowers the intensity of pixel effect to mitigate some of the moiré effect at lower resolutions.
Removes a pair of forgotten `console.log()`'s.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username: @bouveng

## Testing instructions
1, turn down the `F/O PFD` potentiometer to 0%.
2, verify that `CPT PFD` still is on

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
