### PR TITLE
feat: grid-layout same sized buttons on failure page

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 0.8.0
 1. [SOUND] Pack sounds use new APU model variables - @tracernz (Mike)
 1. [EFB] Moved setting for MCDU keyboard input into the EFB - @2hwk (2Cas#1022)
+1. [EFB] Neatened up failure buttons on failure page - @nathanmayall (AbsoluteNath#9406)
 
 ## 0.7.0
 1. [HYD] First building block, more to come. Hydraulics do not impact the sim YET. - @crocket6 (crocket)

--- a/src/instruments/src/EFB/Failures/FailureButton.tsx
+++ b/src/instruments/src/EFB/Failures/FailureButton.tsx
@@ -21,6 +21,7 @@ export const FailureButton: FC<FailureButtonProps> = ({ name, isActive, isChangi
             onClick={onClick}
             type={type}
             disabled={isChanging}
+            className="mx-2 my-2"
         >
             <span>{name}</span>
         </Button>

--- a/src/instruments/src/EFB/Failures/Failures.tsx
+++ b/src/instruments/src/EFB/Failures/Failures.tsx
@@ -22,10 +22,10 @@ export const Failures = () => {
     });
 
     return (
-        <div className="w-full">
-            <h1 className="text-3xl pt-6 text-white">Failures</h1>
-            <h2 className="text-2xl pt-6 text-white">Full simulation of the failures below isn't yet guaranteed.</h2>
-            <div className="text-white overflow-hidden bg-navy-lighter rounded-2xl shadow-lg p-6 h-efb-nav mr-3 w-full">
+        <div className="w-full ">
+            <h1 className="pt-6 text-3xl text-white">Failures</h1>
+            <h2 className="pt-6 text-2xl text-white">Full simulation of the failures below isn't yet guaranteed.</h2>
+            <div className="grid grid-flow-row grid-cols-4 grid-rows-4 gap-4 p-4 mr-3 overflow-hidden text-white shadow-lg bg-navy-lighter rounded-2xl h-efb-nav">
                 {buttons}
             </div>
         </div>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
EFB Failure buttons now look a lot more neat. Also uses a grid pattern, as more failures are added these will conform to the grid automatically.


## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/70609396/132420227-69b8db35-380b-4a31-9437-6ea6d282d167.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): AbsoluteNath#9406

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Go to the Failures page in the EFB and check the buttons look neat and are in a grid 4 columns wide.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
