### PR TITLE
fix: workaround for #5487 in regards to altitude issues

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -156,7 +156,8 @@
 1. [ADIRS] Wind, TAS, and GS indications depend on availability of IR and ADR data - @davidwalschots (David Walschots)
 1. [ADIRS] SAT, TAT, and ISA indications depend on the selected ADR (1 or 3) - @davidwalschots (David Walschots)
 1. [PRESS] First implementation of automatic pressurization system - @MJuhe (Miquel)
-2. [MISC] Added annunciator lights to interactive checklist - @oim1 (oim)
+1. [MISC] Added annunciator lights to interactive checklist - @oim1 (oim)
+1. [MISC] Workaround for altitude issues of MSFS - @aguther (Andreas Guther)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/cockpit.cfg
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/cockpit.cfg
@@ -317,10 +317,13 @@ airspeed_indicator.0 = 1, 0
 airspeed_indicator.1 = 1, 0
 
 [ALTIMETERS]
-altimeter.0 =1
-altimeter_position.0 =5.000000,-5.000000,0.000000
-altimeter.1 =1
-altimeter_position.1 =-5.000000,-5.000000,0.000000
+altimeter.0 = 1 ; PFDs, index 1 in simvars
+altimeter_position.0 =  5.000000, -5.000000, 0.000000
+altimeter.1 = 1 ; ISIS, index 2 in simvars
+altimeter_position.1 = -5.000000, -5.000000, 0.000000
+altimeter.2 = 1 ; Autopilot, index 3 in simvars
+altimeter_position.2 =  5.000000, -5.000000, 0.000000
+
 
 [GPWS]
 max_warning_height = 0

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -89,6 +89,9 @@ bool FlyByWireInterface::update(double sampleTime) {
     return result;
   }
 
+  // update altimeter setting
+  result &= updateAltimeterSetting(sampleTime);
+
   // update autopilot state machine
   result &= updateAutopilotStateMachine(sampleTime);
 
@@ -1333,6 +1336,20 @@ bool FlyByWireInterface::updateFlapsSpoilers(double sampleTime) {
   idSpoilersArmed->set(spoilersHandler->getIsArmed() ? 1 : 0);
   idSpoilersHandlePosition->set(spoilersHandler->getHandlePosition());
   idSpoilersGroundSpoilersActive->set(spoilersHandler->getIsGroundSpoilersActive() ? 1 : 0);
+
+  // result
+  return true;
+}
+
+bool FlyByWireInterface::updateAltimeterSetting(double sampleTime) {
+  // get sim data
+  auto simData = simConnectInterface.getSimData();
+
+  // determine if change is needed
+  if (simData.kohlsmanSettingStd_3 == 0) {
+    SimOutputAltimeter out = {true};
+    simConnectInterface.sendData(out);
+  }
 
   // result
   return true;

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -252,6 +252,8 @@ class FlyByWireInterface {
 
   bool updateFlapsSpoilers(double sampleTime);
 
+  bool updateAltimeterSetting(double sampleTime);
+
   double smoothFlightDirector(double sampleTime, double factor, double limit, double currentValue, double targetValue);
 
   double getHeadingAngleError(double u1, double u2);

--- a/src/fbw/src/interface/SimConnectData.h
+++ b/src/fbw/src/interface/SimConnectData.h
@@ -115,6 +115,7 @@ struct SimData {
   double fuelTankQuantityCenter;
   double fuelTankQuantityTotal;
   double fuelWeightPerGallon;
+  unsigned long long kohlsmanSettingStd_3;
 };
 
 struct SimInput {
@@ -180,6 +181,10 @@ struct SimOutputFlaps {
 
 struct SimOutputSpoilers {
   double spoilersHandlePosition;
+};
+
+struct SimOutputAltimeter {
+  unsigned long long kohlsmanSettingStd_3;
 };
 
 struct ClientDataAutopilotStateMachine {

--- a/src/fbw/src/interface/SimConnectInterface.cpp
+++ b/src/fbw/src/interface/SimConnectInterface.cpp
@@ -110,7 +110,8 @@ bool SimConnectInterface::prepareSimDataSimConnectDataDefinitions() {
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "AIRSPEED TRUE", "KNOTS");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "AIRSPEED MACH", "MACH");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "GROUND VELOCITY", "KNOTS");
-  result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "PRESSURE ALTITUDE", "FEET");
+  // workaround for altitude issues due to MSFS bug, needs to be changed to PRESSURE ALTITUDE again when solved
+  result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "INDICATED ALTITUDE:3", "FEET");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "INDICATED ALTITUDE", "FEET");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "PLANE ALT ABOVE GROUND MINUS CG", "FEET");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "VELOCITY WORLD Y", "FEET PER MINUTE");
@@ -198,6 +199,7 @@ bool SimConnectInterface::prepareSimDataSimConnectDataDefinitions() {
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "FUEL TANK CENTER QUANTITY", "GALLONS");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "FUEL TOTAL QUANTITY", "GALLONS");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "FUEL WEIGHT PER GALLON", "POUNDS");
+  result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_INT64, "KOHLSMAN SETTING STD:3", "BOOL");
 
   return result;
 }
@@ -390,6 +392,8 @@ bool SimConnectInterface::prepareSimOutputSimConnectDataDefinitions() {
   result &= addDataDefinition(hSimConnect, 5, SIMCONNECT_DATATYPE_FLOAT64, "FLAPS HANDLE INDEX", "NUMBER");
 
   result &= addDataDefinition(hSimConnect, 6, SIMCONNECT_DATATYPE_FLOAT64, "SPOILERS HANDLE POSITION", "POSITION");
+
+  result &= addDataDefinition(hSimConnect, 7, SIMCONNECT_DATATYPE_INT64, "KOHLSMAN SETTING STD:3", "BOOL");
 
   return result;
 }
@@ -755,6 +759,11 @@ bool SimConnectInterface::sendData(SimOutputFlaps output) {
 bool SimConnectInterface::sendData(SimOutputSpoilers output) {
   // write data and return result
   return sendData(6, sizeof(output), &output);
+}
+
+bool SimConnectInterface::sendData(SimOutputAltimeter output) {
+  // write data and return result
+  return sendData(7, sizeof(output), &output);
 }
 
 bool SimConnectInterface::sendEvent(Events eventId) {

--- a/src/fbw/src/interface/SimConnectInterface.h
+++ b/src/fbw/src/interface/SimConnectInterface.h
@@ -193,6 +193,8 @@ class SimConnectInterface {
 
   bool sendData(SimOutputSpoilers output);
 
+  bool sendData(SimOutputAltimeter output);
+
   bool sendEvent(Events eventId);
 
   bool sendEvent(Events eventId, DWORD data);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #5487

## Summary of Changes
This PR introduces a workaround for the altimeter issues in MSFS.

The issue in MSFS is that the pressure altitude and indicated altitude
are not correctly calculated. Additionally when the barometer setting
is set to STD both altitudes are not equal.

The impact is that when sea level pressure changes the error between
pressure and indicated altitude varies. The autopilot is using the
pressure altitude as reference when in ALT HOLD mode. Due to this,
when flying through different pressure zones the AP will divert from the
altitude it should follow.

The changes that are made with this commit are as follows:
- add an additional altimeter (index 2)
- force this altimeter to baro setting STD
- use the indicated altitude as pressure altitude

This fixes the autopilot to divert from the altitude when in ALT HOLD.

Known issues that might remain:
- pressure altitude is still wrong compared to ICAO standard atmosphere
- ATC / VATSIM not accepting the altitude as correct flight level

## Testing instructions

### Normal flying
Fly a normal route with a high FL that leads you through different pressure zones. This can be observed by watching the sea level pressure i.e. via SimVarWatcher. Expectation is that the AP always returns to the initially set altitude.

Disclaimer:
There can be still jumps in altitude depending how good the pressure smoothing is done by MSFS. But the AP needs to return to the initially set altitude again.

### Change of baro setting
1. Fly to a certain altitude and wait until "ALT" is shown on the FMA
2. Change baro setting of PFD
3. Plane must fly stable on the altitude reached when ALT engaged
4. Change baro of ISIS, this must be still independent and possible to change

### Additional Information to be aquired
If possible do a flight with VATSIM or built-in ATC and observe if the altitude is seen as correct. This is just for information, right now there is no way to fix this when it is wrong. It would be just good to know.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
