### PR TITLE
fix: default-props-match-prop-types lint errors

### DIFF
--- a/src/instruments/src/EFB/Components/Progress/Progress.tsx
+++ b/src/instruments/src/EFB/Components/Progress/Progress.tsx
@@ -26,23 +26,23 @@ export type ProgressBarProps = {
 }
 
 export const ProgressBar: React.FC<ProgressBarProps> = ({
-    bgcolor,
+    bgcolor = '#6a1b9a',
     completed,
-    displayBar,
+    displayBar = false,
     completedBarEnd,
-    completedBarBegin,
+    completedBarBegin = 0,
     completedBarBeginValue,
     completionValue,
-    baseBgColor,
-    height,
-    width,
+    baseBgColor = '#e0e0de',
+    height = '20px',
+    width = '100%',
     margin,
     padding,
-    borderRadius,
-    labelAlignment,
-    labelColor,
-    labelSize,
-    isLabelVisible,
+    borderRadius = '50px',
+    labelAlignment = 'right',
+    labelColor = '#fff',
+    labelSize = '15px',
+    isLabelVisible = true,
     vertical,
     greenBarsWhenInRange,
 }) => {
@@ -181,18 +181,4 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
             )}
         </div>
     );
-};
-
-ProgressBar.defaultProps = {
-    bgcolor: '#6a1b9a',
-    height: '20px',
-    width: '100%',
-    borderRadius: '50px',
-    labelAlignment: 'right',
-    baseBgColor: '#e0e0de',
-    labelColor: '#fff',
-    labelSize: '15px',
-    isLabelVisible: true,
-    displayBar: false,
-    completedBarBegin: 0,
 };


### PR DESCRIPTION
## Summary of Changes
Fixes issues detected by linting which popped up as `eslint-plugin-react` `v7.25.2` was released.

> /external/src/instruments/src/EFB/Components/Progress/Progress.tsx
  187:5  error  defaultProp "bgcolor" has no corresponding propTypes declaration            react/default-props-match-prop-types
  188:5  error  defaultProp "height" has no corresponding propTypes declaration             react/default-props-match-prop-types
  189:5  error  defaultProp "width" has no corresponding propTypes declaration              react/default-props-match-prop-types
  190:5  error  defaultProp "borderRadius" has no corresponding propTypes declaration       react/default-props-match-prop-types
  191:5  error  defaultProp "labelAlignment" has no corresponding propTypes declaration     react/default-props-match-prop-types
  192:5  error  defaultProp "baseBgColor" has no corresponding propTypes declaration        react/default-props-match-prop-types
  193:5  error  defaultProp "labelColor" has no corresponding propTypes declaration         react/default-props-match-prop-types
  194:5  error  defaultProp "labelSize" has no corresponding propTypes declaration          react/default-props-match-prop-types
  195:5  error  defaultProp "isLabelVisible" has no corresponding propTypes declaration     react/default-props-match-prop-types
  196:5  error  defaultProp "displayBar" has no corresponding propTypes declaration         react/default-props-match-prop-types
  197:5  error  defaultProp "completedBarBegin" has no corresponding propTypes declaration  react/default-props-match-prop-types

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
