### PR TITLE
fix(chrono): pause chrono when sim is paused using escape key

### DIFF
--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -126,6 +126,11 @@
 - A32NX_OVHD_HYD_PTU_PB_HAS_FAULT
     - Bool
     - True if PTU fault
+    
+- A32NX_GAME_PAUSED
+    - Bool
+    - True if game is paused using esc
+    - Used by chrono to determine whether to pause 
 
 - A32NX_OVHD_HYD_PTU_PB_IS_AUTO
     - Bool

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -130,7 +130,6 @@
 - A32NX_GAME_PAUSED
     - Bool
     - True if game is paused using esc
-    - Used by chrono to determine whether to pause 
 
 - A32NX_OVHD_HYD_PTU_PB_IS_AUTO
     - Bool

--- a/src/instruments/src/Clock/Components/Chrono.tsx
+++ b/src/instruments/src/Clock/Components/Chrono.tsx
@@ -9,7 +9,7 @@ export const Chrono = () => {
     const [ltsTest] = useSimVar('L:A32NX_OVHD_INTLT_ANN', 'bool', 250);
     const [dcEssIsPowered] = useSimVar('L:A32NX_ELEC_DC_ESS_BUS_IS_POWERED', 'bool', 250);
     const [absTime] = useSimVar('E:ABSOLUTE TIME', 'Seconds', 200);
-    const [isPaused] = useSimVar('L:A32NX_GAME_PAUSED', 'bool', 250)
+    const [isPaused] = useSimVar('L:A32NX_GAME_PAUSED', 'bool', 1000)
     const [prevTime, setPrevTime] = useState(absTime);
 
     const [elapsedTime, setElapsedTime] = useState<null | number>(null);

--- a/src/instruments/src/Clock/Components/Chrono.tsx
+++ b/src/instruments/src/Clock/Components/Chrono.tsx
@@ -17,7 +17,7 @@ export const Chrono = () => {
 
     useEffect(() => {
         if (isPaused) {
-            setPrevTime(absTime-elapsedTime);
+            setPrevTime(absTime+elapsedTime);
             //Return early to skip updating elapsedTime
             return;
         }

--- a/src/instruments/src/Clock/Components/Chrono.tsx
+++ b/src/instruments/src/Clock/Components/Chrono.tsx
@@ -9,12 +9,18 @@ export const Chrono = () => {
     const [ltsTest] = useSimVar('L:A32NX_OVHD_INTLT_ANN', 'bool', 250);
     const [dcEssIsPowered] = useSimVar('L:A32NX_ELEC_DC_ESS_BUS_IS_POWERED', 'bool', 250);
     const [absTime] = useSimVar('E:ABSOLUTE TIME', 'Seconds', 200);
+    const [isPaused] = useSimVar('L:A32NX_GAME_PAUSED', 'bool', 250)
     const [prevTime, setPrevTime] = useState(absTime);
 
     const [elapsedTime, setElapsedTime] = useState<null | number>(null);
     const [running, setRunning] = useState(false);
 
     useEffect(() => {
+        if (isPaused) {
+            setPrevTime(absTime-elapsedTime);
+            //Return early to skip updating elapsedTime
+            return;
+        }
         if (running) {
             setElapsedTime(Math.max((elapsedTime || 0) + absTime - prevTime, 0));
         }

--- a/src/instruments/src/Clock/Components/Chrono.tsx
+++ b/src/instruments/src/Clock/Components/Chrono.tsx
@@ -17,7 +17,7 @@ export const Chrono = () => {
 
     useEffect(() => {
         if (isPaused) {
-            setPrevTime(absTime+elapsedTime);
+            setPrevTime(absTime-elapsedTime);
             //Return early to skip updating elapsedTime
             return;
         }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
When the sim is paused with the escape key, the chronometer now pauses as well. 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
ManyPandas#0839

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
