### PR TITLE
fix(screens): Adjust emissive power for screens to sane levels

### DIFF
--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -505,7 +505,7 @@
                     <PART_ID>SCREEN_PFD1</PART_ID>
                     <CAMERA_TITLE>PFD</CAMERA_TITLE>
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
-                    <EMISSIVE_CODE>8</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>3</EMISSIVE_CODE>
                 </UseTemplate>
 
                 <UseTemplate Name="FBW_Airbus_Push_EFIS_GPWS">
@@ -606,7 +606,7 @@
                     <PART_ID>SCREEN_MFD1</PART_ID>
                     <CAMERA_TITLE>MFD</CAMERA_TITLE>
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
-                    <EMISSIVE_CODE>8</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>3</EMISSIVE_CODE>
                 </UseTemplate>
 
                 <!-- DCDU -->
@@ -615,7 +615,7 @@
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
                     <EMISSIVE_CODE>
                         (L:A32NX_ELEC_DC_1_BUS_IS_POWERED, Bool) if{
-                            8 (L:#PLANE_NAME#_PANEL_DCDU_L_BRIGHTNESS, percent over 100) *
+                            3 (L:#PLANE_NAME#_PANEL_DCDU_L_BRIGHTNESS, percent over 100) *
                         } els{
                             0
                         }
@@ -650,7 +650,7 @@
                     <POTENTIOMETER>90</POTENTIOMETER>
                     <PART_ID>SCREEN_PFD2</PART_ID>
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
-                    <EMISSIVE_CODE>8</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>3</EMISSIVE_CODE>
                 </UseTemplate>
 
                 <!-- F/O ND SCREEN -->
@@ -667,7 +667,7 @@
                     <POTENTIOMETER>91</POTENTIOMETER>
                     <PART_ID>SCREEN_MFD2</PART_ID>
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
-                    <EMISSIVE_CODE>8</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>3</EMISSIVE_CODE>
                 </UseTemplate>
 
                 <!-- F/O WX SCREEN -->
@@ -685,7 +685,7 @@
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
                     <EMISSIVE_CODE>
                         (L:A32NX_ELEC_DC_2_BUS_IS_POWERED, Bool) if{
-                            8 (L:#PLANE_NAME#_PANEL_DCDU_R_BRIGHTNESS, percent over 100) *
+                            3 (L:#PLANE_NAME#_PANEL_DCDU_R_BRIGHTNESS, percent over 100) *
                         } els{
                             0
                         }
@@ -795,7 +795,7 @@
                 <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
                     <NODE_ID>DYN_SCREEN</NODE_ID>
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
-                    <EMISSIVE_CODE>8</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>3</EMISSIVE_CODE>
                 </UseTemplate>
                 <CameraTitle>PA</CameraTitle>
 
@@ -870,7 +870,7 @@
                     <PART_ID>SCREEN_EICAS1</PART_ID>
                     <CAMERA_TITLE>ECAM</CAMERA_TITLE>
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
-                    <EMISSIVE_CODE>8</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>3</EMISSIVE_CODE>
                 </UseTemplate>
 
                 <!-- LOWER ECAM SCREEN -->
@@ -887,7 +887,7 @@
                     <PART_ID>SCREEN_EICAS2</PART_ID>
                     <CAMERA_TITLE>ECAM</CAMERA_TITLE>
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
-                    <EMISSIVE_CODE>8</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>3</EMISSIVE_CODE>
                 </UseTemplate>
             </Component>
 
@@ -1453,7 +1453,7 @@
                     <WWISE_EVENT>lswitch</WWISE_EVENT>
                 </UseTemplate>
 
-                <!-- Turn off the conenction to the lights when the landing gear is retracted-->
+                <!-- Turn off the connection to the lights when the landing gear is retracted-->
                 <UseTemplate Name="ASOBO_GT_Update">
                     <FREQUENCY>5</FREQUENCY>
                     <UPDATE_CODE>

--- a/src/behavior/src/A32NX_Interior_MCDU.xml
+++ b/src/behavior/src/A32NX_Interior_MCDU.xml
@@ -448,7 +448,7 @@
                 <EMISSIVE_CODE>
                     #DISPLAY_POWERED# sp0
                     l0 if{
-                        8 (L:A32NX_MCDU_#SIDE#_BRIGHTNESS, number) *
+                        3 (L:A32NX_MCDU_#SIDE#_BRIGHTNESS, number) *
                     } els{
                         0
                     }


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Restores `PFD/MFD/EICAS/DCDU` and `MCDU` emissive brightness to sane levels.
This PR renders https://github.com/flybywiresim/a32nx/pull/5571 redundant.

## Screenshot
![bleed](https://user-images.githubusercontent.com/433429/129506610-f9153891-5790-4193-9767-7efbb75c0a7b.png)
<p align="right"><i>Normalized screen @100% potentiometer setting with subtle tint, bleed and dust.<br/>(watch image at 100% to see effect properly)</i></p>

## Additional context
Screens with **pixels** and **reflections** became _overpowered_, causing **bleed** and other strange **artifacts** during some of the following fixes and/or reflective screens.
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): @bouveng

## Testing instructions

1. Spawn.
2. Try screens during day, night, during sunshine and overcast.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
