### PR TITLE
feat(hyd): ptu first start sound trigger simvar

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 0.8.0
 1. [SOUND] Pack sounds use new APU model variables - @tracernz (Mike)
 1. [EFB] Moved setting for MCDU keyboard input into the EFB - @2hwk (2Cas#1022)
+1. [HYD] Placeholder simvar to trigger ptu high pitch sound - @crocket6 (crocket)
 
 ## 0.7.0
 1. [HYD] First building block, more to come. Hydraulics do not impact the sim YET. - @crocket6 (crocket)

--- a/src/systems/a320_systems/src/hydraulic.rs
+++ b/src/systems/a320_systems/src/hydraulic.rs
@@ -373,6 +373,18 @@ impl A320Hydraulic {
         estimated_yellow_epump_flow.max(VolumeRate::new::<gallon_per_second>(0.))
     }
 
+    // Placeholder function to trigger the high pitch PTU sound on specific PTU conditions
+    // Todo remove when PTU physical model is added
+    fn is_ptu_running_high_pitch_sound(&self) -> bool {
+        let is_ptu_rotating = self.power_transfer_unit.is_active_left_to_right()
+            || self.power_transfer_unit.is_active_right_to_left();
+
+        let absolute_delta_pressure =
+            (self.green_loop.pressure() - self.yellow_loop.pressure()).abs();
+
+        absolute_delta_pressure > Pressure::new::<psi>(2700.) && is_ptu_rotating
+    }
+
     fn green_edp_has_low_press_fault(&self) -> bool {
         self.engine_driven_pump_1_controller
             .has_pressure_low_fault()
@@ -677,6 +689,11 @@ impl SimulationElement for A320Hydraulic {
             "HYD_BLUE_EPUMP_FLOW",
             self.blue_electric_pump_estimated_flow()
                 .get::<gallon_per_second>(),
+        );
+
+        writer.write(
+            "HYD_PTU_HIGH_PITCH_SOUND",
+            self.is_ptu_running_high_pitch_sound(),
         );
     }
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This is a simvar trigger used to generate specific high pitch PTU sound.
A32NX_HYD_PTU_HIGH_PITCH_SOUND will go to 1 whenever PTU is activated while there's a lot of pressure differential between green and yellow circuits.

This is a placeholder, will be removed when PTU new model handles this by design.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Simvar A32NX_HYD_PTU_HIGH_PITCH_SOUND should go to 1 whenever ptu is activated while there is more than 2700psi pressure difference between yellow and green circuits.

So it's expected to go 1 on second engine master on when the usual PTU self test is ran, or if EDP is shutdown on one side and ptu off, then ptu reactivated when pressure is close to 0 on the shutdown circuit.

Using PTU while just running yellow electric pump should not trigger the simvar.


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
