### PR TITLE
fix(adirs): use heading as track at low ground speeds

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,7 @@
 1. [EFB] Moved setting for MCDU keyboard input into the EFB - @2hwk (2Cas#1022)
 1. [HYD] Placeholder simvar to trigger ptu high pitch sound - @crocket6 (crocket)
 1. [EFB] Neatened up failure buttons on failure page - @nathanmayall (AbsoluteNath#9406)
+1. [ADIRS] Use heading as track at low ground speeds - @beheh (Benedict Etzel)
 
 ## 0.7.0
 1. [HYD] First building block, more to come. Hydraulics do not impact the sim YET. - @crocket6 (crocket)

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -687,6 +687,7 @@ impl InertialReference {
     const LATITUDE: &'static str = "LATITUDE";
     const LONGITUDE: &'static str = "LONGITUDE";
     const MINIMUM_TRUE_AIRSPEED_FOR_WIND_DETERMINATION_KNOTS: f64 = 100.;
+    const MINIMUM_GROUND_SPEED_FOR_TRACK_KNOTS: f64 = 50.;
 
     fn new(number: usize) -> Self {
         Self {
@@ -853,8 +854,18 @@ impl InertialReference {
     ) {
         let should_set_values = self.is_on && self.is_fully_aligned();
 
-        self.track
-            .set_value(simulator_data.track, should_set_values);
+        let ground_speed_above_minimum_threshold = simulator_data.ground_speed
+            >= Velocity::new::<knot>(Self::MINIMUM_GROUND_SPEED_FOR_TRACK_KNOTS);
+
+        self.track.set_value(
+            if ground_speed_above_minimum_threshold {
+                simulator_data.track
+            } else {
+                simulator_data.heading
+            },
+            should_set_values,
+        );
+
         self.vertical_speed.set_value(
             simulator_data.vertical_speed.get::<foot_per_minute>(),
             should_set_values,
@@ -2169,9 +2180,33 @@ mod tests {
         #[case(1)]
         #[case(2)]
         #[case(3)]
-        fn track_is_supplied_by_ir(#[case] adiru_number: usize) {
+        fn track_is_supplied_when_ground_speed_greater_than_or_equal_to_50_knots(
+            #[case] adiru_number: usize,
+        ) {
             let angle = Angle::new::<degree>(160.);
-            let mut test_bed = all_adirus_aligned_test_bed_with().track_of(angle);
+            let mut test_bed = all_adirus_aligned_test_bed_with()
+                .track_of(angle)
+                .and()
+                .ground_speed_of(Velocity::new::<knot>(
+                    InertialReference::MINIMUM_GROUND_SPEED_FOR_TRACK_KNOTS,
+                ));
+            test_bed.run();
+
+            assert_eq!(test_bed.track(adiru_number), angle);
+        }
+
+        #[rstest]
+        #[case(1)]
+        #[case(2)]
+        #[case(3)]
+        fn track_is_heading_when_ground_speed_less_than_50_knots(#[case] adiru_number: usize) {
+            let angle = Angle::new::<degree>(160.);
+            let mut test_bed = all_adirus_aligned_test_bed_with()
+                .heading_of(angle)
+                .and()
+                .ground_speed_of(Velocity::new::<knot>(
+                    InertialReference::MINIMUM_GROUND_SPEED_FOR_TRACK_KNOTS - 0.01,
+                ));
             test_bed.run();
 
             assert_eq!(test_bed.track(adiru_number), angle);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
When the aircraft has less than 50 knots of ground speed, the IRSs should use the  current heading as track, which they currently do not. This commit fixes that.

This is especially noticeable when spawning in on the ground, or when pushing back, as the track bug at the bottom of the PFD might be not visible at all or initialized in a weird place.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

Spawning or Pushback on Ground (**Old**):
![image](https://user-images.githubusercontent.com/929769/132922968-92531edb-da9a-41c6-963c-2b391614bb02.png)
The green track diamond at the bottom of the PFD is not visible because it is behind the aircraft or out of view.

Spawning or Pushback on Ground (**New**):
![image](https://user-images.githubusercontent.com/929769/132922432-fd7ceff5-3b34-4b92-ac19-79927695e030.png)
The green track diamond at the bottom of the PFD is forced to the current heading below 50 knots, which ensures it's always visible.

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

![reference](https://user-images.githubusercontent.com/929769/132923515-72c10c29-b317-477e-9665-8c7fabdace70.png)

1) Video: https://www.youtube.com/watch?v=cv41hm4JEB8#t=16s
Notice how the green track diamond is visible at the center of the heading scale, despite the aircraft moving backwards due to the push back (and the actual track should thus not be visible because it points to behind the aircraft).

2) Video: https://www.youtube.com/watch?v=ECV3IBkzZLc#t=8s
Notice how the green track diamond jumps to the left once 50 knots are reached.

## Additional context
<!-- Add any other context about the pull request here. -->

This PR does not introduce the missing true track and true heading values, and only fixes the magnetic track (via the magnetic heading). This fix will also have to be applied to true track when it is added in future.

This PR also does not update the MCDU IRS MONITOR page which is currently still using the vars from the sim itself, so this fix will have no effect. It will be fixed in future once that page is hooked up to the LVars from the (Rust) ADIRS.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Spawn in on the ground either cold and dark, or on a runway. The track diamond should be centered at the current heading like in the screenshot above.
2. Perform push back (e.g. via the EFB). The track diamond should remain where it as, at the center of the scale, moving with the heading.
3. Takeoff while turning, or abort a takeoff while turning. Notice how above 50 kts ground speed the track indicator lags behind, whereas below 50 kts ground speed it is attached to the center of the scale.
4. Fly around with varying winds. Your track should be displayed as usual.

Note that the IRS MONITOR pages on the MCDU are not hooked up to the ADIRS yet, so they may still show an incorrect value below 50 knots. This will be hooked up in a future PR.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
