### PR TITLE
fix: change external view HUD back to airliner type (SU5 compatibility fix)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -159,6 +159,7 @@
 1. [MISC] Added annunciator lights to interactive checklist - @oim1 (oim)
 1. [MISC] Workaround for altitude issues of MSFS - @aguther (Andreas Guther)
 1. [DISPLAYS] Improved pixelated screens, only appears when camera is close to displays - @2hwk (2Cas#1022)
+1. [MISC] Change back to airliner hud in external view for SU5 - @donstim (donbikes#4084)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/cockpit.cfg
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/cockpit.cfg
@@ -360,5 +360,7 @@ flaps_level_5 = 40
 
 [MISC]
 g_meter=0
+vcockpit_hud = 1
+
 [MagneticCompass]
 Compass.0=0


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Under MSFS Sim Update 5, the external view HUD for the FBW A320 changed to a GA-airplane style HUD. This PR changes it back to an airliner style HUD.
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Adds a new variable introduced by SU5 to indicated the style of HUD to display in the external view.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before: 
![Screenshot (1080)](https://user-images.githubusercontent.com/70166617/127808810-47185321-78a6-4a98-826d-8326d2e8dc4d.png)

After:
![Screenshot (1085)](https://user-images.githubusercontent.com/70166617/127808831-9e91b1b6-2d6a-4011-8620-999941d9224c.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): donbikes#4084

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
The only thing that changed was to add a variable to the cockpit.cfg that controls which style of HUD is displayed in the external view. Switch back and forth between internal and external views.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
