### PR TITLE
feat(adirs): replace Simplane and AVar usages

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/Adirs.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/Adirs.js
@@ -67,10 +67,26 @@ class ADIRS {
         // In the real aircraft, FMGC 1 is supplied by ADIRU 1, and FMGC 2 by ADIRU 2. When any is unavailable
         // the FMGC switches to ADIRU 3. If only one ADIRU is available, both FMGCs use the same ADIRU.
         // As we don't have a split FMGC, we'll just use the following code for now.
-        for (let adiruNumber = 1; adiruNumber <= 3; adiruNumber++) {
-            const longitude = ADIRS.getValue(`L:A32NX_ADIRS_IR_${adiruNumber}_${type.toUpperCase()}`, `degree ${type}`);
-            if (!Number.isNaN(longitude)) {
-                return longitude;
+        return ADIRS.getFromAnyIr(type.toUpperCase(), `degree ${type}`);
+    }
+
+    static getMachSpeed() {
+        return ADIRS.getFromAnyAdr('MACH', 'Mach');
+    }
+
+    static getFromAnyAdr(name, type) {
+        return ADIRS.getFromAny((number) => ADIRS.getValue(`L:A32NX_ADIRS_ADR_${number}_${name}`, type));
+    }
+
+    static getFromAnyIr(name, type) {
+        return ADIRS.getFromAny((number) => ADIRS.getValue(`L:A32NX_ADIRS_IR_${number}_${name}`, type));
+    }
+
+    static getFromAny(getterFn) {
+        for (let number = 1; number <= 3; number++) {
+            const value = getterFn(number);
+            if (!Number.isNaN(value)) {
+                return value;
             }
         }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.html
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.html
@@ -82,7 +82,7 @@
 <script type="text/html" import-script="/JS/A32NX_Util.js" import-async="false"></script>
 
 <script type="text/html" import-script="/JS/SimPlane.js"></script>
-
+<script type="text/html" import-script="/Pages/A32NX_Core/Adirs.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/Utils/RadioNav.js"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/NavSystems/Shared/Templates/Highlight/Highlight.js"></script>

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
@@ -359,7 +359,11 @@ class A320_Neo_FCU_Speed extends A320_Neo_FCU_Component {
     }
 
     getCurrentMach() {
-        return this.clampMach(Math.round(Simplane.getMachSpeed() * 100) / 100);
+        const mach = ADIRS.getMachSpeed();
+        if (Number.isNaN(mach)) {
+            return this.MIN_MACH;
+        }
+        return this.clampMach(Math.round(mach * 100) / 100);
     }
 
     onRotate() {

--- a/typings/fs-base-ui/html_ui/JS/SimPlane.d.ts
+++ b/typings/fs-base-ui/html_ui/JS/SimPlane.d.ts
@@ -233,6 +233,9 @@ declare global {
         function getIndicatedSpeed(): Knots;
         function getVerticalSpeed(): FeetPerMinute | null;
         function getGroundSpeed(): Knots | null;
+        /**
+         * @deprecated due to custom ADIRS implementation. Use ADIRS.getMachSpeed instead.
+         */
         function getMachSpeed(): Mach | null;
 
         /**


### PR DESCRIPTION
## Summary of Changes
#5242 added a new ADIRS implementation. In this PR, Simplane and Aircraft Variable usages are replaced with variables coming from the new ADIRS.

## Technical notes

It's likely I'll create a `@flybywiresim/adirs` module for this. I'm awaiting the merge of #5359 which contains various improvements in this area before I do this.

## Functionality

- [x] FCU's MACH indication defaults to 0.10 (the minimum) when none of the ADRs are providing MACH information. This is entirely made up for now. I expect a FMGC implementation will supply the correct data to the FCU in the future.

## TODO

- Replace SimVar usages:
  - [ ] PLANE LATITUDE
  - [ ] PLANE LONGITUDE
  - [ ] GPS POSITION LAT
  - [ ] GPS POSITION LON
  - [ ] AIRSPEED MACH
  - [ ] AIRSPEED TRUE
  - [ ] AIRSPEED INDICATED
  - [ ] VELOCITY WORLD Y
  - [ ] PLANE PITCH DEGREES
  - [ ] PLANE BANK DEGREES
  - [ ] PLANE HEADING DEGREES MAGNETIC
  - [ ] GPS GROUND MAGNETIC TRACK
  - [ ] GPS GROUND SPEED
  - [ ] AMBIENT WIND DIRECTION
  - [ ] AMBIENT WIND VELOCITY
  - [ ] AMBIENT TEMPERATURE
  - [ ] TOTAL AIR TEMPERATURE
  - [ ] INDICATED ALTITUDE
- Simplane usages
  - [ ] getMachSpeed
  - [ ] getTrueSpeed
  - [ ] getIndicatedSpeed
  - [ ] getVerticalSpeed
  - [ ] getPitch
  - [ ] getBank
  - [ ] getHeadingMagnetic
  - [ ] getGroundSpeed
  - [ ] getWindDirection
  - [ ] getWindStrength
  - [ ] getAmbientTemperature
  - [ ] getTotalAirTemperature
  - [ ] getAltitude

## Additional context
Discord username (if different from GitHub): SjotgunSjonnie#9623

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
