### PR TITLE
feat: V/S push in ALT* and improved turn coodination

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -424,6 +424,7 @@
 1. [FBW] Support additional mode to handle rudder axis plus/minus events - @aguther (Andreas Guther)
 1. [FBW] Improved pitch/C* law using streamlined pitch rate target - @aguther (Andreas Guther)
 1. [AP] Improved ALT* law that targets 0.05g capture - @aguther (Andreas Guther)
+1. [AP] Allow V/S push (level off) during ALT* - @aguther (Andreas Guther)
 
 ## 0.5.2
 1. [CDU] Changing CRZ/DES speed to acknowledge any speed restriction - @Watsi01 (RogePete)

--- a/src/fbw/src/model/AutopilotStateMachine.cpp
+++ b/src/fbw/src/model/AutopilotStateMachine.cpp
@@ -1015,6 +1015,7 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_ALT_CPT_during(void)
 void AutopilotStateMachineModelClass::AutopilotStateMachine_ALT_CPT(void)
 {
   real_T tmp;
+  boolean_T guard1 = false;
   boolean_T tmp_0;
   if (AutopilotStateMachine_B.BusAssignment_g.vertical.armed.GS &&
       AutopilotStateMachine_B.BusAssignment_g.vertical.condition.GS_CPT) {
@@ -1050,14 +1051,23 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_ALT_CPT(void)
       } else if (AutopilotStateMachine_B.BusAssignment_g.vertical.condition.ALT) {
         AutopilotStateMachine_DWork.is_ON = AutopilotStateMachine_IN_ALT;
         AutopilotStateMachine_ALT_entry();
-      } else if ((std::abs(AutopilotStateMachine_DWork.local_H_fcu_ft -
-                           AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft) > 250.0) ||
-                 AutopilotStateMachine_B.BusAssignment_g.input.Slew_trigger) {
-        AutopilotStateMachine_B.out.mode_reversion = true;
-        AutopilotStateMachine_DWork.is_ON = AutopilotStateMachine_IN_VS;
-        AutopilotStateMachine_VS_entry();
       } else {
-        AutopilotStateMachine_ALT_CPT_during();
+        guard1 = false;
+        if ((std::abs(AutopilotStateMachine_DWork.local_H_fcu_ft -
+                      AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft) > 250.0) ||
+            AutopilotStateMachine_B.BusAssignment_g.input.Slew_trigger) {
+          AutopilotStateMachine_B.out.mode_reversion = true;
+          guard1 = true;
+        } else if (AutopilotStateMachine_B.BusAssignment_g.input.VS_push) {
+          guard1 = true;
+        } else {
+          AutopilotStateMachine_ALT_CPT_during();
+        }
+
+        if (guard1) {
+          AutopilotStateMachine_DWork.is_ON = AutopilotStateMachine_IN_VS;
+          AutopilotStateMachine_VS_entry();
+        }
       }
     }
   }

--- a/src/fbw/src/model/FlyByWire.cpp
+++ b/src/fbw/src/model/FlyByWire.cpp
@@ -66,12 +66,12 @@ void FlyByWireModelClass::FlyByWire_RateLimiter(real_T rtu_u, real_T rtu_up, rea
   }
 
   u0 = rtu_u - localDW->pY;
-  u1 = rtu_up * rtu_Ts;
+  u1 = std::abs(rtu_up) * rtu_Ts;
   if (u0 < u1) {
     u1 = u0;
   }
 
-  u0 = rtu_lo * rtu_Ts;
+  u0 = -std::abs(rtu_lo) * rtu_Ts;
   if (u1 > u0) {
     u0 = u1;
   }
@@ -190,20 +190,19 @@ void FlyByWireModelClass::step()
   real_T rtb_Limiterxi;
   real_T rtb_Limiterxi1;
   real_T rtb_Limiterxi2;
-  real_T rtb_Limiterxi_o;
-  real_T rtb_Loaddemand;
   real_T rtb_ManualSwitch;
   real_T rtb_Min3;
   real_T rtb_Min5;
   real_T rtb_Product_e;
   real_T rtb_Sum1_d5;
   real_T rtb_Switch;
+  real_T rtb_Switch_c;
   real_T rtb_Y;
-  real_T rtb_Y_b;
-  real_T rtb_Y_h;
-  real_T rtb_Y_j;
+  real_T rtb_Y_c;
+  real_T rtb_Y_d;
+  real_T rtb_Y_f;
+  real_T rtb_Y_gj;
   real_T rtb_Y_o;
-  real_T rtb_Y_ps;
   real_T rtb_eta_trim_deg_rate_limit_lo_deg_s;
   real_T rtb_nz_limit_up_g;
   real_T rtb_v_target;
@@ -218,6 +217,7 @@ void FlyByWireModelClass::step()
   int32_T rtb_on_ground;
   boolean_T guard1 = false;
   boolean_T rtb_AND;
+  boolean_T rtb_NOT2;
   boolean_T rtb_eta_trim_deg_reset;
   boolean_T rtb_eta_trim_deg_should_freeze;
   boolean_T rtb_eta_trim_deg_should_write;
@@ -227,11 +227,11 @@ void FlyByWireModelClass::step()
   rtb_Gainqk = FlyByWire_P.Gain_Gain_n * FlyByWire_U.in.data.q_rad_s * FlyByWire_P.Gainqk_Gain;
   rtb_Gain = FlyByWire_P.Gain_Gain_l * FlyByWire_U.in.data.r_rad_s;
   rtb_Gainpk = FlyByWire_P.Gain_Gain_a * FlyByWire_U.in.data.p_rad_s * FlyByWire_P.Gainpk_Gain;
-  FlyByWire_ConvertToEuler(rtb_GainTheta, rtb_GainPhi, rtb_Gainqk, rtb_Gain, rtb_Gainpk, &rtb_Y, &rtb_Y_j, &rtb_Y_h);
+  FlyByWire_ConvertToEuler(rtb_GainTheta, rtb_GainPhi, rtb_Gainqk, rtb_Gain, rtb_Gainpk, &rtb_Y, &rtb_Y_o, &rtb_Y_c);
   FlyByWire_ConvertToEuler(rtb_GainTheta, rtb_GainPhi, FlyByWire_P.Gainqk1_Gain * (FlyByWire_P.Gain_Gain_e *
     FlyByWire_U.in.data.q_dot_rad_s2), FlyByWire_P.Gain_Gain_aw * FlyByWire_U.in.data.r_dot_rad_s2,
-    FlyByWire_P.Gainpk1_Gain * (FlyByWire_P.Gain_Gain_nm * FlyByWire_U.in.data.p_dot_rad_s2), &rtb_Y_ps, &rtb_Y_o,
-    &rtb_Y_b);
+    FlyByWire_P.Gainpk1_Gain * (FlyByWire_P.Gain_Gain_nm * FlyByWire_U.in.data.p_dot_rad_s2), &rtb_Y_f, &rtb_Y_d,
+    &rtb_Y_gj);
   rtb_Gainpk4 = FlyByWire_P.Gainpk4_Gain * FlyByWire_U.in.data.eta_pos;
   rtb_Gainpk2 = FlyByWire_P.Gainpk2_Gain * FlyByWire_U.in.data.eta_trim_deg;
   rtb_Limiterxi2 = FlyByWire_P.Gainpk6_Gain * FlyByWire_U.in.data.zeta_pos;
@@ -298,8 +298,8 @@ void FlyByWireModelClass::step()
     FlyByWire_P.alphafloor_maxIndex, 4U), FlyByWire_P.RateLimiterVariableTs1_up, FlyByWire_P.RateLimiterVariableTs1_lo,
                         FlyByWire_U.in.time.dt, FlyByWire_P.RateLimiterVariableTs1_InitialCondition, &rtb_Gain1_b,
                         &FlyByWire_DWork.sf_RateLimiter_bu);
-  FlyByWire_Y.out.sim.data.rk_dot_deg_s2 = rtb_Y_o;
-  FlyByWire_Y.out.sim.data.pk_dot_deg_s2 = rtb_Y_b;
+  FlyByWire_Y.out.sim.data.rk_dot_deg_s2 = rtb_Y_d;
+  FlyByWire_Y.out.sim.data.pk_dot_deg_s2 = rtb_Y_gj;
   rtb_BusAssignment_c_sim_data_speeds_aoa_alpha_max_deg = rtb_LimiteriH;
   FlyByWire_Y.out.sim.data_speeds_aoa.alpha_floor_deg = rtb_Gain1_b;
   if (FlyByWire_DWork.is_active_c1_FlyByWire == 0U) {
@@ -344,7 +344,7 @@ void FlyByWireModelClass::step()
 
   rtb_Gain_kh = FlyByWire_P.DiscreteDerivativeVariableTs_Gain * FlyByWire_U.in.data.V_ias_kn;
   FlyByWire_LagFilter((rtb_Gain_kh - FlyByWire_DWork.Delay_DSTATE_d) / FlyByWire_U.in.time.dt,
-                      FlyByWire_P.LagFilter_C1_a, FlyByWire_U.in.time.dt, &rtb_Y_b, &FlyByWire_DWork.sf_LagFilter);
+                      FlyByWire_P.LagFilter_C1_a, FlyByWire_U.in.time.dt, &rtb_Y_gj, &FlyByWire_DWork.sf_LagFilter);
   if (FlyByWire_DWork.is_active_c15_FlyByWire == 0U) {
     FlyByWire_DWork.is_active_c15_FlyByWire = 1U;
     FlyByWire_DWork.is_c15_FlyByWire = FlyByWire_IN_Landed;
@@ -418,15 +418,15 @@ void FlyByWireModelClass::step()
       rtb_nz_limit_lo_g = 0;
     }
 
-    if (rtb_Y_b <= rtb_nz_limit_lo_g) {
-      rtb_Y_b = rtb_nz_limit_lo_g;
+    if (rtb_Y_gj <= rtb_nz_limit_lo_g) {
+      rtb_Y_gj = rtb_nz_limit_lo_g;
     }
 
-    if (rtb_Y_b >= 0.0) {
-      rtb_Y_b = 0.0;
+    if (rtb_Y_gj >= 0.0) {
+      rtb_Y_gj = 0.0;
     }
 
-    if ((rtb_Limiterxi1 > rtb_Gain1_b + rtb_Y_b) && (FlyByWire_DWork.Delay_DSTATE > 10.0)) {
+    if ((rtb_Limiterxi1 > rtb_Gain1_b + rtb_Y_gj) && (FlyByWire_DWork.Delay_DSTATE > 10.0)) {
       FlyByWire_DWork.sAlphaFloor = 1.0;
     } else {
       guard1 = true;
@@ -442,11 +442,11 @@ void FlyByWireModelClass::step()
   }
 
   FlyByWire_GetIASforMach4(FlyByWire_U.in.data.V_mach, FlyByWire_P.Constant6_Value, FlyByWire_U.in.data.V_ias_kn,
-    &rtb_Y_o);
-  if (FlyByWire_P.Constant5_Value < rtb_Y_o) {
+    &rtb_Y_d);
+  if (FlyByWire_P.Constant5_Value < rtb_Y_d) {
     rtb_Min3 = FlyByWire_P.Constant5_Value;
   } else {
-    rtb_Min3 = rtb_Y_o;
+    rtb_Min3 = rtb_Y_d;
   }
 
   rtb_LimiteriH = rtb_GainTheta - std::cos(FlyByWire_P.Gain1_Gain_c * rtb_GainPhi) * FlyByWire_U.in.data.alpha_deg;
@@ -486,17 +486,17 @@ void FlyByWireModelClass::step()
   }
 
   FlyByWire_GetIASforMach4(FlyByWire_U.in.data.V_mach, FlyByWire_P.Constant8_Value, FlyByWire_U.in.data.V_ias_kn,
-    &rtb_Y_b);
-  if (FlyByWire_P.Constant7_Value < rtb_Y_b) {
+    &rtb_Y_gj);
+  if (FlyByWire_P.Constant7_Value < rtb_Y_gj) {
     rtb_Min5 = FlyByWire_P.Constant7_Value;
   } else {
-    rtb_Min5 = rtb_Y_b;
+    rtb_Min5 = rtb_Y_gj;
   }
 
   FlyByWire_Y.out.sim.data.qk_deg_s = rtb_Y;
-  FlyByWire_Y.out.sim.data.rk_deg_s = rtb_Y_j;
-  rtb_BusAssignment_a_sim_data_pk_deg_s = rtb_Y_h;
-  rtb_BusAssignment_a_sim_data_qk_dot_deg_s2 = rtb_Y_ps;
+  FlyByWire_Y.out.sim.data.rk_deg_s = rtb_Y_o;
+  rtb_BusAssignment_a_sim_data_pk_deg_s = rtb_Y_c;
+  rtb_BusAssignment_a_sim_data_qk_dot_deg_s2 = rtb_Y_f;
   FlyByWire_Y.out.sim.data_speeds_aoa.v_alpha_max_kn = rtb_Limiterxi2;
   FlyByWire_Y.out.sim.data_speeds_aoa.v_alpha_prot_kn = rtb_Limiterxi;
   FlyByWire_Y.out.sim.data_speeds_aoa.alpha_filtered_deg = rtb_Limiterxi1;
@@ -506,18 +506,18 @@ void FlyByWireModelClass::step()
     (rtb_Limiterxi1 > rtb_BusAssignment_c_sim_data_speeds_aoa_alpha_max_deg)) || (rtb_Limiterxi1 > rtb_Switch + 0.25))) ||
     (FlyByWire_U.in.time.simulation_time - FlyByWire_DWork.eventTime_o > 3.0) || (FlyByWire_DWork.sProtActive != 0.0) ||
     (FlyByWire_DWork.sProtActive_k != 0.0));
-  FlyByWire_eta_trim_limit_lofreeze(rtb_Gainpk2, FlyByWire_DWork.sProtActive_k, &rtb_Y_b,
+  FlyByWire_eta_trim_limit_lofreeze(rtb_Gainpk2, FlyByWire_DWork.sProtActive_k, &rtb_Y_gj,
     &FlyByWire_DWork.sf_eta_trim_limit_lofreeze);
   if (FlyByWire_DWork.sProtActive_k > FlyByWire_P.Switch_Threshold_h) {
-    rtb_BusAssignment_cs_pitch_data_computed_eta_trim_deg_limit_lo = rtb_Y_b;
+    rtb_BusAssignment_cs_pitch_data_computed_eta_trim_deg_limit_lo = rtb_Y_gj;
   } else {
     rtb_BusAssignment_cs_pitch_data_computed_eta_trim_deg_limit_lo = FlyByWire_P.Constant3_Value;
   }
 
-  FlyByWire_eta_trim_limit_lofreeze(rtb_Gainpk2, FlyByWire_DWork.sProtActive, &rtb_Y_b,
+  FlyByWire_eta_trim_limit_lofreeze(rtb_Gainpk2, FlyByWire_DWork.sProtActive, &rtb_Y_gj,
     &FlyByWire_DWork.sf_eta_trim_limit_upfreeze);
   if (FlyByWire_DWork.sProtActive > FlyByWire_P.Switch1_Threshold_k) {
-    rtb_BusAssignment_cs_pitch_data_computed_eta_trim_deg_limit_up = rtb_Y_b;
+    rtb_BusAssignment_cs_pitch_data_computed_eta_trim_deg_limit_up = rtb_Y_gj;
   } else {
     rtb_BusAssignment_cs_pitch_data_computed_eta_trim_deg_limit_up = FlyByWire_P.Constant2_Value;
   }
@@ -569,21 +569,21 @@ void FlyByWireModelClass::step()
   }
 
   FlyByWire_RateLimiter(rtb_Sum1_d5, FlyByWire_P.RateLimiterVariableTs_up_d, FlyByWire_P.RateLimiterVariableTs_lo_c,
-                        FlyByWire_U.in.time.dt, FlyByWire_P.RateLimiterVariableTs_InitialCondition_d, &rtb_Y_h,
+                        FlyByWire_U.in.time.dt, FlyByWire_P.RateLimiterVariableTs_InitialCondition_d, &rtb_Y_c,
                         &FlyByWire_DWork.sf_RateLimiter_b);
   if (FlyByWire_DWork.is_active_c6_FlyByWire == 0U) {
     FlyByWire_DWork.is_active_c6_FlyByWire = 1U;
     FlyByWire_DWork.is_c6_FlyByWire = FlyByWire_IN_OFF;
     rtb_ap_special_disc = 0;
   } else if (FlyByWire_DWork.is_c6_FlyByWire == 1) {
-    if ((rtb_Y_h < 1.0) && (FlyByWire_U.in.data.V_tas_kn > 70.0) && ((FlyByWire_U.in.data.thrust_lever_1_pos >= 35.0) ||
+    if ((rtb_Y_c < 1.0) && (FlyByWire_U.in.data.V_tas_kn > 70.0) && ((FlyByWire_U.in.data.thrust_lever_1_pos >= 35.0) ||
          (FlyByWire_U.in.data.thrust_lever_2_pos >= 35.0))) {
       FlyByWire_DWork.is_c6_FlyByWire = FlyByWire_IN_ON;
       rtb_ap_special_disc = 1;
     } else {
       rtb_ap_special_disc = 0;
     }
-  } else if ((rtb_Y_h == 1.0) || (FlyByWire_U.in.data.H_radio_ft > 400.0) || ((FlyByWire_U.in.data.V_tas_kn < 70.0) &&
+  } else if ((rtb_Y_c == 1.0) || (FlyByWire_U.in.data.H_radio_ft > 400.0) || ((FlyByWire_U.in.data.V_tas_kn < 70.0) &&
               ((FlyByWire_U.in.data.thrust_lever_1_pos < 35.0) || (FlyByWire_U.in.data.thrust_lever_2_pos < 35.0)))) {
     FlyByWire_DWork.is_c6_FlyByWire = FlyByWire_IN_OFF;
     rtb_ap_special_disc = 0;
@@ -591,7 +591,7 @@ void FlyByWireModelClass::step()
     rtb_ap_special_disc = 1;
   }
 
-  FlyByWire_LagFilter(rtb_GainTheta, FlyByWire_P.LagFilter_C1_n, FlyByWire_U.in.time.dt, &rtb_Y_j,
+  FlyByWire_LagFilter(rtb_GainTheta, FlyByWire_P.LagFilter_C1_n, FlyByWire_U.in.time.dt, &rtb_Y_o,
                       &FlyByWire_DWork.sf_LagFilter_l);
   if (FlyByWire_P.ManualSwitch_CurrentSetting == 1) {
     rtb_ManualSwitch = FlyByWire_P.Constant1_Value_f;
@@ -603,7 +603,7 @@ void FlyByWireModelClass::step()
     FlyByWire_DWork.is_active_c2_FlyByWire = 1U;
     FlyByWire_DWork.is_c2_FlyByWire = FlyByWire_IN_Ground;
     rtb_in_flare = 0;
-    FlyByWire_B.flare_Theta_c_deg = rtb_Y_j;
+    FlyByWire_B.flare_Theta_c_deg = rtb_Y_o;
     FlyByWire_B.flare_Theta_c_rate_deg_s = -3.0;
   } else {
     switch (FlyByWire_DWork.is_c2_FlyByWire) {
@@ -611,12 +611,12 @@ void FlyByWireModelClass::step()
       if (FlyByWire_B.in_flight == 0.0) {
         FlyByWire_DWork.is_c2_FlyByWire = FlyByWire_IN_Ground;
         rtb_in_flare = 0;
-        FlyByWire_B.flare_Theta_c_deg = rtb_Y_j;
+        FlyByWire_B.flare_Theta_c_deg = rtb_Y_o;
         FlyByWire_B.flare_Theta_c_rate_deg_s = -3.0;
       } else if ((FlyByWire_U.in.data.H_radio_ft > 50.0) && (rtb_ManualSwitch == 0.0)) {
         FlyByWire_DWork.is_c2_FlyByWire = FlyByWire_IN_Flight_Low;
         rtb_in_flare = 0;
-        FlyByWire_B.flare_Theta_c_deg = rtb_Y_j;
+        FlyByWire_B.flare_Theta_c_deg = rtb_Y_o;
         FlyByWire_B.flare_Theta_c_rate_deg_s = -3.0;
       } else {
         rtb_in_flare = 1;
@@ -638,7 +638,7 @@ void FlyByWireModelClass::step()
       } else if ((FlyByWire_U.in.data.H_radio_ft > 50.0) && (rtb_ManualSwitch == 0.0)) {
         FlyByWire_DWork.is_c2_FlyByWire = FlyByWire_IN_Flight_Low;
         rtb_in_flare = 0;
-        FlyByWire_B.flare_Theta_c_deg = rtb_Y_j;
+        FlyByWire_B.flare_Theta_c_deg = rtb_Y_o;
         FlyByWire_B.flare_Theta_c_rate_deg_s = -3.0;
       } else {
         rtb_in_flare = 1;
@@ -649,10 +649,10 @@ void FlyByWireModelClass::step()
       if ((FlyByWire_U.in.data.H_radio_ft > 50.0) && (rtb_ManualSwitch == 0.0)) {
         FlyByWire_DWork.is_c2_FlyByWire = FlyByWire_IN_Flight_Low;
         rtb_in_flare = 0;
-        FlyByWire_B.flare_Theta_c_deg = rtb_Y_j;
+        FlyByWire_B.flare_Theta_c_deg = rtb_Y_o;
         FlyByWire_B.flare_Theta_c_rate_deg_s = -3.0;
       } else {
-        FlyByWire_B.flare_Theta_c_rate_deg_s = -(rtb_Y_j + 2.0) / 8.0;
+        FlyByWire_B.flare_Theta_c_rate_deg_s = -(rtb_Y_o + 2.0) / 8.0;
         FlyByWire_DWork.is_c2_FlyByWire = FlyByWire_IN_Flare_Set_Rate;
         rtb_in_flare = 1;
       }
@@ -660,12 +660,12 @@ void FlyByWireModelClass::step()
 
      case FlyByWire_IN_Flight_High:
       if ((FlyByWire_U.in.data.H_radio_ft <= 50.0) || (rtb_ManualSwitch == 1.0)) {
-        FlyByWire_B.flare_Theta_c_deg = rtb_Y_j;
+        FlyByWire_B.flare_Theta_c_deg = rtb_Y_o;
         FlyByWire_DWork.is_c2_FlyByWire = FlyByWire_IN_Flare_Store_Theta_c_deg;
         rtb_in_flare = 1;
       } else {
         rtb_in_flare = 0;
-        FlyByWire_B.flare_Theta_c_deg = rtb_Y_j;
+        FlyByWire_B.flare_Theta_c_deg = rtb_Y_o;
         FlyByWire_B.flare_Theta_c_rate_deg_s = -3.0;
       }
       break;
@@ -674,11 +674,11 @@ void FlyByWireModelClass::step()
       if (FlyByWire_U.in.data.H_radio_ft > 50.0) {
         FlyByWire_DWork.is_c2_FlyByWire = FlyByWire_IN_Flight_High;
         rtb_in_flare = 0;
-        FlyByWire_B.flare_Theta_c_deg = rtb_Y_j;
+        FlyByWire_B.flare_Theta_c_deg = rtb_Y_o;
         FlyByWire_B.flare_Theta_c_rate_deg_s = -3.0;
       } else {
         rtb_in_flare = 0;
-        FlyByWire_B.flare_Theta_c_deg = rtb_Y_j;
+        FlyByWire_B.flare_Theta_c_deg = rtb_Y_o;
         FlyByWire_B.flare_Theta_c_rate_deg_s = -3.0;
       }
       break;
@@ -687,11 +687,11 @@ void FlyByWireModelClass::step()
       if (FlyByWire_B.in_flight == 1.0) {
         FlyByWire_DWork.is_c2_FlyByWire = FlyByWire_IN_Flight_Low;
         rtb_in_flare = 0;
-        FlyByWire_B.flare_Theta_c_deg = rtb_Y_j;
+        FlyByWire_B.flare_Theta_c_deg = rtb_Y_o;
         FlyByWire_B.flare_Theta_c_rate_deg_s = -3.0;
       } else {
         rtb_in_flare = 0;
-        FlyByWire_B.flare_Theta_c_deg = rtb_Y_j;
+        FlyByWire_B.flare_Theta_c_deg = rtb_Y_o;
         FlyByWire_B.flare_Theta_c_rate_deg_s = -3.0;
       }
       break;
@@ -708,7 +708,7 @@ void FlyByWireModelClass::step()
 
   FlyByWire_RateLimiter(rtb_ManualSwitch, FlyByWire_P.RateLimiterVariableTs1_up_n,
                         FlyByWire_P.RateLimiterVariableTs1_lo_c, FlyByWire_U.in.time.dt,
-                        FlyByWire_P.RateLimiterVariableTs1_InitialCondition_h, &rtb_Y_ps,
+                        FlyByWire_P.RateLimiterVariableTs1_InitialCondition_h, &rtb_Y_f,
                         &FlyByWire_DWork.sf_RateLimiter_g);
   if (FlyByWire_DWork.is_active_c7_FlyByWire == 0U) {
     FlyByWire_DWork.is_active_c7_FlyByWire = 1U;
@@ -786,11 +786,11 @@ void FlyByWireModelClass::step()
 
   FlyByWire_RateLimiter(rtb_nz_limit_up_g, FlyByWire_P.RateLimiterVariableTs2_up_f,
                         FlyByWire_P.RateLimiterVariableTs2_lo_m, FlyByWire_U.in.time.dt,
-                        FlyByWire_P.RateLimiterVariableTs2_InitialCondition_b, &rtb_Y_o,
+                        FlyByWire_P.RateLimiterVariableTs2_InitialCondition_b, &rtb_Y_d,
                         &FlyByWire_DWork.sf_RateLimiter_m);
   FlyByWire_RateLimiter(static_cast<real_T>(rtb_nz_limit_lo_g), FlyByWire_P.RateLimiterVariableTs3_up_c,
                         FlyByWire_P.RateLimiterVariableTs3_lo_l, FlyByWire_U.in.time.dt,
-                        FlyByWire_P.RateLimiterVariableTs3_InitialCondition_b, &rtb_Y_b,
+                        FlyByWire_P.RateLimiterVariableTs3_InitialCondition_b, &rtb_Y_gj,
                         &FlyByWire_DWork.sf_RateLimiter_a);
   if (FlyByWire_DWork.is_active_c9_FlyByWire == 0U) {
     FlyByWire_DWork.is_active_c9_FlyByWire = 1U;
@@ -894,38 +894,38 @@ void FlyByWireModelClass::step()
   rtb_LimiteriH_n = rtb_Y;
   rtb_BusAssignment_cs_pitch_data_computed_delta_eta_deg = FlyByWire_P.Gain_Gain_d *
     rtb_BusAssignment_sim_input_delta_eta_pos;
-  rtb_BusAssignment_cs_pitch_data_computed_in_flight_gain = rtb_Y_h;
-  rtb_BusAssignment_cs_pitch_data_computed_nz_limit_lo_g = rtb_Y_b;
-  FlyByWire_Y.out.pitch.data_computed.flare_Theta_deg = rtb_Y_j;
+  rtb_BusAssignment_cs_pitch_data_computed_in_flight_gain = rtb_Y_c;
+  rtb_BusAssignment_cs_pitch_data_computed_nz_limit_lo_g = rtb_Y_gj;
+  FlyByWire_Y.out.pitch.data_computed.flare_Theta_deg = rtb_Y_o;
   FlyByWire_RateLimiter(rtb_BusAssignment_sim_input_delta_eta_pos, FlyByWire_P.RateLimiterVariableTs_up_dl,
                         FlyByWire_P.RateLimiterVariableTs_lo_d, FlyByWire_U.in.time.dt,
-                        FlyByWire_P.RateLimiterVariableTs_InitialCondition_n, &rtb_Y_b,
+                        FlyByWire_P.RateLimiterVariableTs_InitialCondition_n, &rtb_Y_gj,
                         &FlyByWire_DWork.sf_RateLimiter_l);
-  if (rtb_Y_b > FlyByWire_P.Saturation3_UpperSat) {
+  if (rtb_Y_gj > FlyByWire_P.Saturation3_UpperSat) {
     rtb_Gain_i = FlyByWire_P.Saturation3_UpperSat;
-  } else if (rtb_Y_b < FlyByWire_P.Saturation3_LowerSat) {
+  } else if (rtb_Y_gj < FlyByWire_P.Saturation3_LowerSat) {
     rtb_Gain_i = FlyByWire_P.Saturation3_LowerSat;
   } else {
-    rtb_Gain_i = rtb_Y_b;
+    rtb_Gain_i = rtb_Y_gj;
   }
 
   rtb_LimiteriH = look1_binlxpw(static_cast<real_T>(FlyByWire_U.in.data.tailstrike_protection_on) * look2_binlxpw
     (rtb_GainTheta, FlyByWire_U.in.data.H_radio_ft, FlyByWire_P.uDLookupTable_bp01Data_l,
      FlyByWire_P.uDLookupTable_bp02Data, FlyByWire_P.uDLookupTable_tableData_d, FlyByWire_P.uDLookupTable_maxIndex, 5U) *
-    rtb_Gain_i + rtb_Y_b, FlyByWire_P.PitchRateDemand_bp01Data, FlyByWire_P.PitchRateDemand_tableData, 2U);
+    rtb_Gain_i + rtb_Y_gj, FlyByWire_P.PitchRateDemand_bp01Data, FlyByWire_P.PitchRateDemand_tableData, 2U);
   rtb_Gain_i = FlyByWire_P.DiscreteDerivativeVariableTs_Gain_c * rtb_LimiteriH;
   rtb_Limiterxi = rtb_Y - rtb_LimiteriH;
   rtb_Gain_g = FlyByWire_P.Gain1_Gain_i * rtb_Limiterxi * FlyByWire_P.DiscreteDerivativeVariableTs_Gain_b;
   FlyByWire_LagFilter(rtb_Y + FlyByWire_P.Gain5_Gain * rtb_BusAssignment_a_sim_data_qk_dot_deg_s2,
-                      FlyByWire_P.LagFilter_C1_i, FlyByWire_U.in.time.dt, &rtb_Y_b, &FlyByWire_DWork.sf_LagFilter_p);
+                      FlyByWire_P.LagFilter_C1_i, FlyByWire_U.in.time.dt, &rtb_Y_gj, &FlyByWire_DWork.sf_LagFilter_p);
   rtb_Gain1_b = (((((rtb_Gain_g - FlyByWire_DWork.Delay_DSTATE_dd) / FlyByWire_U.in.time.dt + FlyByWire_P.Gain_Gain_h *
                     rtb_Limiterxi) * FlyByWire_P.Gain1_Gain_a + (rtb_Gain_i - FlyByWire_DWork.Delay_DSTATE_f) /
-                   FlyByWire_U.in.time.dt * FlyByWire_P.Gain3_Gain_p) + (rtb_Y_b - rtb_LimiteriH) *
+                   FlyByWire_U.in.time.dt * FlyByWire_P.Gain3_Gain_p) + (rtb_Y_gj - rtb_LimiteriH) *
                   FlyByWire_P.Gain4_Gain_g) + FlyByWire_P.Gain6_Gain_f * rtb_BusAssignment_a_sim_data_qk_dot_deg_s2) *
-    (FlyByWire_P.Constant2_Value_l - rtb_Y_h) * FlyByWire_P.DiscreteTimeIntegratorVariableTs_Gain *
+    (FlyByWire_P.Constant2_Value_l - rtb_Y_c) * FlyByWire_P.DiscreteTimeIntegratorVariableTs_Gain *
     FlyByWire_U.in.time.dt;
   FlyByWire_DWork.icLoad = (((rtb_BusAssignment_sim_input_delta_eta_pos <= FlyByWire_P.Constant_Value_j) &&
-    (rtb_on_ground != 0)) || (rtb_Y_ps == 0.0) || (rtb_alpha_floor_inhib != 0) || FlyByWire_DWork.icLoad);
+    (rtb_on_ground != 0)) || (rtb_Y_f == 0.0) || (rtb_alpha_floor_inhib != 0) || FlyByWire_DWork.icLoad);
   if (FlyByWire_DWork.icLoad) {
     FlyByWire_DWork.Delay_DSTATE_e = FlyByWire_P.Constant_Value_h - rtb_Gain1_b;
   }
@@ -984,7 +984,7 @@ void FlyByWireModelClass::step()
   rtb_Limiterxi2 = rtb_Gain1_b / std::cos(FlyByWire_P.Gain1_Gain_b * rtb_Gain_iw);
   FlyByWire_RateLimiter(FlyByWire_U.in.data.autopilot_custom_Theta_c_deg, FlyByWire_P.RateLimiterVariableTs1_up_k,
                         FlyByWire_P.RateLimiterVariableTs1_lo_h, FlyByWire_U.in.time.dt,
-                        FlyByWire_P.RateLimiterVariableTs1_InitialCondition_hb, &rtb_Y_h,
+                        FlyByWire_P.RateLimiterVariableTs1_InitialCondition_hb, &rtb_Y_c,
                         &FlyByWire_DWork.sf_RateLimiter_n);
   u1 = 5.0 - (FlyByWire_U.in.data.V_ias_kn - (FlyByWire_U.in.data.VLS_kn + 5.0)) * 0.25;
   if (0.0 > u1) {
@@ -1006,7 +1006,7 @@ void FlyByWireModelClass::step()
                         FlyByWire_P.RateLimiterVariableTs6_InitialCondition, &rtb_Y, &FlyByWire_DWork.sf_RateLimiter);
   FlyByWire_RateLimiter(rtb_BusAssignment_sim_input_delta_eta_pos, FlyByWire_P.RateLimiterVariableTs_up_f,
                         FlyByWire_P.RateLimiterVariableTs_lo_f, FlyByWire_U.in.time.dt,
-                        FlyByWire_P.RateLimiterVariableTs_InitialCondition_c, &rtb_Y_j,
+                        FlyByWire_P.RateLimiterVariableTs_InitialCondition_c, &rtb_Y_o,
                         &FlyByWire_DWork.sf_RateLimiter_k);
   rtb_Gain_iw = FlyByWire_P.Subsystem2_Gain * rtb_v_target;
   rtb_Divide_m = (rtb_Gain_iw - FlyByWire_DWork.Delay_DSTATE_j) / FlyByWire_U.in.time.dt;
@@ -1033,17 +1033,17 @@ void FlyByWireModelClass::step()
 
   FlyByWire_DWork.Delay_DSTATE_g += rtb_Sum1_d5;
   if (FlyByWire_U.in.data.autopilot_custom_on > FlyByWire_P.Switch1_Threshold_ke) {
-    rtb_Gain1_b = (rtb_Y_h - rtb_GainTheta) * FlyByWire_P.Gain4_Gain;
+    rtb_Gain1_b = (rtb_Y_c - rtb_GainTheta) * FlyByWire_P.Gain4_Gain;
   } else {
     rtb_Gain1_b = FlyByWire_P.Gain1_Gain * rtb_GainTheta;
-    rtb_Y_h = rtb_Divide1 - rtb_Limiterxi2;
-    rtb_Loaddemand = look1_binlxpw(rtb_Y_j, FlyByWire_P.Loaddemand_bp01Data, FlyByWire_P.Loaddemand_tableData, 2U);
+    rtb_Limiterxi = rtb_Divide1 - rtb_Limiterxi2;
+    rtb_Y_c = look1_binlxpw(rtb_Y_o, FlyByWire_P.Loaddemand_bp01Data, FlyByWire_P.Loaddemand_tableData, 2U);
     if (FlyByWire_DWork.Delay_DSTATE_g > FlyByWire_P.Saturation_UpperSat_o) {
-      rtb_Y_j = FlyByWire_P.Saturation_UpperSat_o;
+      rtb_Y_o = FlyByWire_P.Saturation_UpperSat_o;
     } else if (FlyByWire_DWork.Delay_DSTATE_g < FlyByWire_P.Saturation_LowerSat_k) {
-      rtb_Y_j = FlyByWire_P.Saturation_LowerSat_k;
+      rtb_Y_o = FlyByWire_P.Saturation_LowerSat_k;
     } else {
-      rtb_Y_j = FlyByWire_DWork.Delay_DSTATE_g;
+      rtb_Y_o = FlyByWire_DWork.Delay_DSTATE_g;
     }
 
     if (FlyByWire_DWork.sProtActive > FlyByWire_P.Switch2_Threshold) {
@@ -1052,12 +1052,12 @@ void FlyByWireModelClass::step()
                        FlyByWire_P.v_dot_gain_HSP_Gain * FlyByWire_DWork.Delay1_DSTATE_i) + FlyByWire_P.qk_gain_HSP_Gain
                       * rtb_LimiteriH_n) + FlyByWire_P.qk_dot_gain1_Gain * rtb_BusAssignment_a_sim_data_qk_dot_deg_s2) *
         FlyByWire_P.HSP_gain_Gain;
-      if (rtb_Loaddemand > FlyByWire_P.Saturation8_UpperSat) {
-        rtb_Limiterxi = FlyByWire_P.Saturation8_UpperSat;
-      } else if (rtb_Loaddemand < FlyByWire_P.Saturation8_LowerSat) {
-        rtb_Limiterxi = FlyByWire_P.Saturation8_LowerSat;
+      if (rtb_Y_c > FlyByWire_P.Saturation8_UpperSat) {
+        rtb_Switch_c = FlyByWire_P.Saturation8_UpperSat;
+      } else if (rtb_Y_c < FlyByWire_P.Saturation8_LowerSat) {
+        rtb_Switch_c = FlyByWire_P.Saturation8_LowerSat;
       } else {
-        rtb_Limiterxi = rtb_Loaddemand;
+        rtb_Switch_c = rtb_Y_c;
       }
 
       if (rtb_Sum1_d5 > FlyByWire_P.Saturation4_UpperSat) {
@@ -1066,21 +1066,21 @@ void FlyByWireModelClass::step()
         rtb_Sum1_d5 = FlyByWire_P.Saturation4_LowerSat;
       }
 
-      rtb_Limiterxi += rtb_Sum1_d5;
+      rtb_Switch_c += rtb_Sum1_d5;
     } else {
-      rtb_Limiterxi = FlyByWire_P.Constant1_Value;
+      rtb_Switch_c = FlyByWire_P.Constant1_Value;
     }
 
-    rtb_Loaddemand = (FlyByWire_P.Constant_Value_k - rtb_Y_j) * rtb_Loaddemand + rtb_Limiterxi * rtb_Y_j;
+    rtb_Y_c = (FlyByWire_P.Constant_Value_k - rtb_Y_o) * rtb_Y_c + rtb_Switch_c * rtb_Y_o;
     if (rtb_in_flare > FlyByWire_P.Switch_Threshold) {
-      rtb_Limiterxi = (FlyByWire_DWork.Delay_DSTATE_dq - rtb_GainTheta) * FlyByWire_P.Gain_Gain;
-      if (rtb_Limiterxi > FlyByWire_P.Saturation_UpperSat) {
-        rtb_Limiterxi = FlyByWire_P.Saturation_UpperSat;
-      } else if (rtb_Limiterxi < FlyByWire_P.Saturation_LowerSat) {
-        rtb_Limiterxi = FlyByWire_P.Saturation_LowerSat;
+      rtb_Switch_c = (FlyByWire_DWork.Delay_DSTATE_dq - rtb_GainTheta) * FlyByWire_P.Gain_Gain;
+      if (rtb_Switch_c > FlyByWire_P.Saturation_UpperSat) {
+        rtb_Switch_c = FlyByWire_P.Saturation_UpperSat;
+      } else if (rtb_Switch_c < FlyByWire_P.Saturation_LowerSat) {
+        rtb_Switch_c = FlyByWire_P.Saturation_LowerSat;
       }
     } else {
-      rtb_Limiterxi = FlyByWire_P.Constant_Value_m;
+      rtb_Switch_c = FlyByWire_P.Constant_Value_m;
     }
 
     rtb_Sum1_d5 = FlyByWire_P.Gain2_Gain * rtb_Y - rtb_Gain1_b;
@@ -1090,9 +1090,9 @@ void FlyByWireModelClass::step()
       rtb_Sum1_d5 = FlyByWire_P.Saturation1_LowerSat;
     }
 
-    rtb_Y_j = look1_binlxpw(rtb_Sum1_d5, FlyByWire_P.Loaddemand1_bp01Data, FlyByWire_P.Loaddemand1_tableData, 2U) +
-      rtb_Y_h;
-    if (rtb_Loaddemand <= rtb_Y_j) {
+    rtb_Y_o = look1_binlxpw(rtb_Sum1_d5, FlyByWire_P.Loaddemand1_bp01Data, FlyByWire_P.Loaddemand1_tableData, 2U) +
+      rtb_Limiterxi;
+    if (rtb_Y_c <= rtb_Y_o) {
       rtb_Sum1_d5 = FlyByWire_P.Gain3_Gain * FlyByWire_P.Theta_max3_Value - rtb_Gain1_b;
       if (rtb_Sum1_d5 > FlyByWire_P.Saturation2_UpperSat) {
         rtb_Sum1_d5 = FlyByWire_P.Saturation2_UpperSat;
@@ -1100,35 +1100,35 @@ void FlyByWireModelClass::step()
         rtb_Sum1_d5 = FlyByWire_P.Saturation2_LowerSat;
       }
 
-      rtb_Y_j = look1_binlxpw(rtb_Sum1_d5, FlyByWire_P.Loaddemand2_bp01Data, FlyByWire_P.Loaddemand2_tableData, 2U) +
-        rtb_Y_h;
-      if (rtb_Loaddemand >= rtb_Y_j) {
-        rtb_Y_j = rtb_Loaddemand;
+      rtb_Y_o = look1_binlxpw(rtb_Sum1_d5, FlyByWire_P.Loaddemand2_bp01Data, FlyByWire_P.Loaddemand2_tableData, 2U) +
+        rtb_Limiterxi;
+      if (rtb_Y_c >= rtb_Y_o) {
+        rtb_Y_o = rtb_Y_c;
       }
     }
 
-    rtb_Gain1_b = rtb_Y_j + rtb_Limiterxi;
+    rtb_Gain1_b = rtb_Y_o + rtb_Switch_c;
   }
 
   rtb_Gain1_b += rtb_Limiterxi2;
-  if (rtb_Gain1_b > rtb_Y_o) {
-    rtb_Gain1_b = rtb_Y_o;
+  if (rtb_Gain1_b > rtb_Y_d) {
+    rtb_Gain1_b = rtb_Y_d;
   } else if (rtb_Gain1_b < rtb_BusAssignment_cs_pitch_data_computed_nz_limit_lo_g) {
     rtb_Gain1_b = rtb_BusAssignment_cs_pitch_data_computed_nz_limit_lo_g;
   }
 
   FlyByWire_RateLimiter(rtb_BusAssignment_sim_input_delta_eta_pos, FlyByWire_P.RateLimiterVariableTs2_up_b,
                         FlyByWire_P.RateLimiterVariableTs2_lo_n, FlyByWire_U.in.time.dt,
-                        FlyByWire_P.RateLimiterVariableTs2_InitialCondition_j, &rtb_Y_b,
+                        FlyByWire_P.RateLimiterVariableTs2_InitialCondition_j, &rtb_Y_gj,
                         &FlyByWire_DWork.sf_RateLimiter_p);
-  rtb_y_i = (rtb_BusAssignment_c_sim_data_speeds_aoa_alpha_max_deg - rtb_Switch) * rtb_Y_b;
-  FlyByWire_LagFilter(FlyByWire_U.in.data.alpha_deg, FlyByWire_P.LagFilter1_C1, FlyByWire_U.in.time.dt, &rtb_Y_b,
+  rtb_y_i = (rtb_BusAssignment_c_sim_data_speeds_aoa_alpha_max_deg - rtb_Switch) * rtb_Y_gj;
+  FlyByWire_LagFilter(FlyByWire_U.in.data.alpha_deg, FlyByWire_P.LagFilter1_C1, FlyByWire_U.in.time.dt, &rtb_Y_gj,
                       &FlyByWire_DWork.sf_LagFilter_h);
-  rtb_Limiterxi = rtb_Y_b - rtb_Switch;
+  rtb_Limiterxi = rtb_Y_gj - rtb_Switch;
   if (0.0 > rtb_GainTheta - 22.5) {
-    rtb_Y = 0.0;
+    rtb_Sum1_d5 = 0.0;
   } else {
-    rtb_Y = rtb_GainTheta - 22.5;
+    rtb_Sum1_d5 = rtb_GainTheta - 22.5;
   }
 
   u1 = (std::abs(rtb_GainPhi) - 3.0) / 6.0;
@@ -1136,22 +1136,22 @@ void FlyByWireModelClass::step()
     u1 = 0.0;
   }
 
-  if (rtb_Y > u1) {
-    u1 = rtb_Y;
+  if (rtb_Sum1_d5 > u1) {
+    u1 = rtb_Sum1_d5;
   }
 
-  FlyByWire_WashoutFilter(u1, FlyByWire_P.WashoutFilter_C1, FlyByWire_U.in.time.dt, &rtb_Y_b,
+  FlyByWire_WashoutFilter(u1, FlyByWire_P.WashoutFilter_C1, FlyByWire_U.in.time.dt, &rtb_Y_gj,
     &FlyByWire_DWork.sf_WashoutFilter);
-  rtb_Limiterxi = (rtb_y_i - rtb_Limiterxi) - rtb_Y_b;
+  rtb_Limiterxi = (rtb_y_i - rtb_Limiterxi) - rtb_Y_gj;
   rtb_Y = FlyByWire_P.Subsystem1_Gain * rtb_Limiterxi;
-  rtb_Y_j = (rtb_Y - FlyByWire_DWork.Delay_DSTATE_ps) / FlyByWire_U.in.time.dt;
+  rtb_Y_o = (rtb_Y - FlyByWire_DWork.Delay_DSTATE_ps) / FlyByWire_U.in.time.dt;
   rtb_Limiterxi1 = FlyByWire_U.in.time.dt * FlyByWire_P.Subsystem1_C1;
   rtb_Limiterxi2 = rtb_Limiterxi1 + FlyByWire_P.Constant_Value_kr;
   FlyByWire_DWork.Delay1_DSTATE_o = 1.0 / rtb_Limiterxi2 * (FlyByWire_P.Constant_Value_kr - rtb_Limiterxi1) *
-    FlyByWire_DWork.Delay1_DSTATE_o + (rtb_Y_j + FlyByWire_DWork.Delay_DSTATE_c1) * (rtb_Limiterxi1 / rtb_Limiterxi2);
-  rtb_Y_b = FlyByWire_P.alpha_err_gain_Gain * rtb_Limiterxi;
-  rtb_Y_h = FlyByWire_P.Subsystem3_Gain * FlyByWire_U.in.data.V_ias_kn;
-  rtb_Limiterxi2 = (rtb_Y_h - FlyByWire_DWork.Delay_DSTATE_l) / FlyByWire_U.in.time.dt;
+    FlyByWire_DWork.Delay1_DSTATE_o + (rtb_Y_o + FlyByWire_DWork.Delay_DSTATE_c1) * (rtb_Limiterxi1 / rtb_Limiterxi2);
+  rtb_Y_gj = FlyByWire_P.alpha_err_gain_Gain * rtb_Limiterxi;
+  rtb_Y_c = FlyByWire_P.Subsystem3_Gain * FlyByWire_U.in.data.V_ias_kn;
+  rtb_Limiterxi2 = (rtb_Y_c - FlyByWire_DWork.Delay_DSTATE_l) / FlyByWire_U.in.time.dt;
   rtb_Limiterxi = FlyByWire_U.in.time.dt * FlyByWire_P.Subsystem3_C1;
   rtb_Limiterxi1 = rtb_Limiterxi + FlyByWire_P.Constant_Value_c;
   FlyByWire_DWork.Delay1_DSTATE_n = 1.0 / rtb_Limiterxi1 * (FlyByWire_P.Constant_Value_c - rtb_Limiterxi) *
@@ -1177,7 +1177,7 @@ void FlyByWireModelClass::step()
     rtb_Limiterxi1 = FlyByWire_DWork.Delay_DSTATE_k;
   }
 
-  rtb_Loaddemand = FlyByWire_P.DiscreteDerivativeVariableTs1_Gain * rtb_LimiteriH_n;
+  rtb_Switch_c = FlyByWire_P.DiscreteDerivativeVariableTs1_Gain * rtb_LimiteriH_n;
   if (FlyByWire_U.in.data.V_tas_kn > FlyByWire_P.Saturation3_UpperSat_p) {
     rtb_Sum1_d5 = FlyByWire_P.Saturation3_UpperSat_p;
   } else if (FlyByWire_U.in.data.V_tas_kn < FlyByWire_P.Saturation3_LowerSat_i) {
@@ -1191,13 +1191,12 @@ void FlyByWireModelClass::step()
     (rtb_Gain1_b - rtb_Divide1);
   rtb_Divide1 = rtb_Limiterxi * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.DLUT_bp01Data,
     FlyByWire_P.DLUT_tableData, 1U) * FlyByWire_P.DiscreteDerivativeVariableTs_Gain_e;
-  rtb_Sum1_d5 = (((FlyByWire_P.precontrol_gain_Gain * FlyByWire_DWork.Delay1_DSTATE_o + rtb_Y_b) +
+  rtb_Sum1_d5 = (((FlyByWire_P.precontrol_gain_Gain * FlyByWire_DWork.Delay1_DSTATE_o + rtb_Y_gj) +
                   FlyByWire_P.v_dot_gain_Gain * FlyByWire_DWork.Delay1_DSTATE_n) + FlyByWire_P.qk_gain_Gain *
                  rtb_LimiteriH_n) + FlyByWire_P.qk_dot_gain_Gain * rtb_BusAssignment_a_sim_data_qk_dot_deg_s2;
-  rtb_Limiterxi = ((rtb_Loaddemand - FlyByWire_DWork.Delay_DSTATE_ca) / FlyByWire_U.in.time.dt *
-                   FlyByWire_P.Gain3_Gain_l + rtb_Limiterxi * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn,
-    FlyByWire_P.PLUT_bp01Data, FlyByWire_P.PLUT_tableData, 1U)) + (rtb_Divide1 - FlyByWire_DWork.Delay_DSTATE_jv) /
-    FlyByWire_U.in.time.dt;
+  rtb_Limiterxi = ((rtb_Switch_c - FlyByWire_DWork.Delay_DSTATE_ca) / FlyByWire_U.in.time.dt * FlyByWire_P.Gain3_Gain_l
+                   + rtb_Limiterxi * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.PLUT_bp01Data,
+    FlyByWire_P.PLUT_tableData, 1U)) + (rtb_Divide1 - FlyByWire_DWork.Delay_DSTATE_jv) / FlyByWire_U.in.time.dt;
   if (rtb_Sum1_d5 > FlyByWire_P.Saturation3_UpperSat_c) {
     rtb_Sum1_d5 = FlyByWire_P.Saturation3_UpperSat_c;
   } else if (rtb_Sum1_d5 < FlyByWire_P.Saturation3_LowerSat_h) {
@@ -1243,12 +1242,12 @@ void FlyByWireModelClass::step()
 
   rtb_LimiteriH = FlyByWire_DWork.Delay_DSTATE_f1 * rtb_Gain1_b;
   rtb_Sum1_d5 = FlyByWire_P.Constant_Value_o - rtb_Gain1_b;
-  if (rtb_Y_ps > FlyByWire_P.Saturation_UpperSat_c) {
+  if (rtb_Y_f > FlyByWire_P.Saturation_UpperSat_c) {
     rtb_Gain1_b = FlyByWire_P.Saturation_UpperSat_c;
-  } else if (rtb_Y_ps < FlyByWire_P.Saturation_LowerSat_m) {
+  } else if (rtb_Y_f < FlyByWire_P.Saturation_LowerSat_m) {
     rtb_Gain1_b = FlyByWire_P.Saturation_LowerSat_m;
   } else {
-    rtb_Gain1_b = rtb_Y_ps;
+    rtb_Gain1_b = rtb_Y_f;
   }
 
   rtb_LimiteriH_n = ((FlyByWire_P.Constant_Value_ju - rtb_Gain1_b) *
@@ -1286,19 +1285,19 @@ void FlyByWireModelClass::step()
   }
 
   FlyByWire_DWork.Delay_DSTATE_ea += rtb_Sum1_d5;
-  FlyByWire_Y.out.pitch.data_computed.in_rotation_gain = rtb_Y_ps;
-  FlyByWire_Y.out.pitch.data_computed.nz_limit_up_g = rtb_Y_o;
+  FlyByWire_Y.out.pitch.data_computed.in_rotation_gain = rtb_Y_f;
+  FlyByWire_Y.out.pitch.data_computed.nz_limit_up_g = rtb_Y_d;
   FlyByWire_Y.out.pitch.law_normal.eta_dot_deg_s = rtb_Limiterxi;
   FlyByWire_Y.out.pitch.vote.eta_dot_deg_s = rtb_Limiterxi;
-  rtb_Y_ps = look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.uDLookupTable_bp01Data_f,
+  rtb_Y_f = look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.uDLookupTable_bp01Data_f,
     FlyByWire_P.uDLookupTable_tableData_f, 3U);
   rtb_Gain1_o = FlyByWire_P.Gain1_Gain_jh * rtb_BusAssignment_sim_input_delta_zeta_pos;
-  if (rtb_Gain1_o > rtb_Y_ps) {
-    rtb_Gain1_o = rtb_Y_ps;
+  if (rtb_Gain1_o > rtb_Y_f) {
+    rtb_Gain1_o = rtb_Y_f;
   } else {
-    rtb_Y_ps *= FlyByWire_P.Gain2_Gain_n;
-    if (rtb_Gain1_o < rtb_Y_ps) {
-      rtb_Gain1_o = rtb_Y_ps;
+    rtb_Y_f *= FlyByWire_P.Gain2_Gain_n;
+    if (rtb_Gain1_o < rtb_Y_f) {
+      rtb_Gain1_o = rtb_Y_f;
     }
   }
 
@@ -1321,23 +1320,23 @@ void FlyByWireModelClass::step()
   }
 
   if (rtb_nz_limit_lo_g > FlyByWire_P.Saturation_UpperSat_p) {
-    rtb_Y_ps = FlyByWire_P.Saturation_UpperSat_p;
+    rtb_Y_f = FlyByWire_P.Saturation_UpperSat_p;
   } else if (rtb_nz_limit_lo_g < FlyByWire_P.Saturation_LowerSat_h) {
-    rtb_Y_ps = FlyByWire_P.Saturation_LowerSat_h;
+    rtb_Y_f = FlyByWire_P.Saturation_LowerSat_h;
   } else {
-    rtb_Y_ps = rtb_nz_limit_lo_g;
+    rtb_Y_f = rtb_nz_limit_lo_g;
   }
 
-  FlyByWire_RateLimiter(rtb_Y_ps, FlyByWire_P.RateLimiterVariableTs_up_k, FlyByWire_P.RateLimiterVariableTs_lo_fs,
-                        FlyByWire_U.in.time.dt, FlyByWire_P.RateLimiterVariableTs_InitialCondition_f, &rtb_Y_b,
+  FlyByWire_RateLimiter(rtb_Y_f, FlyByWire_P.RateLimiterVariableTs_up_k, FlyByWire_P.RateLimiterVariableTs_lo_fs,
+                        FlyByWire_U.in.time.dt, FlyByWire_P.RateLimiterVariableTs_InitialCondition_f, &rtb_Y_gj,
                         &FlyByWire_DWork.sf_RateLimiter_gp);
   FlyByWire_LagFilter(FlyByWire_U.in.data.engine_1_thrust_lbf - FlyByWire_U.in.data.engine_2_thrust_lbf,
-                      FlyByWire_P.LagFilter_C1_l, FlyByWire_U.in.time.dt, &rtb_Y_o, &FlyByWire_DWork.sf_LagFilter_pl);
-  rtb_Product_e = rtb_Y_o * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn,
+                      FlyByWire_P.LagFilter_C1_l, FlyByWire_U.in.time.dt, &rtb_Y_d, &FlyByWire_DWork.sf_LagFilter_pl);
+  rtb_Product_e = rtb_Y_d * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn,
     FlyByWire_P.ScheduledGain_BreakpointsForDimension1, FlyByWire_P.ScheduledGain_Table, 3U);
   rtb_BusAssignment_p_roll_data_computed_delta_xi_deg = FlyByWire_P.Gain_Gain_c *
     rtb_BusAssignment_sim_input_delta_xi_pos;
-  rtb_BusAssignment_p_roll_data_computed_in_flight_gain = rtb_Y_b;
+  rtb_BusAssignment_p_roll_data_computed_in_flight_gain = rtb_Y_gj;
   if (FlyByWire_DWork.sProtActive > FlyByWire_P.Switch3_Threshold) {
     rtb_Sum1_d5 = look1_binlxpw(rtb_GainPhi, FlyByWire_P.BankAngleProtection2_bp01Data,
       FlyByWire_P.BankAngleProtection2_tableData, 4U);
@@ -1356,9 +1355,9 @@ void FlyByWireModelClass::step()
     rtb_Sum1_d5 = FlyByWire_P.Saturation_LowerSat_o;
   }
 
-  rtb_Gain1_b = rtb_Sum1_d5 * rtb_Y_b;
+  rtb_Gain1_b = rtb_Sum1_d5 * rtb_Y_gj;
   rtb_LimiteriH = FlyByWire_P.DiscreteTimeIntegratorVariableTs_Gain_d * rtb_Gain1_b * FlyByWire_U.in.time.dt;
-  FlyByWire_DWork.icLoad_m = ((rtb_Y_b == 0.0) || (rtb_alpha_floor_inhib != 0) ||
+  FlyByWire_DWork.icLoad_m = ((rtb_Y_gj == 0.0) || (rtb_alpha_floor_inhib != 0) ||
     (FlyByWire_U.in.data.autopilot_custom_on != 0.0) || FlyByWire_DWork.icLoad_m);
   if (FlyByWire_DWork.icLoad_m) {
     FlyByWire_DWork.Delay_DSTATE_ho = rtb_GainPhi - rtb_LimiteriH;
@@ -1382,12 +1381,12 @@ void FlyByWireModelClass::step()
   }
 
   FlyByWire_RateLimiter(rtb_Sum1_d5, FlyByWire_P.RateLimiterVariableTs2_up_bi, FlyByWire_P.RateLimiterVariableTs2_lo_a,
-                        FlyByWire_U.in.time.dt, FlyByWire_P.RateLimiterVariableTs2_InitialCondition_l, &rtb_Y_o,
+                        FlyByWire_U.in.time.dt, FlyByWire_P.RateLimiterVariableTs2_InitialCondition_l, &rtb_Y_d,
                         &FlyByWire_DWork.sf_RateLimiter_j);
   FlyByWire_RateLimiter(rtb_Gain1_o, FlyByWire_P.RateLimiterVariableTs_up_m, FlyByWire_P.RateLimiterVariableTs_lo_p,
-                        FlyByWire_U.in.time.dt, FlyByWire_P.RateLimiterVariableTs_InitialCondition_fc, &rtb_Y_ps,
+                        FlyByWire_U.in.time.dt, FlyByWire_P.RateLimiterVariableTs_InitialCondition_fc, &rtb_Y_f,
                         &FlyByWire_DWork.sf_RateLimiter_lp);
-  FlyByWire_LagFilter(rtb_Gain, FlyByWire_P.LagFilter_C1_d, FlyByWire_U.in.time.dt, &rtb_Y_b,
+  FlyByWire_LagFilter(rtb_Gain, FlyByWire_P.LagFilter_C1_d, FlyByWire_U.in.time.dt, &rtb_Y_gj,
                       &FlyByWire_DWork.sf_LagFilter_c);
   if (FlyByWire_U.in.data.V_tas_kn > FlyByWire_P.Saturation_UpperSat_l) {
     rtb_Sum1_d5 = FlyByWire_P.Saturation_UpperSat_l;
@@ -1397,55 +1396,60 @@ void FlyByWireModelClass::step()
     rtb_Sum1_d5 = FlyByWire_U.in.data.V_tas_kn;
   }
 
-  rtb_LimiteriH = rtb_Y_b - std::sin(FlyByWire_P.Gain1_Gain_br * rtb_Y_o) * FlyByWire_P.Constant2_Value_li * std::cos
-    (FlyByWire_P.Gain1_Gain_cq * rtb_GainTheta) / (FlyByWire_P.Gain6_Gain_j * rtb_Sum1_d5) * FlyByWire_P.Gain_Gain_cd;
-  FlyByWire_WashoutFilter(rtb_Gain, FlyByWire_P.WashoutFilter_C1_i, FlyByWire_U.in.time.dt, &rtb_Y_b,
+  rtb_Sum1_d5 = (rtb_Y_gj - std::sin(FlyByWire_P.Gain1_Gain_br * rtb_Y_d) * FlyByWire_P.Constant2_Value_li * std::cos
+                 (FlyByWire_P.Gain1_Gain_cq * rtb_GainTheta) / (FlyByWire_P.Gain6_Gain_j * rtb_Sum1_d5) *
+                 FlyByWire_P.Gain_Gain_cd) * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn,
+    FlyByWire_P.ScheduledGain_BreakpointsForDimension1_k, FlyByWire_P.ScheduledGain_Table_k, 6U);
+  FlyByWire_WashoutFilter(rtb_Gain, FlyByWire_P.WashoutFilter_C1_i, FlyByWire_U.in.time.dt, &rtb_Y_gj,
     &FlyByWire_DWork.sf_WashoutFilter_i);
-  rtb_Limiterxi1 = FlyByWire_P.Gain6_Gain_k * rtb_Y_b;
+  rtb_Limiterxi1 = rtb_Y_gj * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn,
+    FlyByWire_P.ScheduledGain1_BreakpointsForDimension1, FlyByWire_P.ScheduledGain1_Table, 6U);
   if (rtb_Limiterxi1 > FlyByWire_P.Saturation2_UpperSat_e) {
     rtb_Limiterxi1 = FlyByWire_P.Saturation2_UpperSat_e;
   } else if (rtb_Limiterxi1 < FlyByWire_P.Saturation2_LowerSat_gp) {
     rtb_Limiterxi1 = FlyByWire_P.Saturation2_LowerSat_gp;
   }
 
-  rtb_Sum1_d5 = FlyByWire_P.Gain_Gain_hk * rtb_LimiteriH;
   if (rtb_Sum1_d5 > FlyByWire_P.Saturation1_UpperSat_h) {
     rtb_Sum1_d5 = FlyByWire_P.Saturation1_UpperSat_h;
   } else if (rtb_Sum1_d5 < FlyByWire_P.Saturation1_LowerSat_g) {
     rtb_Sum1_d5 = FlyByWire_P.Saturation1_LowerSat_g;
   }
 
-  rtb_Limiterxi_o = rtb_BusAssignment_p_roll_data_computed_in_flight_gain * rtb_Sum1_d5 + rtb_Limiterxi1;
+  rtb_Limiterxi = rtb_BusAssignment_p_roll_data_computed_in_flight_gain * rtb_Sum1_d5 + rtb_Limiterxi1;
   FlyByWire_Y.out.roll.law_normal.pk_c_deg_s = rtb_Gain1_b;
-  FlyByWire_Y.out.roll.law_normal.Phi_c_deg = rtb_Y_o;
-  rtb_BusAssignment_e_roll_law_normal_xi_deg = (((FlyByWire_P.Gain3_Gain_k * rtb_Y_ps + rtb_Y_o) - rtb_GainPhi) *
+  FlyByWire_Y.out.roll.law_normal.Phi_c_deg = rtb_Y_d;
+  rtb_BusAssignment_e_roll_law_normal_xi_deg = (((FlyByWire_P.Gain3_Gain_k * rtb_Y_f + rtb_Y_d) - rtb_GainPhi) *
     FlyByWire_P.Gain2_Gain_i + FlyByWire_P.PreControlGain_Gain * rtb_Gain1_b) + FlyByWire_P.Gain1_Gain_mg *
     rtb_BusAssignment_a_sim_data_pk_deg_s * FlyByWire_P.pKp_Gain;
+  FlyByWire_Y.out.roll.law_normal.zeta_tc_yd_deg = rtb_Limiterxi;
   FlyByWire_RateLimiter(static_cast<real_T>(rtb_on_ground), FlyByWire_P.RateLimiterVariableTs_up_dlj,
                         FlyByWire_P.RateLimiterVariableTs_lo_fw, FlyByWire_U.in.time.dt,
-                        FlyByWire_P.RateLimiterVariableTs_InitialCondition_p, &rtb_Y_b,
+                        FlyByWire_P.RateLimiterVariableTs_InitialCondition_p, &rtb_Y_gj,
                         &FlyByWire_DWork.sf_RateLimiter_d);
-  if (rtb_Y_b > FlyByWire_P.Saturation_UpperSat_d1) {
+  if (rtb_Y_gj > FlyByWire_P.Saturation_UpperSat_d1) {
     rtb_Gain1_b = FlyByWire_P.Saturation_UpperSat_d1;
-  } else if (rtb_Y_b < FlyByWire_P.Saturation_LowerSat_j) {
+  } else if (rtb_Y_gj < FlyByWire_P.Saturation_LowerSat_j) {
     rtb_Gain1_b = FlyByWire_P.Saturation_LowerSat_j;
   } else {
-    rtb_Gain1_b = rtb_Y_b;
+    rtb_Gain1_b = rtb_Y_gj;
   }
 
   rtb_LimiteriH = FlyByWire_U.in.data.autopilot_custom_Beta_c_deg * rtb_Gain1_b;
   rtb_Sum1_d5 = FlyByWire_P.Constant_Value_i - rtb_Gain1_b;
-  FlyByWire_LagFilter(FlyByWire_U.in.data.beta_deg, FlyByWire_P.LagFilter_C1_c, FlyByWire_U.in.time.dt, &rtb_Y_o,
+  FlyByWire_LagFilter(FlyByWire_U.in.data.beta_deg, FlyByWire_P.LagFilter_C1_c, FlyByWire_U.in.time.dt, &rtb_Y_d,
                       &FlyByWire_DWork.sf_LagFilter_d);
   FlyByWire_LagFilter(FlyByWire_U.in.data.autopilot_custom_Beta_c_deg + rtb_Product_e, FlyByWire_P.LagFilter1_C1_f,
-                      FlyByWire_U.in.time.dt, &rtb_Y_b, &FlyByWire_DWork.sf_LagFilter_k);
-  rtb_AND = ((rtb_alpha_floor_inhib == 0) && (FlyByWire_U.in.data.autopilot_custom_on != 0.0));
+                      FlyByWire_U.in.time.dt, &rtb_Y_gj, &FlyByWire_DWork.sf_LagFilter_k);
+  rtb_NOT2 = ((FlyByWire_U.in.data.autopilot_custom_on != 0.0) || (std::abs(rtb_Y_f) <=
+    FlyByWire_P.CompareToConstant1_const));
+  rtb_AND = ((rtb_alpha_floor_inhib == 0) && rtb_NOT2);
   if (!rtb_AND) {
-    rtb_Y_b = rtb_Y_o;
+    rtb_Y_gj = rtb_Y_d;
   }
 
-  rtb_Gain1_b = rtb_Y_b - rtb_Y_o;
-  rtb_Y_o = FlyByWire_P.Gain4_Gain_o * rtb_Gain1_b;
+  rtb_Gain1_b = rtb_Y_gj - rtb_Y_d;
+  rtb_Y_d = FlyByWire_P.Gain4_Gain_o * rtb_Gain1_b;
   rtb_Gain1_b = FlyByWire_P.Gain7_Gain * rtb_Gain1_b * FlyByWire_P.DiscreteTimeIntegratorVariableTs1_Gain *
     FlyByWire_U.in.time.dt;
   FlyByWire_DWork.icLoad_id = ((!rtb_AND) || FlyByWire_DWork.icLoad_id);
@@ -1460,21 +1464,21 @@ void FlyByWireModelClass::step()
     FlyByWire_DWork.Delay_DSTATE_gt = FlyByWire_P.DiscreteTimeIntegratorVariableTs1_LowerLimit;
   }
 
-  FlyByWire_RateLimiter(rtb_Y_o + FlyByWire_DWork.Delay_DSTATE_gt, FlyByWire_P.RateLimiterVariableTs1_up_p,
+  FlyByWire_RateLimiter(rtb_Y_d + FlyByWire_DWork.Delay_DSTATE_gt, FlyByWire_P.RateLimiterVariableTs1_up_p,
                         FlyByWire_P.RateLimiterVariableTs1_lo_hd, FlyByWire_U.in.time.dt,
-                        FlyByWire_P.RateLimiterVariableTs1_InitialCondition_f, &rtb_Y_b,
+                        FlyByWire_P.RateLimiterVariableTs1_InitialCondition_f, &rtb_Y_gj,
                         &FlyByWire_DWork.sf_RateLimiter_bo);
-  if (FlyByWire_U.in.data.autopilot_custom_on > FlyByWire_P.Saturation_UpperSat_k) {
+  if (static_cast<real_T>(rtb_NOT2) > FlyByWire_P.Saturation_UpperSat_k) {
     rtb_Gain1_b = FlyByWire_P.Saturation_UpperSat_k;
-  } else if (FlyByWire_U.in.data.autopilot_custom_on < FlyByWire_P.Saturation_LowerSat_ae) {
+  } else if (static_cast<real_T>(rtb_NOT2) < FlyByWire_P.Saturation_LowerSat_ae) {
     rtb_Gain1_b = FlyByWire_P.Saturation_LowerSat_ae;
   } else {
-    rtb_Gain1_b = FlyByWire_U.in.data.autopilot_custom_on;
+    rtb_Gain1_b = rtb_NOT2;
   }
 
-  rtb_Gain1_b = ((rtb_Sum1_d5 * rtb_Y_b + rtb_LimiteriH) * rtb_Gain1_b + (FlyByWire_P.Constant_Value_l - rtb_Gain1_b) *
-                 FlyByWire_P.Constant3_Value_l) + rtb_Limiterxi_o;
-  rtb_LimiteriH = rtb_Y_ps + rtb_Gain1_b;
+  rtb_Gain1_b = ((rtb_Sum1_d5 * rtb_Y_gj + rtb_LimiteriH) * rtb_Gain1_b + (FlyByWire_P.Constant_Value_l - rtb_Gain1_b) *
+                 FlyByWire_P.Constant3_Value_l) + rtb_Limiterxi;
+  rtb_LimiteriH = rtb_Y_f + rtb_Gain1_b;
   if (FlyByWire_U.in.data.H_radio_ft <= FlyByWire_P.CompareToConstant_const_g) {
     rtb_Gain1_b = FlyByWire_P.Constant2_Value_c;
   }
@@ -1506,13 +1510,13 @@ void FlyByWireModelClass::step()
   }
 
   FlyByWire_DWork.Delay_DSTATE_j5 += rtb_Sum1_d5;
-  rtb_Y_o = rtb_BusAssignment_p_roll_data_computed_in_flight_gain + FlyByWire_U.in.data.autopilot_custom_on;
-  if (rtb_Y_o > FlyByWire_P.Saturation1_UpperSat_e) {
+  rtb_Y_d = rtb_BusAssignment_p_roll_data_computed_in_flight_gain + FlyByWire_U.in.data.autopilot_custom_on;
+  if (rtb_Y_d > FlyByWire_P.Saturation1_UpperSat_e) {
     rtb_Gain1_b = FlyByWire_P.Saturation1_UpperSat_e;
-  } else if (rtb_Y_o < FlyByWire_P.Saturation1_LowerSat_l) {
+  } else if (rtb_Y_d < FlyByWire_P.Saturation1_LowerSat_l) {
     rtb_Gain1_b = FlyByWire_P.Saturation1_LowerSat_l;
   } else {
-    rtb_Gain1_b = rtb_Y_o;
+    rtb_Gain1_b = rtb_Y_d;
   }
 
   if (rtb_Gain1_b > FlyByWire_P.Saturation_UpperSat_ll) {
@@ -1521,32 +1525,32 @@ void FlyByWireModelClass::step()
     rtb_Gain1_b = FlyByWire_P.Saturation_LowerSat_og;
   }
 
-  rtb_Y_ps = (FlyByWire_P.Constant_Value_l1 - rtb_Gain1_b) * rtb_BusAssignment_p_roll_data_computed_delta_xi_deg +
+  rtb_Y_f = (FlyByWire_P.Constant_Value_l1 - rtb_Gain1_b) * rtb_BusAssignment_p_roll_data_computed_delta_xi_deg +
     rtb_BusAssignment_e_roll_law_normal_xi_deg * rtb_Gain1_b;
-  if (rtb_Y_o > FlyByWire_P.Saturation_UpperSat_eq) {
-    rtb_Y_o = FlyByWire_P.Saturation_UpperSat_eq;
-  } else if (rtb_Y_o < FlyByWire_P.Saturation_LowerSat_n) {
-    rtb_Y_o = FlyByWire_P.Saturation_LowerSat_n;
+  if (rtb_Y_d > FlyByWire_P.Saturation_UpperSat_eq) {
+    rtb_Y_d = FlyByWire_P.Saturation_UpperSat_eq;
+  } else if (rtb_Y_d < FlyByWire_P.Saturation_LowerSat_n) {
+    rtb_Y_d = FlyByWire_P.Saturation_LowerSat_n;
   }
 
-  if (rtb_Y_o > FlyByWire_P.Saturation_UpperSat_i) {
+  if (rtb_Y_d > FlyByWire_P.Saturation_UpperSat_i) {
     rtb_Gain1_b = FlyByWire_P.Saturation_UpperSat_i;
-  } else if (rtb_Y_o < FlyByWire_P.Saturation_LowerSat_f) {
+  } else if (rtb_Y_d < FlyByWire_P.Saturation_LowerSat_f) {
     rtb_Gain1_b = FlyByWire_P.Saturation_LowerSat_f;
   } else {
-    rtb_Gain1_b = rtb_Y_o;
+    rtb_Gain1_b = rtb_Y_d;
   }
 
   rtb_Limiterxi = rtb_LimiteriH * rtb_Gain1_b;
   rtb_Gain1_b = (FlyByWire_P.Constant_Value_f - rtb_Gain1_b) * rtb_Gain1_o;
   rtb_Limiterxi += rtb_Gain1_b;
-  rtb_Y_o = rtb_Limiterxi;
+  rtb_Y_d = rtb_Limiterxi;
   FlyByWire_RateLimiter(rtb_LimiteriH_n, FlyByWire_P.RateLimitereta_up, FlyByWire_P.RateLimitereta_lo,
                         FlyByWire_U.in.time.dt, FlyByWire_P.RateLimitereta_InitialCondition, &rtb_Gain1_b,
                         &FlyByWire_DWork.sf_RateLimiter_mi);
-  FlyByWire_RateLimiter(rtb_Y_ps, FlyByWire_P.RateLimiterxi_up, FlyByWire_P.RateLimiterxi_lo, FlyByWire_U.in.time.dt,
+  FlyByWire_RateLimiter(rtb_Y_f, FlyByWire_P.RateLimiterxi_up, FlyByWire_P.RateLimiterxi_lo, FlyByWire_U.in.time.dt,
                         FlyByWire_P.RateLimiterxi_InitialCondition, &rtb_Limiterxi, &FlyByWire_DWork.sf_RateLimiter_h);
-  FlyByWire_RateLimiter(rtb_Y_o, FlyByWire_P.RateLimiterzeta_up, FlyByWire_P.RateLimiterzeta_lo, FlyByWire_U.in.time.dt,
+  FlyByWire_RateLimiter(rtb_Y_d, FlyByWire_P.RateLimiterzeta_up, FlyByWire_P.RateLimiterzeta_lo, FlyByWire_U.in.time.dt,
                         FlyByWire_P.RateLimiterzeta_InitialCondition, &rtb_Limiterxi1,
                         &FlyByWire_DWork.sf_RateLimiter_d0);
   FlyByWire_Y.out.sim.time.dt = FlyByWire_U.in.time.dt;
@@ -1665,9 +1669,8 @@ void FlyByWireModelClass::step()
   FlyByWire_Y.out.roll.data_computed.beta_target_deg = rtb_Product_e;
   FlyByWire_Y.out.roll.law_normal.xi_deg = rtb_BusAssignment_e_roll_law_normal_xi_deg;
   FlyByWire_Y.out.roll.law_normal.zeta_deg = rtb_LimiteriH;
-  FlyByWire_Y.out.roll.law_normal.zeta_tc_yd_deg = rtb_Limiterxi_o;
-  FlyByWire_Y.out.roll.output.xi_deg = rtb_Y_ps;
-  FlyByWire_Y.out.roll.output.zeta_deg = rtb_Y_o;
+  FlyByWire_Y.out.roll.output.xi_deg = rtb_Y_f;
+  FlyByWire_Y.out.roll.output.zeta_deg = rtb_Y_d;
   FlyByWire_Y.out.roll.output.zeta_trim_deg = FlyByWire_DWork.Delay_DSTATE_j5;
   u0 = FlyByWire_P.Gaineta_Gain_d * rtb_Gain1_b;
   if (u0 > FlyByWire_P.Limitereta_UpperSat) {
@@ -1725,10 +1728,10 @@ void FlyByWireModelClass::step()
   FlyByWire_DWork.Delay_DSTATE_p = rtb_Gain_oj;
   FlyByWire_DWork.Delay_DSTATE_m = rtb_Divide_e;
   FlyByWire_DWork.Delay_DSTATE_ps = rtb_Y;
-  FlyByWire_DWork.Delay_DSTATE_c1 = rtb_Y_j;
-  FlyByWire_DWork.Delay_DSTATE_l = rtb_Y_h;
+  FlyByWire_DWork.Delay_DSTATE_c1 = rtb_Y_o;
+  FlyByWire_DWork.Delay_DSTATE_l = rtb_Y_c;
   FlyByWire_DWork.Delay_DSTATE_n = rtb_Limiterxi2;
-  FlyByWire_DWork.Delay_DSTATE_ca = rtb_Loaddemand;
+  FlyByWire_DWork.Delay_DSTATE_ca = rtb_Switch_c;
   FlyByWire_DWork.Delay_DSTATE_jv = rtb_Divide1;
   FlyByWire_DWork.icLoad_e = false;
   FlyByWire_DWork.icLoad_i = false;

--- a/src/fbw/src/model/FlyByWire.h
+++ b/src/fbw/src/model/FlyByWire.h
@@ -148,6 +148,8 @@ class FlyByWireModelClass {
   struct Parameters_FlyByWire_T {
     fbw_output fbw_output_MATLABStruct;
     real_T ScheduledGain_BreakpointsForDimension1[4];
+    real_T ScheduledGain_BreakpointsForDimension1_k[7];
+    real_T ScheduledGain1_BreakpointsForDimension1[7];
     real_T LagFilter_C1;
     real_T LagFilter_C1_a;
     real_T LagFilter_C1_n;
@@ -220,12 +222,15 @@ class FlyByWireModelClass {
     real_T DiscreteTimeIntegratorVariableTs1_LowerLimit;
     real_T DiscreteTimeIntegratorVariableTs1_LowerLimit_o;
     real_T ScheduledGain_Table[4];
+    real_T ScheduledGain_Table_k[7];
+    real_T ScheduledGain1_Table[7];
     real_T DiscreteTimeIntegratorVariableTs_UpperLimit;
     real_T DiscreteTimeIntegratorVariableTs_UpperLimit_c;
     real_T DiscreteTimeIntegratorVariableTs_UpperLimit_d;
     real_T DiscreteTimeIntegratorVariableTs1_UpperLimit;
     real_T DiscreteTimeIntegratorVariableTs1_UpperLimit_e;
     real_T CompareToConstant_const;
+    real_T CompareToConstant1_const;
     real_T CompareToConstant_const_g;
     real_T RateLimiterVariableTs2_lo;
     real_T RateLimiterVariableTs3_lo;
@@ -482,10 +487,8 @@ class FlyByWireModelClass {
     real_T Saturation_LowerSat_lu;
     real_T Gain6_Gain_j;
     real_T Gain_Gain_cd;
-    real_T Gain_Gain_hk;
     real_T Saturation1_UpperSat_h;
     real_T Saturation1_LowerSat_g;
-    real_T Gain6_Gain_k;
     real_T Saturation2_UpperSat_e;
     real_T Saturation2_LowerSat_gp;
     real_T Saturation_UpperSat_d1;

--- a/src/fbw/src/model/FlyByWire_data.cpp
+++ b/src/fbw/src/model/FlyByWire_data.cpp
@@ -196,6 +196,12 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P = {
 
   { 120.0, 160.0, 250.0, 300.0 },
 
+
+  { 0.0, 100.0, 150.0, 200.0, 250.0, 300.0, 400.0 },
+
+
+  { 0.0, 100.0, 150.0, 200.0, 250.0, 300.0, 400.0 },
+
   0.5,
 
   0.4,
@@ -341,6 +347,12 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P = {
 
   { 0.00025833333333333334, 0.00025833333333333334, 5.8333333333333333E-5, 5.8333333333333333E-5 },
 
+
+  { 5.5, 5.5, 5.5, 1.0, 0.5, 0.5, 0.5 },
+
+
+  { 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5 },
+
   30.0,
 
   30.0,
@@ -352,6 +364,8 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P = {
   20.0,
 
   5.0,
+
+  1.0,
 
   100.0,
 
@@ -393,7 +407,7 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P = {
 
   -15.0,
 
-  1000.0,
+  -1000.0,
 
   -5.0,
 
@@ -911,13 +925,9 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P = {
 
   57.295779513082323,
 
-  0.5,
-
   25.0,
 
   -25.0,
-
-  1.5,
 
   25.0,
 
@@ -929,9 +939,9 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P = {
 
   1.0,
 
-  2.0,
+  3.0,
 
-  1.0,
+  0.0,
 
   1.0,
 


### PR DESCRIPTION
## Summary of Changes
This PR introduces the following improvements:
* allow to push V/S knob and therefore to level off during ALT*
* improved rudder / turn coordination when flying with AP off (especially with low speeds)

## Testing instructions
* fly with AP off with different speeds and check if turn coordination is working
* fly with AP engaged and check of turn coordination is working
* do manual landing with different wind conditions
* do autoland with different wind conditions

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
