### PR TITLE
feat(sound): cockpit sounds part 4

### DIFF
--- a/flybywire-aircraft-a320-neo/ModelBehaviorDefs/A32NX/Airbus.xml
+++ b/flybywire-aircraft-a320-neo/ModelBehaviorDefs/A32NX/Airbus.xml
@@ -128,8 +128,8 @@
             <ANIM_NAME>AIRBUS_Push_Transfer</ANIM_NAME>
             <PART_ID>AIRBUS_Push_Transfer</PART_ID>
             <ID>1</ID>
-            <WWISE_EVENT_1>mpb1on</WWISE_EVENT_1>
-            <WWISE_EVENT_2>mpb1off</WWISE_EVENT_2>
+            <WWISE_EVENT_1>roundbutton</WWISE_EVENT_1>
+            <WWISE_EVENT_2>roundbutton</WWISE_EVENT_2>
         </DefaultTemplateParameters>
 
         <Component ID="#NODE_ID#" Node="#NODE_ID#">
@@ -789,8 +789,8 @@
         <DefaultTemplateParameters>
             <HELPID/>
             <PART_ID>Chrono</PART_ID>
-            <WWISE_EVENT_1>mpb1on</WWISE_EVENT_1>
-            <WWISE_EVENT_2>mpb1off</WWISE_EVENT_2>
+            <WWISE_EVENT_1>roundbutton</WWISE_EVENT_1>
+            <WWISE_EVENT_2>roundbutton</WWISE_EVENT_2>
             <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
             <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
             <MouseFlags>LeftSingle</MouseFlags>

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -1682,6 +1682,7 @@
                         <MOMENTARY/>
                         <NO_SEQ1 />
                         <NO_SEQ2 />
+                        <ROUND/>
                     </UseTemplate>
 
                     <Component ID="ADIRS">
@@ -1760,6 +1761,7 @@
                             <MOMENTARY/>
                             <NO_SEQ1 />
                             <NO_SEQ2 />
+                            <ROUND/>
                         </UseTemplate>
 
                         <!-- CAPT & PURS / CAPT -->

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -1682,7 +1682,7 @@
                         <MOMENTARY/>
                         <NO_SEQ1 />
                         <NO_SEQ2 />
-                        <ROUND/>
+                        <ROUND />
                     </UseTemplate>
 
                     <Component ID="ADIRS">

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -1761,7 +1761,7 @@
                             <MOMENTARY/>
                             <NO_SEQ1 />
                             <NO_SEQ2 />
-                            <ROUND/>
+                            <ROUND />
                         </UseTemplate>
 
                         <!-- CAPT & PURS / CAPT -->

--- a/src/behavior/src/A32NX_Interior_FCU.xml
+++ b/src/behavior/src/A32NX_Interior_FCU.xml
@@ -318,6 +318,8 @@
             <NODE_ID>PUSH_AUTOPILOT_AUTOLAND_#SIDE#</NODE_ID>
             <SEQ_POWERED>1</SEQ_POWERED>
             <NO_SEQ1/>
+            <WWISE_EVENT_1>mpb1on</WWISE_EVENT_1>
+            <WWISE_EVENT_2>mpb1off</WWISE_EVENT_2>
         </DefaultTemplateParameters>
 
         <UseTemplate Name="FBW_Push_Held">

--- a/src/behavior/src/A32NX_Interior_Fire.xml
+++ b/src/behavior/src/A32NX_Interior_Fire.xml
@@ -10,16 +10,16 @@
     <Template Name="FBW_Airbus_FIRE_TEST_BUTTON">
         <UseTemplate Name="FBW_Push_Held">
             <HOLD_SIMVAR>L:A32NX_FIRE_TEST_#TYPE##ID#</HOLD_SIMVAR>
-            <WWISE_EVENT_1>fcubutton</WWISE_EVENT_1>
-            <WWISE_EVENT_2>fcubutton</WWISE_EVENT_2>
+            <WWISE_EVENT_1>firetestbutton</WWISE_EVENT_1>
+            <WWISE_EVENT_2>firetestbutton</WWISE_EVENT_2>
         </UseTemplate>
     </Template>
 
     <Template Name="FBW_Airbus_CARGOSMOKE_TEST_BUTTON">
         <UseTemplate Name="FBW_Push_Held">
             <HOLD_SIMVAR>L:A32NX_FIRE_TEST_#TYPE##ID#</HOLD_SIMVAR>
-            <WWISE_EVENT_1>mpb1on</WWISE_EVENT_1>
-            <WWISE_EVENT_2>mpb1off</WWISE_EVENT_2>
+            <WWISE_EVENT_1>roundbutton</WWISE_EVENT_1>
+            <WWISE_EVENT_2>roundbutton</WWISE_EVENT_2>
         </UseTemplate>
     </Template>
 

--- a/src/behavior/src/A32NX_Interior_Generics.xml
+++ b/src/behavior/src/A32NX_Interior_Generics.xml
@@ -294,6 +294,13 @@
                     <SEQ2_EMISSIVE_CODE>0</SEQ2_EMISSIVE_CODE>
                 </True>
             </Condition>
+
+            <Condition Check="ROUND">
+                <True>
+                    <WWISE_EVENT_1>roundbutton</WWISE_EVENT_1>
+                    <WWISE_EVENT_2>roundbutton</WWISE_EVENT_2>
+                </True>
+            </Condition>
         </UseTemplate>
     </Template>
 
@@ -384,8 +391,8 @@
     <Template Name="FBW_Push_Held">
         <DefaultTemplateParameters>
             <ANIM_NAME>#NODE_ID#</ANIM_NAME>
-            <WWISE_EVENT_1>mpb1on</WWISE_EVENT_1>
-            <WWISE_EVENT_2>mpb1off</WWISE_EVENT_2>
+            <WWISE_EVENT_1>roundbutton</WWISE_EVENT_1>
+            <WWISE_EVENT_2>roundbutton</WWISE_EVENT_2>
             <CURSOR>Hand</CURSOR>
 
             <SEQ1_EMISSIVE_DRIVES_VISIBILITY>True</SEQ1_EMISSIVE_DRIVES_VISIBILITY>

--- a/src/behavior/src/A32NX_Interior_Handling.xml
+++ b/src/behavior/src/A32NX_Interior_Handling.xml
@@ -420,8 +420,8 @@
                             <UseTemplate Name = "ASOBO_GT_Push_Button_Held">
                                 <ANIM_NAME>#RESET_PUSH_ANIM_NAME#</ANIM_NAME>
                                 <LEFT_SINGLE_CODE>(&gt;K:RUDDER_TRIM_RESET)</LEFT_SINGLE_CODE>
-                                <WWISE_EVENT_1>mpb1on</WWISE_EVENT_1>
-                                <WWISE_EVENT_2>mpb1off</WWISE_EVENT_2>
+                                <WWISE_EVENT_1>roundbutton</WWISE_EVENT_1>
+                                <WWISE_EVENT_2>roundbutton</WWISE_EVENT_2>
                                 <TOOLTIPID>TT:COCKPIT.TOOLTIPS.RUDDER_TRIM_RESET</TOOLTIPID>
                             </UseTemplate>
                         </Component>

--- a/src/behavior/src/A32NX_Interior_MCDU.xml
+++ b/src/behavior/src/A32NX_Interior_MCDU.xml
@@ -387,8 +387,8 @@
         <DefaultTemplateParameters>
             <NORMALIZED_TIME_1>0.3</NORMALIZED_TIME_1>
             <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
-            <WWISE_EVENT_1>fmc_push_button_on</WWISE_EVENT_1>
-            <WWISE_EVENT_2>fmc_push_button_off</WWISE_EVENT_2>
+            <WWISE_EVENT_1>mcdubuttons</WWISE_EVENT_1>
+            <WWISE_EVENT_2>mcdubuttons</WWISE_EVENT_2>
             <NODE_ID_BRT_DIM>PUSH_MCDU#SIDE#_BRT</NODE_ID_BRT_DIM>
             <ANIM_NAME_BRT_DIM>PUSH_MCDU#SIDE#_BRT</ANIM_NAME_BRT_DIM>
             <NODE_ID_BRT_DIM_SEQ1>PUSH_MCDU#SIDE#_BRT_SEQ1</NODE_ID_BRT_DIM_SEQ1>
@@ -417,7 +417,7 @@
                 <STATE0_TIMER>0.01</STATE0_TIMER>
                 <MOMENTARY_REPEAT_FREQUENCY>5</MOMENTARY_REPEAT_FREQUENCY>
                 <MOMENTARY_SWITCH/>
-                <WWISE_EVENT>fmc_push_button_on</WWISE_EVENT>
+                <WWISE_EVENT>mcdubuttons</WWISE_EVENT>
             </UseTemplate>
         </Component>
 

--- a/src/behavior/src/A32NX_Interior_Misc.xml
+++ b/src/behavior/src/A32NX_Interior_Misc.xml
@@ -68,8 +68,8 @@
         <DefaultTemplateParameters>
             <POTENTIOMETER_ID>85</POTENTIOMETER_ID>
             <SEQ1_EMISSIVE_DRIVES_VISIBILITY>False</SEQ1_EMISSIVE_DRIVES_VISIBILITY>
-            <WWISE_EVENT_1>fmc_push_button_on</WWISE_EVENT_1>
-            <WWISE_EVENT_2>fmc_push_button_off</WWISE_EVENT_2>
+            <WWISE_EVENT_1>mcdubuttons</WWISE_EVENT_1>
+            <WWISE_EVENT_2>mcdubuttons</WWISE_EVENT_2>
             <NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
             <NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
             <SEQ1_POWERED>1</SEQ1_POWERED>
@@ -356,8 +356,8 @@
 
     <Template Name="FBW_Airbus_Sidestick_Priority">
         <DefaultTemplateParameters>
-            <WWISE_EVENT_1>yoke_push_button_on</WWISE_EVENT_1>
-            <WWISE_EVENT_2>yoke_push_button_off</WWISE_EVENT_2>
+            <WWISE_EVENT_1>firetestbutton</WWISE_EVENT_1>
+            <WWISE_EVENT_2>firetestbutton</WWISE_EVENT_2>
             <ANIM_NAME>#NODE_ID#</ANIM_NAME>
             <ID>1</ID>
         </DefaultTemplateParameters>
@@ -503,6 +503,8 @@
             <SEQ1_CODE>(L:A32NX_DCDU_ATC_MSG_WAITING, Bool)</SEQ1_CODE>
             <LEFT_SINGLE_CODE>1 (&gt;L:A32NX_DCDU_ATC_MSG_ACK, Bool)</LEFT_SINGLE_CODE>
             <NO_SEQ2/>
+            <WWISE_EVENT_1>mpb1on</WWISE_EVENT_1>
+            <WWISE_EVENT_2>mpb1off</WWISE_EVENT_2>
         </UseTemplate>
     </Template>
 


### PR DESCRIPTION
## Summary of Changes
Additional changes to cockpit soundscape:

- all round-buttons, like chrono, calls, rudder trim, etc.. (except fire test and the three on the FCU) now have their own custom roundbutton sound event.
- Red sidestick button
- DCDU buttons
- MCDU brightness 
- Fire test buttons on the fire panel now have their own firetestbutton event (the same event is used for the sidestick AP disengage)

## Additional context

Credit for the custom wwise events goes to @hotshotp 

Discord username: Imenes#0001

## Testing instructions

Test all the buttons described above, and please also click all the square push buttons to make sure they don't play the new roundbutton sound but remain the same as they were before.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
