### PR TITLE
fix(lnav): sequence type 1 at ITP, not INP

### DIFF
--- a/src/fmgc/src/flightplanning/GeoMath.ts
+++ b/src/fmgc/src/flightplanning/GeoMath.ts
@@ -22,7 +22,9 @@
  * SOFTWARE.
  */
 
+import { Coordinates } from '@fmgc/flightplanning/data/geo';
 import { WorldMagneticModel } from './WorldMagneticModel';
+import { NauticalMiles } from '../../../../typings';
 
 /** A class for geographical mathematics. */
 export class GeoMath {
@@ -93,5 +95,20 @@ export class GeoMath {
    */
   public static getMagvar(lat: number, lon: number): number {
       return GeoMath.magneticModel.declination(0, lat, lon, 2020);
+  }
+
+  public static directedDistanceToGo(from: Coordinates, to: Coordinates, acDirectedLineBearing: number): NauticalMiles {
+      const absDtg = Avionics.Utils.computeGreatCircleDistance(from, to);
+
+      // @todo should be abeam distance
+      if (acDirectedLineBearing >= 90 && acDirectedLineBearing <= 270) {
+          // Since a line perpendicular to the leg is formed by two 90 degree angles, an aircraftLegBearing outside
+          // (North - 90) and (North + 90) is in the lower quadrants of a plane centered at the TO fix. This means
+          // the aircraft is NOT past the TO fix, and DTG must be positive.
+
+          return absDtg;
+      }
+
+      return -absDtg;
   }
 }

--- a/src/fmgc/src/guidance/Geometry.ts
+++ b/src/fmgc/src/guidance/Geometry.ts
@@ -49,7 +49,7 @@ export class Geometry {
      */
     getGuidanceParameters(ppos, trueTrack, gs) {
         // first, check if we're abeam with one of the transitions (start or end)
-        const fromTransition = this.transitions.get(1);
+        const fromTransition = this.transitions.get(0);
         // TODO RAD
         if (fromTransition && fromTransition.isAbeam(ppos)) {
             return fromTransition.getGuidanceParameters(ppos, trueTrack);
@@ -57,7 +57,7 @@ export class Geometry {
 
         const activeLeg = this.legs.get(1);
 
-        const toTransition = this.transitions.get(2);
+        const toTransition = this.transitions.get(1);
         if (toTransition) {
             if (toTransition.isAbeam(ppos)) {
                 return toTransition.getGuidanceParameters(ppos, trueTrack);

--- a/src/fmgc/src/guidance/GuidanceManager.ts
+++ b/src/fmgc/src/guidance/GuidanceManager.ts
@@ -108,13 +108,14 @@ export class GuidanceManager {
 
         // TODO generalise selection of transitions
         if (nextLeg) {
-            legs.set(2, nextLeg);
             if (activeLeg instanceof TFLeg && !(nextLeg instanceof RFLeg)) {
-                transitions.set(2, new Type1Transition(
+                transitions.set(1, new Type1Transition(
                     activeLeg,
                     nextLeg,
                 ));
             }
+
+            legs.set(2, nextLeg);
         }
 
         return new Geometry(transitions, legs);

--- a/src/fmgc/src/guidance/GuidanceManager.ts
+++ b/src/fmgc/src/guidance/GuidanceManager.ts
@@ -179,7 +179,9 @@ export class GuidanceManager {
             : this.flightPlanManager.getCurrentFlightPlan().length;
         for (let i = wpCount - 1; (i >= activeIdx - 1); i--) {
             const nextLeg = legs.get(i + 1);
-            const isActive = i === activeIdx;
+
+            // We need to predict every path before the active leg + the active leg itself with the current speed
+            const predictWithCurrentSpeed = i <= activeIdx;
 
             const from = temp
                 ? this.flightPlanManager.getWaypoint(i - 1, 1)
@@ -225,7 +227,7 @@ export class GuidanceManager {
                 const transition = new Type1Transition(
                     currentLeg,
                     nextLeg,
-                    isActive,
+                    predictWithCurrentSpeed,
                 );
 
                 transitions.set(i, transition);

--- a/src/fmgc/src/guidance/lnav/transitions/Type1.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/Type1.ts
@@ -10,7 +10,7 @@ const mod = (x: number, n: number) => x - Math.floor(x / n) * n;
 /**
  * A type I transition uses a fixed turn radius between two fix-referenced legs.
  */
- export class Type1Transition extends Transition {
+export class Type1Transition extends Transition {
     public previousLeg: TFLeg;
 
     public nextLeg: TFLeg | VMLeg;
@@ -42,7 +42,7 @@ const mod = (x: number, n: number) => x - Math.floor(x / n) * n;
         const minBankAngle = 5;
 
         // Start with half the track change
-        const bankAngle = Math.abs(courseChange) / 2
+        const bankAngle = Math.abs(courseChange) / 2;
 
         // Bank angle limits, always assume limit 2 for now @ 25 degrees between 150 and 300 knots
         let maxBankAngle = 25;
@@ -92,11 +92,15 @@ const mod = (x: number, n: number) => x - Math.floor(x / n) * n;
     }
 
     isAbeam(ppos: LatLongAlt): boolean {
-        const [inbound] = this.getTurningPoints();
+        const [inbound, outbound] = this.getTurningPoints();
 
-        const bearingAC = Avionics.Utils.computeGreatCircleHeading(inbound, ppos);
-        const headingAC = Math.abs(MathUtils.diffAngle(this.previousLeg.bearing, bearingAC));
-        return headingAC <= 90;
+        const inBearingAc = Avionics.Utils.computeGreatCircleHeading(inbound, ppos);
+        const inHeadingAc = Math.abs(MathUtils.diffAngle(this.previousLeg.bearing, inBearingAc));
+
+        const outBearingAc = Avionics.Utils.computeGreatCircleHeading(outbound, ppos);
+        const outHeadingAc = Math.abs(MathUtils.diffAngle(this.nextLeg.bearing, outBearingAc));
+
+        return inHeadingAc <= 90 && outHeadingAc >= 90;
     }
 
     get distance(): NauticalMiles {

--- a/src/fmgc/src/guidance/lnav/transitions/Type1.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/Type1.ts
@@ -22,7 +22,7 @@ export class Type1Transition extends Transition {
     constructor(
         previousLeg: TFLeg,
         nextLeg: TFLeg | VMLeg, // FIXME this cannot happen, but what are you gonna do about it ?,
-        isActive: boolean = true,
+        predictWithCurrentSpeed: boolean = true,
     ) {
         super();
         this.previousLeg = previousLeg;
@@ -30,7 +30,7 @@ export class Type1Transition extends Transition {
 
         let kts: Knots;
         // TODO remove this hack when VNAV can provide a proper prediction
-        if (!isActive && this.previousLeg.to.additionalData.predictedSpeed) {
+        if (!predictWithCurrentSpeed && this.previousLeg.to.additionalData.predictedSpeed) {
             kts = this.previousLeg.to.additionalData.predictedSpeed;
         } else {
             kts = Math.max(SimVar.GetSimVarValue('AIRSPEED TRUE', 'knots'), 150); // knots, i.e. nautical miles per hour

--- a/src/instruments/src/ND/elements/FlightPlan.tsx
+++ b/src/instruments/src/ND/elements/FlightPlan.tsx
@@ -47,7 +47,7 @@ export const FlightPlan: FC<FlightPathProps> = ({ x = 0, y = 0, flightPlanManage
     }, 2_000);
 
     if (geometry) {
-        let legs = Array.from(geometry.legs.values());
+        const legs = Array.from(geometry.legs.values());
         const unslicedLegs = legs;
 
         const origin = flightPlan.originAirfield;
@@ -117,8 +117,8 @@ export const FlightPlan: FC<FlightPathProps> = ({ x = 0, y = 0, flightPlanManage
                             ))
                         }
                         {
-                            Array.from(geometry.transitions.values()).map((transition) => (
-                                <DebugTransition transition={transition} mapParams={mapParams} />
+                            Array.from(geometry.transitions.entries()).map(([index, transition]) => (
+                                <DebugTransition transition={transition} index={index} mapParams={mapParams} />
                             ))
                         }
                     </>
@@ -502,10 +502,11 @@ const DebugVMLeg: FC<DebugLegProps<VMLeg>> = ({ leg, mapParams }) => {
 
 export type DebugTransitionProps = {
     transition: Transition,
+    index: number,
     mapParams: MapParameters,
 }
 
-const DebugTransition: FC<DebugTransitionProps> = ({ transition, mapParams }) => {
+const DebugTransition: FC<DebugTransitionProps> = ({ transition, index, mapParams }) => {
     if (!(transition instanceof Type1Transition)) {
         return null;
     }
@@ -521,16 +522,32 @@ const DebugTransition: FC<DebugTransitionProps> = ({ transition, mapParams }) =>
         Math.round(Math.min(fromY, toY) + (Math.abs(toY - fromY) / 2)),
     ];
 
-    let transitionType;
-    if (transition instanceof Type1Transition) {
-        transitionType = 'Type 1';
-    }
+    const transitionType = 'Type 1';
+    const fromLegType = 'TF';
+    const toLegType = (transition.nextLeg instanceof TFLeg) ? 'TF' : 'VM';
+
+    const [itp, ftp] = transition.getTurningPoints();
+    const [inX, inY] = mapParams.coordinatesToXYy(itp);
+    const [outX, outY] = mapParams.coordinatesToXYy(ftp);
 
     return (
         <>
-            <text fill="yellow" x={infoX} y={infoY} fontSize={16}>
+            <text fill="yellow" x={infoX - 15} y={infoY} fontSize={16} textAnchor="end">
                 {transitionType}
+                {' '}
+                (
+                {fromLegType}
+                {' '}
+                -&gt;
+                {' '}
+                {toLegType}
+                ) (
+                {index}
+                )
             </text>
+
+            <circle cx={inX} cy={inY} r={5} fill="yellow" />
+            <circle cx={outX} cy={outY} r={5} fill="yellow" />
         </>
     );
 };

--- a/src/shared/src/MathUtils.ts
+++ b/src/shared/src/MathUtils.ts
@@ -30,6 +30,43 @@ export class MathUtils {
        return diff;
    }
 
+   /**
+    * Calculates the inner angle of the small triangle formed by two intersecting lines
+    *
+    * This effectively returns the angle XYZ in the figure shown below:
+    *
+    * ```
+    * * Y
+    * |\
+    * | \
+    * |  \
+    * |   \
+    * |    \
+    * |     \
+    * |      \
+    * * X     * Z
+    * ```
+    *
+    * @param xyAngle {number} bearing of line XY
+    * @param zyAngle {number} bearing of line ZY
+    */
+   public static smallCrossingAngle(xyAngle: number, zyAngle: number): number {
+       // Rotate frame of reference to 0deg
+       let correctedXyBearing = xyAngle - zyAngle;
+       if (correctedXyBearing < 0) {
+           correctedXyBearing = 360 + correctedXyBearing;
+       }
+
+       let xyzAngle = 180 - correctedXyBearing;
+       if (xyzAngle < 0) {
+           // correctedXyBearing was > 180
+
+           xyzAngle = 360 + xyzAngle;
+       }
+
+       return xyzAngle;
+   }
+
    public static mod(x: number, n: number): number {
        return x - Math.floor(x / n) * n;
    }


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

* We change the sequencing method of Type 1 transitions. Instead of checking for both directed DTG to the TERM FIX and directed DTG to INP, we now simply check for directed DTG to ITP. This aligns with the system sequencing behaviour of the FMS, but NOT with the visual sequencing behaviour, which is less important right now.
* We make sure to also include the transition onto the active leg as part of the active path geometry, in order to guide along the transition after sequencing instead of guiding along the active leg
* Clean up various directed DTG calculations

Discord username (if different from GitHub): someperson#4953

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

* Ensure that sequencing works correctly with all leg types (try SIDs with MANUAL legs, try RNP approaches)
* Ensure there is no excessive sequencing

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
