### PR TITLE
fix(ecam): drop redundant CABIN READY memo

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -1337,16 +1337,6 @@ var A320_Neo_UpperECAM;
                         )
                     },
                     {
-                        message: "CABIN READY",
-                        isActive: () => {
-                            return (
-                                (this.getCachedSimVar("L:A32NX_CABIN_READY", "Bool")) &&
-                                ((this.isInFlightPhase(2)) ||
-                                (this.isInFlightPhase(6, 7) && this.getCachedSimVar("GEAR CENTER POSITION", "Percent") > 80))
-                            );
-                        }
-                    },
-                    {
                         message: "PRED W/S OFF",
                         style: () => (
                             this.isInFlightPhase(3, 4, 5, 7, 8, 9) || this.predWsMemo.read()


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
There are two places where the A320 has shown the cabin readiness in the past:
- the right column on the EWD, as a memo
- in the left column on the EWD as part of the T.O and LDG MEMO

After reviewing some references and footage, we think that CEOs originally only showed it in the right column, and eventually got an option to move it into the T.O/LDG MEMO instead. NEOs nowadays seem to always show it in the T.O/LDG MEMO, and the option does not really exist anymore.

In any case, showing the cabin readiness in two places seems nonsensical, and this PR drops the memo from the right column so that it's only showed in the T.O and LDG MEMO.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

https://discord.com/channels/738864299392630914/817470205260726322/885981452800491531

Video showing an A21N landing with the cabin readiness only in the LDG MEMO (not in the right column: https://www.youtube.com/watch?v=fR9iRUpbesU#t=5m58s

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

This is a trivial change and should barely require testing.

1. Spawn on the runway. Ensure that CABIN READY is only shown once in the left column of the EWD, not in the right.
2. Spawn on approach, and click the CABIN CALL in the OHP to make sure the cabin is ready. Observe the same as above (no CABIN READY in the right column)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
