### PR TITLE
revert: pixels, keep bleed

### DIFF
--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -876,7 +876,6 @@
                     <PART_ID>SCREEN_EICAS1</PART_ID>
                     <CAMERA_TITLE>ECAM</CAMERA_TITLE>
                     <!-- Pixelated screens needs more light -->
-                    <!-- Pixels disabled for now -->
                 </UseTemplate>
 
                 <!-- LOWER ECAM SCREEN -->

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -791,7 +791,6 @@
                 <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
                     <NODE_ID>DYN_SCREEN</NODE_ID>
                     <!-- Pixelated screens needs more light -->
-                    <!-- Pixels disabled for now -->
                 </UseTemplate>
 
                 <UseTemplate Name="ASOBO_AUTOPILOT_Knob_Baro_Template">

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -898,7 +898,6 @@
                     <PART_ID>SCREEN_EICAS2</PART_ID>
                     <CAMERA_TITLE>ECAM</CAMERA_TITLE>
                     <!-- Pixelated screens needs more light -->
-                    <!-- Pixels disabled for now -->
                 </UseTemplate>
             </Component>
 

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -605,7 +605,6 @@
                     <PART_ID>SCREEN_MFD1</PART_ID>
                     <CAMERA_TITLE>MFD</CAMERA_TITLE>
                     <!-- Pixelated screens needs more light -->
-                    <!-- Pixels disabled for now -->
                 </UseTemplate>
 
                 <!-- DCDU -->

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -664,7 +664,6 @@
                     <POTENTIOMETER>91</POTENTIOMETER>
                     <PART_ID>SCREEN_MFD2</PART_ID>
                     <!-- Pixelated screens needs more light -->
-                    <!-- Pixels disabled for now -->
                 </UseTemplate>
 
                 <!-- F/O WX SCREEN -->

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -505,7 +505,6 @@
                     <PART_ID>SCREEN_PFD1</PART_ID>
                     <CAMERA_TITLE>PFD</CAMERA_TITLE>
                     <!-- Pixelated screens needs more light -->
-                    <!-- Pixels disabled for now -->
                 </UseTemplate>
 
                 <UseTemplate Name="FBW_Airbus_Push_EFIS_GPWS">

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -505,7 +505,7 @@
                     <PART_ID>SCREEN_PFD1</PART_ID>
                     <CAMERA_TITLE>PFD</CAMERA_TITLE>
                     <!-- Pixelated screens needs more light -->
-                    <EMISSIVE_CODE>2</EMISSIVE_CODE>
+                    <!-- Pixels disabled for now -->
                 </UseTemplate>
 
                 <UseTemplate Name="FBW_Airbus_Push_EFIS_GPWS">
@@ -606,7 +606,7 @@
                     <PART_ID>SCREEN_MFD1</PART_ID>
                     <CAMERA_TITLE>MFD</CAMERA_TITLE>
                     <!-- Pixelated screens needs more light -->
-                    <EMISSIVE_CODE>2</EMISSIVE_CODE>
+                    <!-- Pixels disabled for now -->
                 </UseTemplate>
 
                 <!-- DCDU -->
@@ -615,7 +615,7 @@
                     <!-- Pixelated screens needs more light -->
                     <EMISSIVE_CODE>
                         (L:A32NX_ELEC_DC_1_BUS_IS_POWERED, Bool) if{
-                            2 (L:#PLANE_NAME#_PANEL_DCDU_L_BRIGHTNESS, percent over 100) *
+                            1 (L:#PLANE_NAME#_PANEL_DCDU_L_BRIGHTNESS, percent over 100) *
                         } els{
                             0
                         }
@@ -650,7 +650,7 @@
                     <POTENTIOMETER>90</POTENTIOMETER>
                     <PART_ID>SCREEN_PFD2</PART_ID>
                     <!-- Pixelated screens needs more light -->
-                    <EMISSIVE_CODE>2</EMISSIVE_CODE>
+                    <!-- Pixels disabled for now -->
                 </UseTemplate>
 
                 <!-- F/O ND SCREEN -->
@@ -667,7 +667,7 @@
                     <POTENTIOMETER>91</POTENTIOMETER>
                     <PART_ID>SCREEN_MFD2</PART_ID>
                     <!-- Pixelated screens needs more light -->
-                    <EMISSIVE_CODE>2</EMISSIVE_CODE>
+                    <!-- Pixels disabled for now -->
                 </UseTemplate>
 
                 <!-- F/O WX SCREEN -->
@@ -685,7 +685,7 @@
                     <!-- Pixelated screens needs more light -->
                     <EMISSIVE_CODE>
                         (L:A32NX_ELEC_DC_2_BUS_IS_POWERED, Bool) if{
-                            2 (L:#PLANE_NAME#_PANEL_DCDU_R_BRIGHTNESS, percent over 100) *
+                            1 (L:#PLANE_NAME#_PANEL_DCDU_R_BRIGHTNESS, percent over 100) *
                         } els{
                             0
                         }
@@ -795,7 +795,7 @@
                 <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
                     <NODE_ID>DYN_SCREEN</NODE_ID>
                     <!-- Pixelated screens needs more light -->
-                    <EMISSIVE_CODE>2</EMISSIVE_CODE>
+                    <!-- Pixels disabled for now -->
                 </UseTemplate>
 
                 <UseTemplate Name="ASOBO_AUTOPILOT_Knob_Baro_Template">
@@ -881,7 +881,7 @@
                     <PART_ID>SCREEN_EICAS1</PART_ID>
                     <CAMERA_TITLE>ECAM</CAMERA_TITLE>
                     <!-- Pixelated screens needs more light -->
-                    <EMISSIVE_CODE>2</EMISSIVE_CODE>
+                    <!-- Pixels disabled for now -->
                 </UseTemplate>
 
                 <!-- LOWER ECAM SCREEN -->
@@ -898,7 +898,7 @@
                     <PART_ID>SCREEN_EICAS2</PART_ID>
                     <CAMERA_TITLE>ECAM</CAMERA_TITLE>
                     <!-- Pixelated screens needs more light -->
-                    <EMISSIVE_CODE>2</EMISSIVE_CODE>
+                    <!-- Pixels disabled for now -->
                 </UseTemplate>
             </Component>
 

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -648,7 +648,6 @@
                     <POTENTIOMETER>90</POTENTIOMETER>
                     <PART_ID>SCREEN_PFD2</PART_ID>
                     <!-- Pixelated screens needs more light -->
-                    <!-- Pixels disabled for now -->
                 </UseTemplate>
 
                 <!-- F/O ND SCREEN -->

--- a/flybywire-aircraft-a320-neo/html_ui/CSS/A32NX_Display_Common.css
+++ b/flybywire-aircraft-a320-neo/html_ui/CSS/A32NX_Display_Common.css
@@ -54,7 +54,7 @@ text {
   z-index: 999;
   position: absolute;
   /* custom svg */
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M0 0 V10 Z H10 Z' stroke='%23000' stroke-width='3' fill='none'/%3E%3C/svg%3E");
+  /* pixels disabled for now */
   background-size: 2px;
   opacity: 0.35;
   /* subtle tint and edge bleed */

--- a/flybywire-aircraft-a320-neo/html_ui/CSS/A32NX_Display_Common.css
+++ b/flybywire-aircraft-a320-neo/html_ui/CSS/A32NX_Display_Common.css
@@ -54,7 +54,6 @@ text {
   z-index: 999;
   position: absolute;
   /* custom svg */
-  /* pixels disabled for now */
   background-size: 2px;
   opacity: 0.35;
   /* subtle tint and edge bleed */

--- a/src/instruments/src/Common/pixels.scss
+++ b/src/instruments/src/Common/pixels.scss
@@ -13,7 +13,6 @@
     background-position: 1px 0;
     background-color: rgba(80, 80, 80, 0.2);
   } @else {
-    /* pixels disabled for now */
     @if $bleed {
       /* subtle tint, bleed and edge bleed */
       background-color: rgba(0, 0, 255, 0.025);

--- a/src/instruments/src/Common/pixels.scss
+++ b/src/instruments/src/Common/pixels.scss
@@ -13,7 +13,7 @@
     background-position: 1px 0;
     background-color: rgba(80, 80, 80, 0.2);
   } @else {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M0 0 V10 Z H10 Z' stroke='%23000' stroke-width='#{$spacing}' fill='none'/%3E%3C/svg%3E");
+    /* pixels disabled for now */
     @if $bleed {
       /* subtle tint, bleed and edge bleed */
       background-color: rgba(0, 0, 255, 0.025);

--- a/src/instruments/src/DCDU/style.scss
+++ b/src/instruments/src/DCDU/style.scss
@@ -13,10 +13,7 @@
 }
 
 /* pixels for screen */
-@import "../Common/pixels";
-#panel:after {
-  @include pixels($checkered: true);
-}
+/* pixels disabled for now */
 
 .dcdu-lines {
   position: absolute;

--- a/src/instruments/src/DCDU/style.scss
+++ b/src/instruments/src/DCDU/style.scss
@@ -12,7 +12,6 @@
   font-style: normal;
 }
 
-/* pixels disabled for now */
 
 .dcdu-lines {
   position: absolute;

--- a/src/instruments/src/DCDU/style.scss
+++ b/src/instruments/src/DCDU/style.scss
@@ -12,7 +12,6 @@
   font-style: normal;
 }
 
-/* pixels for screen */
 /* pixels disabled for now */
 
 .dcdu-lines {


### PR DESCRIPTION
## Summary of Changes
Reverts pixels , restores screen emissive intensity, but keeps the bleed effect + tint.


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username: @bouveng

## Testing instructions
1, spawn
2, verify pixels is removed from PFD, ND, EICAS, MCDU and DCDU.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
