### PR TITLE
fix(pfd): fix mach number flickering between mach 0.45 and 0.5

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,6 +11,7 @@
 1. [HYD] Placeholder simvar to trigger ptu high pitch sound - @crocket6 (crocket)
 1. [EFB] Neatened up failure buttons on failure page - @nathanmayall (AbsoluteNath#9406)
 1. [ADIRS] Use heading as track at low ground speeds - @beheh (Benedict Etzel)
+1. [PFD] Fix mach number flickering between mach 0.45 and 0.5 - @beheh (Benedict Etzel)
 
 ## 0.7.0
 1. [HYD] First building block, more to come. Hydraulics do not impact the sim YET. - @crocket6 (crocket)

--- a/src/instruments/src/PFD/SpeedIndicator.tsx
+++ b/src/instruments/src/PFD/SpeedIndicator.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { VerticalTape, BarberpoleIndicator } from './PFDUtils';
 import { getSimVar } from '../util.js';
 
@@ -228,19 +228,31 @@ const SpeedTapeOutline = ({ airspeed, isRed = false }) => {
     );
 };
 
-export const MachNumber = ({ mach, airspeedAcc }) => {
+export const MachNumber = ({ mach }) => {
+    const machPermille = Math.round(mach * 1000);
+    const [showMach, setShowMach] = useState(machPermille > 500);
+
+    useEffect(() => {
+        if (showMach && machPermille < 450) {
+            setShowMach(false);
+        }
+        if (!showMach && machPermille > 500) {
+            setShowMach(true);
+        }
+    }, [showMach, machPermille]);
+
     if (Number.isNaN(mach)) {
         return (
             <text id="MachFailText" className="Blink9Seconds FontLargest StartAlign Red" x="5.4257932" y="136.88908">MACH</text>
         );
     }
 
-    if ((airspeedAcc >= 0 && mach < 0.5) || (airspeedAcc < 0 && mach <= 0.45)) {
+    if (!showMach) {
         return null;
     }
 
     return (
-        <text id="CurrentMachText" className="FontLargest StartAlign Green" x="5.4257932" y="136.88908">{`.${Math.round(mach * 1000)}`}</text>
+        <text id="CurrentMachText" className="FontLargest StartAlign Green" x="5.4257932" y="136.88908">{`.${machPermille}`}</text>
     );
 };
 

--- a/src/instruments/src/PFD/index.tsx
+++ b/src/instruments/src/PFD/index.tsx
@@ -243,7 +243,7 @@ class PFD extends Component {
                     <HeadingOfftape ILSCourse={ILSCourse} groundTrack={groundTrack} heading={heading} selectedHeading={selectedHeading} />
                     <AltitudeIndicatorOfftape altitude={altitude} radioAlt={radioAlt} MDA={mda} targetAlt={targetAlt} altIsManaged={isManaged} mode={pressureMode} />
                     <AirspeedIndicatorOfftape airspeed={clampedAirspeed} targetSpeed={targetSpeed} speedIsManaged={!isSelected} />
-                    <MachNumber mach={mach} airspeedAcc={filteredAirspeedAcc} />
+                    <MachNumber mach={mach} />
                     <FMA isAttExcessive={this.isAttExcessive} />
                 </svg>
             </DisplayUnit>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

This PR fixes the case where the mach number is between 0.450 and 0.500 and the indicator in the bottom left flickers in same-speed flight. This was because it was using the computed airspeed trend to decide which threshold (0.450 and 0.500) to use. As an aircraft flying at a fixed speed will be kept at the speed by the autopilot modulating thrust downwards and upwards just a tiny bit, the trend was constantly switching between positive/negative. If the indicated mach number was at say 0.475, this would mean that it would constantly switch being above or below the threshold, causing flickering.

The new behavior is as follows:
- when the mach number was below .45, it stays hidden until increasing above .5
- when the mach number was above .5, it stays visible until reducing below .45

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

- Video: https://www.youtube.com/watch?v=0B1yu7Ju7fM#t=16m55s  
Observe the mach indicator appearing for the first time with .501
- Video: https://www.youtube.com/watch?v=orXbHqbXkUc#t=15m30s  
Observe the mach indiactor staying visible until the last value .450

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Start on the runway, on the ground. Verify the mach number is not shown.
2. Start flying and reach mach .475. Hold the speed, ensure mach indicator does not appear at all (it remains invisible).
4. Ensure the mach number appears first with .501.
3. Once the mach number appears, try to decrease below mach .500 again. The mach number should remain visible.
4. Hold speed at mach .475. Observe no on/off flickering of the mach indicator, it should always remain visible.
5. Decrease speed below mach .450, mach number should disappear, with the last shown mach value being .450.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
