### PR TITLE
docs(readme): reduce docs/website duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
-# <img src="https://raw.githubusercontent.com/flybywiresim/fbw-branding/master/svg/FBW-Logo.svg" placeholder="FlyByWire" width="400"/>
+<img src="https://raw.githubusercontent.com/flybywiresim/fbw-branding/master/svg/FBW-Logo.svg" placeholder="FlyByWire" width="400"/>
 
-
-[![Discord](https://img.shields.io/discord/738864299392630914.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/UjzuHMU)
+# FlyByWireSim A32NX
 
 [![GitHub latest release version](https://img.shields.io/github/v/release/flybywiresim/a32nx.svg?style=flat)](https://github.com/flybywiresim/a32nx/releases/latest)
 [![Github All Releases download count](https://img.shields.io/github/downloads/flybywiresim/a32nx/total.svg?style=flat)](https://github.com/flybywiresim/a32nx/releases/latest)
 [![GitHub contributors](https://img.shields.io/github/contributors/flybywiresim/a32nx.svg?style=flat)](https://github.com/flybywiresim/a32nx/graphs/contributors)
 
-#### Socials
+[![Discord](https://img.shields.io/discord/738864299392630914.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/UjzuHMU)
 [![Twitter](https://img.shields.io/badge/-@FlyByWireSim-e84393?label=&logo=twitter&logoColor=ffffff&color=6399AE&labelColor=00C2CB)](https://twitter.com/FlybywireSim)
-[![Instagram](https://img.shields.io/badge/-@FlyByWireSim-e84393?label=&logo=instagram&logoColor=ffffff&color=6399AE&labelColor=00C2CB)](https://instagram.com/flybywiresim)
 [![YouTube](https://img.shields.io/badge/-FlyByWireSimulations-e84393?label=&logo=youtube&logoColor=ffffff&color=6399AE&labelColor=00C2CB)](https://www.youtube.com/c/FlyByWire-Simulations)
 [![Facebook](https://img.shields.io/badge/-FlyByWireSimulations-e84393?label=&logo=facebook&logoColor=ffffff&color=6399AE&labelColor=00C2CB)](https://www.facebook.com/FlyByWireSimulations/)
-
-## About
+[![Instagram](https://img.shields.io/badge/-@FlyByWireSim-e84393?label=&logo=instagram&logoColor=ffffff&color=6399AE&labelColor=00C2CB)](https://instagram.com/flybywiresim)
 
 The A32NX Project is a community-driven open source project to create a free Airbus A320neo in Microsoft Flight Simulator that is as close to reality as possible.
 
@@ -28,119 +25,55 @@ The following aircraft configuration is currently simulated:
 
 Please note that this configuration may change in the future as the A32NX project evolves and changes.
 
-### SimBrief Integration
-✈[SimBrief A20N Airframe with the correct weights](https://www.simbrief.com/system/dispatch.php?sharefleet=eyJ0cyI6IjE2MjAyMTYxMzY2MjciLCJiYXNldHlwZSI6IkEyME4iLCJjb21tZW50cyI6IkZCVyBBMzJOWCIsImljYW8iOiJBMjBOIiwibmFtZSI6IkEzMjBORU8gRkJXIiwiZW5naW5lcyI6IkxFQVAtMUEyNiIsInJlZyI6IkQtQUZCVyIsImZpbiI6IiIsInNlbGNhbCI6IiIsImhleGNvZGUiOiIiLCJjYXQiOiJNIiwicGVyIjoiQyIsImVxdWlwIjoiU0RFMkUzRkdISUoxUldYWSIsInRyYW5zcG9uZGVyIjoiTEIxIiwicGJuIjoiQTFCMUMxRDFPMVMyIiwiZXh0cmFybWsiOiIiLCJtYXhwYXgiOiIxODAiLCJ3Z3R1bml0cyI6IktHUyIsIm9ldyI6IjQxMDA1IiwibXpmdyI6IjY0MzAwIiwibXRvdyI6Ijc5MDAwIiwibWx3IjoiNjc0MDAiLCJtYXhmdWVsIjoiMTkwNDUiLCJwYXh3Z3QiOiIxMDQiLCJkZWZhdWx0Y2kiOiIiLCJmdWVsZmFjdG9yIjoiUDAwIiwiY3J1aXNlb2Zmc2V0IjoiUDAwMDAifQ--) Credits: [@viniciusfont](https://github.com/viniciusfont)
+## How to download and use the aircraft
 
-In the above profile change the aircrafts registration to your liking and save it to your fleet. Happy Landings!
+To download the aircraft please go to the [FlyByWire Simulations website](https://flybywiresim.com). Please be sure to thoroughly read the [documentation](https://docs.flybywiresim.com) on how to install and use the aircraft.
 
-Pilot ID can be found in the Optional Entries section of the Dispatch Options page.
+If you're still running into problems after reading through the documentation, feel free to jump into our Discord [#support channel](https://discord.gg/snueqJjDUN).
 
-## Downloads
-**Warning:** All versions of the A32NX have been forked as a separate package/aircraft in MSFS, and will appear separate from the default A320neo. Existing Asobo A320neo liveries will be incompatible with the new package.
-
-### A32NX Installer
-
-Download the new A32NX installer where you can select either the Stable, or Development build, and install the mod directly into your community folder, [download here](https://api.flybywiresim.com/installer) ([source](https://github.com/flybywiresim/installer/)).
-
-### Traditional Download Methods
-
-#### Latest Stable Release
-
-This is the recommended stable release, as it has been thoroughly tested.
-
-[Download the stable release here.](https://github.com/flybywiresim/a32nx/releases/latest/download/flybywiresim-a32nx.zip)
-
-You can view the changelog on the [releases page.](https://github.com/flybywiresim/a32nx/releases)
-
-#### Unstable Master Branch Build
-
-This has the latest features, but is much more unstable, use at your own risk.
-
-
-[Download development build here.](https://github.com/flybywiresim/a32nx/releases/download/vmaster/A32NX-master.zip)
-
-[View information regarding the latest build here.](https://github.com/flybywiresim/a32nx/releases/tag/vmaster)
-
-#### Experimental Branch Build
-
-This branch is used from time-to-time for experimental features under heavy development. It's content will vary over time, and doesn't necessarily include everything in the master branch. No support will be provided via Discord, although users of the branch are advised to keep themselves updated with development progress via Discord.
-
-## Installation
-
-### Please follow ALL steps in this README if you encounter any issues with installation before seeking support.
-
-Open the zip that you downloaded from one of the links above, and drag the `flybywire-aircraft-a320-neo` folder inside the zip into your `Community` folder.
-
-See below for the location of your `Community` folder:
-
-For the Microsoft Store edition AND/OR Gamepass edition:
-- Copy the `flybywire-aircraft-a320-neo` folder into your community package folder. The path is:
-`C:\Users\[YOUR USERNAME]\AppData\Local\Packages\Microsoft.FlightSimulator_<RANDOMLETTERS>\LocalCache\Packages\Community`.
-
-For the Steam edition:
-- Copy the `flybywire-aircraft-a320-neo` folder into your community package folder. The path is:
-`C:\Users\[YOUR USERNAME]\AppData\Roaming\Microsoft Flight Simulator\Packages\Community`.
-
-For the Boxed edition:
-- Copy the `flybywire-aircraft-a320-neo` folder into your community package folder. The path is:
-`C:\Users\[YOUR USERNAME]\AppData\Local\MSFSPackages\Community`.
-
-If the above methods do not work:
-- You can find your `Community` folder by going into MSFS general options and enabling developer mode. Once enabled, you will notice a bar pop up at the top of your screen. Go to tools and virtual file system. Click on watch bases and your `Community` folder will be listed in one of the folders.
-- Please make sure you're copying the `flybywire-aircraft-a320-neo` folder into your `Community` package folder, **NOT** the `flybywiresim-a32nx` folder.
-
-## Contributing
+## How to contribute
 
 If you would like to contribute to the project, see [Contributing.md](.github/Contributing.md)
 
-## Known Issues
+### Known issues and bug reporting
 
-[List of most commonly reported and known issues](https://docs.flybywiresim.com/start/reported-issues/). To request a new feature or report a new issue, please see our [Issues](https://github.com/flybywiresim/a32nx/issues) tracker.
+Our [known issues](https://docs.flybywiresim.com/start/reported-issues) list contains the most commonly reported issues. Should you have an issue not found on this list, then please take a look at the reported issues within the [issue tracker](https://github.com/flybywiresim/a32nx/issues) and report a new issue if your issue isn't found there. You can also use the issue tracker to request a new feature.
+
+## FAQ
+
+### What liveries are available?
+
+Liveries for the A32NX can be found on [Flightsim.to](https://flightsim.to). However, default A320neo liveries are not compatible with the A32NX.
+
+### When is the next update?
+
+We don't know, since it depends on many factors. We will announce each new stable version via [Discord](https://discord.gg/flybywire) and our social media channels listed above.
+
+### How do I join the team?
+
+Read [Contributing.md](.github/Contributing.md) and join our Discord to get started.
+
+### Is the A32NX payware?
+
+No, it is a completely free aircraft, open-source.
+
+### How do we report bugs?
+
+Please read the [known Issues and bug reporting](#known-issues-and-bug-reporting) section.
+
+### Why is my version not the same as what I see others using?
+
+We have two versions: stable and development. The stable version is a 'snapshot' of the development which we regard as stable with the current version of the simulator. The developer build is updated daily and is a constant work in progress and although we test thoroughly each update, minor issues may occur from time to time.
 
 ## License
 
 Original source code assets present in this repository are licensed under the GNU GPLv3.
 Original 3D assets are licensed under CC BY-NC 4.0.
 
-**Microsoft Flight Simulator © Microsoft Corporation. The FlyByWire Simulations A32NX was created under Microsoft's "Game Content Usage Rules" using assets from Microsoft Flight Simulator, and it is not endorsed by or affiliated with Microsoft.**
+Microsoft Flight Simulator © Microsoft Corporation. The FlyByWire Simulations A32NX was created under Microsoft's "Game Content Usage Rules" using assets from Microsoft Flight Simulator, and it is not endorsed by or affiliated with Microsoft.
 
 The contents of distribution packages built from the sources in this repository are therefore licensed as follows:
 
 - in the case of original source code from FBW or compiled binaries generated from it, under GPLv3.
 - in the case of original 3D assets from FBW, under CC BY-NC 4.0.
 - in the case of assets covered by the "Game Content Usage Rules", under the license granted by those rules.
-
-## FAQ
-
-**Q: Can I download the aircraft in the current state?**
-
-A: Yes, see [downloads.](#downloads)
-
-**Q: What liveries are available?**
-
-A: Liveries for the A32NX mod can be found on [Flightsim.to](https://flightsim.to).
-**However, default A320neo liveries are not compatible on the A32NX.**
-
-**Q: When will it be released?**
-
-A: The project is an ongoing rolling release. See [Downloads](#Downloads).
-
-**Q: When is the next update?**
-
-A: We don't know, since it depends on many factors. We will announce each Stable build update via [Discord](https://discord.gg/flybywire) and our [social media.](#Socials)
-
-**Q: How do I join the team?**
-
-A: Head over to [Contributing.md](.github/Contributing.md) and join our Discord to get started.
-
-**Q: Is it payware?**
-
-A: No, it is a completely free aircraft, open-source.
-
-**Q: How do we report bugs?**
-
-A: You can report bugs to us via the [#support channel](https://discord.gg/snueqJjDUN) in the Discord server. Addtionally, you can start/create a GitHub issue (please make sure your issue doesn't already exist).
-
-**Q: Why is my version not the same as what I see others using?**
-
-A: We have two versions, the Stable and Development (Master). The Stable version is a 'snapshot' of the development which we regard as stable with the current version of the simulator. The Developer build is updated daily and is a constant work in progress and although we test thoroughly each update, minor issues may occur from time to time. If you find this to be the case, you can report these issues in the [#support channel](https://discord.gg/snueqJjDUN) Discord or via GitHub issues (check there is not an existing issue of the same nature as yours).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://raw.githubusercontent.com/flybywiresim/fbw-branding/master/svg/FBW-Logo.svg" placeholder="FlyByWire" width="400"/>
 
-# FlyByWireSim A32NX
+# FlyByWire Simulations A32NX
 
 [![GitHub latest release version](https://img.shields.io/github/v/release/flybywiresim/a32nx.svg?style=flat)](https://github.com/flybywiresim/a32nx/releases/latest)
 [![Github All Releases download count](https://img.shields.io/github/downloads/flybywiresim/a32nx/total.svg?style=flat)](https://github.com/flybywiresim/a32nx/releases/latest)


### PR DESCRIPTION
## Summary of Changes
The README was full of clutter and duplication when compared to our beautiful website. The download link for the stable release was also broken. So I decided to cut out a lot of stuff in hopes of keeping the content up to date.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623