### PR TITLE
fix(displays): excessive screen brightness when pixels not visible

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/CSS/A32NX_Display_Common.css
+++ b/flybywire-aircraft-a320-neo/html_ui/CSS/A32NX_Display_Common.css
@@ -65,6 +65,16 @@ text {
   */
 }
 
+#BrightnessCompensation {
+  content: '';
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  z-index: 1000;
+  background-color: rgba(0, 0, 0, 0.35);
+  transition: opacity 0.5s;
+}
+
 /* Backlight Bleed*/
 #BacklightBleed {
   content: '';

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/A320_Neo_EICAS.html
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/A320_Neo_EICAS.html
@@ -6,6 +6,7 @@
     <div id="Mainframe">
         <div id="Electricity" state="off">
             <div id="LcdOverlay"></div>
+            <div id="BrightnessCompensation"></div>
             <div id="BacklightBleed"></div>
             <div style="height: 0;">
                 <svg>

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -139,6 +139,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
 
         // LCD OVERLAY
         this.lcdOverlay = document.querySelector("#LcdOverlay");
+        this.brightnessCompensation = document.querySelector("#BrightnessCompensation");
     }
 
     onUpdate() {
@@ -152,6 +153,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
             return;
         }
         this.lcdOverlay.style.opacity = SimVar.GetSimVarValue("L:A32NX_MFD_MASK_OPACITY", "number");
+        this.brightnessCompensation.style.opacity = 1 - SimVar.GetSimVarValue("L:A32NX_MFD_MASK_OPACITY", "number");
 
         this.displayUnit.update(deltaTime);
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/MFD/A320_Neo_MFD.html
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/MFD/A320_Neo_MFD.html
@@ -6,6 +6,7 @@
     <div id="Mainframe">
         <div id="Electricity" state="off">
             <div id="LcdOverlay"></div>
+            <div id="BrightnessCompensation"></div>
             <div id="BacklightBleed"></div>
             <svg id="MfdEngTest" class="engineering-mode-overlay" viewBox="0 0 600 600">
                 <text class="start" x="9" y="250">P/N : C19755BA01</text>

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/MFD/A320_Neo_MFD.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/MFD/A320_Neo_MFD.js
@@ -107,6 +107,7 @@ class A320_Neo_MFD_MainPage extends NavSystemPage {
 
         // LCD OVERLAY
         this.lcdOverlay = document.querySelector("#LcdOverlay");
+        this.brightnessCompensation = document.querySelector("#BrightnessCompensation");
 
         //ENGINEERING TEST
         this.engTestDiv = document.querySelector("#MfdEngTest");
@@ -181,6 +182,7 @@ class A320_Neo_MFD_MainPage extends NavSystemPage {
         }
 
         this.lcdOverlay.style.opacity = SimVar.GetSimVarValue("L:A32NX_MFD_MASK_OPACITY", "number");
+        this.brightnessCompensation.style.opacity = 1 - SimVar.GetSimVarValue("L:A32NX_MFD_MASK_OPACITY", "number");
 
         this.displayUnit.update(deltaTime);
 

--- a/src/instruments/src/Common/displayUnit.tsx
+++ b/src/instruments/src/Common/displayUnit.tsx
@@ -90,6 +90,7 @@ export const DisplayUnit: React.FC<DisplayUnitProps> = (props) => {
     return (
         <>
             <div className="LcdOverlay" style={{ opacity }} />
+            <div className="LcdOverlay2" style={{ opacity: 1 - opacity }} />
             <div className="BacklightBleed" />
             <div style={{ display: state === DisplayUnitState.On ? 'block' : 'none' }}>{props.children}</div>
         </>

--- a/src/instruments/src/Common/pixels.scss
+++ b/src/instruments/src/Common/pixels.scss
@@ -22,6 +22,16 @@
   @include pixels;
 }
 
+.BrightnessCompensation {
+  content: '';
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  z-index: 1000;
+  background-color: rgba(0, 0, 0, 0.35);
+  transition: opacity 0.5s;
+}
+
 .BacklightBleed {
   content: '';
   width: 100%;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Pixels make the screen appear slightly darker. To compensate for this, the brightness of the screens was increased. In #5483, the pixel effect is removed when not zoomed in on the screen, however the brightness is still increased. This PR fixes this issue by adding a translucent black overlay on the screens when the pixels are not visible.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
