### PR TITLE
fix: NXDataStore cannot store numbers

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -182,6 +182,7 @@
 1. [ECAM] ENG oil temperature amber while below takeoff minimum - @tracernz (Mike)
 1. [MISC] Sync settings across instruments - @tracernz (Mike)
 1. [MCDU] Remove some settings from MCDU the are now in the FlyPad - @tracernz (Mike)
+1. [EFB] Persist sound and EFB settings correctly - @tracernz (Mike)
 
 ## 0.6.0
 1. [CDU] Added WIND page - @tyler58546 (tyler58546)

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -96,6 +96,14 @@ module.exports = {
         'jsx-a11y/anchor-is-valid': 'off',
         'object-curly-newline': ['error', { multiline: true }],
         'linebreak-style': 'off',
+
+        // allow typescript overloads
+        'no-redeclare': 'off',
+        '@typescript-eslint/no-redeclare': ['error'],
+        'lines-between-class-members': 'off',
+        '@typescript-eslint/lines-between-class-members': ['error'],
+        'no-dupe-class-members': 'off',
+        '@typescript-eslint/no-dupe-class-members': ['error'],
     },
     globals: {
         Simplane: 'readonly',

--- a/src/instruments/src/Common/displayUnit.tsx
+++ b/src/instruments/src/Common/displayUnit.tsx
@@ -53,7 +53,7 @@ export const DisplayUnit: React.FC<DisplayUnitProps> = (props) => {
             setTimer(null);
         } else if (state === DisplayUnitState.Off && (potentiometer !== 0 && electricityState !== 0 && !props.failed)) {
             setState(DisplayUnitState.Selftest);
-            setTimer(NXDataStore.get<number>('CONFIG_SELF_TEST_TIME', 15));
+            setTimer(parseInt(NXDataStore.get('CONFIG_SELF_TEST_TIME', '15')));
         } else if (state === DisplayUnitState.Selftest && (potentiometer === 0 || electricityState === 0)) {
             setState(DisplayUnitState.Off);
             setTimer(null);

--- a/src/instruments/src/Common/persistence.tsx
+++ b/src/instruments/src/Common/persistence.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { NXDataStore, StorageValue, StorageContents } from '@shared/persistence';
-import { useSimVar } from './simVars';
 
 /**
  * This hook allows to read and set a persistent storage property.
@@ -8,7 +7,7 @@ import { useSimVar } from './simVars';
  * Note: The value of the persistent property does not automatically refresh for now
  */
 export const usePersistentProperty = <T extends StorageValue>(propertyName: string, defaultValue?: StorageContents<T>): [StorageContents<T>, (value: StorageContents<T>) => void] => {
-    const [propertyValue, rawPropertySetter] = useState(() => NXDataStore.get(propertyName, defaultValue));
+    const [propertyValue, rawPropertySetter] = useState(() => NXDataStore.get<T>(propertyName, defaultValue));
 
     if (defaultValue !== undefined && propertyValue === undefined) {
         rawPropertySetter(defaultValue);
@@ -45,28 +44,4 @@ export const usePersistentPropertyWithDefault = <T extends StorageValue>(propert
     };
 
     return [propertyValue, propertySetter];
-};
-
-type SimVarSyncedPersistentPropertyType = (simVarName: string, simVarUnit: string, propertyName: string) => [number, (value: number) => void];
-
-/**
- * This hook allows to set the value of a persistent storage property from the value of a simvar, and sync in an unidirectional fashion
- *
- * Note: The value of the persistent property does not automatically refresh for now
- */
-export const useSimVarSyncedPersistentProperty: SimVarSyncedPersistentPropertyType = (simVarName, simVarUnit, propertyName) => {
-    const [, setPropertyValue] = usePersistentProperty(propertyName);
-    const [simVarValue, setSimVarValue] = useSimVar(simVarName, simVarUnit, 1_000);
-
-    useEffect(() => {
-        if (simVarValue || simVarValue === 0) {
-            setPropertyValue((simVarValue as number).toString());
-        }
-    }, [simVarValue]);
-
-    const setter = (value: number) => {
-        setSimVarValue(value);
-    };
-
-    return [simVarValue, setter];
 };

--- a/src/instruments/src/EFB/ATC/ATC.tsx
+++ b/src/instruments/src/EFB/ATC/ATC.tsx
@@ -18,7 +18,7 @@ export const ATC = () => {
     const [currentAtc, setCurrentAtc] = useState<ATCInfoExtended>();
     const [currentLatitude] = useSimVar('GPS POSITION LAT', 'Degrees', 5000);
     const [currentLongitude] = useSimVar('GPS POSITION LON', 'Degrees', 5000);
-    const [atisSource] = usePersistentProperty<string>('CONFIG_ATIS_SRC', 'FAA');
+    const [atisSource] = usePersistentProperty('CONFIG_ATIS_SRC', 'FAA');
 
     const loadAtc = useCallback(() => {
         apiClient.ATC.getAtc((atisSource as string).toLowerCase()).then((res) => {

--- a/src/instruments/src/EFB/ChartsApi/Navigraph.tsx
+++ b/src/instruments/src/EFB/ChartsApi/Navigraph.tsx
@@ -92,7 +92,7 @@ export default class NavigraphClient {
         if (NavigraphClient.sufficientEnv()) {
             this.pkce = pkce();
 
-            const token = NXDataStore.get<string>('NAVIGRAPH_REFRESH_TOKEN');
+            const token = NXDataStore.get('NAVIGRAPH_REFRESH_TOKEN');
 
             if (token === undefined || token === null || token === '') {
                 this.authenticate();

--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -74,7 +74,7 @@ type WeatherWidgetProps = { name: string, editIcao: string, icao: string};
 const WeatherWidget = (props: WeatherWidgetProps) => {
     const [metar, setMetar] = useState<MetarParserType>(MetarParserTypeProp);
 
-    let [metarSource] = usePersistentProperty<string>('CONFIG_METAR_SRC', 'MSFS');
+    let [metarSource] = usePersistentProperty('CONFIG_METAR_SRC', 'MSFS');
 
     if (metarSource === 'MSFS') {
         metarSource = 'MS';

--- a/src/instruments/src/EFB/Dispatch/Pages/FuelPage.tsx
+++ b/src/instruments/src/EFB/Dispatch/Pages/FuelPage.tsx
@@ -17,7 +17,7 @@ export const FuelPage = () => {
     const centerTankGallon = 2179;
     const wingTotalRefuelTimeSeconds = 1020;
     const CenterTotalRefuelTimeSeconds = 180;
-    const [usingMetrics] = usePersistentProperty<string>('CONFIG_USING_METRIC_UNIT');
+    const [usingMetrics] = usePersistentProperty('CONFIG_USING_METRIC_UNIT', '1');
 
     const currentUnit = () => {
         if (usingMetrics === '1') {
@@ -46,7 +46,7 @@ export const FuelPage = () => {
     const [isOnGround] = useSimVar('SIM ON GROUND', 'Bool', 1_000);
     const [eng1Running] = useSimVar('ENG COMBUSTION:1', 'Bool', 1_000);
     const [eng2Running] = useSimVar('ENG COMBUSTION:2', 'Bool', 1_000);
-    const [refuelRate, setRefuelRate] = usePersistentProperty<string>('REFUEL_RATE_SETTING');
+    const [refuelRate, setRefuelRate] = usePersistentProperty('REFUEL_RATE_SETTING');
     const [sliderValue, setSliderValue] = useSimVar('L:A32NX_FUEL_DESIRED_PERCENT', 'Number');
     const [inputValue, setInputValue] = useSimVar('L:A32NX_FUEL_DESIRED', 'Number');
     const [totalTarget, setTotalTarget] = useSimVar('L:A32NX_FUEL_TOTAL_DESIRED', 'Number');

--- a/src/instruments/src/EFB/Dispatch/Pages/LoadsheetPage.tsx
+++ b/src/instruments/src/EFB/Dispatch/Pages/LoadsheetPage.tsx
@@ -10,7 +10,7 @@ const LoadSheetWidget = (props: LoadsheetPageProps) => {
     const position = useRef({ top: 0, y: 0 });
     const ref = useRef<HTMLDivElement>(null);
 
-    const [fontSize, setFontSize] = usePersistentProperty<string>('LOADSHEET_FONTSIZE', '14');
+    const [fontSize, setFontSize] = usePersistentProperty('LOADSHEET_FONTSIZE', '14');
     const [imageSize, setImageSize] = useState(60);
 
     useEffect(() => {

--- a/src/instruments/src/EFB/Efb.tsx
+++ b/src/instruments/src/EFB/Efb.tsx
@@ -135,7 +135,7 @@ const Efb = () => {
 
     const [performanceState, performanceDispatch] = useReducer(PerformanceReducer, performanceInitialState);
     const [simbriefData, setSimbriefData] = useState<SimbriefData>(emptySimbriefData);
-    const [simbriefUsername, setSimbriefUsername] = usePersistentProperty<string>('SimbriefUsername');
+    const [simbriefUsername, setSimbriefUsername] = usePersistentProperty('SimbriefUsername');
 
     const [timeState, setTimeState] = useState<TimeState>({
         currentTime: new Date(),

--- a/src/instruments/src/EFB/Efb.tsx
+++ b/src/instruments/src/EFB/Efb.tsx
@@ -121,7 +121,7 @@ const Efb = () => {
 
     const [currentLocalTime] = useSimVar('E:LOCAL TIME', 'seconds', 3000);
     const [, setBrightness] = useSimVar('L:A32NX_EFB_BRIGHTNESS', 'number');
-    const [brightnessSetting] = usePersistentNumberProperty('EFB_BRIGHTNESS', 0)
+    const [brightnessSetting] = usePersistentNumberProperty('EFB_BRIGHTNESS', 0);
     const [usingAutobrightness] = useSimVar('L:A32NX_EFB_USING_AUTOBRIGHTNESS', 'bool', 5000);
 
     // handle setting brightness if user is using autobrightness

--- a/src/instruments/src/EFB/Efb.tsx
+++ b/src/instruments/src/EFB/Efb.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState, useReducer } from 'react';
 import { Provider } from 'react-redux';
 import { Route, Switch, useHistory } from 'react-router-dom';
 import { useSimVar } from '@instruments/common/simVars';
-import { usePersistentProperty } from '../Common/persistence';
+import { usePersistentNumberProperty, usePersistentProperty } from '../Common/persistence';
 import NavigraphClient, { NavigraphContext } from './ChartsApi/Navigraph';
 import { getSimbriefData, IFuel, IWeights } from './SimbriefApi';
 import StatusBar from './StatusBar/StatusBar';
@@ -121,6 +121,7 @@ const Efb = () => {
 
     const [currentLocalTime] = useSimVar('E:LOCAL TIME', 'seconds', 3000);
     const [, setBrightness] = useSimVar('L:A32NX_EFB_BRIGHTNESS', 'number');
+    const [brightnessSetting] = usePersistentNumberProperty('EFB_BRIGHTNESS', 0)
     const [usingAutobrightness] = useSimVar('L:A32NX_EFB_USING_AUTOBRIGHTNESS', 'bool', 5000);
 
     // handle setting brightness if user is using autobrightness
@@ -130,6 +131,8 @@ const Efb = () => {
             // the below code defines a semicircular function.
             // eslint-disable-next-line no-restricted-properties
             setBrightness(((Math.sqrt(48 - Math.pow((localTime - 14), 2))) * 14.431) || 0);
+        } else {
+            setBrightness(brightnessSetting);
         }
     }, [currentLocalTime, usingAutobrightness]);
 

--- a/src/instruments/src/EFB/Navigation/Navigation.tsx
+++ b/src/instruments/src/EFB/Navigation/Navigation.tsx
@@ -60,7 +60,7 @@ type ChartDisplay = {
 
 const Loading = () => {
     const navigraph = useNavigraph();
-    const [, setRefreshToken] = usePersistentProperty<string>('NAVIGRAPH_REFRESH_TOKEN');
+    const [, setRefreshToken] = usePersistentProperty('NAVIGRAPH_REFRESH_TOKEN');
 
     const handleResetRefreshToken = () => {
         setRefreshToken('');

--- a/src/instruments/src/EFB/Settings/Settings.tsx
+++ b/src/instruments/src/EFB/Settings/Settings.tsx
@@ -35,7 +35,6 @@ const DefaultsPage = () => {
     const [accelerationOutHeight, setAccelerationOutHeight] = usePersistentProperty('CONFIG_ENG_OUT_ACCEL_ALT', '1500');
     const [accelerationOutHeightSetting, setAccelerationOutHeightSetting] = useState(accelerationOutHeight);
 
-
     const handleSetThrustReductionAlt = (value: string) => {
         setThrustReductionHeightSetting(value);
 

--- a/src/instruments/src/EFB/Settings/Settings.tsx
+++ b/src/instruments/src/EFB/Settings/Settings.tsx
@@ -166,7 +166,7 @@ const SimOptionsPage = () => {
     const [, setAdirsAlignTimeSimVar] = useSimVar('L:A32NX_CONFIG_ADIRS_IR_ALIGN_TIME', 'Enum', Number.MAX_SAFE_INTEGER);
     const [dmcSelfTestTime, setDmcSelfTestTime] = usePersistentProperty('CONFIG_SELF_TEST_TIME', '12');
 
-    const [defaultBaro, setDefaultBaro] = usePersistentProperty('CONFIG_INIT_BARO_UNIT', 'IN HG');
+    const [defaultBaro, setDefaultBaro] = usePersistentProperty('CONFIG_INIT_BARO_UNIT', 'AUTO');
 
     const adirsAlignTimeButtons: (ButtonType & AdirsButton)[] = [
         { name: 'Instant', setting: 'INSTANT', simVarValue: 1 },

--- a/src/instruments/src/EFB/Settings/Settings.tsx
+++ b/src/instruments/src/EFB/Settings/Settings.tsx
@@ -3,7 +3,7 @@ import { Slider, Toggle } from '@flybywiresim/react-components';
 import { useSimVar } from '@instruments/common/simVars';
 import { IconArrowLeft, IconArrowRight } from '@tabler/icons';
 import { SelectGroup, SelectItem } from '../Components/Form/Select';
-import { usePersistentProperty } from '../../Common/persistence';
+import { usePersistentNumberProperty, usePersistentProperty } from '../../Common/persistence';
 import Button from '../Components/Button/Button';
 import ThrottleConfig from './ThrottleConfig/ThrottleConfig';
 import SimpleInput from '../Components/Form/SimpleInput/SimpleInput';
@@ -28,11 +28,11 @@ const ControlSettings = ({ setShowSettings }) => (
 );
 
 const DefaultsPage = () => {
-    const [thrustReductionHeight, setThrustReductionHeight] = usePersistentProperty<string>('CONFIG_THR_RED_ALT', '1500');
+    const [thrustReductionHeight, setThrustReductionHeight] = usePersistentProperty('CONFIG_THR_RED_ALT', '1500');
     const [thrustReductionHeightSetting, setThrustReductionHeightSetting] = useState(thrustReductionHeight);
-    const [accelerationHeight, setAccelerationHeight] = usePersistentProperty<string>('CONFIG_ACCEL_ALT', '1500');
+    const [accelerationHeight, setAccelerationHeight] = usePersistentProperty('CONFIG_ACCEL_ALT', '1500');
     const [accelerationHeightSetting, setAccelerationHeightSetting] = useState(accelerationHeight);
-    const [accelerationOutHeight, setAccelerationOutHeight] = usePersistentProperty<string>('CONFIG_ENG_OUT_ACCEL_ALT', '1500');
+    const [accelerationOutHeight, setAccelerationOutHeight] = usePersistentProperty('CONFIG_ENG_OUT_ACCEL_ALT', '1500');
     const [accelerationOutHeightSetting, setAccelerationOutHeightSetting] = useState(accelerationOutHeight);
 
     const handleSetThrustReductionAlt = (value: string) => {
@@ -112,8 +112,8 @@ const DefaultsPage = () => {
 };
 
 const AircraftConfigurationPage = () => {
-    const [weightUnit, setWeightUnit] = usePersistentProperty<string>('CONFIG_USING_METRIC_UNIT', '1');
-    const [paxSigns, setPaxSigns] = usePersistentProperty<string>('CONFIG_USING_PORTABLE_DEVICES', '0');
+    const [weightUnit, setWeightUnit] = usePersistentProperty('CONFIG_USING_METRIC_UNIT', '1');
+    const [paxSigns, setPaxSigns] = usePersistentProperty('CONFIG_USING_PORTABLE_DEVICES', '0');
 
     const paxSignsButtons: ButtonType[] = [
         { name: 'No Smoking', setting: '0' },
@@ -162,11 +162,11 @@ const SimOptionsPage = () => {
     const [showThrottleSettings, setShowThrottleSettings] = useState(false);
     const { setShowNavbar } = useContext(SettingsNavbarContext);
 
-    const [adirsAlignTime, setAdirsAlignTime] = usePersistentProperty<string>('CONFIG_ALIGN_TIME', 'REAL');
+    const [adirsAlignTime, setAdirsAlignTime] = usePersistentProperty('CONFIG_ALIGN_TIME', 'REAL');
     const [, setAdirsAlignTimeSimVar] = useSimVar('L:A32NX_CONFIG_ADIRS_IR_ALIGN_TIME', 'Enum', Number.MAX_SAFE_INTEGER);
-    const [dmcSelfTestTime, setDmcSelfTestTime] = usePersistentProperty<string>('CONFIG_SELF_TEST_TIME', '12');
+    const [dmcSelfTestTime, setDmcSelfTestTime] = usePersistentProperty('CONFIG_SELF_TEST_TIME', '12');
 
-    const [defaultBaro, setDefaultBaro] = usePersistentProperty<string>('CONFIG_INIT_BARO_UNIT', 'IN HG');
+    const [defaultBaro, setDefaultBaro] = usePersistentProperty('CONFIG_INIT_BARO_UNIT', 'IN HG');
 
     const adirsAlignTimeButtons: (ButtonType & AdirsButton)[] = [
         { name: 'Instant', setting: 'INSTANT', simVarValue: 1 },
@@ -250,9 +250,9 @@ const SimOptionsPage = () => {
 };
 
 const ATSUAOCPage = (props: {simbriefUsername, setSimbriefUsername}) => {
-    const [atisSource, setAtisSource] = usePersistentProperty<string>('CONFIG_ATIS_SRC', 'FAA');
-    const [metarSource, setMetarSource] = usePersistentProperty<string>('CONFIG_METAR_SRC', 'MSFS');
-    const [tafSource, setTafSource] = usePersistentProperty<string>('CONFIG_TAF_SRC', 'NOAA');
+    const [atisSource, setAtisSource] = usePersistentProperty('CONFIG_ATIS_SRC', 'FAA');
+    const [metarSource, setMetarSource] = usePersistentProperty('CONFIG_METAR_SRC', 'MSFS');
+    const [tafSource, setTafSource] = usePersistentProperty('CONFIG_TAF_SRC', 'NOAA');
 
     const atisSourceButtons: ButtonType[] = [
         { name: 'FAA (US)', setting: 'FAA' },
@@ -330,10 +330,10 @@ const ATSUAOCPage = (props: {simbriefUsername, setSimbriefUsername}) => {
 };
 
 const AudioPage = () => {
-    const [ptuAudible, setPtuAudible] = usePersistentProperty<string>('SOUND_PTU_AUDIBLE_COCKPIT');
-    const [exteriorVolume, setExteriorVolume] = usePersistentProperty<string>('SOUND_EXTERIOR_MASTER');
-    const [engineVolume, setEngineVolume] = usePersistentProperty<string>('SOUND_INTERIOR_ENGINE');
-    const [windVolume, setWindVolume] = usePersistentProperty<string>('SOUND_INTERIOR_WIND');
+    const [ptuAudible, setPtuAudible] = usePersistentNumberProperty('SOUND_PTU_AUDIBLE_COCKPIT', 0);
+    const [exteriorVolume, setExteriorVolume] = usePersistentNumberProperty('SOUND_EXTERIOR_MASTER', 0);
+    const [engineVolume, setEngineVolume] = usePersistentNumberProperty('SOUND_INTERIOR_ENGINE', 0);
+    const [windVolume, setWindVolume] = usePersistentNumberProperty('SOUND_INTERIOR_WIND', 0);
 
     return (
         <div className="bg-navy-lighter divide-y divide-gray-700 flex flex-col rounded-xl px-6 ">
@@ -342,27 +342,27 @@ const AudioPage = () => {
                     <span className="text-lg text-gray-300">PTU Audible in Cockpit</span>
                     <span className="text-lg text-gray-500 ml-2">(unrealistic)</span>
                 </span>
-                <Toggle value={ptuAudible === "1"} onToggle={(value) => setPtuAudible(value ? "1" : "0")} />
+                <Toggle value={!!ptuAudible} onToggle={(value) => setPtuAudible(value ? 1 : 0)} />
             </div>
             <div className="py-4 flex flex-row justify-between items-center">
                 <span className="text-lg text-gray-300">Exterior Master Volume</span>
                 <div className="flex flex-row items-center py-1.5">
                     <span className="text-base pr-3">{exteriorVolume}</span>
-                    <Slider className="w-60" value={parseInt(exteriorVolume) + 50} onInput={(value) => setExteriorVolume("" + (value - 50))} />
+                    <Slider className="w-60" value={exteriorVolume + 50} onInput={(value) => setExteriorVolume(value - 50)} />
                 </div>
             </div>
             <div className="py-4 flex flex-row justify-between items-center">
                 <span className="text-lg text-gray-300">Engine Interior Volume</span>
                 <div className="flex flex-row items-center py-1.5">
                     <span className="text-base pr-3">{engineVolume}</span>
-                    <Slider className="w-60" value={parseInt(engineVolume + 50)} onInput={(value) => setEngineVolume("" + (value - 50))} />
+                    <Slider className="w-60" value={engineVolume + 50} onInput={(value) => setEngineVolume(value - 50)} />
                 </div>
             </div>
             <div className="py-4 flex flex-row justify-between items-center">
                 <span className="text-lg text-gray-300">Wind Interior Volume</span>
                 <div className="flex flex-row items-center py-1.5">
                     <span className="text-base pr-3">{windVolume}</span>
-                    <Slider className="w-60" value={parseInt(windVolume + 50)} onInput={(value) => setWindVolume("" + (value - 50))} />
+                    <Slider className="w-60" value={windVolume + 50} onInput={(value) => setWindVolume(value - 50)} />
                 </div>
             </div>
         </div>
@@ -370,21 +370,21 @@ const AudioPage = () => {
 };
 
 const FlyPadPage = () => {
-    const [brightness, setBrightness] = usePersistentProperty<string>('EFB_BRIGHTNESS');
-    const [usingAutobrightness, setUsingAutobrightness] = usePersistentProperty<string>('EFB_USING_AUTOBRIGHTNESS');
+    const [brightness, setBrightness] = usePersistentNumberProperty('EFB_BRIGHTNESS', 0);
+    const [usingAutobrightness, setUsingAutobrightness] = usePersistentNumberProperty('EFB_USING_AUTOBRIGHTNESS', 0);
 
     return (
         <div className="bg-navy-lighter rounded-xl px-6 shadow-lg divide-y divide-gray-700 flex flex-col">
             <div className="py-4 flex flex-row justify-between items-center">
                 <span className="text-lg text-gray-300">Brightness</span>
                 <div className={`flex flex-row items-center py-1.5 ${usingAutobrightness && 'pointer-events-none filter saturate-0'}`}>
-                    <Slider className="w-60" value={parseInt(brightness)} onInput={(value) => setBrightness("" + value)} />
+                    <Slider className="w-60" value={brightness} onInput={(value) => setBrightness(value)} />
                 </div>
             </div>
             <div className="py-4 flex flex-row justify-between items-center">
                 <span className="text-lg text-gray-300">Auto Brightness</span>
                 <div className="flex flex-row items-center py-1.5">
-                    <Toggle value={usingAutobrightness === "1"} onToggle={(value) => setUsingAutobrightness(value ? "1" : "0")} />
+                    <Toggle value={!!usingAutobrightness} onToggle={(value) => setUsingAutobrightness(value ? 1 : 0)} />
                 </div>
             </div>
         </div>

--- a/src/instruments/src/EFB/Settings/Settings.tsx
+++ b/src/instruments/src/EFB/Settings/Settings.tsx
@@ -371,16 +371,8 @@ const AudioPage = () => {
 
 const FlyPadPage = () => {
     const [brightnessSetting, setBrightnessSetting] = usePersistentNumberProperty('EFB_BRIGHTNESS', 0);
-    const [brightness, setBrightness] = useSimVar('L:A32NX_EFB_BRIGHTNESS', 'number', 500);
+    const [brightness] = useSimVar('L:A32NX_EFB_BRIGHTNESS', 'number', 500);
     const [usingAutobrightness, setUsingAutobrightness] = usePersistentNumberProperty('EFB_USING_AUTOBRIGHTNESS', 0);
-
-    const handleSetAutobrightness = (value: boolean) => {
-        setUsingAutobrightness(value ? 1 : 0);
-
-        if (!value) {
-            setBrightness(brightnessSetting);
-        }
-    };
 
     return (
         <div className="bg-navy-lighter rounded-xl px-6 shadow-lg divide-y divide-gray-700 flex flex-col">
@@ -393,7 +385,7 @@ const FlyPadPage = () => {
             <div className="py-4 flex flex-row justify-between items-center">
                 <span className="text-lg text-gray-300">Auto Brightness</span>
                 <div className="flex flex-row items-center py-1.5">
-                    <Toggle value={!!usingAutobrightness} onToggle={(value) => handleSetAutobrightness(value)} />
+                    <Toggle value={!!usingAutobrightness} onToggle={(value) => setUsingAutobrightness(value ? 1 : 0)} />
                 </div>
             </div>
         </div>

--- a/src/instruments/src/EFB/Settings/Settings.tsx
+++ b/src/instruments/src/EFB/Settings/Settings.tsx
@@ -370,7 +370,8 @@ const AudioPage = () => {
 };
 
 const FlyPadPage = () => {
-    const [brightness, setBrightness] = usePersistentNumberProperty('EFB_BRIGHTNESS', 0);
+    const [brightnessSetting, setBrightnessSetting] = usePersistentNumberProperty('EFB_BRIGHTNESS', 0);
+    const [brightness] = useSimVar('L:A32NX_EFB_BRIGHTNESS', 'number');
     const [usingAutobrightness, setUsingAutobrightness] = usePersistentNumberProperty('EFB_USING_AUTOBRIGHTNESS', 0);
 
     return (
@@ -378,7 +379,7 @@ const FlyPadPage = () => {
             <div className="py-4 flex flex-row justify-between items-center">
                 <span className="text-lg text-gray-300">Brightness</span>
                 <div className={`flex flex-row items-center py-1.5 ${usingAutobrightness && 'pointer-events-none filter saturate-0'}`}>
-                    <Slider className="w-60" value={brightness} onInput={(value) => setBrightness(value)} />
+                    <Slider className="w-60" value={usingAutobrightness ? brightness : brightnessSetting} onInput={(value) => setBrightnessSetting(value)} />
                 </div>
             </div>
             <div className="py-4 flex flex-row justify-between items-center">

--- a/src/instruments/src/EFB/Settings/Settings.tsx
+++ b/src/instruments/src/EFB/Settings/Settings.tsx
@@ -35,6 +35,7 @@ const DefaultsPage = () => {
     const [accelerationOutHeight, setAccelerationOutHeight] = usePersistentProperty('CONFIG_ENG_OUT_ACCEL_ALT', '1500');
     const [accelerationOutHeightSetting, setAccelerationOutHeightSetting] = useState(accelerationOutHeight);
 
+
     const handleSetThrustReductionAlt = (value: string) => {
         setThrustReductionHeightSetting(value);
 
@@ -371,8 +372,16 @@ const AudioPage = () => {
 
 const FlyPadPage = () => {
     const [brightnessSetting, setBrightnessSetting] = usePersistentNumberProperty('EFB_BRIGHTNESS', 0);
-    const [brightness] = useSimVar('L:A32NX_EFB_BRIGHTNESS', 'number');
+    const [brightness, setBrightness] = useSimVar('L:A32NX_EFB_BRIGHTNESS', 'number', 500);
     const [usingAutobrightness, setUsingAutobrightness] = usePersistentNumberProperty('EFB_USING_AUTOBRIGHTNESS', 0);
+
+    const handleSetAutobrightness = (value: boolean) => {
+        setUsingAutobrightness(value ? 1 : 0);
+
+        if (!value) {
+            setBrightness(brightnessSetting);
+        }
+    };
 
     return (
         <div className="bg-navy-lighter rounded-xl px-6 shadow-lg divide-y divide-gray-700 flex flex-col">
@@ -385,7 +394,7 @@ const FlyPadPage = () => {
             <div className="py-4 flex flex-row justify-between items-center">
                 <span className="text-lg text-gray-300">Auto Brightness</span>
                 <div className="flex flex-row items-center py-1.5">
-                    <Toggle value={!!usingAutobrightness} onToggle={(value) => setUsingAutobrightness(value ? 1 : 0)} />
+                    <Toggle value={!!usingAutobrightness} onToggle={(value) => handleSetAutobrightness(value)} />
                 </div>
             </div>
         </div>

--- a/src/instruments/src/EFB/Settings/Settings.tsx
+++ b/src/instruments/src/EFB/Settings/Settings.tsx
@@ -3,7 +3,7 @@ import { Slider, Toggle } from '@flybywiresim/react-components';
 import { useSimVar } from '@instruments/common/simVars';
 import { IconArrowLeft, IconArrowRight } from '@tabler/icons';
 import { SelectGroup, SelectItem } from '../Components/Form/Select';
-import { usePersistentProperty, useSimVarSyncedPersistentProperty } from '../../Common/persistence';
+import { usePersistentProperty } from '../../Common/persistence';
 import Button from '../Components/Button/Button';
 import ThrottleConfig from './ThrottleConfig/ThrottleConfig';
 import SimpleInput from '../Components/Form/SimpleInput/SimpleInput';
@@ -330,10 +330,10 @@ const ATSUAOCPage = (props: {simbriefUsername, setSimbriefUsername}) => {
 };
 
 const AudioPage = () => {
-    const [ptuAudible, setPtuAudible] = useSimVarSyncedPersistentProperty('L:A32NX_SOUND_PTU_AUDIBLE_COCKPIT', 'Bool', 'SOUND_PTU_AUDIBLE_COCKPIT');
-    const [exteriorVolume, setExteriorVolume] = useSimVarSyncedPersistentProperty('L:A32NX_SOUND_EXTERIOR_MASTER', 'number', 'SOUND_EXTERIOR_MASTER');
-    const [engineVolume, setEngineVolume] = useSimVarSyncedPersistentProperty('L:A32NX_SOUND_INTERIOR_ENGINE', 'number', 'SOUND_INTERIOR_ENGINE');
-    const [windVolume, setWindVolume] = useSimVarSyncedPersistentProperty('L:A32NX_SOUND_INTERIOR_WIND', 'number', 'SOUND_INTERIOR_WIND');
+    const [ptuAudible, setPtuAudible] = usePersistentProperty<string>('SOUND_PTU_AUDIBLE_COCKPIT');
+    const [exteriorVolume, setExteriorVolume] = usePersistentProperty<string>('SOUND_EXTERIOR_MASTER');
+    const [engineVolume, setEngineVolume] = usePersistentProperty<string>('SOUND_INTERIOR_ENGINE');
+    const [windVolume, setWindVolume] = usePersistentProperty<string>('SOUND_INTERIOR_WIND');
 
     return (
         <div className="bg-navy-lighter divide-y divide-gray-700 flex flex-col rounded-xl px-6 ">
@@ -342,27 +342,27 @@ const AudioPage = () => {
                     <span className="text-lg text-gray-300">PTU Audible in Cockpit</span>
                     <span className="text-lg text-gray-500 ml-2">(unrealistic)</span>
                 </span>
-                <Toggle value={!!ptuAudible} onToggle={(value) => setPtuAudible(value ? 1 : 0)} />
+                <Toggle value={ptuAudible === "1"} onToggle={(value) => setPtuAudible(value ? "1" : "0")} />
             </div>
             <div className="py-4 flex flex-row justify-between items-center">
                 <span className="text-lg text-gray-300">Exterior Master Volume</span>
                 <div className="flex flex-row items-center py-1.5">
                     <span className="text-base pr-3">{exteriorVolume}</span>
-                    <Slider className="w-60" value={exteriorVolume + 50} onInput={(value) => setExteriorVolume(value - 50)} />
+                    <Slider className="w-60" value={parseInt(exteriorVolume) + 50} onInput={(value) => setExteriorVolume("" + (value - 50))} />
                 </div>
             </div>
             <div className="py-4 flex flex-row justify-between items-center">
                 <span className="text-lg text-gray-300">Engine Interior Volume</span>
                 <div className="flex flex-row items-center py-1.5">
                     <span className="text-base pr-3">{engineVolume}</span>
-                    <Slider className="w-60" value={engineVolume + 50} onInput={(value) => setEngineVolume(value - 50)} />
+                    <Slider className="w-60" value={parseInt(engineVolume + 50)} onInput={(value) => setEngineVolume("" + (value - 50))} />
                 </div>
             </div>
             <div className="py-4 flex flex-row justify-between items-center">
                 <span className="text-lg text-gray-300">Wind Interior Volume</span>
                 <div className="flex flex-row items-center py-1.5">
                     <span className="text-base pr-3">{windVolume}</span>
-                    <Slider className="w-60" value={windVolume + 50} onInput={(value) => setWindVolume(value - 50)} />
+                    <Slider className="w-60" value={parseInt(windVolume + 50)} onInput={(value) => setWindVolume("" + (value - 50))} />
                 </div>
             </div>
         </div>
@@ -370,21 +370,21 @@ const AudioPage = () => {
 };
 
 const FlyPadPage = () => {
-    const [brightness, setBrightness] = useSimVarSyncedPersistentProperty('L:A32NX_EFB_BRIGHTNESS', 'number', 'EFB_BRIGHTNESS');
-    const [usingAutobrightness, setUsingAutobrightness] = useSimVarSyncedPersistentProperty('L:A32NX_EFB_USING_AUTOBRIGHTNESS', 'bool', 'EFB_USING_AUTOBRIGHTNESS');
+    const [brightness, setBrightness] = usePersistentProperty<string>('EFB_BRIGHTNESS');
+    const [usingAutobrightness, setUsingAutobrightness] = usePersistentProperty<string>('EFB_USING_AUTOBRIGHTNESS');
 
     return (
         <div className="bg-navy-lighter rounded-xl px-6 shadow-lg divide-y divide-gray-700 flex flex-col">
             <div className="py-4 flex flex-row justify-between items-center">
                 <span className="text-lg text-gray-300">Brightness</span>
                 <div className={`flex flex-row items-center py-1.5 ${usingAutobrightness && 'pointer-events-none filter saturate-0'}`}>
-                    <Slider className="w-60" value={brightness} onInput={(value) => setBrightness(value)} />
+                    <Slider className="w-60" value={parseInt(brightness)} onInput={(value) => setBrightness("" + value)} />
                 </div>
             </div>
             <div className="py-4 flex flex-row justify-between items-center">
                 <span className="text-lg text-gray-300">Auto Brightness</span>
                 <div className="flex flex-row items-center py-1.5">
-                    <Toggle value={!!usingAutobrightness} onToggle={(value) => setUsingAutobrightness(value ? 1 : 0)} />
+                    <Toggle value={usingAutobrightness === "1"} onToggle={(value) => setUsingAutobrightness(value ? "1" : "0")} />
                 </div>
             </div>
         </div>

--- a/src/instruments/src/EFB/Settings/ThrottleConfig/DetentConfig.tsx
+++ b/src/instruments/src/EFB/Settings/ThrottleConfig/DetentConfig.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { usePersistentProperty, usePersistentPropertyWithDefault } from '../../../Common/persistence';
+import { usePersistentProperty } from '../../../Common/persistence';
 
 import Button, { BUTTON_TYPE } from '../../Components/Button/Button';
 import Input from '../../Components/Form/Input/Input';
@@ -23,10 +23,10 @@ interface Props {
 const DetentConfig: React.FC<Props> = (props: Props) => {
     const [showWarning, setShowWarning] = useState(false);
 
-    const [deadZone, setDeadZone] = usePersistentPropertyWithDefault<string>(`THROTTLE_${props.throttleNumber}DETENT_${props.index}_RANGE`, '0.05');
+    const [deadZone, setDeadZone] = usePersistentProperty(`THROTTLE_${props.throttleNumber}DETENT_${props.index}_RANGE`, '0.05');
 
     const [previousMode, setPreviousMode] = useState(props.expertMode);
-    const [axisValue, setAxisValue] = usePersistentProperty<string>(`THROTTLE_${props.throttleNumber}AXIS_${props.index}_VALUE`);
+    const [axisValue, setAxisValue] = usePersistentProperty(`THROTTLE_${props.throttleNumber}AXIS_${props.index}_VALUE`);
 
     const setFromTo = (throttle1Position, settingLower, settingUpper, deadZone: number, overrideValue?: string) => {
         const newSetting = overrideValue || throttle1Position;

--- a/src/instruments/src/EFB/Settings/ThrottleConfig/ThrottleConfig.tsx
+++ b/src/instruments/src/EFB/Settings/ThrottleConfig/ThrottleConfig.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Toggle } from '@flybywiresim/react-components';
-import { usePersistentPropertyWithDefault } from '../../../Common/persistence';
+import { usePersistentProperty } from '../../../Common/persistence';
 import { useSimVar } from '../../../Common/simVars';
 import Button, { BUTTON_TYPE } from '../../Components/Button/Button';
 import { SelectItem, VerticalSelectGroup } from '../../Components/Form/Select';
@@ -14,7 +14,7 @@ interface Props {
 }
 
 const ThrottleConfig: React.FC<Props> = (props: Props) => {
-    const [isDualAxis, setDualAxis] = usePersistentPropertyWithDefault<string>('THROTTLE_DUAL_AXIS', '1');
+    const [isDualAxis, setDualAxis] = usePersistentProperty('THROTTLE_DUAL_AXIS', '1');
 
     const [selectedIndex, setSelectedIndex] = useState(0);
 

--- a/src/instruments/src/EFB/Settings/sync.ts
+++ b/src/instruments/src/EFB/Settings/sync.ts
@@ -4,7 +4,7 @@ import { setSimVar } from '../../util.js';
 type SimVar = [name: string, type: string, defaultValue: string];
 
 function syncSetting(simVar: SimVar, propertyName: string) {
-    NXDataStore.getAndSubscribe<string>(propertyName, (prop, value) => {
+    NXDataStore.getAndSubscribe(propertyName, (prop, value) => {
         setSimVar(simVar[0], parseInt(value), simVar[1]).catch((e) => console.log(propertyName, e));
     }, simVar[2]);
 }

--- a/src/instruments/src/EFB/Settings/sync.ts
+++ b/src/instruments/src/EFB/Settings/sync.ts
@@ -1,48 +1,26 @@
 import { NXDataStore } from '@shared/persistence';
 import { setSimVar } from '../../util.js';
 
-type SettingSync = { simVar: [name: string, type: string], propertyName: string }
+type SimVar = [name: string, type: string, defaultValue: string];
 
-function syncSetting(simVarName, propertyName) {
-    const propertyValue = NXDataStore.get<string>(propertyName);
-
-    try {
-        setSimVar(simVarName, Number.parseInt(propertyValue), 'number');
-    } catch (e) {
-        console.error(`Could not sync simvar '${simVarName}' because it was not of type number`);
-    }
+function syncSetting(simVar: SimVar, propertyName: string) {
+    NXDataStore.getAndSubscribe<string>(propertyName, (prop, value) => {
+        setSimVar(simVar[0], parseInt(value), simVar[1]).catch((e) => console.log(propertyName, e));
+    }, simVar[2]);
 }
 
 /**
  * This contains a list of NXDataStore settings that must be synced to simvars on plane load
  */
-const settingsToSync: SettingSync[] = [
-    {
-        simVar: ['L:A32NX_SOUND_PTU_AUDIBLE_COCKPIT', 'Bool'],
-        propertyName: 'SOUND_PTU_AUDIBLE_COCKPIT',
-    },
-    {
-        simVar: ['L:A32NX_SOUND_EXTERIOR_MASTER', 'number'],
-        propertyName: 'SOUND_EXTERIOR_MASTER',
-    },
-    {
-        simVar: ['L:A32NX_SOUND_INTERIOR_ENGINE', 'number'],
-        propertyName: 'SOUND_INTERIOR_ENGINE',
-    },
-    {
-        simVar: ['L:A32NX_SOUND_INTERIOR_WIND', 'number'],
-        propertyName: 'SOUND_INTERIOR_WIND',
-    },
-    {
-        simVar: ['L:A32NX_EFB_BRIGHTNESS', 'number'],
-        propertyName: 'EFB_BRIGHTNESS',
-    },
-    {
-        simVar: ['L:A32NX_EFB_USING_AUTOBRIGHTNESS', 'bool'],
-        propertyName: 'EFB_USING_AUTOBRIGHTNESS',
-    },
-];
+const settingsToSync: Map<string, SimVar> = new Map([
+    ['SOUND_PTU_AUDIBLE_COCKPIT', ['L:A32NX_SOUND_PTU_AUDIBLE_COCKPIT', 'number', '0']],
+    ['SOUND_EXTERIOR_MASTER', ['L:A32NX_SOUND_EXTERIOR_MASTER', 'number', '0']],
+    ['SOUND_INTERIOR_ENGINE', ['L:A32NX_SOUND_INTERIOR_ENGINE', 'number', '0']],
+    ['SOUND_INTERIOR_WIND', ['L:A32NX_SOUND_INTERIOR_WIND', 'number', '0']],
+    ['EFB_BRIGHTNESS', ['L:A32NX_EFB_BRIGHTNESS', 'number', '0']],
+    ['EFB_USING_AUTOBRIGHTNESS', ['L:A32NX_EFB_USING_AUTOBRIGHTNESS', 'bool', '0']],
+]);
 
 export function readSettingsFromPersistentStorage() {
-    settingsToSync.forEach((setting) => syncSetting(setting.simVar[0], setting.simVar[1], setting.propertyName));
+    settingsToSync.forEach((simVar, propertyName) => syncSetting(simVar, propertyName));
 }

--- a/src/instruments/src/SD/Pages/Crz/Crz.tsx
+++ b/src/instruments/src/SD/Pages/Crz/Crz.tsx
@@ -28,7 +28,7 @@ export const CrzPage = () => (
 );
 
 export const FuelComponent = () => {
-    const [unit] = usePersistentProperty<string>('CONFIG_USING_METRIC_UNIT');
+    const [unit] = usePersistentProperty('CONFIG_USING_METRIC_UNIT', '1');
 
     const [leftConsumption] = useSimVar('L:A32NX_FUEL_USED:1', 'number', 1000);
     const [rightConsumption] = useSimVar('L:A32NX_FUEL_USED:2', 'number', 1000);

--- a/src/instruments/src/SD/Pages/Eng/Eng.tsx
+++ b/src/instruments/src/SD/Pages/Eng/Eng.tsx
@@ -14,7 +14,7 @@ import './Eng.scss';
 setIsEcamPage('eng_page');
 
 export const EngPage: FC = () => {
-    const [weightUnit] = usePersistentProperty<string>('CONFIG_USING_METRIC_UNIT', '1');
+    const [weightUnit] = usePersistentProperty('CONFIG_USING_METRIC_UNIT', '1');
     const [engSelectorPosition] = useSimVar('L:XMLVAR_ENG_MODE_SEL', 'Enum', 1000);
 
     return (

--- a/src/instruments/src/SD/Pages/Fuel/Fuel.tsx
+++ b/src/instruments/src/SD/Pages/Fuel/Fuel.tsx
@@ -21,7 +21,7 @@ export const FuelPage = () => {
     const [leftOuterInnerValve] = useSimVar('FUELSYSTEM VALVE OPEN:4', 'bool', 500);
     const [rightOuterInnerValve] = useSimVar('FUELSYSTEM VALVE OPEN:5', 'bool', 500);
 
-    const [unit] = usePersistentProperty<string>('CONFIG_USING_METRIC_UNIT');
+    const [unit] = usePersistentProperty('CONFIG_USING_METRIC_UNIT', '1');
 
     const [leftConsumption] = useSimVar('L:A32NX_FUEL_USED:1', 'number', 1000); // Note these values are in KG
     const [rightConsumption] = useSimVar('L:A32NX_FUEL_USED:2', 'number', 1000);

--- a/src/shared/src/persistence.ts
+++ b/src/shared/src/persistence.ts
@@ -1,4 +1,4 @@
-export type StorageValue = string | number;
+export type StorageValue = string; // this is the ONLY type that SetStoredData accepts, it silently fails otherwise
 
 export type StorageContents<T> = T extends undefined ? StorageValue : T;
 
@@ -29,7 +29,7 @@ export class NXDataStore {
      */
     static get<T extends StorageValue>(key: string, defaultVal?: StorageContents<T>): StorageContents<T> {
         const val = GetStoredData(`A32NX_${key}`);
-        if (!val) {
+        if (val === null) {
             return defaultVal;
         }
         return val;
@@ -42,7 +42,9 @@ export class NXDataStore {
      * @param val The value to assign to the property
      */
     static set<T extends StorageValue>(key: string, val: StorageContents<T>): void {
-        SetStoredData(`A32NX_${key}`, val);
+        if (SetStoredData(`A32NX_${key}`, val) !== val) {
+            console.error(`NXDataStore: Failed to set ${key} = ${val}`);
+        }
         this.listener.triggerToAllSubscribers('A32NX_NXDATASTORE_UPDATE', key, val);
     }
 

--- a/src/shared/src/persistence.ts
+++ b/src/shared/src/persistence.ts
@@ -19,7 +19,6 @@ export class NXDataStore {
 
     /**
      * Reads a value from persistent storage
-     *
      * @param key The property key
      * @param defaultVal The default value if the property is not set
      */
@@ -27,7 +26,9 @@ export class NXDataStore {
     static get(key: string, defaultVal?: string): string | undefined;
     static get(key: string, defaultVal?: string): any {
         const val = GetStoredData(`A32NX_${key}`);
-        if (val === null) {
+        // GetStoredData returns null on error, or empty string for keys that don't exist (why isn't that an error??)
+        // We could use SearchStoredData, but that spams the console with every key (somebody left their debug print in)
+        if (val === null || val.length === 0) {
             return defaultVal;
         }
         return val;
@@ -40,9 +41,7 @@ export class NXDataStore {
      * @param val The value to assign to the property
      */
     static set(key: string, val: string): void {
-        if (SetStoredData(`A32NX_${key}`, val) !== val) {
-            console.error(`NXDataStore: Failed to set ${key} = ${val}`);
-        }
+        SetStoredData(`A32NX_${key}`, val);
         this.listener.triggerToAllSubscribers('A32NX_NXDATASTORE_UPDATE', key, val);
     }
 


### PR DESCRIPTION
The underlying Coherent datastore errors out when anything other than a
string is set.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #5722
Fixes  #5751

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The Coherent datastore cannot store anything other than strings. Our typescript NXDataStore implementation was attempting to store numbers. The exception was being caught by the SetStoredData function in JS, which returned null, and we ignored that return value so the failure was silent.

Ammed the NXDataStore class to only take strings as it's type and adjust consumers to use strings. Hopefully we can come up with a solution later, but TS overloads don't seem to be useful here, and generics won't do it.


Additionally the SimVarSyncedProperty did not make a lot of sense, as it was attempting to sync in the opposite direction to what _all_ of the consumers desired. Use the new NXDataStore syncing functionality to sync settings across instruments instead, and make the one way sync from the setting to the simvar, not the other way around.

Tagging for 0.7 at this stage, as the bug would be quite annoying to release.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Make sure sound and EFB brightness settings are persisted across MSFS restarts (not Alt+F4 ones!).

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
