### PR TITLE
fix(screens): Restore pixels on ISIS

### DIFF
--- a/src/instruments/src/ISIS/ISISDisplayUnit.tsx
+++ b/src/instruments/src/ISIS/ISISDisplayUnit.tsx
@@ -16,6 +16,7 @@ type ISISDisplayUnitProps = {
 export const ISISDisplayUnit: React.FC<ISISDisplayUnitProps> = ({ indicatedAirspeed, children }) => {
     const powerUpTime = 90;
     const [isColdAndDark] = useSimVar('L:A32NX_COLD_AND_DARK_SPAWN', 'Bool', 200);
+    const [opacity] = useSimVar('L:A32NX_MFD_MASK_OPACITY', 'number', 200);
 
     const [state, setState] = useState(isColdAndDark ? DisplayUnitState.Off : DisplayUnitState.Standby);
     const [timer, setTimer] = useState<number | null>(null);
@@ -57,28 +58,31 @@ export const ISISDisplayUnit: React.FC<ISISDisplayUnitProps> = ({ indicatedAirsp
 
     if (state === DisplayUnitState.Selftest) {
         return (
-            <svg id="SelfTest" className="SelfTest" version="1.1" viewBox="0 0 512 512">
-                <g id="AttFlag">
-                    <rect id="AttTest" className="FillYellow" width="84" height="40" x="214" y="174" />
-                    <text id="AltTestTxt" className="TextBackground" textAnchor="middle" x="256" y="206">ATT</text>
-                </g>
-                <g id="SpeedFlag">
-                    <rect id="SpeedTest" className="FillYellow" width="84" height="40" x="70" y="244" />
-                    <text id="SpeedTestTxt" className="TextBackground" textAnchor="middle" x="112" y="276">SPD</text>
-                </g>
-                <g id="AltFlag">
-                    <rect id="AltTest" className="FillYellow" width="84" height="40" x="358" y="244" />
-                    <text id="AltTestTxt" className="TextBackground" textAnchor="middle" x="400" y="276">ALT</text>
-                </g>
-                <g id="TimerFlag">
-                    <rect id="TmrTest" className="FillYellow" width="160" height="40" x="178" y="332" />
-                    <text id="TmrTestTxt" className="TextBackground" x="186" y="366">INIT</text>
-                    <text id="TmrTestCountdown" className="TextBackground" textAnchor="end" x="330" y="366">
-                        {Math.max(0, Math.ceil(timer!))}
-                        s
-                    </text>
-                </g>
-            </svg>
+            <>
+                <div className="LcdOverlayISIS" style={{ opacity }} />
+                <svg id="SelfTest" className="SelfTest" version="1.1" viewBox="0 0 512 512">
+                    <g id="AttFlag">
+                        <rect id="AttTest" className="FillYellow" width="84" height="40" x="214" y="174" />
+                        <text id="AltTestTxt" className="TextBackground" textAnchor="middle" x="256" y="206">ATT</text>
+                    </g>
+                    <g id="SpeedFlag">
+                        <rect id="SpeedTest" className="FillYellow" width="84" height="40" x="70" y="244" />
+                        <text id="SpeedTestTxt" className="TextBackground" textAnchor="middle" x="112" y="276">SPD</text>
+                    </g>
+                    <g id="AltFlag">
+                        <rect id="AltTest" className="FillYellow" width="84" height="40" x="358" y="244" />
+                        <text id="AltTestTxt" className="TextBackground" textAnchor="middle" x="400" y="276">ALT</text>
+                    </g>
+                    <g id="TimerFlag">
+                        <rect id="TmrTest" className="FillYellow" width="160" height="40" x="178" y="332" />
+                        <text id="TmrTestTxt" className="TextBackground" x="186" y="366">INIT</text>
+                        <text id="TmrTestCountdown" className="TextBackground" textAnchor="end" x="330" y="366">
+                            {Math.max(0, Math.ceil(timer!))}
+                            s
+                        </text>
+                    </g>
+                </svg>
+            </>
         );
     }
 
@@ -89,6 +93,9 @@ export const ISISDisplayUnit: React.FC<ISISDisplayUnitProps> = ({ indicatedAirsp
     }
 
     return (
-        <>{children}</>
+        <>
+            <div className="LcdOverlay" style={{ opacity }} />
+            {children}
+        </>
     );
 };

--- a/src/instruments/src/ISIS/style.scss
+++ b/src/instruments/src/ISIS/style.scss
@@ -19,6 +19,12 @@
   font-family: "Ecam", monospace !important;
 }
 
+/* pixels for screen */
+@import "../Common/pixels";
+.LcdOverlayISIS {
+  @include pixels($bleed: false);
+}
+
 .sky {
   fill: #0698ff;
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #5637

## Summary of Changes
Adds back pixels to ISIS screen that was lost during react conversion.

## Screenshots
![Microsoft Flight Simulator 2021-08-16 06_14_15](https://user-images.githubusercontent.com/433429/129510935-24bf7edc-cc26-4840-8208-42ce4d765e5d.png)
<p align="right"><i>Before: no pixels</i></p>

![Microsoft Flight Simulator 2021-08-16 06_13_34](https://user-images.githubusercontent.com/433429/129510993-f3de1c8c-0cfd-4681-95e7-f1654f85b2d5.png)
<p align="right"><i>After: restored pixels (watch image at 100% to see effect properly)</i></p>

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username: @bouveng

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Spawn
2. Move down and forwards as close to ISIS screen as possible.
3. Verify visible pixels
4. Verify that they disappear when moving back/zooming out

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
