### PR TITLE
fix(fbw): improved handling of rudder axis plus/minus

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -408,6 +408,7 @@
 1. [TEXTURE] Upscaled the external airframe decals to go nicely with the upscaled livery. @FoxinTale (Aubrey)
 1. [MCDU] Scratchpad is now limited to 22 characters - @tyler58546 (tyler58546)
 1. [MISC] Added Marketplace Data - @kiwi2021 (kiwi2022#0001)
+1. [FBW] Support additional mode to handle rudder axis plus/minus events - @aguther (Andreas Guther)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -36,7 +36,8 @@ bool FlyByWireInterface::connect() {
   // connect to sim connect
   return simConnectInterface.connect(autopilotStateMachineEnabled, autopilotLawsEnabled, flyByWireEnabled, throttleAxis, flapsHandler,
                                      spoilersHandler, elevatorTrimHandler, rudderTrimHandler, flightControlsKeyChangeAileron,
-                                     flightControlsKeyChangeElevator, flightControlsKeyChangeRudder);
+                                     flightControlsKeyChangeElevator, flightControlsKeyChangeRudder,
+                                     disableXboxCompatibilityRudderAxisPlusMinus);
 }
 
 void FlyByWireInterface::disconnect() {
@@ -149,6 +150,8 @@ void FlyByWireInterface::loadConfiguration() {
   flightControlsKeyChangeElevator = abs(flightControlsKeyChangeElevator);
   flightControlsKeyChangeRudder = INITypeConversion::getDouble(iniStructure, "FLIGHT_CONTROLS", "KEY_CHANGE_RUDDER", 0.02);
   flightControlsKeyChangeRudder = abs(flightControlsKeyChangeRudder);
+  disableXboxCompatibilityRudderAxisPlusMinus =
+      INITypeConversion::getBoolean(iniStructure, "FLIGHT_CONTROLS", "DISABLE_XBOX_COMPATIBILITY_RUDDER_AXIS_PLUS_MINUS", false);
 
   // print configuration into console
   std::cout << "WASM: MODEL     : AUTOPILOT_STATE_MACHINE_ENABLED   = " << autopilotStateMachineEnabled << endl;
@@ -164,6 +167,8 @@ void FlyByWireInterface::loadConfiguration() {
   std::cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_AILERON = " << flightControlsKeyChangeAileron << endl;
   std::cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_ELEVATOR = " << flightControlsKeyChangeElevator << endl;
   std::cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_RUDDER = " << flightControlsKeyChangeRudder << endl;
+  std::cout << "WASM: FLIGHT_CONTROLS : DISABLE_XBOX_COMPATIBILITY_RUDDER_AXIS_PLUS_MINUS = " << disableXboxCompatibilityRudderAxisPlusMinus
+            << endl;
 
   // create axis and load configuration
   for (size_t i = 1; i <= 2; i++) {

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -71,6 +71,8 @@ class FlyByWireInterface {
   double flightControlsKeyChangeElevator = 0.0;
   double flightControlsKeyChangeRudder = 0.0;
 
+  bool disableXboxCompatibilityRudderAxisPlusMinus = false;
+
   FlightDataRecorder flightDataRecorder;
 
   SimConnectInterface simConnectInterface;

--- a/src/fbw/src/interface/SimConnectInterface.cpp
+++ b/src/fbw/src/interface/SimConnectInterface.cpp
@@ -921,33 +921,40 @@ void SimConnectInterface::simConnectProcessDispatchMessage(SIMCONNECT_RECV* pDat
 void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* event) {
   // process depending on event id
   switch (event->uEventID) {
-    case Events::AXIS_ELEVATOR_SET:
+    case Events::AXIS_ELEVATOR_SET: {
       simInput.inputs[AXIS_ELEVATOR_SET] = static_cast<long>(event->dwData) / 16384.0;
       break;
+    }
 
-    case Events::AXIS_AILERONS_SET:
+    case Events::AXIS_AILERONS_SET: {
       simInput.inputs[AXIS_AILERONS_SET] = static_cast<long>(event->dwData) / 16384.0;
       break;
+    }
 
-    case Events::AXIS_RUDDER_SET:
+    case Events::AXIS_RUDDER_SET: {
       simInput.inputs[AXIS_RUDDER_SET] = static_cast<long>(event->dwData) / 16384.0;
       break;
+    }
 
-    case Events::RUDDER_SET:
+    case Events::RUDDER_SET: {
       simInput.inputs[AXIS_RUDDER_SET] = static_cast<long>(event->dwData) / 16384.0;
       break;
+    }
 
-    case Events::RUDDER_LEFT:
+    case Events::RUDDER_LEFT: {
       simInput.inputs[AXIS_RUDDER_SET] = fmin(1.0, simInput.inputs[AXIS_RUDDER_SET] + flightControlsKeyChangeRudder);
       break;
+    }
 
-    case Events::RUDDER_CENTER:
+    case Events::RUDDER_CENTER: {
       simInput.inputs[AXIS_RUDDER_SET] = 0.0;
       break;
+    }
 
-    case Events::RUDDER_RIGHT:
+    case Events::RUDDER_RIGHT: {
       simInput.inputs[AXIS_RUDDER_SET] = fmax(-1.0, simInput.inputs[AXIS_RUDDER_SET] - flightControlsKeyChangeRudder);
       break;
+    }
 
     case Events::RUDDER_AXIS_MINUS: {
       if (this->disableXboxCompatibilityRudderPlusMinus) {
@@ -975,64 +982,78 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       rudderTrimHandler->onEventRudderTrimLeft(sampleTime);
       break;
     }
+
     case Events::RUDDER_TRIM_RESET: {
       rudderTrimHandler->onEventRudderTrimReset();
       break;
     }
+
     case Events::RUDDER_TRIM_RIGHT: {
       rudderTrimHandler->onEventRudderTrimRight(sampleTime);
       break;
     }
+
     case Events::RUDDER_TRIM_SET: {
       rudderTrimHandler->onEventRudderTrimSet(static_cast<long>(event->dwData));
       break;
     }
+
     case Events::RUDDER_TRIM_SET_EX1: {
       rudderTrimHandler->onEventRudderTrimSet(static_cast<long>(event->dwData));
       break;
     }
 
-    case Events::AILERON_SET:
+    case Events::AILERON_SET: {
       simInput.inputs[AXIS_AILERONS_SET] = static_cast<long>(event->dwData) / 16384.0;
       break;
+    }
 
-    case Events::AILERONS_LEFT:
+    case Events::AILERONS_LEFT: {
       simInput.inputs[AXIS_AILERONS_SET] = fmin(1.0, simInput.inputs[AXIS_AILERONS_SET] + flightControlsKeyChangeAileron);
       break;
+    }
 
-    case Events::AILERONS_RIGHT:
+    case Events::AILERONS_RIGHT: {
       simInput.inputs[AXIS_AILERONS_SET] = fmax(-1.0, simInput.inputs[AXIS_AILERONS_SET] - flightControlsKeyChangeAileron);
       break;
+    }
 
-    case Events::CENTER_AILER_RUDDER:
+    case Events::CENTER_AILER_RUDDER: {
       simInput.inputs[AXIS_RUDDER_SET] = 0.0;
       simInput.inputs[AXIS_AILERONS_SET] = 0.0;
       break;
+    }
 
-    case Events::ELEVATOR_SET:
+    case Events::ELEVATOR_SET: {
       simInput.inputs[AXIS_ELEVATOR_SET] = static_cast<long>(event->dwData) / 16384.0;
       break;
+    }
 
-    case Events::ELEV_DOWN:
+    case Events::ELEV_DOWN: {
       simInput.inputs[AXIS_ELEVATOR_SET] = fmin(1.0, simInput.inputs[AXIS_ELEVATOR_SET] + flightControlsKeyChangeElevator);
       break;
+    }
 
-    case Events::ELEV_UP:
+    case Events::ELEV_UP: {
       simInput.inputs[AXIS_ELEVATOR_SET] = fmax(-1.0, simInput.inputs[AXIS_ELEVATOR_SET] - flightControlsKeyChangeElevator);
       break;
+    }
 
     case Events::ELEV_TRIM_DN: {
       elevatorTrimHandler->onEventElevatorTrimDown();
       break;
     }
+
     case Events::ELEV_TRIM_UP: {
       elevatorTrimHandler->onEventElevatorTrimUp();
       break;
     }
+
     case Events::ELEVATOR_TRIM_SET: {
       elevatorTrimHandler->onEventElevatorTrimSet(static_cast<long>(event->dwData));
       break;
     }
+
     case Events::AXIS_ELEV_TRIM_SET: {
       elevatorTrimHandler->onEventElevatorTrimAxisSet(static_cast<long>(event->dwData));
       break;
@@ -1102,27 +1123,32 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       cout << "WASM: event triggered: A32NX_FCU_SPD_INC" << endl;
       break;
     }
+
     case Events::A32NX_FCU_SPD_DEC: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_DEC)", nullptr, nullptr, nullptr);
       cout << "WASM: event triggered: A32NX_FCU_SPD_DEC" << endl;
       break;
     }
+
     case Events::A32NX_FCU_SPD_SET: {
       idFcuEventSetSPEED->set(static_cast<long>(event->dwData));
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_SET)", nullptr, nullptr, nullptr);
       cout << "WASM: event triggered: A32NX_FCU_SPD_SET: " << static_cast<long>(event->dwData) << endl;
       break;
     }
+
     case Events::A32NX_FCU_SPD_PUSH: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_PUSH)", nullptr, nullptr, nullptr);
       cout << "WASM: event triggered: A32NX_FCU_SPD_PUSH" << endl;
       break;
     }
+
     case Events::A32NX_FCU_SPD_PULL: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_PULL)", nullptr, nullptr, nullptr);
       cout << "WASM: event triggered: A32NX_FCU_SPD_PULL" << endl;
       break;
     }
+
     case Events::A32NX_FCU_SPD_MACH_TOGGLE_PUSH: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_TOGGLE_SPEED_MACH)", nullptr, nullptr, nullptr);
       cout << "WASM: event triggered: A32NX_FCU_SPD_MACH_TOGGLE_PUSH" << endl;
@@ -1136,6 +1162,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       cout << "WASM: event triggered: A32NX_FCU_HDG_INC" << endl;
       break;
     }
+
     case Events::A32NX_FCU_HDG_DEC: {
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_HDG_DEC_TRACK) } els{ (>H:A320_Neo_FCU_HDG_DEC_HEADING) }",
@@ -1143,22 +1170,26 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       cout << "WASM: event triggered: A32NX_FCU_HDG_DEC" << endl;
       break;
     }
+
     case Events::A32NX_FCU_HDG_SET: {
       idFcuEventSetHDG->set(static_cast<long>(event->dwData));
       execute_calculator_code("(>H:A320_Neo_FCU_HDG_SET)", nullptr, nullptr, nullptr);
       cout << "WASM: event triggered: A32NX_FCU_HDG_SET: " << static_cast<long>(event->dwData) << endl;
       break;
     }
+
     case Events::A32NX_FCU_HDG_PUSH: {
       execute_calculator_code("(>H:A320_Neo_FCU_HDG_PUSH)", nullptr, nullptr, nullptr);
       cout << "WASM: event triggered: A32NX_FCU_HDG_PUSH" << endl;
       break;
     }
+
     case Events::A32NX_FCU_HDG_PULL: {
       execute_calculator_code("(>H:A320_Neo_FCU_HDG_PULL)", nullptr, nullptr, nullptr);
       cout << "WASM: event triggered: A32NX_FCU_HDG_PULL" << endl;
       break;
     }
+
     case Events::A32NX_FCU_TRK_FPA_TOGGLE_PUSH: {
       execute_calculator_code("(L:A32NX_TRK_FPA_MODE_ACTIVE) ! (>L:A32NX_TRK_FPA_MODE_ACTIVE)", nullptr, nullptr, nullptr);
       cout << "WASM: event triggered: A32NX_FCU_TRK_FPA_TOGGLE_PUSH" << endl;
@@ -1170,6 +1201,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       cout << "WASM: event triggered: A32NX_FCU_TO_AP_HDG_PUSH" << endl;
       break;
     }
+
     case Events::A32NX_FCU_TO_AP_HDG_PULL: {
       simInputAutopilot.HDG_pull = 1;
       cout << "WASM: event triggered: A32NX_FCU_TO_AP_HDG_PULL" << endl;
@@ -1200,6 +1232,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       cout << "WASM: event triggered: A32NX_FCU_ALT_INC" << endl;
       break;
     }
+
     case Events::A32NX_FCU_ALT_DEC: {
       long increment = static_cast<long>(event->dwData);
       if (increment == 100) {
@@ -1224,6 +1257,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       cout << "WASM: event triggered: A32NX_FCU_ALT_INC" << endl;
       break;
     }
+
     case Events::A32NX_FCU_ALT_SET: {
       long value = 100 * (static_cast<long>(event->dwData) / 100);
       ostringstream stringStream;
@@ -1233,6 +1267,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       cout << "WASM: event triggered: A32NX_FCU_ALT_SET: " << value << endl;
       break;
     }
+
     case Events::A32NX_FCU_ALT_INCREMENT_TOGGLE: {
       execute_calculator_code(
           "(L:XMLVAR_Autopilot_Altitude_Increment, number) 100 == "
@@ -1242,6 +1277,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       cout << "WASM: event triggered: A32NX_FCU_ALT_INCREMENT_TOGGLE" << endl;
       break;
     }
+
     case Events::A32NX_FCU_ALT_INCREMENT_SET: {
       long value = static_cast<long>(event->dwData);
       if (value == 100 || value == 1000) {
@@ -1253,12 +1289,14 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       }
       break;
     }
+
     case Events::A32NX_FCU_ALT_PUSH: {
       simInputAutopilot.ALT_push = 1;
       execute_calculator_code("(>H:A320_Neo_CDU_MODE_MANAGED_ALTITUDE)", nullptr, nullptr, nullptr);
       cout << "WASM: event triggered: A32NX_FCU_ALT_PUSH" << endl;
       break;
     }
+
     case Events::A32NX_FCU_ALT_PULL: {
       simInputAutopilot.ALT_pull = 1;
       execute_calculator_code("(>H:A320_Neo_CDU_MODE_SELECTED_ALTITUDE)", nullptr, nullptr, nullptr);
@@ -1274,6 +1312,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       cout << "WASM: event triggered: A32NX_FCU_VS_INC" << endl;
       break;
     }
+
     case Events::A32NX_FCU_VS_DEC: {
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_VS_DEC_FPA) } els{ (>H:A320_Neo_FCU_VS_DEC_VS) } "
@@ -1282,17 +1321,20 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       cout << "WASM: event triggered: A32NX_FCU_VS_DEC" << endl;
       break;
     }
+
     case Events::A32NX_FCU_VS_SET: {
       idFcuEventSetVS->set(static_cast<long>(event->dwData));
       execute_calculator_code("(>H:A320_Neo_FCU_VS_SET) (>H:A320_Neo_CDU_VS)", nullptr, nullptr, nullptr);
       cout << "WASM: event triggered: A32NX_FCU_VS_SET: " << static_cast<long>(event->dwData) << endl;
       break;
     }
+
     case Events::A32NX_FCU_VS_PUSH: {
       execute_calculator_code("(>H:A320_Neo_FCU_VS_PUSH) (>H:A320_Neo_CDU_VS)", nullptr, nullptr, nullptr);
       cout << "WASM: event triggered: A32NX_FCU_VS_PUSH" << endl;
       break;
     }
+
     case Events::A32NX_FCU_VS_PULL: {
       execute_calculator_code("(>H:A320_Neo_FCU_VS_PULL) (>H:A320_Neo_CDU_VS)", nullptr, nullptr, nullptr);
       cout << "WASM: event triggered: A32NX_FCU_VS_PULL" << endl;
@@ -1554,45 +1596,53 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::THROTTLE_20:
+    case Events::THROTTLE_20: {
       throttleAxis[0]->onEventThrottleSet_20();
       throttleAxis[1]->onEventThrottleSet_20();
       break;
+    }
 
-    case Events::THROTTLE_30:
+    case Events::THROTTLE_30: {
       throttleAxis[0]->onEventThrottleSet_30();
       throttleAxis[1]->onEventThrottleSet_30();
       break;
+    }
 
-    case Events::THROTTLE_40:
+    case Events::THROTTLE_40: {
       throttleAxis[0]->onEventThrottleSet_40();
       throttleAxis[1]->onEventThrottleSet_40();
       break;
+    }
 
-    case Events::THROTTLE_50:
+    case Events::THROTTLE_50: {
       throttleAxis[0]->onEventThrottleSet_50();
       throttleAxis[1]->onEventThrottleSet_50();
       break;
+    }
 
-    case Events::THROTTLE_60:
+    case Events::THROTTLE_60: {
       throttleAxis[0]->onEventThrottleSet_50();
       throttleAxis[1]->onEventThrottleSet_60();
       break;
+    }
 
-    case Events::THROTTLE_70:
+    case Events::THROTTLE_70: {
       throttleAxis[0]->onEventThrottleSet_70();
       throttleAxis[1]->onEventThrottleSet_70();
       break;
+    }
 
-    case Events::THROTTLE_80:
+    case Events::THROTTLE_80: {
       throttleAxis[0]->onEventThrottleSet_80();
       throttleAxis[1]->onEventThrottleSet_80();
       break;
+    }
 
-    case Events::THROTTLE_90:
+    case Events::THROTTLE_90: {
       throttleAxis[0]->onEventThrottleSet_90();
       throttleAxis[1]->onEventThrottleSet_90();
       break;
+    }
 
     case Events::THROTTLE1_FULL: {
       throttleAxis[0]->onEventThrottleFull();

--- a/src/fbw/src/interface/SimConnectInterface.h
+++ b/src/fbw/src/interface/SimConnectInterface.h
@@ -171,7 +171,8 @@ class SimConnectInterface {
                std::shared_ptr<RudderTrimHandler> rudderTrimHandler,
                double keyChangeAileron,
                double keyChangeElevator,
-               double keyChangeRudder);
+               double keyChangeRudder,
+               bool disableXboxCompatibilityRudderPlusMinus);
 
   void disconnect();
 
@@ -263,6 +264,7 @@ class SimConnectInterface {
   double flightControlsKeyChangeAileron = 0.0;
   double flightControlsKeyChangeElevator = 0.0;
   double flightControlsKeyChangeRudder = 0.0;
+  bool disableXboxCompatibilityRudderPlusMinus = false;
 
   std::unique_ptr<LocalVariable> idFcuEventSetSPEED;
   std::unique_ptr<LocalVariable> idFcuEventSetHDG;


### PR DESCRIPTION
Fixes #5633

## Summary of Changes
This PR fixes an issue with handling of events `RUDDER_AXIS_PLUS` and `RUDDER_AXIS_MINUS`. To do this it allows to disable XBOX controller compatibility for those axes.

This can be done by putting the file `ModelConfiguration.ini` with the following content into the work folder:
```
[flight_controls]
disable_xbox_compatibility_rudder_axis_plus_minus = true
```

Disclaimer:
I did not code-style clean up going along with this PR.

## Testing instructions
Test if you can assign independent axis to Rudder Axis Left and Right assignment and that it works as expected. The expectation is that one axis is from neutral to full left and the other from neutral to full right. If both axis are applied the same time the last wins.

⚠This PR needs to be tested with an XBOX Controller!

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page