### PR TITLE
feat(ap): tuned ALT* and VS/FPA laws

### DIFF
--- a/src/fbw/src/model/AutopilotLaws.cpp
+++ b/src/fbw/src/model/AutopilotLaws.cpp
@@ -256,6 +256,24 @@ void AutopilotLawsModelClass::AutopilotLaws_SpeedProtectionMode(const ap_laws_ou
   }
 }
 
+void AutopilotLawsModelClass::AutopilotLaws_VSLimiter(real_T rtu_u, real_T rtu_V_tas_kn, real_T *rty_y)
+{
+  real_T limit;
+  real_T y;
+  limit = 9.81 / (rtu_V_tas_kn * 0.51444444444444448) * 0.1 * 57.295779513082323;
+  if (limit < rtu_u) {
+    y = limit;
+  } else {
+    y = rtu_u;
+  }
+
+  if (-limit > y) {
+    *rty_y = -limit;
+  } else {
+    *rty_y = y;
+  }
+}
+
 void AutopilotLawsModelClass::AutopilotLaws_V_LSSpeedSelection(const ap_laws_output *rtu_in, real_T *rty_y)
 {
   if (rtu_in->input.V_c_kn <= rtu_in->data.VLS_kn) {
@@ -296,6 +314,7 @@ void AutopilotLawsModelClass::step()
   real_T result_tmp[9];
   real_T result[3];
   real_T result_0[3];
+  real_T dH_tmp;
   real_T rtb_Divide_h;
   real_T rtb_Gain4;
   real_T rtb_Gain5;
@@ -311,14 +330,13 @@ void AutopilotLawsModelClass::step()
   real_T rtb_Mod2_k;
   real_T rtb_Saturation;
   real_T rtb_Saturation1;
-  real_T rtb_Sum2_f;
-  real_T rtb_Sum2_h;
-  real_T rtb_Sum2_j4;
+  real_T rtb_Sum2_d;
+  real_T rtb_Sum2_j;
   real_T rtb_Sum_gh;
-  real_T rtb_Sum_ib_tmp;
   real_T rtb_Sum_j;
-  real_T rtb_Y_fh;
+  real_T rtb_Y_b;
   real_T rtb_Y_ic;
+  real_T rtb_Y_m;
   real_T rtb_Y_p;
   real_T rtb_out_c;
   real_T u1;
@@ -343,9 +361,9 @@ void AutopilotLawsModelClass::step()
   result_tmp[4] = rtb_Mod2_k;
   result_tmp[7] = -rtb_ManualSwitch;
   result_tmp[2] = 0.0;
-  rtb_Y_fh = 1.0 / std::cos(rtb_Saturation);
-  result_tmp[5] = rtb_Y_fh * rtb_ManualSwitch;
-  result_tmp[8] = rtb_Y_fh * rtb_Mod2_k;
+  rtb_Y_b = 1.0 / std::cos(rtb_Saturation);
+  result_tmp[5] = rtb_Y_b * rtb_ManualSwitch;
+  result_tmp[8] = rtb_Y_b * rtb_Mod2_k;
   rtb_ManualSwitch = AutopilotLaws_P.Gain_Gain_de * AutopilotLaws_U.in.data.p_rad_s * AutopilotLaws_P.Gainpk_Gain;
   rtb_Mod2_k = AutopilotLaws_P.Gain_Gain_d * AutopilotLaws_U.in.data.q_rad_s * AutopilotLaws_P.Gainqk_Gain;
   rtb_out_c = AutopilotLaws_P.Gain_Gain_m * AutopilotLaws_U.in.data.r_rad_s;
@@ -515,14 +533,14 @@ void AutopilotLawsModelClass::step()
   }
 
   if (AutopilotLaws_U.in.data.nav_dme_nmi > AutopilotLaws_P.Saturation_UpperSat_c) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_c;
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_c;
   } else if (AutopilotLaws_U.in.data.nav_dme_nmi < AutopilotLaws_P.Saturation_LowerSat_d) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_d;
+    rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_d;
   } else {
-    rtb_Y_fh = AutopilotLaws_U.in.data.nav_dme_nmi;
+    rtb_Y_b = AutopilotLaws_U.in.data.nav_dme_nmi;
   }
 
-  rtb_Saturation1 = std::sin(AutopilotLaws_P.Gain1_Gain_g * AutopilotLaws_U.in.data.nav_loc_error_deg) * rtb_Y_fh;
+  rtb_Saturation1 = std::sin(AutopilotLaws_P.Gain1_Gain_g * AutopilotLaws_U.in.data.nav_loc_error_deg) * rtb_Y_b;
   rtb_Saturation = rtb_Saturation1 * look1_binlxpw(AutopilotLaws_U.in.data.nav_dme_nmi,
     AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1, AutopilotLaws_P.ScheduledGain_Table, 4U);
   rtb_Saturation1 = look1_binlxpw(rtb_Saturation1, AutopilotLaws_P.ScheduledGain3_BreakpointsForDimension1,
@@ -557,14 +575,14 @@ void AutopilotLawsModelClass::step()
     rtb_Saturation, AutopilotLaws_P.Constant3_Value_j), AutopilotLaws_P.Constant2_Value, &rtb_out_c,
                         &AutopilotLaws_DWork.sf_Chart_j);
   if (AutopilotLaws_U.in.data.nav_dme_nmi > AutopilotLaws_P.Saturation_UpperSat_o) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_o;
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_o;
   } else if (AutopilotLaws_U.in.data.nav_dme_nmi < AutopilotLaws_P.Saturation_LowerSat_o) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_o;
+    rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_o;
   } else {
-    rtb_Y_fh = AutopilotLaws_U.in.data.nav_dme_nmi;
+    rtb_Y_b = AutopilotLaws_U.in.data.nav_dme_nmi;
   }
 
-  rtb_Saturation1 = std::sin(AutopilotLaws_P.Gain1_Gain_h5 * AutopilotLaws_U.in.data.nav_loc_error_deg) * rtb_Y_fh *
+  rtb_Saturation1 = std::sin(AutopilotLaws_P.Gain1_Gain_h5 * AutopilotLaws_U.in.data.nav_loc_error_deg) * rtb_Y_b *
     AutopilotLaws_P.Gain2_Gain_g;
   if (rtb_Saturation1 > AutopilotLaws_P.Saturation1_UpperSat_g) {
     rtb_Saturation1 = AutopilotLaws_P.Saturation1_UpperSat_g;
@@ -666,7 +684,7 @@ void AutopilotLawsModelClass::step()
   rtb_Saturation = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain * AutopilotLaws_U.in.data.nav_loc_error_deg;
   AutopilotLaws_LagFilter(AutopilotLaws_U.in.data.nav_loc_error_deg + AutopilotLaws_P.Gain3_Gain_i * ((rtb_Saturation -
     AutopilotLaws_DWork.Delay_DSTATE_i) / AutopilotLaws_U.in.time.dt), AutopilotLaws_P.LagFilter_C1,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_fh, &AutopilotLaws_DWork.sf_LagFilter);
+    AutopilotLaws_U.in.time.dt, &rtb_Y_m, &AutopilotLaws_DWork.sf_LagFilter);
   switch (static_cast<int32_T>(rtb_ManualSwitch)) {
    case 0:
     rtb_Saturation1 = rtb_GainTheta1;
@@ -683,16 +701,16 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 3:
-    rtb_Y_fh = AutopilotLaws_P.Gain_Gain_n * AutopilotLaws_U.in.data.flight_guidance_xtk_nmi;
-    if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat) {
-      rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat;
+    rtb_Y_b = AutopilotLaws_P.Gain_Gain_n * AutopilotLaws_U.in.data.flight_guidance_xtk_nmi;
+    if (rtb_Y_b > AutopilotLaws_P.Saturation_UpperSat) {
+      rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat;
     } else {
-      if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat) {
-        rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat;
+      if (rtb_Y_b < AutopilotLaws_P.Saturation_LowerSat) {
+        rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat;
       }
     }
 
-    rtb_Saturation1 = (AutopilotLaws_P.Gain2_Gain * AutopilotLaws_U.in.data.flight_guidance_tae_deg + rtb_Y_fh) *
+    rtb_Saturation1 = (AutopilotLaws_P.Gain2_Gain * AutopilotLaws_U.in.data.flight_guidance_tae_deg + rtb_Y_b) *
       AutopilotLaws_P.Gain1_Gain_n * look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn,
       AutopilotLaws_P.ScheduledGain2_BreakpointsForDimension1_k, AutopilotLaws_P.ScheduledGain2_Table_g, 5U) +
       AutopilotLaws_U.in.data.flight_guidance_phi_deg;
@@ -703,7 +721,7 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 5:
-    rtb_Saturation1 = rtb_Y_fh * look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft,
+    rtb_Saturation1 = rtb_Y_m * look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft,
       AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_e, AutopilotLaws_P.ScheduledGain_Table_pf, 4U) *
       look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn, AutopilotLaws_P.ScheduledGain2_BreakpointsForDimension1_j,
                     AutopilotLaws_P.ScheduledGain2_Table_h, 5U);
@@ -733,10 +751,10 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.Delay_DSTATE_h = rtb_GainTheta1;
   }
 
-  rtb_Y_fh = rtb_Saturation1 - AutopilotLaws_DWork.Delay_DSTATE_h;
+  rtb_Y_b = rtb_Saturation1 - AutopilotLaws_DWork.Delay_DSTATE_h;
   u1 = AutopilotLaws_P.Constant2_Value_h * AutopilotLaws_U.in.time.dt;
-  if (rtb_Y_fh < u1) {
-    u1 = rtb_Y_fh;
+  if (rtb_Y_b < u1) {
+    u1 = rtb_Y_b;
   }
 
   rtb_Y_p = AutopilotLaws_P.Gain1_Gain_k * AutopilotLaws_P.Constant2_Value_h * AutopilotLaws_U.in.time.dt;
@@ -763,12 +781,12 @@ void AutopilotLawsModelClass::step()
   rtb_Gain_ny *= rtb_GainTheta1;
   AutopilotLaws_Y.out.output.autopilot.Phi_c_deg = rtb_Divide_h + rtb_Gain_ny;
   if (AutopilotLaws_U.in.data.H_radio_ft <= AutopilotLaws_P.CompareToConstant_const_d) {
-    rtb_Y_fh = AutopilotLaws_P.Gain_Gain_a * rtb_out_c;
+    rtb_Y_b = AutopilotLaws_P.Gain_Gain_a * rtb_out_c;
   } else {
-    rtb_Y_fh = AutopilotLaws_P.Constant1_Value;
+    rtb_Y_b = AutopilotLaws_P.Constant1_Value;
   }
 
-  AutopilotLaws_LagFilter(rtb_Y_fh, AutopilotLaws_P.LagFilter1_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_p,
+  AutopilotLaws_LagFilter(rtb_Y_b, AutopilotLaws_P.LagFilter1_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_p,
     &AutopilotLaws_DWork.sf_LagFilter_j);
   switch (static_cast<int32_T>(rtb_ManualSwitch)) {
    case 0:
@@ -840,45 +858,46 @@ void AutopilotLawsModelClass::step()
   }
 
   rtb_Saturation1 -= AutopilotLaws_U.in.data.H_dot_ft_min;
-  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain * AutopilotLaws_U.in.data.V_tas_kn;
-  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_n3) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_n3;
+  rtb_Y_b = AutopilotLaws_P.kntoms_Gain * AutopilotLaws_U.in.data.V_tas_kn;
+  if (rtb_Y_b > AutopilotLaws_P.Saturation_UpperSat_n3) {
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_n3;
   } else {
-    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_m) {
-      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_m;
+    if (rtb_Y_b < AutopilotLaws_P.Saturation_LowerSat_m) {
+      rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_m;
     }
   }
 
-  rtb_Y_fh = AutopilotLaws_P.ftmintoms_Gain * rtb_Saturation1 / rtb_Y_fh;
-  if (rtb_Y_fh > 1.0) {
-    rtb_Y_fh = 1.0;
+  rtb_Y_b = AutopilotLaws_P.ftmintoms_Gain * rtb_Saturation1 / rtb_Y_b;
+  if (rtb_Y_b > 1.0) {
+    rtb_Y_b = 1.0;
   } else {
-    if (rtb_Y_fh < -1.0) {
-      rtb_Y_fh = -1.0;
+    if (rtb_Y_b < -1.0) {
+      rtb_Y_b = -1.0;
     }
   }
 
-  rtb_ManualSwitch = AutopilotLaws_P.Gain_Gain_kr * std::asin(rtb_Y_fh);
-  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain_a * AutopilotLaws_U.in.data.V_tas_kn;
-  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_d) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_d;
+  rtb_ManualSwitch = AutopilotLaws_P.Gain_Gain_kr * std::asin(rtb_Y_b);
+  rtb_Y_b = AutopilotLaws_P.kntoms_Gain_a * AutopilotLaws_U.in.data.V_tas_kn;
+  if (rtb_Y_b > AutopilotLaws_P.Saturation_UpperSat_d) {
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_d;
   } else {
-    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_b) {
-      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_b;
+    if (rtb_Y_b < AutopilotLaws_P.Saturation_LowerSat_b) {
+      rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_b;
     }
   }
 
-  rtb_Y_fh = (AutopilotLaws_U.in.input.H_dot_c_fpm - AutopilotLaws_U.in.data.H_dot_ft_min) *
-    AutopilotLaws_P.ftmintoms_Gain_h / rtb_Y_fh;
-  if (rtb_Y_fh > 1.0) {
-    rtb_Y_fh = 1.0;
+  rtb_Y_b = (AutopilotLaws_U.in.input.H_dot_c_fpm - AutopilotLaws_U.in.data.H_dot_ft_min) *
+    AutopilotLaws_P.ftmintoms_Gain_h / rtb_Y_b;
+  if (rtb_Y_b > 1.0) {
+    rtb_Y_b = 1.0;
   } else {
-    if (rtb_Y_fh < -1.0) {
-      rtb_Y_fh = -1.0;
+    if (rtb_Y_b < -1.0) {
+      rtb_Y_b = -1.0;
     }
   }
 
-  rtb_Divide_h = AutopilotLaws_P.Gain_Gain_df * std::asin(rtb_Y_fh);
+  rtb_Divide_h = AutopilotLaws_P.Gain_Gain_df * std::asin(rtb_Y_b);
+  AutopilotLaws_VSLimiter(AutopilotLaws_P.VS_Gain_h * rtb_Divide_h, AutopilotLaws_U.in.data.V_tas_kn, &rtb_Y_p);
   rtb_Saturation1 = AutopilotLaws_P.Gain1_Gain_fu * AutopilotLaws_U.in.data.alpha_deg;
   rtb_Gain_ny = result_0[2] * std::sin(rtb_Saturation1);
   rtb_Saturation1 = std::cos(rtb_Saturation1);
@@ -895,77 +914,76 @@ void AutopilotLawsModelClass::step()
     }
   }
 
-  rtb_Sum2_j4 = AutopilotLaws_P.Gain_Gain_o * rtb_Mod2_k + rtb_Saturation1;
+  rtb_Y_m = AutopilotLaws_P.Gain_Gain_o * rtb_Mod2_k + rtb_Saturation1;
   rtb_Saturation1 = AutopilotLaws_P.Gain1_Gain_nv * AutopilotLaws_U.in.data.alpha_deg;
   rtb_Gain_ny = result_0[2] * std::sin(rtb_Saturation1);
   rtb_Saturation1 = std::cos(rtb_Saturation1);
   rtb_Saturation1 *= result_0[0];
   rtb_Mod2_f = AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.data.VMAX_kn;
-  rtb_Y_fh = rtb_Mod2_f * AutopilotLaws_P.Gain1_Gain_ji;
-  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_jm) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_jm;
+  rtb_Y_b = rtb_Mod2_f * AutopilotLaws_P.Gain1_Gain_ji;
+  if (rtb_Y_b > AutopilotLaws_P.Saturation_UpperSat_jm) {
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_jm;
   } else {
-    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_on) {
-      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_on;
+    if (rtb_Y_b < AutopilotLaws_P.Saturation_LowerSat_on) {
+      rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_on;
     }
   }
 
   rtb_Saturation1 = (rtb_Gain_ny + rtb_Saturation1) * AutopilotLaws_P.Gain_Gain_e1 * AutopilotLaws_P.Gain_Gain_eq +
-    rtb_Y_fh;
-  AutopilotLaws_SpeedProtectionMode(&AutopilotLaws_Y.out, rtb_Divide_h, AutopilotLaws_P.VS_Gain_h * rtb_Divide_h,
-    rtb_Sum2_j4, AutopilotLaws_P.Gain_Gain_of * rtb_Sum2_j4, rtb_Saturation1, AutopilotLaws_P.Gain_Gain_mw *
-    rtb_Saturation1, &rtb_Mod2_k, &rtb_out_c);
-  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain_p * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_k) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_k;
+    rtb_Y_b;
+  AutopilotLaws_SpeedProtectionMode(&AutopilotLaws_Y.out, rtb_Divide_h, rtb_Y_p, rtb_Y_m, AutopilotLaws_P.Gain_Gain_of *
+    rtb_Y_m, rtb_Saturation1, AutopilotLaws_P.Gain_Gain_mw * rtb_Saturation1, &rtb_Mod2_k, &rtb_out_c);
+  rtb_Y_b = AutopilotLaws_P.kntoms_Gain_p * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Y_b > AutopilotLaws_P.Saturation_UpperSat_k) {
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_k;
   } else {
-    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_l) {
-      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_l;
+    if (rtb_Y_b < AutopilotLaws_P.Saturation_LowerSat_l) {
+      rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_l;
     }
   }
 
   rtb_Divide_h = AutopilotLaws_U.in.input.FPA_c_deg - std::atan(AutopilotLaws_P.fpmtoms_Gain *
-    AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Y_fh) * AutopilotLaws_P.Gain_Gain_l;
+    AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Y_b) * AutopilotLaws_P.Gain_Gain_l;
+  AutopilotLaws_VSLimiter(AutopilotLaws_P.Gain_Gain_c * rtb_Divide_h, AutopilotLaws_U.in.data.V_tas_kn, &rtb_Y_p);
   rtb_Saturation1 = AutopilotLaws_P.Gain1_Gain_b2 * AutopilotLaws_U.in.data.alpha_deg;
   rtb_Gain_ny = result_0[2] * std::sin(rtb_Saturation1);
   rtb_Saturation1 = std::cos(rtb_Saturation1);
   rtb_Saturation1 *= result_0[0];
   AutopilotLaws_V_LSSpeedSelection(&AutopilotLaws_Y.out, &rtb_Y_ic);
-  rtb_Y_fh = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_ic) * AutopilotLaws_P.Gain1_Gain_fq;
-  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_h) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_h;
+  rtb_Y_b = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_ic) * AutopilotLaws_P.Gain1_Gain_fq;
+  if (rtb_Y_b > AutopilotLaws_P.Saturation_UpperSat_h) {
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_h;
   } else {
-    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_a) {
-      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_a;
+    if (rtb_Y_b < AutopilotLaws_P.Saturation_LowerSat_a) {
+      rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_a;
     }
   }
 
-  rtb_Y_p = (rtb_Gain_ny + rtb_Saturation1) * AutopilotLaws_P.Gain_Gain_p2 * AutopilotLaws_P.Gain_Gain_n1 + rtb_Y_fh;
+  rtb_Y_ic = (rtb_Gain_ny + rtb_Saturation1) * AutopilotLaws_P.Gain_Gain_p2 * AutopilotLaws_P.Gain_Gain_n1 + rtb_Y_b;
   rtb_Saturation1 = AutopilotLaws_P.Gain1_Gain_ib * AutopilotLaws_U.in.data.alpha_deg;
   rtb_Gain_ny = result_0[2] * std::sin(rtb_Saturation1);
   rtb_Saturation1 = std::cos(rtb_Saturation1);
   rtb_Saturation1 *= result_0[0];
-  rtb_Y_fh = rtb_Mod2_f * AutopilotLaws_P.Gain1_Gain_gs;
-  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_l) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_l;
+  rtb_Y_b = rtb_Mod2_f * AutopilotLaws_P.Gain1_Gain_gs;
+  if (rtb_Y_b > AutopilotLaws_P.Saturation_UpperSat_l) {
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_l;
   } else {
-    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_i) {
-      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_i;
+    if (rtb_Y_b < AutopilotLaws_P.Saturation_LowerSat_i) {
+      rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_i;
     }
   }
 
   rtb_Saturation1 = (rtb_Gain_ny + rtb_Saturation1) * AutopilotLaws_P.Gain_Gain_he * AutopilotLaws_P.Gain_Gain_p4 +
-    rtb_Y_fh;
-  AutopilotLaws_SpeedProtectionMode(&AutopilotLaws_Y.out, rtb_Divide_h, AutopilotLaws_P.Gain_Gain_c * rtb_Divide_h,
-    rtb_Y_p, AutopilotLaws_P.Gain_Gain_i * rtb_Y_p, rtb_Saturation1, AutopilotLaws_P.Gain_Gain_e5 * rtb_Saturation1,
-    &rtb_Mod2_f, &rtb_Sum2_j4);
+    rtb_Y_b;
+  AutopilotLaws_SpeedProtectionMode(&AutopilotLaws_Y.out, rtb_Divide_h, rtb_Y_p, rtb_Y_ic, AutopilotLaws_P.Gain_Gain_i *
+    rtb_Y_ic, rtb_Saturation1, AutopilotLaws_P.Gain_Gain_e5 * rtb_Saturation1, &rtb_Mod2_f, &rtb_Y_m);
   AutopilotLaws_WashoutFilter(result_0[2], AutopilotLaws_P.WashoutFilter_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_ic,
     &AutopilotLaws_DWork.sf_WashoutFilter_c);
   AutopilotLaws_LagFilter(AutopilotLaws_U.in.data.nav_gs_error_deg, AutopilotLaws_P.LagFilter1_C1_a,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_fh, &AutopilotLaws_DWork.sf_LagFilter_h);
-  rtb_Divide_h = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain_l * rtb_Y_fh;
-  AutopilotLaws_LagFilter(rtb_Y_fh + AutopilotLaws_P.Gain3_Gain_o * ((rtb_Divide_h - AutopilotLaws_DWork.Delay_DSTATE_g)
-    / AutopilotLaws_U.in.time.dt), AutopilotLaws_P.LagFilter_C1_n, AutopilotLaws_U.in.time.dt, &rtb_Saturation1,
+    AutopilotLaws_U.in.time.dt, &rtb_Y_b, &AutopilotLaws_DWork.sf_LagFilter_h);
+  rtb_Divide_h = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain_l * rtb_Y_b;
+  AutopilotLaws_LagFilter(rtb_Y_b + AutopilotLaws_P.Gain3_Gain_o * ((rtb_Divide_h - AutopilotLaws_DWork.Delay_DSTATE_g) /
+    AutopilotLaws_U.in.time.dt), AutopilotLaws_P.LagFilter_C1_n, AutopilotLaws_U.in.time.dt, &rtb_Saturation1,
     &AutopilotLaws_DWork.sf_LagFilter_d2);
   AutopilotLaws_storevalue(rtb_GainTheta1 == AutopilotLaws_P.CompareToConstant6_const,
     AutopilotLaws_Y.out.data.nav_gs_deg, &rtb_Y_p, &AutopilotLaws_DWork.sf_storevalue_m);
@@ -977,64 +995,87 @@ void AutopilotLawsModelClass::step()
     }
   }
 
-  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain_i * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_g) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_g;
+  rtb_Y_b = AutopilotLaws_P.kntoms_Gain_i * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Y_b > AutopilotLaws_P.Saturation_UpperSat_g) {
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_g;
   } else {
-    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_c) {
-      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_c;
+    if (rtb_Y_b < AutopilotLaws_P.Saturation_LowerSat_c) {
+      rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_c;
     }
   }
 
-  rtb_Gain_ny = std::atan(AutopilotLaws_P.fpmtoms_Gain_e * AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Y_fh) *
+  rtb_Gain_ny = std::atan(AutopilotLaws_P.fpmtoms_Gain_e * AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Y_b) *
     AutopilotLaws_P.Gain_Gain_nu;
   if ((AutopilotLaws_U.in.data.H_radio_ft > AutopilotLaws_P.CompareToConstant_const_n) &&
       AutopilotLaws_U.in.data.nav_gs_valid) {
-    rtb_Y_fh = AutopilotLaws_P.Gain_Gain_h * rtb_Y_ic + rtb_Saturation1 * look1_binlxpw
+    rtb_Y_b = AutopilotLaws_P.Gain_Gain_h * rtb_Y_ic + rtb_Saturation1 * look1_binlxpw
       (AutopilotLaws_U.in.data.H_radio_ft, AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_h,
        AutopilotLaws_P.ScheduledGain_Table_ir, 5U);
   } else {
-    rtb_Y_fh = (rtb_Y_p - rtb_Gain_ny) * AutopilotLaws_P.Gain2_Gain_j;
+    rtb_Y_b = (rtb_Y_p - rtb_Gain_ny) * AutopilotLaws_P.Gain2_Gain_j;
   }
 
-  AutopilotLaws_Voter1(rtb_Y_fh, AutopilotLaws_P.Gain1_Gain_nq * ((rtb_Y_p + AutopilotLaws_P.Bias_Bias) - rtb_Gain_ny),
+  AutopilotLaws_Voter1(rtb_Y_b, AutopilotLaws_P.Gain1_Gain_nq * ((rtb_Y_p + AutopilotLaws_P.Bias_Bias) - rtb_Gain_ny),
                        AutopilotLaws_P.Gain_Gain_p2b * ((rtb_Y_p + AutopilotLaws_P.Bias1_Bias) - rtb_Gain_ny), &rtb_Y_ic);
-  rtb_Sum_ib_tmp = AutopilotLaws_U.in.input.H_c_ft - AutopilotLaws_U.in.data.H_ind_ft;
-  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain_e * AutopilotLaws_U.in.data.V_tas_kn;
-  if (rtb_Sum_ib_tmp < 0.0) {
+  rtb_OR = (rtb_GainTheta1 == AutopilotLaws_P.CompareToConstant1_const);
+  if (!AutopilotLaws_DWork.wasActive_not_empty_d) {
+    AutopilotLaws_DWork.wasActive_g = rtb_OR;
+    AutopilotLaws_DWork.wasActive_not_empty_d = true;
+  }
+
+  dH_tmp = AutopilotLaws_U.in.input.H_c_ft - AutopilotLaws_U.in.data.H_ind_ft;
+  if (dH_tmp < 0.0) {
     rtb_Saturation1 = -1.0;
-  } else if (rtb_Sum_ib_tmp > 0.0) {
+  } else if (dH_tmp > 0.0) {
     rtb_Saturation1 = 1.0;
   } else {
-    rtb_Saturation1 = rtb_Sum_ib_tmp;
+    rtb_Saturation1 = dH_tmp;
   }
 
-  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_dn) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_dn;
+  rtb_Saturation1 = rtb_Saturation1 * AutopilotLaws_DWork.dH_offset + dH_tmp;
+  if ((!AutopilotLaws_DWork.wasActive_g) && rtb_OR) {
+    AutopilotLaws_DWork.k = AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Saturation1;
+    AutopilotLaws_DWork.dH_offset = std::abs(500.0 / std::abs(AutopilotLaws_DWork.k) - 100.0);
+    if (rtb_Saturation1 < 0.0) {
+      rtb_Y_b = -1.0;
+    } else if (rtb_Saturation1 > 0.0) {
+      rtb_Y_b = 1.0;
+    } else {
+      rtb_Y_b = rtb_Saturation1;
+    }
+
+    rtb_Saturation1 += rtb_Y_b * AutopilotLaws_DWork.dH_offset;
+    AutopilotLaws_DWork.k = AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Saturation1;
+  }
+
+  AutopilotLaws_DWork.wasActive_g = rtb_OR;
+  rtb_Y_b = AutopilotLaws_P.kntoms_Gain_e * AutopilotLaws_U.in.data.V_tas_kn;
+  if (rtb_Y_b > AutopilotLaws_P.Saturation_UpperSat_dn) {
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_dn;
   } else {
-    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_bx) {
-      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_bx;
+    if (rtb_Y_b < AutopilotLaws_P.Saturation_LowerSat_bx) {
+      rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_bx;
     }
   }
 
-  rtb_Y_fh = ((AutopilotLaws_P.Constant_Value_b * rtb_Saturation1 + rtb_Sum_ib_tmp) * AutopilotLaws_P.Gain_Gain_el -
-              AutopilotLaws_U.in.data.H_dot_ft_min) * AutopilotLaws_P.ftmintoms_Gain_g / rtb_Y_fh;
-  if (rtb_Y_fh > 1.0) {
-    rtb_Y_fh = 1.0;
+  rtb_Y_b = (AutopilotLaws_DWork.k * rtb_Saturation1 - AutopilotLaws_U.in.data.H_dot_ft_min) *
+    AutopilotLaws_P.ftmintoms_Gain_g / rtb_Y_b;
+  if (rtb_Y_b > 1.0) {
+    rtb_Y_b = 1.0;
   } else {
-    if (rtb_Y_fh < -1.0) {
-      rtb_Y_fh = -1.0;
+    if (rtb_Y_b < -1.0) {
+      rtb_Y_b = -1.0;
     }
   }
 
-  rtb_Gain_hl = AutopilotLaws_P.Gain_Gain_da * std::asin(rtb_Y_fh);
+  rtb_Gain_hl = AutopilotLaws_P.Gain_Gain_da * std::asin(rtb_Y_b);
   rtb_Saturation1 = AutopilotLaws_P.Gain1_Gain_kw * AutopilotLaws_U.in.data.alpha_deg;
   rtb_Gain_ny = result_0[2] * std::sin(rtb_Saturation1);
   rtb_Saturation1 = std::cos(rtb_Saturation1);
   rtb_Saturation1 *= result_0[0];
   AutopilotLaws_Voter1(AutopilotLaws_U.in.data.VLS_kn, AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VMAX_kn,
-                       &rtb_Y_fh);
-  rtb_Sum_gh = AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_fh;
+                       &rtb_Y_b);
+  rtb_Sum_gh = AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_b;
   if (!AutopilotLaws_DWork.eventTime_not_empty) {
     AutopilotLaws_DWork.eventTime = AutopilotLaws_U.in.time.simulation_time;
     AutopilotLaws_DWork.eventTime_not_empty = true;
@@ -1055,7 +1096,7 @@ void AutopilotLawsModelClass::step()
     rtb_Y_p = 0.0;
   }
 
-  rtb_Y_fh = AutopilotLaws_P.Gain1_Gain_hn * rtb_Sum_gh;
+  rtb_Y_b = AutopilotLaws_P.Gain1_Gain_hn * rtb_Sum_gh;
   if (1.0 > u1) {
     u1 = 1.0;
   }
@@ -1064,37 +1105,37 @@ void AutopilotLawsModelClass::step()
     rtb_Y_p = AutopilotLaws_P.GammaTCorrection_time;
   }
 
-  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_j4) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_j4;
+  if (rtb_Y_b > AutopilotLaws_P.Saturation_UpperSat_j4) {
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_j4;
   } else {
-    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_bb) {
-      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_bb;
+    if (rtb_Y_b < AutopilotLaws_P.Saturation_LowerSat_bb) {
+      rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_bb;
     }
   }
 
-  rtb_Sum2_h = ((1.0 - (u1 - 1.0) * 0.1111111111111111) * AutopilotLaws_P.GammaTCorrection_gain * (1.0 /
+  rtb_Sum2_d = ((1.0 - (u1 - 1.0) * 0.1111111111111111) * AutopilotLaws_P.GammaTCorrection_gain * (1.0 /
     AutopilotLaws_P.GammaTCorrection_time * rtb_Y_p) * rtb_Sum_gh + (rtb_Gain_ny + rtb_Saturation1) *
-                AutopilotLaws_P.Gain_Gain_bi * AutopilotLaws_P.Gain_Gain_ei) + rtb_Y_fh;
-  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain_iw * AutopilotLaws_U.in.data.V_tas_kn;
-  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_kg) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_kg;
+                AutopilotLaws_P.Gain_Gain_bi * AutopilotLaws_P.Gain_Gain_ei) + rtb_Y_b;
+  rtb_Y_b = AutopilotLaws_P.kntoms_Gain_iw * AutopilotLaws_U.in.data.V_tas_kn;
+  if (rtb_Y_b > AutopilotLaws_P.Saturation_UpperSat_kg) {
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_kg;
   } else {
-    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_ce) {
-      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_ce;
+    if (rtb_Y_b < AutopilotLaws_P.Saturation_LowerSat_ce) {
+      rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_ce;
     }
   }
 
-  rtb_Y_fh = (AutopilotLaws_P.Constant_Value_k - AutopilotLaws_U.in.data.H_dot_ft_min) *
-    AutopilotLaws_P.ftmintoms_Gain_p / rtb_Y_fh;
-  if (rtb_Y_fh > 1.0) {
-    rtb_Y_fh = 1.0;
+  rtb_Y_b = (AutopilotLaws_P.Constant_Value_k - AutopilotLaws_U.in.data.H_dot_ft_min) * AutopilotLaws_P.ftmintoms_Gain_p
+    / rtb_Y_b;
+  if (rtb_Y_b > 1.0) {
+    rtb_Y_b = 1.0;
   } else {
-    if (rtb_Y_fh < -1.0) {
-      rtb_Y_fh = -1.0;
+    if (rtb_Y_b < -1.0) {
+      rtb_Y_b = -1.0;
     }
   }
 
-  rtb_Gain_gd = AutopilotLaws_P.Gain_Gain_md * std::asin(rtb_Y_fh);
+  rtb_Gain_gd = AutopilotLaws_P.Gain_Gain_md * std::asin(rtb_Y_b);
   rtb_Saturation1 = rtb_GainTheta - AutopilotLaws_P.Constant2_Value_f;
   rtb_Gain4 = AutopilotLaws_P.Gain4_Gain * rtb_Saturation1;
   rtb_Gain5 = AutopilotLaws_P.Gain5_Gain_c * AutopilotLaws_U.in.data.bz_m_s2;
@@ -1103,22 +1144,22 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_WashoutFilter(AutopilotLaws_U.in.data.H_ind_ft, AutopilotLaws_P.WashoutFilter_C1_h,
     AutopilotLaws_U.in.time.dt, &rtb_Saturation1, &AutopilotLaws_DWork.sf_WashoutFilter);
   if (AutopilotLaws_U.in.data.H_radio_ft > AutopilotLaws_P.Saturation_UpperSat_e0) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_e0;
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_e0;
   } else if (AutopilotLaws_U.in.data.H_radio_ft < AutopilotLaws_P.Saturation_LowerSat_mg) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_mg;
+    rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_mg;
   } else {
-    rtb_Y_fh = AutopilotLaws_U.in.data.H_radio_ft;
+    rtb_Y_b = AutopilotLaws_U.in.data.H_radio_ft;
   }
 
-  AutopilotLaws_LagFilter(rtb_Y_fh, AutopilotLaws_P.LagFilter_C1_h, AutopilotLaws_U.in.time.dt, &rtb_Gain_ny,
+  AutopilotLaws_LagFilter(rtb_Y_b, AutopilotLaws_P.LagFilter_C1_h, AutopilotLaws_U.in.time.dt, &rtb_Gain_ny,
     &AutopilotLaws_DWork.sf_LagFilter_g);
   rtb_Sum_gh = (rtb_Saturation1 + rtb_Gain_ny) * AutopilotLaws_P.DiscreteDerivativeVariableTs2_Gain;
   rtb_Saturation1 = (rtb_Sum_gh - AutopilotLaws_DWork.Delay_DSTATE_k) / AutopilotLaws_U.in.time.dt;
   AutopilotLaws_LagFilter(AutopilotLaws_P.Gain2_Gain_c * rtb_Saturation1, AutopilotLaws_P.LagFilter3_C1,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_fh, &AutopilotLaws_DWork.sf_LagFilter_e);
+    AutopilotLaws_U.in.time.dt, &rtb_Y_b, &AutopilotLaws_DWork.sf_LagFilter_e);
   AutopilotLaws_WashoutFilter(AutopilotLaws_U.in.data.H_dot_ft_min, AutopilotLaws_P.WashoutFilter1_C1,
     AutopilotLaws_U.in.time.dt, &rtb_Saturation1, &AutopilotLaws_DWork.sf_WashoutFilter_h);
-  rtb_Saturation1 += rtb_Y_fh;
+  rtb_Saturation1 += rtb_Y_b;
   rtb_OR = (rtb_GainTheta1 == AutopilotLaws_P.CompareToConstant7_const);
   if (!AutopilotLaws_DWork.wasActive_not_empty) {
     AutopilotLaws_DWork.wasActive = rtb_OR;
@@ -1126,9 +1167,9 @@ void AutopilotLawsModelClass::step()
   }
 
   if ((!AutopilotLaws_DWork.wasActive) && rtb_OR) {
-    rtb_Y_fh = std::abs(rtb_Saturation1) / 60.0;
-    AutopilotLaws_DWork.Tau = AutopilotLaws_U.in.data.H_radio_ft / (rtb_Y_fh - 1.6666666666666667);
-    AutopilotLaws_DWork.H_bias = AutopilotLaws_DWork.Tau * rtb_Y_fh - AutopilotLaws_U.in.data.H_radio_ft;
+    rtb_Y_b = std::abs(rtb_Saturation1) / 60.0;
+    AutopilotLaws_DWork.Tau = AutopilotLaws_U.in.data.H_radio_ft / (rtb_Y_b - 1.6666666666666667);
+    AutopilotLaws_DWork.H_bias = AutopilotLaws_DWork.Tau * rtb_Y_b - AutopilotLaws_U.in.data.H_radio_ft;
   }
 
   if (rtb_OR) {
@@ -1139,61 +1180,61 @@ void AutopilotLawsModelClass::step()
   }
 
   AutopilotLaws_DWork.wasActive = rtb_OR;
-  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain_av * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_m) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_m;
+  rtb_Y_b = AutopilotLaws_P.kntoms_Gain_av * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Y_b > AutopilotLaws_P.Saturation_UpperSat_m) {
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_m;
   } else {
-    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_d1) {
-      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_d1;
+    if (rtb_Y_b < AutopilotLaws_P.Saturation_LowerSat_d1) {
+      rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_d1;
     }
   }
 
-  rtb_Y_fh = (rtb_Gain_ny - rtb_Saturation1) * AutopilotLaws_P.ftmintoms_Gain_i / rtb_Y_fh;
-  if (rtb_Y_fh > 1.0) {
-    rtb_Y_fh = 1.0;
+  rtb_Y_b = (rtb_Gain_ny - rtb_Saturation1) * AutopilotLaws_P.ftmintoms_Gain_i / rtb_Y_b;
+  if (rtb_Y_b > 1.0) {
+    rtb_Y_b = 1.0;
   } else {
-    if (rtb_Y_fh < -1.0) {
-      rtb_Y_fh = -1.0;
+    if (rtb_Y_b < -1.0) {
+      rtb_Y_b = -1.0;
     }
   }
 
-  rtb_Gain_hz = AutopilotLaws_P.Gain_Gain_fz * std::asin(rtb_Y_fh);
+  rtb_Gain_hz = AutopilotLaws_P.Gain_Gain_fz * std::asin(rtb_Y_b);
   rtb_Sum_j = AutopilotLaws_P.Constant1_Value_d - rtb_GainTheta;
   rtb_Saturation1 = AutopilotLaws_P.Gain1_Gain_fy * AutopilotLaws_U.in.data.alpha_deg;
   rtb_Gain_ny = result_0[2] * std::sin(rtb_Saturation1);
   rtb_Saturation1 = std::cos(rtb_Saturation1);
   rtb_Saturation1 *= result_0[0];
-  rtb_Y_fh = (AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.input.V_c_kn) * AutopilotLaws_P.Gain1_Gain_fr;
-  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_e3) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_e3;
+  rtb_Y_b = (AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.input.V_c_kn) * AutopilotLaws_P.Gain1_Gain_fr;
+  if (rtb_Y_b > AutopilotLaws_P.Saturation_UpperSat_e3) {
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_e3;
   } else {
-    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_py) {
-      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_py;
+    if (rtb_Y_b < AutopilotLaws_P.Saturation_LowerSat_py) {
+      rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_py;
     }
   }
 
-  rtb_Sum2_f = (rtb_Gain_ny + rtb_Saturation1) * AutopilotLaws_P.Gain_Gain_nub * AutopilotLaws_P.Gain_Gain_ao + rtb_Y_fh;
-  rtb_Y_fh = AutopilotLaws_P.kntoms_Gain_f * AutopilotLaws_U.in.data.V_tas_kn;
-  if (rtb_Y_fh > AutopilotLaws_P.Saturation_UpperSat_b) {
-    rtb_Y_fh = AutopilotLaws_P.Saturation_UpperSat_b;
+  rtb_Sum2_j = (rtb_Gain_ny + rtb_Saturation1) * AutopilotLaws_P.Gain_Gain_nub * AutopilotLaws_P.Gain_Gain_ao + rtb_Y_b;
+  rtb_Y_b = AutopilotLaws_P.kntoms_Gain_f * AutopilotLaws_U.in.data.V_tas_kn;
+  if (rtb_Y_b > AutopilotLaws_P.Saturation_UpperSat_b) {
+    rtb_Y_b = AutopilotLaws_P.Saturation_UpperSat_b;
   } else {
-    if (rtb_Y_fh < AutopilotLaws_P.Saturation_LowerSat_ow) {
-      rtb_Y_fh = AutopilotLaws_P.Saturation_LowerSat_ow;
+    if (rtb_Y_b < AutopilotLaws_P.Saturation_LowerSat_ow) {
+      rtb_Y_b = AutopilotLaws_P.Saturation_LowerSat_ow;
     }
   }
 
-  rtb_Y_fh = (AutopilotLaws_P.Constant_Value_i - AutopilotLaws_U.in.data.H_dot_ft_min) *
-    AutopilotLaws_P.ftmintoms_Gain_j / rtb_Y_fh;
-  if (rtb_Y_fh > 1.0) {
-    rtb_Y_fh = 1.0;
+  rtb_Y_b = (AutopilotLaws_P.Constant_Value_i - AutopilotLaws_U.in.data.H_dot_ft_min) * AutopilotLaws_P.ftmintoms_Gain_j
+    / rtb_Y_b;
+  if (rtb_Y_b > 1.0) {
+    rtb_Y_b = 1.0;
   } else {
-    if (rtb_Y_fh < -1.0) {
-      rtb_Y_fh = -1.0;
+    if (rtb_Y_b < -1.0) {
+      rtb_Y_b = -1.0;
     }
   }
 
-  rtb_Gain_a3 = AutopilotLaws_P.Gain_Gain_bd * std::asin(rtb_Y_fh);
-  AutopilotLaws_Voter1(rtb_Sum_j, AutopilotLaws_P.Gain_Gain_b2 * rtb_Sum2_f, AutopilotLaws_P.VS_Gain_c * rtb_Gain_a3,
+  rtb_Gain_a3 = AutopilotLaws_P.Gain_Gain_bd * std::asin(rtb_Y_b);
+  AutopilotLaws_Voter1(rtb_Sum_j, AutopilotLaws_P.Gain_Gain_b2 * rtb_Sum2_j, AutopilotLaws_P.VS_Gain_c * rtb_Gain_a3,
                        &rtb_Saturation1);
   switch (static_cast<int32_T>(rtb_GainTheta1)) {
    case 0:
@@ -1209,17 +1250,17 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 3:
-    if (rtb_Sum_ib_tmp > AutopilotLaws_P.Switch_Threshold_n) {
-      rtb_Y_fh = AutopilotLaws_P.Gain_Gain_kg * rtb_Sum2_h;
+    if (dH_tmp > AutopilotLaws_P.Switch_Threshold_n) {
+      rtb_Y_b = AutopilotLaws_P.Gain_Gain_kg * rtb_Sum2_d;
       rtb_Saturation1 = AutopilotLaws_P.VS_Gain_j * rtb_Gain_gd;
-      if (rtb_Y_fh > rtb_Saturation1) {
-        rtb_Saturation1 = rtb_Y_fh;
+      if (rtb_Y_b > rtb_Saturation1) {
+        rtb_Saturation1 = rtb_Y_b;
       }
     } else {
-      rtb_Y_fh = AutopilotLaws_P.Gain_Gain_kg * rtb_Sum2_h;
+      rtb_Y_b = AutopilotLaws_P.Gain_Gain_kg * rtb_Sum2_d;
       rtb_Saturation1 = AutopilotLaws_P.VS_Gain_j * rtb_Gain_gd;
-      if (rtb_Y_fh < rtb_Saturation1) {
-        rtb_Saturation1 = rtb_Y_fh;
+      if (rtb_Y_b < rtb_Saturation1) {
+        rtb_Saturation1 = rtb_Y_b;
       }
     }
     break;
@@ -1229,7 +1270,7 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 5:
-    rtb_Saturation1 = rtb_Sum2_j4;
+    rtb_Saturation1 = rtb_Y_m;
     break;
 
    case 6:
@@ -1292,7 +1333,7 @@ void AutopilotLawsModelClass::step()
   rtb_Saturation1 = AutopilotLaws_P.Constant_Value_f - rtb_Saturation1;
   rtb_Saturation1 *= rtb_GainTheta;
   AutopilotLaws_Y.out.output.autopilot.Theta_c_deg = rtb_out_c + rtb_Saturation1;
-  AutopilotLaws_Voter1(rtb_Sum_j, rtb_Sum2_f, rtb_Gain_a3, &rtb_Gain_ny);
+  AutopilotLaws_Voter1(rtb_Sum_j, rtb_Sum2_j, rtb_Gain_a3, &rtb_Gain_ny);
   switch (static_cast<int32_T>(rtb_GainTheta1)) {
    case 0:
     rtb_Gain_ny = rtb_GainTheta;
@@ -1307,14 +1348,14 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 3:
-    if (rtb_Sum_ib_tmp > AutopilotLaws_P.Switch_Threshold) {
-      if (rtb_Sum2_h > rtb_Gain_gd) {
-        rtb_Gain_ny = rtb_Sum2_h;
+    if (dH_tmp > AutopilotLaws_P.Switch_Threshold) {
+      if (rtb_Sum2_d > rtb_Gain_gd) {
+        rtb_Gain_ny = rtb_Sum2_d;
       } else {
         rtb_Gain_ny = rtb_Gain_gd;
       }
-    } else if (rtb_Sum2_h < rtb_Gain_gd) {
-      rtb_Gain_ny = rtb_Sum2_h;
+    } else if (rtb_Sum2_d < rtb_Gain_gd) {
+      rtb_Gain_ny = rtb_Sum2_d;
     } else {
       rtb_Gain_ny = rtb_Gain_gd;
     }
@@ -1383,6 +1424,7 @@ void AutopilotLawsModelClass::initialize()
     AutopilotLaws_DWork.Delay_DSTATE_k = AutopilotLaws_P.DiscreteDerivativeVariableTs2_InitialCondition;
     AutopilotLaws_DWork.icLoad_f = 1U;
     AutopilotLaws_B.u = AutopilotLaws_P.Y_Y0;
+    AutopilotLaws_DWork.k = 5.0;
   }
 }
 

--- a/src/fbw/src/model/AutopilotLaws.h
+++ b/src/fbw/src/model/AutopilotLaws.h
@@ -54,6 +54,8 @@ class AutopilotLawsModelClass {
     real_T eventTime;
     real_T Tau;
     real_T H_bias;
+    real_T dH_offset;
+    real_T k;
     real_T limit;
     boolean_T Delay_DSTATE_l[100];
     boolean_T Delay_DSTATE_h5[100];
@@ -64,6 +66,8 @@ class AutopilotLawsModelClass {
     boolean_T eventTime_not_empty;
     boolean_T wasActive;
     boolean_T wasActive_not_empty;
+    boolean_T wasActive_g;
+    boolean_T wasActive_not_empty_d;
     boolean_T limit_not_empty;
     rtDW_RateLimiter_AutopilotLaws_T sf_RateLimiter_g;
     rtDW_LagFilter_AutopilotLaws_T sf_LagFilter_n;
@@ -161,6 +165,7 @@ class AutopilotLawsModelClass {
     real_T CompareToConstant5_const_e;
     real_T CompareToConstant_const_n;
     real_T CompareToConstant6_const;
+    real_T CompareToConstant1_const;
     real_T CompareToConstant2_const_e;
     real_T CompareToConstant7_const;
     real_T GammaTCorrection_gain;
@@ -322,8 +327,6 @@ class AutopilotLawsModelClass {
     real_T Gain1_Gain_nq;
     real_T Bias1_Bias;
     real_T Gain_Gain_p2b;
-    real_T Constant_Value_b;
-    real_T Gain_Gain_el;
     real_T ftmintoms_Gain_g;
     real_T kntoms_Gain_e;
     real_T Saturation_UpperSat_dn;
@@ -414,6 +417,7 @@ class AutopilotLawsModelClass {
     rtDW_WashoutFilter_AutopilotLaws_T *localDW);
   static void AutopilotLaws_SpeedProtectionMode(const ap_laws_output *rtu_in, real_T rtu_VS_FD, real_T rtu_VS_AP, real_T
     rtu_VLS_FD, real_T rtu_VLS_AP, real_T rtu_VMAX_FD, real_T rtu_VMAX_AP, real_T *rty_FD, real_T *rty_AP);
+  static void AutopilotLaws_VSLimiter(real_T rtu_u, real_T rtu_V_tas_kn, real_T *rty_y);
   static void AutopilotLaws_V_LSSpeedSelection(const ap_laws_output *rtu_in, real_T *rty_y);
   static void AutopilotLaws_Voter1(real_T rtu_u1, real_T rtu_u2, real_T rtu_u3, real_T *rty_Y);
 };

--- a/src/fbw/src/model/AutopilotLaws_data.cpp
+++ b/src/fbw/src/model/AutopilotLaws_data.cpp
@@ -262,6 +262,8 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
 
   6.0,
 
+  2.0,
+
   3.0,
 
   7.0,
@@ -585,10 +587,6 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
   -2.0,
 
   0.35,
-
-  20.0,
-
-  5.0,
 
   0.00508,
 

--- a/src/fbw/src/model/AutopilotStateMachine.cpp
+++ b/src/fbw/src/model/AutopilotStateMachine.cpp
@@ -2107,7 +2107,7 @@ void AutopilotStateMachineModelClass::step()
   real_T result_tmp[9];
   real_T result[3];
   real_T result_0[3];
-  real_T dPsi_2;
+  real_T dPsi_1;
   real_T rtb_DataTypeConversion2_f;
   real_T rtb_GainTheta;
   real_T rtb_GainTheta1;
@@ -2167,12 +2167,12 @@ void AutopilotStateMachineModelClass::step()
   rtb_GainTheta1 = AutopilotStateMachine_P.GainTheta1_Gain * AutopilotStateMachine_U.in.data.Phi_deg;
   rtb_Saturation = 0.017453292519943295 * rtb_GainTheta;
   rtb_Saturation1 = 0.017453292519943295 * rtb_GainTheta1;
-  rtb_DataTypeConversion2_f = std::tan(rtb_Saturation);
+  rtb_y_d = std::tan(rtb_Saturation);
   rtb_y_a = std::sin(rtb_Saturation1);
   rtb_y_j = std::cos(rtb_Saturation1);
   result_tmp[0] = 1.0;
-  result_tmp[3] = rtb_y_a * rtb_DataTypeConversion2_f;
-  result_tmp[6] = rtb_y_j * rtb_DataTypeConversion2_f;
+  result_tmp[3] = rtb_y_a * rtb_y_d;
+  result_tmp[6] = rtb_y_j * rtb_y_d;
   result_tmp[1] = 0.0;
   result_tmp[4] = rtb_y_j;
   result_tmp[7] = -rtb_y_a;
@@ -2184,25 +2184,25 @@ void AutopilotStateMachineModelClass::step()
     AutopilotStateMachine_P.Gainpk_Gain;
   rtb_y_j = AutopilotStateMachine_P.Gain_Gain * AutopilotStateMachine_U.in.data.q_rad_s *
     AutopilotStateMachine_P.Gainqk_Gain;
-  rtb_DataTypeConversion2_f = AutopilotStateMachine_P.Gain_Gain_a * AutopilotStateMachine_U.in.data.r_rad_s;
+  rtb_y_d = AutopilotStateMachine_P.Gain_Gain_a * AutopilotStateMachine_U.in.data.r_rad_s;
   for (rtb_on_ground = 0; rtb_on_ground < 3; rtb_on_ground++) {
-    result[rtb_on_ground] = result_tmp[rtb_on_ground + 6] * rtb_DataTypeConversion2_f + (result_tmp[rtb_on_ground + 3] *
-      rtb_y_j + result_tmp[rtb_on_ground] * rtb_y_a);
+    result[rtb_on_ground] = result_tmp[rtb_on_ground + 6] * rtb_y_d + (result_tmp[rtb_on_ground + 3] * rtb_y_j +
+      result_tmp[rtb_on_ground] * rtb_y_a);
   }
 
-  rtb_DataTypeConversion2_f = std::cos(rtb_Saturation);
+  rtb_y_d = std::cos(rtb_Saturation);
   rtb_y_a = std::sin(rtb_Saturation);
   rtb_y_j = std::sin(rtb_Saturation1);
   rtb_Saturation = std::cos(rtb_Saturation1);
-  result_tmp[0] = rtb_DataTypeConversion2_f;
+  result_tmp[0] = rtb_y_d;
   result_tmp[3] = 0.0;
   result_tmp[6] = -rtb_y_a;
   result_tmp[1] = rtb_y_j * rtb_y_a;
   result_tmp[4] = rtb_Saturation;
-  result_tmp[7] = rtb_DataTypeConversion2_f * rtb_y_j;
+  result_tmp[7] = rtb_y_d * rtb_y_j;
   result_tmp[2] = rtb_Saturation * rtb_y_a;
   result_tmp[5] = 0.0 - rtb_y_j;
-  result_tmp[8] = rtb_Saturation * rtb_DataTypeConversion2_f;
+  result_tmp[8] = rtb_Saturation * rtb_y_d;
   for (rtb_on_ground = 0; rtb_on_ground < 3; rtb_on_ground++) {
     result_0[rtb_on_ground] = result_tmp[rtb_on_ground + 6] * AutopilotStateMachine_U.in.data.bz_m_s2 +
       (result_tmp[rtb_on_ground + 3] * AutopilotStateMachine_U.in.data.by_m_s2 + result_tmp[rtb_on_ground] *
@@ -2529,45 +2529,45 @@ void AutopilotStateMachineModelClass::step()
   rtb_DataTypeConversion2_f = (AutopilotStateMachine_U.in.data.Psi_magnetic_deg -
     (AutopilotStateMachine_U.in.data.nav_loc_deg + 360.0)) + 360.0;
   if (rtb_DataTypeConversion2_f == 0.0) {
+    dPsi_1 = 0.0;
+  } else {
+    dPsi_1 = std::fmod(rtb_DataTypeConversion2_f, 360.0);
+    if (dPsi_1 == 0.0) {
+      dPsi_1 = 0.0;
+    } else {
+      if (rtb_DataTypeConversion2_f < 0.0) {
+        dPsi_1 += 360.0;
+      }
+    }
+  }
+
+  if (360.0 - dPsi_1 == 0.0) {
     rtb_y_m = 0.0;
   } else {
-    rtb_y_m = std::fmod(rtb_DataTypeConversion2_f, 360.0);
+    rtb_y_m = std::fmod(360.0 - dPsi_1, 360.0);
     if (rtb_y_m == 0.0) {
       rtb_y_m = 0.0;
     } else {
-      if (rtb_DataTypeConversion2_f < 0.0) {
+      if (360.0 - dPsi_1 < 0.0) {
         rtb_y_m += 360.0;
       }
     }
   }
 
-  if (360.0 - rtb_y_m == 0.0) {
-    dPsi_2 = 0.0;
-  } else {
-    dPsi_2 = std::fmod(360.0 - rtb_y_m, 360.0);
-    if (dPsi_2 == 0.0) {
-      dPsi_2 = 0.0;
-    } else {
-      if (360.0 - rtb_y_m < 0.0) {
-        dPsi_2 += 360.0;
-      }
-    }
-  }
-
-  if (rtb_y_m < dPsi_2) {
-    dPsi_2 = -rtb_y_m;
+  if (dPsi_1 < rtb_y_m) {
+    rtb_y_m = -dPsi_1;
   }
 
   if (AutopilotStateMachine_U.in.data.nav_valid && AutopilotStateMachine_U.in.data.nav_loc_valid) {
-    rtb_DataTypeConversion2_f = std::abs(dPsi_2);
+    rtb_DataTypeConversion2_f = std::abs(rtb_y_m);
     if (rtb_DataTypeConversion2_f < 115.0) {
-      rtb_y_m = std::abs(AutopilotStateMachine_U.in.data.nav_loc_error_deg);
-      if (rtb_y_m < 3.0) {
-        if (dPsi_2 < 0.0) {
-          dPsi_2 = -1.0;
+      dPsi_1 = std::abs(AutopilotStateMachine_U.in.data.nav_loc_error_deg);
+      if (dPsi_1 < 3.0) {
+        if (rtb_y_m < 0.0) {
+          rtb_y_m = -1.0;
         } else {
-          if (dPsi_2 > 0.0) {
-            dPsi_2 = 1.0;
+          if (rtb_y_m > 0.0) {
+            rtb_y_m = 1.0;
           }
         }
 
@@ -2579,11 +2579,11 @@ void AutopilotStateMachineModelClass::step()
           u = AutopilotStateMachine_U.in.input.Phi_loc_c;
         }
 
-        if ((dPsi_2 == u) && (std::abs(AutopilotStateMachine_U.in.input.Phi_loc_c) > 5.0)) {
+        if ((rtb_y_m == u) && (std::abs(AutopilotStateMachine_U.in.input.Phi_loc_c) > 5.0)) {
           AutopilotStateMachine_B.BusAssignment_g.lateral.condition.LOC_CPT = true;
         } else {
           AutopilotStateMachine_B.BusAssignment_g.lateral.condition.LOC_CPT = ((rtb_DataTypeConversion2_f < 15.0) &&
-            (rtb_y_m < 1.1));
+            (dPsi_1 < 1.1));
         }
       } else {
         AutopilotStateMachine_B.BusAssignment_g.lateral.condition.LOC_CPT = false;
@@ -2809,11 +2809,11 @@ void AutopilotStateMachineModelClass::step()
     (AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode != vertical_mode_ALT_CPT) &&
     ((AutopilotStateMachine_U.in.data.flight_phase == 2.0) || (AutopilotStateMachine_U.in.data.flight_phase == 6.0))));
   AutopilotStateMachine_DWork.sCLB = (throttleCondition || AutopilotStateMachine_DWork.sCLB);
-  dPsi_2 = std::abs(AutopilotStateMachine_U.in.input.H_fcu_ft - AutopilotStateMachine_U.in.data.H_ind_ft);
+  rtb_y_m = std::abs(AutopilotStateMachine_U.in.input.H_fcu_ft - AutopilotStateMachine_U.in.data.H_ind_ft);
   sCLB_tmp = ((!AutopilotStateMachine_DWork.DelayInput1_DSTATE_i) && (!AutopilotStateMachine_DWork.DelayInput1_DSTATE_bd)
               && (!AutopilotStateMachine_DWork.DelayInput1_DSTATE_ah));
   AutopilotStateMachine_DWork.sCLB = (sCLB_tmp && ((AutopilotStateMachine_U.in.data.H_radio_ft < 30.0) ||
-    ((AutopilotStateMachine_U.in.input.H_fcu_ft >= AutopilotStateMachine_U.in.data.H_ind_ft) && ((dPsi_2 >= 50.0) &&
+    ((AutopilotStateMachine_U.in.input.H_fcu_ft >= AutopilotStateMachine_U.in.data.H_ind_ft) && ((rtb_y_m >= 50.0) &&
     ((AutopilotStateMachine_U.in.input.H_fcu_ft != AutopilotStateMachine_U.in.input.H_constraint_ft) &&
      ((!(AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode != vertical_mode_ALT_CST)) ||
       (!(AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode != vertical_mode_ALT_CST_CPT)) ||
@@ -2828,7 +2828,7 @@ void AutopilotStateMachineModelClass::step()
      (AutopilotStateMachine_DWork.Delay_DSTATE.output.mode == lateral_mode_LOC_TRACK))) ||
     AutopilotStateMachine_DWork.sDES);
   AutopilotStateMachine_DWork.sDES = (sCLB_tmp && ((rtb_on_ground != 0) || ((AutopilotStateMachine_U.in.input.H_fcu_ft <=
-    AutopilotStateMachine_U.in.data.H_ind_ft) && ((dPsi_2 >= 50.0) && ((AutopilotStateMachine_U.in.input.H_fcu_ft !=
+    AutopilotStateMachine_U.in.data.H_ind_ft) && ((rtb_y_m >= 50.0) && ((AutopilotStateMachine_U.in.input.H_fcu_ft !=
     AutopilotStateMachine_U.in.input.H_constraint_ft) && ((!(AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode !=
     vertical_mode_ALT_CST)) || (!(AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode != vertical_mode_ALT_CST_CPT))) &&
     ((!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode != lateral_mode_NAV)) ||
@@ -2852,8 +2852,18 @@ void AutopilotStateMachineModelClass::step()
     (AutopilotStateMachine_U.in.data.throttle_lever_1_pos != 45.0) &&
     (AutopilotStateMachine_U.in.data.throttle_lever_2_pos != 45.0) && speedTargetChanged &&
     AutopilotStateMachine_DWork.state_j);
-  rtb_DataTypeConversion2_f = std::abs(AutopilotStateMachine_U.in.data.H_dot_ft_min);
-  if (dPsi_2 <= rtb_DataTypeConversion2_f / 5.0) {
+  rtb_DataTypeConversion2_f = AutopilotStateMachine_U.in.data.H_dot_ft_min * 0.00508;
+  rtb_DataTypeConversion2_f = rtb_DataTypeConversion2_f * rtb_DataTypeConversion2_f / 0.49050000000000005 *
+    3.2808398950131235;
+  if (80.0 > rtb_DataTypeConversion2_f) {
+    rtb_DataTypeConversion2_f = 80.0;
+  }
+
+  if (2500.0 < rtb_DataTypeConversion2_f) {
+    rtb_DataTypeConversion2_f = 2500.0;
+  }
+
+  if (rtb_y_m <= rtb_DataTypeConversion2_f) {
     u = AutopilotStateMachine_U.in.input.H_fcu_ft - AutopilotStateMachine_U.in.data.H_ind_ft;
     if (u < 0.0) {
       u = -1.0;
@@ -2864,24 +2874,25 @@ void AutopilotStateMachineModelClass::step()
     }
 
     if (AutopilotStateMachine_U.in.data.H_dot_ft_min < 0.0) {
-      rtb_y_m = -1.0;
+      rtb_DataTypeConversion2_f = -1.0;
     } else if (AutopilotStateMachine_U.in.data.H_dot_ft_min > 0.0) {
-      rtb_y_m = 1.0;
+      rtb_DataTypeConversion2_f = 1.0;
     } else {
-      rtb_y_m = AutopilotStateMachine_U.in.data.H_dot_ft_min;
+      rtb_DataTypeConversion2_f = AutopilotStateMachine_U.in.data.H_dot_ft_min;
     }
 
-    AutopilotStateMachine_B.BusAssignment_g.vertical.condition.ALT_CPT = ((u == rtb_y_m) && ((rtb_DataTypeConversion2_f >=
-      100.0) && ((!AutopilotStateMachine_DWork.DelayInput1_DSTATE_o) && (AutopilotStateMachine_U.in.data.H_radio_ft >
-      400.0))));
+    AutopilotStateMachine_B.BusAssignment_g.vertical.condition.ALT_CPT = ((u == rtb_DataTypeConversion2_f) && ((std::abs
+      (AutopilotStateMachine_U.in.data.H_dot_ft_min) >= 100.0) && ((!AutopilotStateMachine_DWork.DelayInput1_DSTATE_o) &&
+      (AutopilotStateMachine_U.in.data.H_radio_ft > 400.0))));
   } else {
     AutopilotStateMachine_B.BusAssignment_g.vertical.condition.ALT_CPT = false;
   }
 
   if ((AutopilotStateMachine_U.in.input.H_constraint_ft != 0.0) && (AutopilotStateMachine_U.in.input.H_constraint_ft !=
        AutopilotStateMachine_U.in.input.H_fcu_ft)) {
+    rtb_DataTypeConversion2_f = std::abs(AutopilotStateMachine_U.in.data.H_dot_ft_min);
     u = AutopilotStateMachine_U.in.input.H_constraint_ft - AutopilotStateMachine_U.in.data.H_ind_ft;
-    if (std::abs(u) <= std::abs(AutopilotStateMachine_U.in.data.H_dot_ft_min) / 5.0) {
+    if (std::abs(u) <= rtb_DataTypeConversion2_f / 5.0) {
       if (u < 0.0) {
         u = -1.0;
       } else {
@@ -2891,14 +2902,14 @@ void AutopilotStateMachineModelClass::step()
       }
 
       if (AutopilotStateMachine_U.in.data.H_dot_ft_min < 0.0) {
-        rtb_y_m = -1.0;
+        dPsi_1 = -1.0;
       } else if (AutopilotStateMachine_U.in.data.H_dot_ft_min > 0.0) {
-        rtb_y_m = 1.0;
+        dPsi_1 = 1.0;
       } else {
-        rtb_y_m = AutopilotStateMachine_U.in.data.H_dot_ft_min;
+        dPsi_1 = AutopilotStateMachine_U.in.data.H_dot_ft_min;
       }
 
-      AutopilotStateMachine_B.BusAssignment_g.vertical.condition.ALT_CST_CPT = ((u == rtb_y_m) &&
+      AutopilotStateMachine_B.BusAssignment_g.vertical.condition.ALT_CST_CPT = ((u == dPsi_1) &&
         ((rtb_DataTypeConversion2_f >= 300.0) && ((!AutopilotStateMachine_DWork.DelayInput1_DSTATE_o) &&
         (AutopilotStateMachine_U.in.data.H_radio_ft > 400.0))));
     } else {
@@ -3153,7 +3164,7 @@ void AutopilotStateMachineModelClass::step()
   AutopilotStateMachine_B.BusAssignment_g.vertical.armed.DES = AutopilotStateMachine_DWork.sDES;
   AutopilotStateMachine_B.BusAssignment_g.vertical.armed.GS = AutopilotStateMachine_DWork.state_j;
   engageCondition = !AutopilotStateMachine_DWork.DelayInput1_DSTATE_o;
-  AutopilotStateMachine_B.BusAssignment_g.vertical.condition.ALT = ((dPsi_2 < 20.0) && engageCondition);
+  AutopilotStateMachine_B.BusAssignment_g.vertical.condition.ALT = ((rtb_y_m < 20.0) && engageCondition);
   AutopilotStateMachine_B.BusAssignment_g.vertical.condition.ALT_CST =
     ((AutopilotStateMachine_U.in.input.H_constraint_ft != 0.0) && (AutopilotStateMachine_U.in.input.H_constraint_ft !=
       AutopilotStateMachine_U.in.input.H_fcu_ft) && ((std::abs(AutopilotStateMachine_U.in.input.H_constraint_ft -
@@ -3431,54 +3442,54 @@ void AutopilotStateMachineModelClass::step()
     AutopilotStateMachine_Y.out.output.vertical_mode_armed = AutopilotStateMachine_P.Constant_Value_a;
   }
 
-  rtb_GainTheta1 = static_cast<real_T>(AutopilotStateMachine_B.BusAssignment_g.lateral.output.mode_reversion) -
+  rtb_GainTheta = static_cast<real_T>(AutopilotStateMachine_B.BusAssignment_g.lateral.output.mode_reversion) -
     AutopilotStateMachine_DWork.Delay_DSTATE_f;
-  rtb_GainTheta = AutopilotStateMachine_P.Raising_Value * AutopilotStateMachine_B.BusAssignment_g.time.dt;
-  if (rtb_GainTheta1 < rtb_GainTheta) {
-    rtb_GainTheta = rtb_GainTheta1;
+  rtb_DataTypeConversion2_f = AutopilotStateMachine_P.Raising_Value * AutopilotStateMachine_B.BusAssignment_g.time.dt;
+  if (rtb_GainTheta < rtb_DataTypeConversion2_f) {
+    rtb_DataTypeConversion2_f = rtb_GainTheta;
   }
 
-  rtb_GainTheta1 = AutopilotStateMachine_P.Falling_Value / AutopilotStateMachine_P.Debounce_Value *
+  rtb_GainTheta = AutopilotStateMachine_P.Falling_Value / AutopilotStateMachine_P.Debounce_Value *
     AutopilotStateMachine_B.BusAssignment_g.time.dt;
-  if (rtb_GainTheta > rtb_GainTheta1) {
-    rtb_GainTheta1 = rtb_GainTheta;
+  if (rtb_DataTypeConversion2_f > rtb_GainTheta) {
+    rtb_GainTheta = rtb_DataTypeConversion2_f;
   }
 
-  AutopilotStateMachine_DWork.Delay_DSTATE_f += rtb_GainTheta1;
+  AutopilotStateMachine_DWork.Delay_DSTATE_f += rtb_GainTheta;
   AutopilotStateMachine_DWork.DelayInput1_DSTATE_o = (AutopilotStateMachine_DWork.Delay_DSTATE_f !=
     AutopilotStateMachine_P.CompareToConstant_const_d);
   AutopilotStateMachine_Y.out.output.mode_reversion_lateral = AutopilotStateMachine_DWork.DelayInput1_DSTATE_o;
-  rtb_GainTheta1 = static_cast<real_T>(AutopilotStateMachine_B.out.mode_reversion) -
+  rtb_GainTheta = static_cast<real_T>(AutopilotStateMachine_B.out.mode_reversion) -
     AutopilotStateMachine_DWork.Delay_DSTATE_l;
-  rtb_GainTheta = AutopilotStateMachine_P.Raising_Value_f * AutopilotStateMachine_B.BusAssignment_g.time.dt;
-  if (rtb_GainTheta1 < rtb_GainTheta) {
-    rtb_GainTheta = rtb_GainTheta1;
+  rtb_DataTypeConversion2_f = AutopilotStateMachine_P.Raising_Value_f * AutopilotStateMachine_B.BusAssignment_g.time.dt;
+  if (rtb_GainTheta < rtb_DataTypeConversion2_f) {
+    rtb_DataTypeConversion2_f = rtb_GainTheta;
   }
 
-  rtb_GainTheta1 = AutopilotStateMachine_P.Falling_Value_b / AutopilotStateMachine_P.Debounce_Value_a *
+  rtb_GainTheta = AutopilotStateMachine_P.Falling_Value_b / AutopilotStateMachine_P.Debounce_Value_a *
     AutopilotStateMachine_B.BusAssignment_g.time.dt;
-  if (rtb_GainTheta > rtb_GainTheta1) {
-    rtb_GainTheta1 = rtb_GainTheta;
+  if (rtb_DataTypeConversion2_f > rtb_GainTheta) {
+    rtb_GainTheta = rtb_DataTypeConversion2_f;
   }
 
-  AutopilotStateMachine_DWork.Delay_DSTATE_l += rtb_GainTheta1;
+  AutopilotStateMachine_DWork.Delay_DSTATE_l += rtb_GainTheta;
   AutopilotStateMachine_DWork.DelayInput1_DSTATE_o = (AutopilotStateMachine_DWork.Delay_DSTATE_l !=
     AutopilotStateMachine_P.CompareToConstant_const_j);
   AutopilotStateMachine_Y.out.output.mode_reversion_vertical = AutopilotStateMachine_DWork.DelayInput1_DSTATE_o;
-  rtb_GainTheta1 = static_cast<real_T>(AutopilotStateMachine_B.BusAssignment_g.lateral.output.mode_reversion_TRK_FPA) -
+  rtb_GainTheta = static_cast<real_T>(AutopilotStateMachine_B.BusAssignment_g.lateral.output.mode_reversion_TRK_FPA) -
     AutopilotStateMachine_DWork.Delay_DSTATE_e;
-  rtb_GainTheta = AutopilotStateMachine_P.Raising_Value_c * AutopilotStateMachine_B.BusAssignment_g.time.dt;
-  if (rtb_GainTheta1 < rtb_GainTheta) {
-    rtb_GainTheta = rtb_GainTheta1;
+  rtb_DataTypeConversion2_f = AutopilotStateMachine_P.Raising_Value_c * AutopilotStateMachine_B.BusAssignment_g.time.dt;
+  if (rtb_GainTheta < rtb_DataTypeConversion2_f) {
+    rtb_DataTypeConversion2_f = rtb_GainTheta;
   }
 
-  rtb_GainTheta1 = AutopilotStateMachine_P.Falling_Value_a / AutopilotStateMachine_P.Debounce_Value_j *
+  rtb_GainTheta = AutopilotStateMachine_P.Falling_Value_a / AutopilotStateMachine_P.Debounce_Value_j *
     AutopilotStateMachine_B.BusAssignment_g.time.dt;
-  if (rtb_GainTheta > rtb_GainTheta1) {
-    rtb_GainTheta1 = rtb_GainTheta;
+  if (rtb_DataTypeConversion2_f > rtb_GainTheta) {
+    rtb_GainTheta = rtb_DataTypeConversion2_f;
   }
 
-  AutopilotStateMachine_DWork.Delay_DSTATE_e += rtb_GainTheta1;
+  AutopilotStateMachine_DWork.Delay_DSTATE_e += rtb_GainTheta;
   AutopilotStateMachine_DWork.DelayInput1_DSTATE_o = (AutopilotStateMachine_DWork.Delay_DSTATE_e !=
     AutopilotStateMachine_P.CompareToConstant_const_da);
   if (!AutopilotStateMachine_DWork.eventTimeTC_not_empty) {
@@ -3586,19 +3597,19 @@ void AutopilotStateMachineModelClass::step()
     AutopilotStateMachine_Y.out.output.mode_reversion_fma = AutopilotStateMachine_DWork.modeReversionFMA;
   }
 
-  rtb_GainTheta1 = static_cast<real_T>(rtb_on_ground) - AutopilotStateMachine_DWork.Delay_DSTATE_n;
-  rtb_GainTheta = AutopilotStateMachine_P.Raising_Value_a * AutopilotStateMachine_B.BusAssignment_g.time.dt;
-  if (rtb_GainTheta1 < rtb_GainTheta) {
-    rtb_GainTheta = rtb_GainTheta1;
+  rtb_GainTheta = static_cast<real_T>(rtb_on_ground) - AutopilotStateMachine_DWork.Delay_DSTATE_n;
+  rtb_DataTypeConversion2_f = AutopilotStateMachine_P.Raising_Value_a * AutopilotStateMachine_B.BusAssignment_g.time.dt;
+  if (rtb_GainTheta < rtb_DataTypeConversion2_f) {
+    rtb_DataTypeConversion2_f = rtb_GainTheta;
   }
 
-  rtb_GainTheta1 = AutopilotStateMachine_P.Falling_Value_k / AutopilotStateMachine_P.Debounce1_Value *
+  rtb_GainTheta = AutopilotStateMachine_P.Falling_Value_k / AutopilotStateMachine_P.Debounce1_Value *
     AutopilotStateMachine_B.BusAssignment_g.time.dt;
-  if (rtb_GainTheta > rtb_GainTheta1) {
-    rtb_GainTheta1 = rtb_GainTheta;
+  if (rtb_DataTypeConversion2_f > rtb_GainTheta) {
+    rtb_GainTheta = rtb_DataTypeConversion2_f;
   }
 
-  AutopilotStateMachine_DWork.Delay_DSTATE_n += rtb_GainTheta1;
+  AutopilotStateMachine_DWork.Delay_DSTATE_n += rtb_GainTheta;
   AutopilotStateMachine_DWork.DelayInput1_DSTATE_h = (AutopilotStateMachine_DWork.Delay_DSTATE_n !=
     AutopilotStateMachine_P.CompareToConstant_const_n);
   AutopilotStateMachine_Y.out.time = AutopilotStateMachine_B.BusAssignment_g.time;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
This PR improves the load factor achieved during ALT*. It usually follows an initial 0.05 Nz curve, but the altitude to engage ALT* is limited from 80 ft to 2500 ft.

Additionally the load factor for V/S and FPA law has been limited to 0.1 Nz to make it less aggressive are more smooth on engage or change.

## Testing instructions
- do normal flights and test ALT* with different V/S and with different modes
- expected result: selected altitude is reached

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
