### PR TITLE
fix(pfd): correct roll indicator triangle height

### DIFF
--- a/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
+++ b/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
@@ -27,7 +27,7 @@ export const AttitudeIndicatorFixedUpper = ({ pitch, roll }) => {
                 <path d="m53.553 41.563-0.90818-2.4967 0.9466-0.34474 0.9466-0.34472 0.90818 2.4966" />
                 <path d="m46.973 44.827-1.8313-3.1738 1.7448-1.0079 1.8313 3.1738" />
             </g>
-            <path className="NormalStroke Yellow CornerRound" d="m68.906 38.741-2.5184-4.7373h5.0367l-2.5184 4.7373" />
+            <path className="NormalStroke Yellow CornerRound" d="m68.906 38.650-2.5184-3.7000h5.0367l-2.5184 3.7000" />
         </g>
     );
 };


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

This PR tweaks the height of the top-most yellow triangle near the top of the PFD that indicates 0 degrees roll.
Comparing it to references recently I found it significantly too tall, and have thus reduced it's height. See screenshots below.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![roll indicator comparison](https://user-images.githubusercontent.com/929769/132920332-6fdca17c-5aa6-496e-9139-cff166bedccd.png)
Left is old, center is reference, right is new.

### Old
![old PFD](https://user-images.githubusercontent.com/929769/132920422-955b2b93-38b3-4520-8acb-7a2c57080b0d.png)

### New
![new PFD](https://user-images.githubusercontent.com/929769/132920401-f55056b6-1998-43d2-a3c9-06221a04fb46.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

![reference image](https://user-images.githubusercontent.com/929769/132920473-6f9bd37f-e1f4-492a-b7a7-1fc0b664366c.png)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. The changes are extremely minor and visual only. Nonetheless, start up as usual, make sure the PFD still works
2. In flight, roll a bit or reach extreme roll angles and confirm the triangle continues to be displayed as expected

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
