### PR TITLE
refactor(flaps): move flaps logic and animation to Rust

### DIFF
--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -937,6 +937,72 @@
       0 | Retracted
       1 | Full extension
 
+- A32NX_LEFT_FLAPS_POSITION_PERCENT
+    - Percent
+    - Indicates the angle of the left flaps out of 40 degrees
+
+- A32NX_RIGHT_FLAPS_POSITION_PERCENT
+    - Percent
+    - Indicates the angle of the right flaps out of 40 degrees
+
+- A32NX_LEFT_SLATS_POSITION_PERCENT
+    - Percent
+    - Indicates the angle of the left slats out of 27 degrees
+
+- A32NX_RIGHT_SLATS_POSITION_PERCENT
+    - Percent
+    - Indicates the angle of the right slats out of 27 degrees
+
+- A32NX_LEFT_FLAPS_TARGET_ANGLE
+    - Degrees
+    - Indicates the target angle of the left flaps
+    - according to the configuration.
+    
+- A32NX_RIGHT_FLAPS_TARGET_ANGLE
+    - Degrees
+    - Indicates the target angle of the right flaps
+    - according to the configuration.
+
+- A32NX_LEFT_SLATS_TARGET_ANGLE
+    - Degrees
+    - Indicates the target angle of the left slats
+    - according to the configuration.
+    
+- A32NX_RIGHT_SLATS_TARGET_ANGLE
+    - Degrees
+    - Indicates the target angle of the right slats
+    - according to the configuration.
+
+- A32NX_LEFT_FLAPS_ANGLE
+    - Degrees
+    - The actual angle of the left flaps
+
+- A32NX_RIGHT_FLAPS_ANGLE
+    - Degrees
+    - The actual angle of the right flaps
+
+- A32NX_LEFT_SLATS_ANGLE
+    - Degrees
+    - The actual angle of the left slats
+
+- A32NX_RIGHT_SLATS_ANGLE
+    - Degrees
+    - The actual angle of the right slats
+    
+
+- A32NX_FLAPS_CONF_HANDLE_INDEX_HELPER
+    - Number
+    - A helper variable that indicates the flaps configuration
+    - Value | Meaning
+      --- | ---
+      0 | Conf0
+      1 | Conf1
+      2 | Conf1F
+      3 | Conf2
+      4 | Conf3
+      5 | ConfFull
+
+
 - A32NX_SPOILERS_ARMED
     - Bool
     - Indicates if the ground spoilers are armed

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js
@@ -9,7 +9,7 @@ const FLAPS_IN_MOTION_MIN_DELTA = 0.1;
 class A32NX_LocalVarUpdater {
     constructor() {
         // Initial data for deltas
-        this.lastFlapsPosition = SimVar.GetSimVarValue("TRAILING EDGE FLAPS LEFT PERCENT", "percent");
+        this.lastFlapsPosition = SimVar.GetSimVarValue("L:A32NX_LEFT_FLAPS_POSITION_PERCENT", "Percent");
         // track which compartment has gotten temperature initialization
         this.initializedCabinTemp = {
             "CKPT":false,
@@ -191,7 +191,7 @@ class A32NX_LocalVarUpdater {
     }
 
     _flapsInMotionSelector() {
-        const currentFlapsPosition = SimVar.GetSimVarValue("TRAILING EDGE FLAPS LEFT PERCENT", "percent");
+        const currentFlapsPosition = SimVar.GetSimVarValue("L:A32NX_LEFT_FLAPS_POSITION_PERCENT", "Percent");
         const lastFlapsPosition = this.lastFlapsPosition;
 
         this.lastFlapsPosition = currentFlapsPosition;

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_Speeds.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_Speeds.js
@@ -33,7 +33,7 @@ class A32NX_Speeds {
         /** Using true fhi for comparison */
         const isTo = fhi === SimVar.GetSimVarValue("L:A32NX_TO_CONFIG_FLAPS", "number");
         /** Change fhi to differentiate between 1 and 1 + F */
-        if (fhi === 1 && SimVar.GetSimVarValue("FLAPS HANDLE INDEX", "Enum") === 1) {
+        if (fhi === 1 && SimVar.GetSimVarValue("L:A32NX_FLAPS_CONF_HANDLE_INDEX_HELPER") === 1) {
             fhi = 5;
         }
         const gw = this.round(SimVar.GetSimVarValue("TOTAL WEIGHT", "kg")) / 1000;

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -1756,10 +1756,10 @@ var A320_Neo_UpperECAM;
             }
         }
         updateTakeoffConfigWarnings(_test) {
-            const slatsLeft = SimVar.GetSimVarValue("LEADING EDGE FLAPS LEFT ANGLE", "degrees");
-            const slatsRight = SimVar.GetSimVarValue("LEADING EDGE FLAPS RIGHT ANGLE", "degrees");
-            const flapsLeft = SimVar.GetSimVarValue("TRAILING EDGE FLAPS LEFT ANGLE", "degrees");
-            const flapsRight = SimVar.GetSimVarValue("TRAILING EDGE FLAPS RIGHT ANGLE", "degrees");
+            const slatsLeft = SimVar.GetSimVarValue("L:A32NX_LEFT_SLATS_ANGLE", "degrees");
+            const slatsRight = SimVar.GetSimVarValue("L:A32NX_RIGHT_SLATS_ANGLE", "degrees");
+            const flapsLeft = SimVar.GetSimVarValue("L:A32NX_LEFT_FLAPS_ANGLE", "degrees");
+            const flapsRight = SimVar.GetSimVarValue("L:A32NX_LEFT_FLAPS_ANGLE", "degrees");
             const flapsHandle = SimVar.GetSimVarValue("L:A32NX_FLAPS_HANDLE_INDEX", "Enum");
             const flapsMcdu = SimVar.GetSimVarValue("L:A32NX_TO_CONFIG_FLAPS", "number");
             const flapsMcduEntered = SimVar.GetSimVarValue("L:A32NX_TO_CONFIG_FLAPS_ENTERED", "bool");
@@ -2618,9 +2618,9 @@ var A320_Neo_UpperECAM;
         }
         update(_deltaTime) {
             super.update(_deltaTime);
-            const slatsAngle = (SimVar.GetSimVarValue("LEADING EDGE FLAPS LEFT ANGLE", "degrees") + SimVar.GetSimVarValue("LEADING EDGE FLAPS RIGHT ANGLE", "degrees")) * 0.5;
-            const flapsAngle = Math.max(0, (SimVar.GetSimVarValue("TRAILING EDGE FLAPS LEFT ANGLE", "degrees") + SimVar.GetSimVarValue("TRAILING EDGE FLAPS RIGHT ANGLE", "degrees")) * 0.5);
-            const handleIndex = SimVar.GetSimVarValue("FLAPS HANDLE INDEX", "Number");
+            const slatsAngle = (SimVar.GetSimVarValue("L:A32NX_LEFT_SLATS_ANGLE", "degrees") + SimVar.GetSimVarValue("L:A32NX_LEFT_SLATS_ANGLE", "degrees")) * 0.5;
+            const flapsAngle = Math.max(0, (SimVar.GetSimVarValue("L:A32NX_LEFT_FLAPS_ANGLE", "degrees") + SimVar.GetSimVarValue("L:A32NX_LEFT_FLAPS_ANGLE", "degrees")) * 0.5);
+            const handleIndex = SimVar.GetSimVarValue("L:A32NX_FLAPS_CONF_HANDLE_INDEX_HELPER", "Number");
             let slatsTargetIndex = 0;
             let flapsTargetIndex = 0;
             switch (handleIndex) {

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -551,7 +551,7 @@ bool FlyByWireInterface::updateAutopilotStateMachine(double sampleTime) {
     autopilotStateMachineInput.in.data.gear_strut_compression_1 = simData.gear_animation_pos_1;
     autopilotStateMachineInput.in.data.gear_strut_compression_2 = simData.gear_animation_pos_2;
     autopilotStateMachineInput.in.data.zeta_pos = simData.zeta_pos;
-    autopilotStateMachineInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get(true);
+    autopilotStateMachineInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get();
     autopilotStateMachineInput.in.data.is_engine_operative_1 = simData.engine_combustion_1;
     autopilotStateMachineInput.in.data.is_engine_operative_2 = simData.engine_combustion_2;
 
@@ -848,7 +848,7 @@ bool FlyByWireInterface::updateAutopilotLaws(double sampleTime) {
     autopilotLawsInput.in.data.gear_strut_compression_1 = simData.gear_animation_pos_1;
     autopilotLawsInput.in.data.gear_strut_compression_2 = simData.gear_animation_pos_2;
     autopilotLawsInput.in.data.zeta_pos = simData.zeta_pos;
-    autopilotLawsInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get(true);
+    autopilotLawsInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get();
     autopilotLawsInput.in.data.is_engine_operative_1 = simData.engine_combustion_1;
     autopilotLawsInput.in.data.is_engine_operative_2 = simData.engine_combustion_2;
 
@@ -967,7 +967,7 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
     flyByWireInput.in.data.gear_animation_pos_0 = simData.gear_animation_pos_0;
     flyByWireInput.in.data.gear_animation_pos_1 = simData.gear_animation_pos_1;
     flyByWireInput.in.data.gear_animation_pos_2 = simData.gear_animation_pos_2;
-    flyByWireInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get(true);
+    flyByWireInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get();
     flyByWireInput.in.data.spoilers_left_pos = simData.spoilers_left_pos;
     flyByWireInput.in.data.spoilers_right_pos = simData.spoilers_right_pos;
     flyByWireInput.in.data.autopilot_master_on = simData.autopilot_master_on;
@@ -1099,7 +1099,7 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
 
   // update aileron positions
   animationAileronHandler->update(idAutopilotActiveAny->get(), spoilersHandler->getIsGroundSpoilersActive(), simData.simulationTime,
-                                  simData.Theta_deg, flapsHandleIndexFlapConf->get(true), flapsPosition->get(true),
+                                  simData.Theta_deg, flapsHandleIndexFlapConf->get(), flapsPosition->get(),
                                   idExternalOverride->get() == 1 ? simData.xi_pos : flyByWireOutput.output.xi_pos, sampleTime);
   idAileronPositionLeft->set(animationAileronHandler->getPositionLeft());
   idAileronPositionRight->set(animationAileronHandler->getPositionRight());
@@ -1178,7 +1178,7 @@ bool FlyByWireInterface::updateAutothrust(double sampleTime) {
     autoThrustInput.in.data.bz_m_s2 = simData.bz_m_s2;
     autoThrustInput.in.data.gear_strut_compression_1 = simData.gear_animation_pos_1;
     autoThrustInput.in.data.gear_strut_compression_2 = simData.gear_animation_pos_2;
-    autoThrustInput.in.data.flap_handle_index = flapsHandleIndexFlapConf->get(true);
+    autoThrustInput.in.data.flap_handle_index = flapsHandleIndexFlapConf->get();
     autoThrustInput.in.data.is_engine_operative_1 = simData.engine_combustion_1;
     autoThrustInput.in.data.is_engine_operative_2 = simData.engine_combustion_2;
     autoThrustInput.in.data.commanded_engine_N1_1_percent = simData.commanded_engine_N1_1_percent;
@@ -1333,7 +1333,7 @@ bool FlyByWireInterface::updateFlapsSpoilers(double sampleTime) {
   spoilersHandler->setSimulationVariables(
       simData.simulationTime, autopilotStateMachineOutput.enabled_AP1 == 1 || autopilotStateMachineOutput.enabled_AP2 == 1,
       simData.V_gnd_kn, thrustLeverAngle_1->get(), thrustLeverAngle_2->get(), simData.gear_animation_pos_1, simData.gear_animation_pos_2,
-      flapsHandleIndexFlapConf->get(true)/*simData.flaps_handle_index*/, flyByWireOutput.sim.data_computed.high_aoa_prot_active == 1);
+      flapsHandleIndexFlapConf->get(), flyByWireOutput.sim.data_computed.high_aoa_prot_active == 1);
 
   // check state of spoilers and adapt if necessary
   if (spoilersHandler->getSimPosition() != simData.spoilers_handle_position) {

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -329,9 +329,8 @@ void FlyByWireInterface::setupLocalVariables() {
   engineEngine1Timer = make_unique<LocalVariable>("A32NX_ENGINE_TIMER:1");
   engineEngine2Timer = make_unique<LocalVariable>("A32NX_ENGINE_TIMER:2");
 
-  // idFlapsHandleIndex = make_unique<LocalVariable>("A32NX_FLAPS_HANDLE_INDEX");
-  // idFlapsHandlePercent = make_unique<LocalVariable>("A32NX_FLAPS_HANDLE_PERCENT");
   flapsHandleIndexFlapConf = make_unique<LocalVariable>("A32NX_FLAPS_CONF_HANDLE_INDEX_HELPER");
+  flapsPosition = make_unique<LocalVariable>("A32NX_LEFT_FLAPS_ANGLE");
 
   idSpoilersArmed = make_unique<LocalVariable>("A32NX_SPOILERS_ARMED");
   idSpoilersHandlePosition = make_unique<LocalVariable>("A32NX_SPOILERS_HANDLE_POSITION");
@@ -552,7 +551,7 @@ bool FlyByWireInterface::updateAutopilotStateMachine(double sampleTime) {
     autopilotStateMachineInput.in.data.gear_strut_compression_1 = simData.gear_animation_pos_1;
     autopilotStateMachineInput.in.data.gear_strut_compression_2 = simData.gear_animation_pos_2;
     autopilotStateMachineInput.in.data.zeta_pos = simData.zeta_pos;
-    autopilotStateMachineInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get();//simData.flaps_handle_index;
+    autopilotStateMachineInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get(true);
     autopilotStateMachineInput.in.data.is_engine_operative_1 = simData.engine_combustion_1;
     autopilotStateMachineInput.in.data.is_engine_operative_2 = simData.engine_combustion_2;
 
@@ -849,7 +848,7 @@ bool FlyByWireInterface::updateAutopilotLaws(double sampleTime) {
     autopilotLawsInput.in.data.gear_strut_compression_1 = simData.gear_animation_pos_1;
     autopilotLawsInput.in.data.gear_strut_compression_2 = simData.gear_animation_pos_2;
     autopilotLawsInput.in.data.zeta_pos = simData.zeta_pos;
-    autopilotLawsInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get();//simData.flaps_handle_index;
+    autopilotLawsInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get(true);
     autopilotLawsInput.in.data.is_engine_operative_1 = simData.engine_combustion_1;
     autopilotLawsInput.in.data.is_engine_operative_2 = simData.engine_combustion_2;
 
@@ -968,7 +967,7 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
     flyByWireInput.in.data.gear_animation_pos_0 = simData.gear_animation_pos_0;
     flyByWireInput.in.data.gear_animation_pos_1 = simData.gear_animation_pos_1;
     flyByWireInput.in.data.gear_animation_pos_2 = simData.gear_animation_pos_2;
-    flyByWireInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get();// simData.flaps_handle_index;
+    flyByWireInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get(true);
     flyByWireInput.in.data.spoilers_left_pos = simData.spoilers_left_pos;
     flyByWireInput.in.data.spoilers_right_pos = simData.spoilers_right_pos;
     flyByWireInput.in.data.autopilot_master_on = simData.autopilot_master_on;
@@ -1100,7 +1099,7 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
 
   // update aileron positions
   animationAileronHandler->update(idAutopilotActiveAny->get(), spoilersHandler->getIsGroundSpoilersActive(), simData.simulationTime,
-                                  simData.Theta_deg, flapsHandleIndexFlapConf->get()/*simData.flaps_handle_index*/, simData.flaps_position,
+                                  simData.Theta_deg, flapsHandleIndexFlapConf->get(true), flapsPosition->get(true),
                                   idExternalOverride->get() == 1 ? simData.xi_pos : flyByWireOutput.output.xi_pos, sampleTime);
   idAileronPositionLeft->set(animationAileronHandler->getPositionLeft());
   idAileronPositionRight->set(animationAileronHandler->getPositionRight());
@@ -1179,7 +1178,7 @@ bool FlyByWireInterface::updateAutothrust(double sampleTime) {
     autoThrustInput.in.data.bz_m_s2 = simData.bz_m_s2;
     autoThrustInput.in.data.gear_strut_compression_1 = simData.gear_animation_pos_1;
     autoThrustInput.in.data.gear_strut_compression_2 = simData.gear_animation_pos_2;
-    autoThrustInput.in.data.flap_handle_index = flapsHandleIndexFlapConf->get(); //simData.flaps_handle_index;
+    autoThrustInput.in.data.flap_handle_index = flapsHandleIndexFlapConf->get(true);
     autoThrustInput.in.data.is_engine_operative_1 = simData.engine_combustion_1;
     autoThrustInput.in.data.is_engine_operative_2 = simData.engine_combustion_2;
     autoThrustInput.in.data.commanded_engine_N1_1_percent = simData.commanded_engine_N1_1_percent;
@@ -1334,7 +1333,7 @@ bool FlyByWireInterface::updateFlapsSpoilers(double sampleTime) {
   spoilersHandler->setSimulationVariables(
       simData.simulationTime, autopilotStateMachineOutput.enabled_AP1 == 1 || autopilotStateMachineOutput.enabled_AP2 == 1,
       simData.V_gnd_kn, thrustLeverAngle_1->get(), thrustLeverAngle_2->get(), simData.gear_animation_pos_1, simData.gear_animation_pos_2,
-      flapsHandleIndexFlapConf->get()/*simData.flaps_handle_index*/, flyByWireOutput.sim.data_computed.high_aoa_prot_active == 1);
+      flapsHandleIndexFlapConf->get(true)/*simData.flaps_handle_index*/, flyByWireOutput.sim.data_computed.high_aoa_prot_active == 1);
 
   // check state of spoilers and adapt if necessary
   if (spoilersHandler->getSimPosition() != simData.spoilers_handle_position) {

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -1312,15 +1312,15 @@ bool FlyByWireInterface::updateFlapsSpoilers(double sampleTime) {
   // update airspeed on flaps logic
   flapsHandler->setAirspeed(simData.V_ias_kn);
 
-  // determine if flaps setting has changed
-  if (flapsHandler->getSimPosition() != simData.flaps_handle_index) {
-    SimOutputFlaps out = {flapsHandler->getSimPosition()};
-    simConnectInterface.sendData(out);
-  }
+  // // determine if flaps setting has changed
+  // if (flapsHandler->getSimPosition() != simData.flaps_handle_index) {
+  //   SimOutputFlaps out = {flapsHandler->getSimPosition()};
+  //   simConnectInterface.sendData(out);
+  // }
 
-  // set 3D handle position
-  idFlapsHandleIndex->set(flapsHandler->getHandlePosition());
-  idFlapsHandlePercent->set(flapsHandler->getHandlePositionPercent());
+  // // set 3D handle position
+  // idFlapsHandleIndex->set(flapsHandler->getHandlePosition());
+  // idFlapsHandlePercent->set(flapsHandler->getHandlePositionPercent());
 
   // spoilers ---------------------------------------------------------------------------------------------------------
 

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -329,8 +329,9 @@ void FlyByWireInterface::setupLocalVariables() {
   engineEngine1Timer = make_unique<LocalVariable>("A32NX_ENGINE_TIMER:1");
   engineEngine2Timer = make_unique<LocalVariable>("A32NX_ENGINE_TIMER:2");
 
-  idFlapsHandleIndex = make_unique<LocalVariable>("A32NX_FLAPS_HANDLE_INDEX");
-  idFlapsHandlePercent = make_unique<LocalVariable>("A32NX_FLAPS_HANDLE_PERCENT");
+  // idFlapsHandleIndex = make_unique<LocalVariable>("A32NX_FLAPS_HANDLE_INDEX");
+  // idFlapsHandlePercent = make_unique<LocalVariable>("A32NX_FLAPS_HANDLE_PERCENT");
+  flapsHandleIndexFlapConf = make_unique<LocalVariable>("A32NX_FLAPS_CONF_HANDLE_INDEX_HELPER");
 
   idSpoilersArmed = make_unique<LocalVariable>("A32NX_SPOILERS_ARMED");
   idSpoilersHandlePosition = make_unique<LocalVariable>("A32NX_SPOILERS_HANDLE_POSITION");
@@ -551,7 +552,7 @@ bool FlyByWireInterface::updateAutopilotStateMachine(double sampleTime) {
     autopilotStateMachineInput.in.data.gear_strut_compression_1 = simData.gear_animation_pos_1;
     autopilotStateMachineInput.in.data.gear_strut_compression_2 = simData.gear_animation_pos_2;
     autopilotStateMachineInput.in.data.zeta_pos = simData.zeta_pos;
-    autopilotStateMachineInput.in.data.flaps_handle_index = simData.flaps_handle_index;
+    autopilotStateMachineInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get();//simData.flaps_handle_index;
     autopilotStateMachineInput.in.data.is_engine_operative_1 = simData.engine_combustion_1;
     autopilotStateMachineInput.in.data.is_engine_operative_2 = simData.engine_combustion_2;
 
@@ -848,7 +849,7 @@ bool FlyByWireInterface::updateAutopilotLaws(double sampleTime) {
     autopilotLawsInput.in.data.gear_strut_compression_1 = simData.gear_animation_pos_1;
     autopilotLawsInput.in.data.gear_strut_compression_2 = simData.gear_animation_pos_2;
     autopilotLawsInput.in.data.zeta_pos = simData.zeta_pos;
-    autopilotLawsInput.in.data.flaps_handle_index = simData.flaps_handle_index;
+    autopilotLawsInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get();//simData.flaps_handle_index;
     autopilotLawsInput.in.data.is_engine_operative_1 = simData.engine_combustion_1;
     autopilotLawsInput.in.data.is_engine_operative_2 = simData.engine_combustion_2;
 
@@ -967,7 +968,7 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
     flyByWireInput.in.data.gear_animation_pos_0 = simData.gear_animation_pos_0;
     flyByWireInput.in.data.gear_animation_pos_1 = simData.gear_animation_pos_1;
     flyByWireInput.in.data.gear_animation_pos_2 = simData.gear_animation_pos_2;
-    flyByWireInput.in.data.flaps_handle_index = simData.flaps_handle_index;
+    flyByWireInput.in.data.flaps_handle_index = flapsHandleIndexFlapConf->get();// simData.flaps_handle_index;
     flyByWireInput.in.data.spoilers_left_pos = simData.spoilers_left_pos;
     flyByWireInput.in.data.spoilers_right_pos = simData.spoilers_right_pos;
     flyByWireInput.in.data.autopilot_master_on = simData.autopilot_master_on;
@@ -1099,7 +1100,7 @@ bool FlyByWireInterface::updateFlyByWire(double sampleTime) {
 
   // update aileron positions
   animationAileronHandler->update(idAutopilotActiveAny->get(), spoilersHandler->getIsGroundSpoilersActive(), simData.simulationTime,
-                                  simData.Theta_deg, simData.flaps_handle_index, simData.flaps_position,
+                                  simData.Theta_deg, flapsHandleIndexFlapConf->get()/*simData.flaps_handle_index*/, simData.flaps_position,
                                   idExternalOverride->get() == 1 ? simData.xi_pos : flyByWireOutput.output.xi_pos, sampleTime);
   idAileronPositionLeft->set(animationAileronHandler->getPositionLeft());
   idAileronPositionRight->set(animationAileronHandler->getPositionRight());
@@ -1178,7 +1179,7 @@ bool FlyByWireInterface::updateAutothrust(double sampleTime) {
     autoThrustInput.in.data.bz_m_s2 = simData.bz_m_s2;
     autoThrustInput.in.data.gear_strut_compression_1 = simData.gear_animation_pos_1;
     autoThrustInput.in.data.gear_strut_compression_2 = simData.gear_animation_pos_2;
-    autoThrustInput.in.data.flap_handle_index = simData.flaps_handle_index;
+    autoThrustInput.in.data.flap_handle_index = flapsHandleIndexFlapConf->get(); //simData.flaps_handle_index;
     autoThrustInput.in.data.is_engine_operative_1 = simData.engine_combustion_1;
     autoThrustInput.in.data.is_engine_operative_2 = simData.engine_combustion_2;
     autoThrustInput.in.data.commanded_engine_N1_1_percent = simData.commanded_engine_N1_1_percent;
@@ -1295,22 +1296,22 @@ bool FlyByWireInterface::updateFlapsSpoilers(double sampleTime) {
   // falps ------------------------------------------------------------------------------------------------------------
 
   // initialize position if needed
-  if (!flapsHandler->getIsInitialized()) {
-    if (simData.flaps_handle_index == 0) {
-      flapsHandler->setInitialPosition(FlapsHandler::HANDLE_POSITION_FLAPS_0);
-    } else if (simData.flaps_handle_index == 1 || simData.flaps_handle_index == 2) {
-      flapsHandler->setInitialPosition(FlapsHandler::HANDLE_POSITION_FLAPS_1);
-    } else if (simData.flaps_handle_index == 3) {
-      flapsHandler->setInitialPosition(FlapsHandler::HANDLE_POSITION_FLAPS_2);
-    } else if (simData.flaps_handle_index == 4) {
-      flapsHandler->setInitialPosition(FlapsHandler::HANDLE_POSITION_FLAPS_3);
-    } else if (simData.flaps_handle_index == 5) {
-      flapsHandler->setInitialPosition(FlapsHandler::HANDLE_POSITION_FLAPS_4);
-    }
-  }
+  // if (!flapsHandler->getIsInitialized()) {
+  //   if (simData.flaps_handle_index == 0) {
+  //     flapsHandler->setInitialPosition(FlapsHandler::HANDLE_POSITION_FLAPS_0);
+  //   } else if (simData.flaps_handle_index == 1 || simData.flaps_handle_index == 2) {
+  //     flapsHandler->setInitialPosition(FlapsHandler::HANDLE_POSITION_FLAPS_1);
+  //   } else if (simData.flaps_handle_index == 3) {
+  //     flapsHandler->setInitialPosition(FlapsHandler::HANDLE_POSITION_FLAPS_2);
+  //   } else if (simData.flaps_handle_index == 4) {
+  //     flapsHandler->setInitialPosition(FlapsHandler::HANDLE_POSITION_FLAPS_3);
+  //   } else if (simData.flaps_handle_index == 5) {
+  //     flapsHandler->setInitialPosition(FlapsHandler::HANDLE_POSITION_FLAPS_4);
+  //   }
+  // }
 
   // update airspeed on flaps logic
-  flapsHandler->setAirspeed(simData.V_ias_kn);
+  // flapsHandler->setAirspeed(simData.V_ias_kn);
 
   // // determine if flaps setting has changed
   // if (flapsHandler->getSimPosition() != simData.flaps_handle_index) {
@@ -1333,7 +1334,7 @@ bool FlyByWireInterface::updateFlapsSpoilers(double sampleTime) {
   spoilersHandler->setSimulationVariables(
       simData.simulationTime, autopilotStateMachineOutput.enabled_AP1 == 1 || autopilotStateMachineOutput.enabled_AP2 == 1,
       simData.V_gnd_kn, thrustLeverAngle_1->get(), thrustLeverAngle_2->get(), simData.gear_animation_pos_1, simData.gear_animation_pos_2,
-      simData.flaps_handle_index, flyByWireOutput.sim.data_computed.high_aoa_prot_active == 1);
+      flapsHandleIndexFlapConf->get()/*simData.flaps_handle_index*/, flyByWireOutput.sim.data_computed.high_aoa_prot_active == 1);
 
   // check state of spoilers and adapt if necessary
   if (spoilersHandler->getSimPosition() != simData.spoilers_handle_position) {

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -229,6 +229,7 @@ class FlyByWireInterface {
   std::unique_ptr<LocalVariable> idFlapsHandlePercent;
   std::shared_ptr<FlapsHandler> flapsHandler;
   std::unique_ptr<LocalVariable> flapsHandleIndexFlapConf;
+  std::unique_ptr<LocalVariable> flapsPosition;
 
   std::unique_ptr<LocalVariable> idSpoilersArmed;
   std::unique_ptr<LocalVariable> idSpoilersHandlePosition;

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -228,6 +228,7 @@ class FlyByWireInterface {
   std::unique_ptr<LocalVariable> idFlapsHandleIndex;
   std::unique_ptr<LocalVariable> idFlapsHandlePercent;
   std::shared_ptr<FlapsHandler> flapsHandler;
+  std::unique_ptr<LocalVariable> flapsHandleIndexFlapConf;
 
   std::unique_ptr<LocalVariable> idSpoilersArmed;
   std::unique_ptr<LocalVariable> idSpoilersHandlePosition;

--- a/src/fbw/src/interface/SimConnectData.h
+++ b/src/fbw/src/interface/SimConnectData.h
@@ -36,8 +36,6 @@ struct SimData {
   double gear_animation_pos_0;
   double gear_animation_pos_1;
   double gear_animation_pos_2;
-  // double flaps_handle_index;
-  double flaps_position;
   double spoilers_handle_position;
   double spoilers_left_pos;
   double spoilers_right_pos;

--- a/src/fbw/src/interface/SimConnectData.h
+++ b/src/fbw/src/interface/SimConnectData.h
@@ -36,7 +36,7 @@ struct SimData {
   double gear_animation_pos_0;
   double gear_animation_pos_1;
   double gear_animation_pos_2;
-  double flaps_handle_index;
+  // double flaps_handle_index;
   double flaps_position;
   double spoilers_handle_position;
   double spoilers_left_pos;

--- a/src/fbw/src/interface/SimConnectInterface.cpp
+++ b/src/fbw/src/interface/SimConnectInterface.cpp
@@ -125,8 +125,6 @@ bool SimConnectInterface::prepareSimDataSimConnectDataDefinitions() {
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "GEAR ANIMATION POSITION:0", "NUMBER");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "GEAR ANIMATION POSITION:1", "NUMBER");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "GEAR ANIMATION POSITION:2", "NUMBER");
-  // result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "FLAPS HANDLE INDEX", "NUMBER");
-  result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "TRAILING EDGE FLAPS LEFT ANGLE", "DEGREES");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "SPOILERS HANDLE POSITION", "POSITION");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "SPOILERS LEFT POSITION", "PERCENT OVER 100");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "SPOILERS RIGHT POSITION", "PERCENT OVER 100");

--- a/src/fbw/src/interface/SimConnectInterface.cpp
+++ b/src/fbw/src/interface/SimConnectInterface.cpp
@@ -125,7 +125,7 @@ bool SimConnectInterface::prepareSimDataSimConnectDataDefinitions() {
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "GEAR ANIMATION POSITION:0", "NUMBER");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "GEAR ANIMATION POSITION:1", "NUMBER");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "GEAR ANIMATION POSITION:2", "NUMBER");
-  result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "FLAPS HANDLE INDEX", "NUMBER");
+  // result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "FLAPS HANDLE INDEX", "NUMBER");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "TRAILING EDGE FLAPS LEFT ANGLE", "DEGREES");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "SPOILERS HANDLE POSITION", "POSITION");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "SPOILERS LEFT POSITION", "PERCENT OVER 100");

--- a/src/fbw/src/interface/SimConnectInterface.cpp
+++ b/src/fbw/src/interface/SimConnectInterface.cpp
@@ -358,15 +358,15 @@ bool SimConnectInterface::prepareSimInputSimConnectDataDefinitions(bool autopilo
   result &= addInputDataDefinition(hSimConnect, 0, Events::THROTTLE_REVERSE_THRUST_TOGGLE, "THROTTLE_REVERSE_THRUST_TOGGLE", true);
   result &= addInputDataDefinition(hSimConnect, 0, Events::THROTTLE_REVERSE_THRUST_HOLD, "THROTTLE_REVERSE_THRUST_HOLD", true);
 
-  result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_UP, "FLAPS_UP", true);
-  result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_1, "FLAPS_1", true);
-  result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_2, "FLAPS_2", true);
-  result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_3, "FLAPS_3", true);
-  result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_DOWN, "FLAPS_DOWN", true);
-  result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_INCR, "FLAPS_INCR", true);
-  result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_DECR, "FLAPS_DECR", true);
-  result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_SET, "FLAPS_SET", true);
-  result &= addInputDataDefinition(hSimConnect, 0, Events::AXIS_FLAPS_SET, "AXIS_FLAPS_SET", true);
+  // result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_UP, "FLAPS_UP", true);
+  // result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_1, "FLAPS_1", true);
+  // result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_2, "FLAPS_2", true);
+  // result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_3, "FLAPS_3", true);
+  // result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_DOWN, "FLAPS_DOWN", true);
+  // result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_INCR, "FLAPS_INCR", true);
+  // result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_DECR, "FLAPS_DECR", true);
+  // result &= addInputDataDefinition(hSimConnect, 0, Events::FLAPS_SET, "FLAPS_SET", true);
+  // result &= addInputDataDefinition(hSimConnect, 0, Events::AXIS_FLAPS_SET, "AXIS_FLAPS_SET", true);
 
   result &= addInputDataDefinition(hSimConnect, 0, Events::SPOILERS_ON, "SPOILERS_ON", true);
   result &= addInputDataDefinition(hSimConnect, 0, Events::SPOILERS_OFF, "SPOILERS_OFF", true);
@@ -397,7 +397,7 @@ bool SimConnectInterface::prepareSimOutputSimConnectDataDefinitions() {
   result &= addDataDefinition(hSimConnect, 4, SIMCONNECT_DATATYPE_FLOAT64, "GENERAL ENG THROTTLE MANAGED MODE:1", "NUMBER");
   result &= addDataDefinition(hSimConnect, 4, SIMCONNECT_DATATYPE_FLOAT64, "GENERAL ENG THROTTLE MANAGED MODE:2", "NUMBER");
 
-  result &= addDataDefinition(hSimConnect, 5, SIMCONNECT_DATATYPE_FLOAT64, "FLAPS HANDLE INDEX", "NUMBER");
+  // result &= addDataDefinition(hSimConnect, 5, SIMCONNECT_DATATYPE_FLOAT64, "FLAPS HANDLE INDEX", "NUMBER");
 
   result &= addDataDefinition(hSimConnect, 6, SIMCONNECT_DATATYPE_FLOAT64, "SPOILERS HANDLE POSITION", "POSITION");
 
@@ -759,10 +759,10 @@ bool SimConnectInterface::sendData(SimOutputThrottles output) {
   return sendData(4, sizeof(output), &output);
 }
 
-bool SimConnectInterface::sendData(SimOutputFlaps output) {
-  // write data and return result
-  return sendData(5, sizeof(output), &output);
-}
+// bool SimConnectInterface::sendData(SimOutputFlaps output) {
+//   // write data and return result
+//   return sendData(5, sizeof(output), &output);
+// }
 
 bool SimConnectInterface::sendData(SimOutputSpoilers output) {
   // write data and return result
@@ -1715,50 +1715,50 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       break;
     }
 
-    case Events::FLAPS_UP: {
-      flapsHandler->onEventFlapsUp();
-      break;
-    }
+    // case Events::FLAPS_UP: {
+    //   flapsHandler->onEventFlapsUp();
+    //   break;
+    // }
 
-    case Events::FLAPS_1: {
-      flapsHandler->onEventFlapsSet_1();
-      break;
-    }
+    // case Events::FLAPS_1: {
+    //   flapsHandler->onEventFlapsSet_1();
+    //   break;
+    // }
 
-    case Events::FLAPS_2: {
-      flapsHandler->onEventFlapsSet_2();
-      break;
-    }
+    // case Events::FLAPS_2: {
+    //   flapsHandler->onEventFlapsSet_2();
+    //   break;
+    // }
 
-    case Events::FLAPS_3: {
-      flapsHandler->onEventFlapsSet_3();
-      break;
-    }
+    // case Events::FLAPS_3: {
+    //   flapsHandler->onEventFlapsSet_3();
+    //   break;
+    // }
 
-    case Events::FLAPS_DOWN: {
-      flapsHandler->onEventFlapsDown();
-      break;
-    }
+    // case Events::FLAPS_DOWN: {
+    //   flapsHandler->onEventFlapsDown();
+    //   break;
+    // }
 
-    case Events::FLAPS_INCR: {
-      flapsHandler->onEventFlapsIncrease();
-      break;
-    }
+    // case Events::FLAPS_INCR: {
+    //   flapsHandler->onEventFlapsIncrease();
+    //   break;
+    // }
 
-    case Events::FLAPS_DECR: {
-      flapsHandler->onEventFlapsDecrease();
-      break;
-    }
+    // case Events::FLAPS_DECR: {
+    //   flapsHandler->onEventFlapsDecrease();
+    //   break;
+    // }
 
-    case Events::FLAPS_SET: {
-      flapsHandler->onEventFlapsSet(static_cast<long>(event->dwData));
-      break;
-    }
+    // case Events::FLAPS_SET: {
+    //   flapsHandler->onEventFlapsSet(static_cast<long>(event->dwData));
+    //   break;
+    // }
 
-    case Events::AXIS_FLAPS_SET: {
-      flapsHandler->onEventFlapsAxisSet(static_cast<long>(event->dwData));
-      break;
-    }
+    // case Events::AXIS_FLAPS_SET: {
+    //   flapsHandler->onEventFlapsAxisSet(static_cast<long>(event->dwData));
+    //   break;
+    // }
 
     case Events::SPOILERS_ON: {
       spoilersHandler->onEventSpoilersOn();

--- a/src/systems/a320_systems/src/flaps_computer.rs
+++ b/src/systems/a320_systems/src/flaps_computer.rs
@@ -123,6 +123,10 @@ impl SlatFlapControlComputer {
         self.get_flaps_conf() as f64
     }
 
+    fn get_flaps_conf_enum(&self) -> FlapsConf {
+        self.flaps_conf
+    }
+
     fn target_flaps_angle_from_state(flap_state: FlapsConf) -> Angle {
         match flap_state {
             FlapsConf::Conf0 => Angle::new::<degree>(0.),
@@ -148,46 +152,93 @@ impl SlatFlapControlComputer {
     pub fn update(
         &mut self,
         context: &UpdateContext,
-        transition: &str,
+        transition: (u8,u8),
     ) {
-
-        match transition {
-            "0->1" => {
-                if self.air_speed <= 100. {
-                    self.flaps_conf = FlapsConf::Conf1F;
-                } else {
-                    self.flaps_conf = FlapsConf::Conf1;
-                }
-            },
-            "2->1" => {
-                if self.air_speed <= 210. {
-                    self.flaps_conf = FlapsConf::Conf1F;
-                } else {
-                    self.flaps_conf = FlapsConf::Conf1;
-                }
-            },
-            "x->x" => {
-                if self.flaps_conf == FlapsConf::Conf1F 
-                    && self.air_speed > 210. {
+        let (from, to) = transition;
+        println!("FT = {},{}", from,to);
+        match from {
+            0 => {
+                if to == 1 {
+                    if self.air_speed <= 100. {
+                        self.flaps_conf = FlapsConf::Conf1F;
+                    } else {
                         self.flaps_conf = FlapsConf::Conf1;
+                    }
+                } else {
+                    if to == 0 {
+                        self.flaps_conf = FlapsConf::from(0);
+                    } else {
+                        self.flaps_conf = FlapsConf::from(to+1);
+                    }
                 }
             },
-            "x->y" => {
-                if self.flaps_conf == FlapsConf::Conf1 || self.flaps_conf == FlapsConf::Conf1F {
-                    self.flaps_conf = FlapsConf::Conf2;
+            1 => {
+                if to == 1 {
+                    if self.air_speed > 210. {
+                        self.flaps_conf = FlapsConf::Conf1;
+                    }
                 } else {
-                    self.flaps_conf = FlapsConf::from(self.flaps_conf as u8 + 1);
+                    if to == 0 {
+                        self.flaps_conf = FlapsConf::from(to);
+                    } else {
+                        self.flaps_conf = FlapsConf::from(to+1);
+                    }
                 }
             },
-            "y->x" => {
-                if self.flaps_conf == FlapsConf::Conf1 || self.flaps_conf == FlapsConf::Conf1F {
-                    self.flaps_conf = FlapsConf::Conf0;
+            _ => {
+                if to == 1 {
+                    if self.air_speed <= 210. {
+                        self.flaps_conf = FlapsConf::Conf1F;
+                    } else {
+                        self.flaps_conf = FlapsConf::Conf1;
+                    }
                 } else {
-                    self.flaps_conf = FlapsConf::from(self.flaps_conf as u8 - 1);
+                    if to == 0 {
+                        self.flaps_conf = FlapsConf::from(to);
+                    } else {
+                        self.flaps_conf = FlapsConf::from(to+1);
+                    }
                 }
-            }
-            _ => {},
+            },
         }
+        println!("FlapConf = {:?}", self.flaps_conf);
+        // match transition {
+        //     (0,1) => {
+        //         if self.air_speed <= 100. {
+        //             self.flaps_conf = FlapsConf::Conf1F;
+        //         } else {
+        //             self.flaps_conf = FlapsConf::Conf1;
+        //         }
+        //     },
+        //     (2,1) => {
+        //         if self.air_speed <= 210. {
+        //             self.flaps_conf = FlapsConf::Conf1F;
+        //         } else {
+        //             self.flaps_conf = FlapsConf::Conf1;
+        //         }
+        //     },
+        //     "x->x" => {
+        //         if self.flaps_conf == FlapsConf::Conf1F 
+        //             && self.air_speed > 210. {
+        //                 self.flaps_conf = FlapsConf::Conf1;
+        //         }
+        //     },
+        //     "x->y" => {
+        //         if self.flaps_conf == FlapsConf::Conf1 || self.flaps_conf == FlapsConf::Conf1F {
+        //             self.flaps_conf = FlapsConf::Conf2;
+        //         } else {
+        //             self.flaps_conf = FlapsConf::from(self.flaps_conf as u8 + 1);
+        //         }
+        //     },
+        //     "y->x" => {
+        //         if self.flaps_conf == FlapsConf::Conf1 || self.flaps_conf == FlapsConf::Conf1F {
+        //             self.flaps_conf = FlapsConf::Conf0;
+        //         } else {
+        //             self.flaps_conf = FlapsConf::from(self.flaps_conf as u8 - 1);
+        //         }
+        //     }
+        //     _ => {},
+        // }
 
         //Update target angle based on handle position
         self.set_target_flaps_angle(Self::target_flaps_angle_from_state(self.flaps_conf));
@@ -259,23 +310,27 @@ impl SlatFlapComplex {
     pub fn update(
         &mut self,
         context: &UpdateContext) {
+            // for n in 0..2 {
+            //     if self.old_flaps_handle_position as u8 == self.flaps_handle.handle_position as u8 {
+            //         self.sfcc[n].update(context,"x->x");
+            //     } else {
+            //         if self.old_flaps_handle_position as u8 == 0 {
+            //             self.sfcc[n].update(context,"0->1");
+            //         } else if self.old_flaps_handle_position as u8 == 2
+            //                     && self.flaps_handle.handle_position as u8 == 1 {
+            //             self.sfcc[n].update(context,"2->1");
+            //         } else {
+            //             if self.old_flaps_handle_position < self.flaps_handle.handle_position {
+            //                 self.sfcc[n].update(context,"x->y");
+            //             } else {
+            //                 self.sfcc[n].update(context,"y->x");
+            //             }
+            //         }
+            //     }
+            // }
             for n in 0..2 {
-                if self.old_flaps_handle_position as u8 == self.flaps_handle.handle_position as u8 {
-                    self.sfcc[n].update(context,"x->x");
-                } else {
-                    if self.old_flaps_handle_position as u8 == 0 {
-                        self.sfcc[n].update(context,"0->1");
-                    } else if self.old_flaps_handle_position as u8 == 2
-                                && self.flaps_handle.handle_position as u8 == 1 {
-                        self.sfcc[n].update(context,"2->1");
-                    } else {
-                        if self.old_flaps_handle_position < self.flaps_handle.handle_position {
-                            self.sfcc[n].update(context,"x->y");
-                        } else {
-                            self.sfcc[n].update(context,"y->x");
-                        }
-                    }
-                }
+                self.sfcc[n].update(context, 
+                    (self.old_flaps_handle_position as u8 ,self.flaps_handle.handle_position as u8));
             }
             self.old_flaps_handle_position = self.flaps_handle.handle_position;
 
@@ -283,6 +338,14 @@ impl SlatFlapComplex {
                 self.flaps_conf_handle_index_helper = self.sfcc[0].get_flaps_conf_f64();
             }
         }
+    
+    fn get_handle_position(&self) -> f64 {
+        self.flaps_handle.handle_position
+    }
+
+    fn get_old_handle_position(&self) -> f64 {
+        self.old_flaps_handle_position
+    }
 }
 
 impl SimulationElement for SlatFlapComplex {
@@ -332,5 +395,580 @@ impl SimulationElement for SlatFlapComplex {
             Self::SLATS_PERCENT_TO_DEGREE*left_slats_angle_percent/100.);
         self.sfcc[1].set_slats_angle_from_f64(
             Self::SLATS_PERCENT_TO_DEGREE*right_slats_angle_percent/100.);
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use systems::simulation::test::TestBed;
+    use systems::simulation::{test::SimulationTestBed, Aircraft};
+
+    struct A320FlapsTestAircraft {
+        slat_flap_complex: SlatFlapComplex,
+    }
+
+    impl A320FlapsTestAircraft {
+        fn new() -> Self {
+            Self { slat_flap_complex: SlatFlapComplex::new(), }
+        }
+    }
+
+    impl Aircraft for A320FlapsTestAircraft {
+        fn update_after_power_distribution(&mut self, context: &UpdateContext) {
+            self.slat_flap_complex.update(context);
+        }
+    }
+
+    impl SimulationElement for A320FlapsTestAircraft {
+        fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
+            self.slat_flap_complex.accept(visitor);
+            visitor.visit(self);
+        }
+    }
+
+    struct A320FlapsTestBed {
+        test_bed: SimulationTestBed<A320FlapsTestAircraft>,
+    }
+
+    impl A320FlapsTestBed {
+        const HYD_TIME_STEP_MILI: u64 = 100;
+        fn new() -> Self {
+            Self {test_bed: SimulationTestBed::new(|a| {A320FlapsTestAircraft::new()}),}
+        }
+
+        fn run_one_tick(mut self) -> Self {
+            self.test_bed.run_with_delta(Duration::from_millis(Self::HYD_TIME_STEP_MILI));
+            self
+        }
+
+        fn run_waiting_for(mut self, delta: Duration) -> Self {
+            self.test_bed.run_multiple_frames(delta);
+            self
+        }
+
+        fn set_flaps_handle_position(mut self, pos: u8) -> Self {
+            self.write("FLAPS_HANDLE_INDEX", pos as f64);
+            self
+        }
+
+        fn read_flaps_handle_position(&mut self) -> f64 {
+            self.read("FLAPS_HANDLE_INDEX")
+        }
+
+        
+
+        fn set_air_speed(mut self, air_speed: f64) -> Self {
+            self.write("AIRSPEED INDICATED", air_speed);
+            self
+        }
+
+        fn get_flaps_target_angle(&self) -> f64 {
+            self.query(|a| a.slat_flap_complex.sfcc[0].get_target_flaps_angle_f64())
+        }
+
+        fn get_slats_target_angle(&self) -> f64 {
+            self.query(|a| a.slat_flap_complex.sfcc[0].get_target_slats_angle_f64())
+        }
+
+        fn get_flaps_current_angle(&self) -> f64 {
+            self.query(|a| a.slat_flap_complex.sfcc[0].get_flaps_angle_f64())
+        }
+
+        fn get_handle_position(&self) -> f64 {
+            self.query(|a| a.slat_flap_complex.get_handle_position())
+        }
+        fn get_old_handle_position(&self) -> f64 {
+            self.query(|a| a.slat_flap_complex.get_old_handle_position())
+        }
+
+        fn get_flaps_conf(&self) -> FlapsConf {
+            self.query(|a| a.slat_flap_complex.sfcc[0].get_flaps_conf_enum())
+        }
+    }
+    impl TestBed for A320FlapsTestBed {
+        type Aircraft = A320FlapsTestAircraft;
+
+        fn test_bed(&self) -> &SimulationTestBed<A320FlapsTestAircraft> {
+            &self.test_bed
+        }
+
+        fn test_bed_mut(&mut self) -> &mut SimulationTestBed<A320FlapsTestAircraft> {
+            &mut self.test_bed
+        }
+    }
+
+    fn test_bed() -> A320FlapsTestBed {
+        A320FlapsTestBed::new()
+    }
+
+    fn test_bed_with() -> A320FlapsTestBed {
+        test_bed()
+    }
+
+
+    // Tests flaps configuration and angles for regular 
+    // increasing handle transitions, i.e 0->1->2->3->4 in sequence
+    // below 100 knots
+    #[test]
+    fn flaps_test_regular_handle_increase_transitions_flaps_target_airspeed_below_100() {
+        let angle_delta: f64 = 0.1;
+        let mut test_bed = test_bed_with().set_air_speed(50.).run_one_tick();
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 0);
+        assert!(test_bed.get_flaps_target_angle() == 0.);
+        assert!(test_bed.get_slats_target_angle() == 0.);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf0);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_waiting_for(Duration::from_millis(500));
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 1);
+        assert!((test_bed.get_flaps_target_angle() - 10.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 18.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1F);
+
+        test_bed = test_bed.set_flaps_handle_position(2).run_waiting_for(Duration::from_millis(500));
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 2);
+        assert!((test_bed.get_flaps_target_angle() - 15.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 22.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf2);
+
+        test_bed = test_bed.set_flaps_handle_position(3).run_waiting_for(Duration::from_millis(500));
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 3);
+        assert!((test_bed.get_flaps_target_angle() - 20.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 22.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+        test_bed = test_bed.set_flaps_handle_position(4).run_waiting_for(Duration::from_millis(500));
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 4);
+        assert!((test_bed.get_flaps_target_angle() - 40.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 27.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+    }
+    
+    // Tests flaps configuration and angles for regular 
+    // increasing handle transitions, i.e 0->1->2->3->4 in sequence
+    // above 100 knots
+    #[test]
+    fn flaps_test_regular_handle_increase_transitions_flaps_target_airspeed_above_100() {
+        let angle_delta: f64 = 0.1;
+        let mut test_bed = test_bed_with().set_air_speed(150.).run_one_tick();
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 0);
+        assert!(test_bed.get_flaps_target_angle() == 0.);
+        assert!(test_bed.get_slats_target_angle() == 0.);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf0);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_waiting_for(Duration::from_millis(500));
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 1);
+        assert!(test_bed.get_flaps_target_angle() == 0.);
+        assert!((test_bed.get_slats_target_angle() - 18.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1);
+
+        test_bed = test_bed.set_flaps_handle_position(2).run_waiting_for(Duration::from_millis(500));
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 2);
+        assert!((test_bed.get_flaps_target_angle() - 15.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 22.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf2);
+
+        test_bed = test_bed.set_flaps_handle_position(3).run_waiting_for(Duration::from_millis(500));
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 3);
+        assert!((test_bed.get_flaps_target_angle() - 20.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 22.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+        test_bed = test_bed.set_flaps_handle_position(4).run_waiting_for(Duration::from_millis(500));
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 4);
+        assert!((test_bed.get_flaps_target_angle() - 40.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 27.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+    }
+
+    //Tests regular transition 2->1 below and above 210 knots
+    #[test]
+    fn flaps_test_regular_handle_transition_pos_2_to_1() {
+        let mut test_bed = test_bed_with().set_air_speed(150.)
+            .set_flaps_handle_position(2)
+            .run_one_tick();
+        
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf2);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
+        
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1F);
+
+        test_bed = test_bed.set_air_speed(220.).set_flaps_handle_position(2)
+            .run_one_tick();
+        
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf2);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1);
+    }
+
+    //Tests transition between Conf1F to Conf1 above 210 knots
+    #[test]
+    fn flaps_test_regular_handle_transition_pos_1_to_1() {
+        let mut test_bed = test_bed_with().set_air_speed(50.)
+            .set_flaps_handle_position(1)
+            .run_one_tick();
+        
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1F);
+
+        test_bed = test_bed.set_air_speed(150.);
+        
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1F);
+
+        test_bed = test_bed.set_air_speed(220.).run_one_tick();
+        
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1);
+    }
+
+    // Tests flaps configuration and angles for regular 
+    // decreasing handle transitions, i.e 0->1->2->3->4 in sequence
+    // below 210 knots
+    #[test]
+    fn flaps_test_regular_decrease_handle_transition_flaps_target_airspeed_below_210() {
+        let angle_delta: f64 = 0.1;
+        let mut test_bed = test_bed_with().set_air_speed(150.).run_one_tick();
+
+        test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 4);
+        assert!((test_bed.get_flaps_target_angle() - 40.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 27.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+        test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 3);
+        assert!((test_bed.get_flaps_target_angle() - 20.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 22.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+        test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 2);
+        assert!((test_bed.get_flaps_target_angle() - 15.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 22.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf2);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 1);
+        assert!((test_bed.get_flaps_target_angle() - 10.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 18.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1F);
+
+        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 0);
+        assert!((test_bed.get_flaps_target_angle() - 0.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 0.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf0);
+    }
+    
+    // Tests flaps configuration and angles for regular 
+    // decreasing handle transitions, i.e 0->1->2->3->4 in sequence
+    // above 210 knots
+    #[test]
+    fn flaps_test_regular_decrease_handle_transition_flaps_target_airspeed_above_210() {
+        let angle_delta: f64 = 0.1;
+        let mut test_bed = test_bed_with().set_air_speed(220.).run_one_tick();
+
+        test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 4);
+        assert!((test_bed.get_flaps_target_angle() - 40.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 27.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+        test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 3);
+        assert!((test_bed.get_flaps_target_angle() - 20.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 22.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+        test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 2);
+        assert!((test_bed.get_flaps_target_angle() - 15.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 22.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf2);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 1);
+        assert!((test_bed.get_flaps_target_angle() - 0.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 18.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1);
+
+        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
+
+        assert!(test_bed.read_flaps_handle_position() as u8 == 0);
+        assert!((test_bed.get_flaps_target_angle() - 0.).abs() < angle_delta);
+        assert!((test_bed.get_slats_target_angle() - 0.).abs() < angle_delta);
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf0);
+    }
+
+
+    //All the tests that follow test irregular transitions
+    //i.e. direct from 0 to 3 or direct from 4 to 0.
+    //This is possible in the simulator, but obviously
+    //not possible in real life. An irregular transition from x = 2,3,4
+    // to y = 0,1 should behave like a sequential transition.
+    #[test]
+    fn flaps_test_irregular_handle_transition_init_pos_0() {
+        let mut test_bed = test_bed_with().set_air_speed(0.)
+            .set_flaps_handle_position(0)
+            .run_one_tick();
+
+        test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf2);
+
+        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf0);
+
+        test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf0);
+
+        test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+        test_bed = test_bed.set_air_speed(110.)
+            .set_flaps_handle_position(0)
+            .run_one_tick();
+
+        test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf2);
+
+        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf0);
+
+        test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf0);
+
+        test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+        test_bed = test_bed.set_air_speed(220.)
+            .set_flaps_handle_position(0)
+            .run_one_tick();
+
+        test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf2);
+
+        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf0);
+
+        test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf0);
+
+        test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+        
+    }
+
+    #[test]
+    fn flaps_test_irregular_handle_transition_init_pos_1() {
+        let mut test_bed = test_bed_with().set_air_speed(0.)
+            .set_flaps_handle_position(1)
+            .run_one_tick();
+
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1F);
+
+        test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1F);
+
+        test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+        test_bed = test_bed_with().set_air_speed(110.)
+            .set_flaps_handle_position(1)
+            .run_one_tick();
+
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1);
+
+        test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1F);
+
+        test_bed = test_bed_with().set_air_speed(110.)
+            .set_flaps_handle_position(1)
+            .run_one_tick();
+
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1);
+        test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1F);
+
+        test_bed = test_bed_with().set_air_speed(220.)
+            .set_flaps_handle_position(1)
+            .run_one_tick();
+
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1);
+
+        test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1);
+
+        test_bed = test_bed_with().set_air_speed(220.)
+            .set_flaps_handle_position(1)
+            .run_one_tick();
+
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1);
+
+        test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1);
+
+    }
+
+    #[test]
+    fn flaps_test_irregular_handle_transition_init_pos_2() {
+        let mut test_bed = test_bed_with().set_air_speed(0.)
+            .set_flaps_handle_position(2)
+            .run_one_tick();
+
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf2);
+
+        test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+        test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf2);
+
+        test_bed = test_bed_with().set_air_speed(0.)
+            .set_flaps_handle_position(2)
+            .run_one_tick();
+
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf2);
+
+        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf0);
+
+        test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf2);
+        
+    }
+
+    #[test]
+    fn flaps_test_irregular_handle_transition_init_pos_3() {
+        let mut test_bed = test_bed_with().set_air_speed(150.)
+            .set_flaps_handle_position(3)
+            .run_one_tick();
+
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1F);
+
+        test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+        test_bed = test_bed_with().set_air_speed(220.)
+            .set_flaps_handle_position(3)
+            .run_one_tick();
+        
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1);
+        
+        test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+
+        test_bed = test_bed_with().set_air_speed(0.)
+            .set_flaps_handle_position(3)
+            .run_one_tick();
+
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+
+        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf0);
+
+        test_bed = test_bed.set_flaps_handle_position(3).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf3);
+        
+    }
+
+    #[test]
+    fn flaps_test_irregular_handle_transition_init_pos_4() {
+        let mut test_bed = test_bed_with().set_air_speed(150.)
+            .set_flaps_handle_position(4)
+            .run_one_tick();
+
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1F);
+
+        test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+        test_bed = test_bed_with().set_air_speed(220.)
+            .set_flaps_handle_position(4)
+            .run_one_tick();
+        
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+        test_bed = test_bed.set_flaps_handle_position(1).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf1);
+        
+        test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+
+        test_bed = test_bed_with().set_air_speed(0.)
+            .set_flaps_handle_position(4)
+            .run_one_tick();
+
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+        test_bed = test_bed.set_flaps_handle_position(0).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf0);
+
+        test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+
+        test_bed = test_bed.set_flaps_handle_position(2).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::Conf2);
+
+        test_bed = test_bed.set_flaps_handle_position(4).run_one_tick();
+        assert!(test_bed.get_flaps_conf() == FlapsConf::ConfFull);
+        
     }
 }

--- a/src/systems/a320_systems/src/flaps_computer.rs
+++ b/src/systems/a320_systems/src/flaps_computer.rs
@@ -60,9 +60,9 @@ struct SlatFlapControlComputer {
 impl SlatFlapControlComputer {
 
     //Place holder until implementing Davy's model
-    const FLAPS_SPEED: f64 = 1.;
-    const SLATS_SPEED: f64 = 1.5;
-    const ANGLE_DELTA: f64 = 0.01;
+    const FLAPS_SPEED: f64 = 10.;
+    const SLATS_SPEED: f64 = 10.5;
+    const ANGLE_DELTA: f64 = 0.1;
 
     fn new() -> Self {
         Self {
@@ -200,6 +200,8 @@ impl SlatFlapControlComputer {
             if self.flaps_angle < Angle::new::<degree>(0.) {
                 self.flaps_angle = Angle::new::<degree>(0.);
             }
+        } else {
+            self.flaps_angle = self.flaps_target_angle;
         }
         if slats_actual_minus_target.abs() > Self::ANGLE_DELTA {
             self.slats_angle += Angle::new::<degree>(
@@ -207,6 +209,8 @@ impl SlatFlapControlComputer {
             if self.slats_angle < Angle::new::<degree>(0.) {
                 self.slats_angle = Angle::new::<degree>(0.);
             }
+        } else {
+            self.slats_angle = self.slats_target_angle;
         }
     }
 }
@@ -281,9 +285,6 @@ impl SimulationElement for SlatFlapComplex {
     }
 
     fn write(&self, writer: &mut SimulatorWriter) {
-        writer.write("LEFT_FLAPS_POSITION_PERCENT_DUMMY", self.sfcc[0].get_flaps_angle_f64()*Self::FLAPS_DEGREE_TO_PERCENT * 100.);
-        writer.write("DUMMY_HANDLE_POSITION", self.flaps_handle.handle_position);
-
         writer.write("LEFT_FLAPS_POSITION_PERCENT", self.sfcc[0].get_flaps_angle_f64()*Self::FLAPS_DEGREE_TO_PERCENT * 100.);
         writer.write("RIGHT_FLAPS_POSITION_PERCENT", self.sfcc[1].get_flaps_angle_f64()*Self::FLAPS_DEGREE_TO_PERCENT * 100.);
         writer.write("LEFT_FLAPS_TARGET_ANGLE", self.sfcc[0].get_target_flaps_angle_f64());
@@ -307,7 +308,6 @@ impl SimulationElement for SlatFlapComplex {
         let left_slats_angle_percent: f64 = reader.read("LEFT_SLATS_POSITION_PERCENT");
         let right_slats_angle_percent: f64 = reader.read("RIGHT_SLATS_POSITION_PERCENT");
 
-        // self.flaps_handle_index = reader.read("FLAPS HANDLE INDEX");
 
         self.sfcc[0].set_flaps_angle_from_f64(
             Self::FLAPS_PERCENT_TO_DEGREE*left_flaps_angle_percent/100.);

--- a/src/systems/a320_systems/src/flaps_computer.rs
+++ b/src/systems/a320_systems/src/flaps_computer.rs
@@ -1,0 +1,323 @@
+use systems::{simulation::{
+    Read, Reader, SimulationElement, SimulationElementVisitor, SimulatorReader,
+    SimulatorWriter, UpdateContext, Write,
+}};
+use std::string::String;
+use std::time::Duration;
+use uom::si::{
+    f64::*,
+    angle::degree,
+};
+
+
+#[derive(Debug,Copy,Clone,PartialEq)]
+enum FlapsState {
+    State0 = 0,
+    State1 = 1,
+    State1F = 2,
+    State2 = 3,
+    State3 = 4,
+    StateFull = 5,
+}
+
+impl From<u8> for FlapsState {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => FlapsState::State0,
+            1 => FlapsState::State1,
+            2 => FlapsState::State1F,
+            3 => FlapsState::State2,
+            4 => FlapsState::State3,
+            _ => FlapsState::StateFull,
+
+        }
+    }
+}
+
+struct FlapsHandle {
+    handle_position: f64,
+}
+
+impl SimulationElement for FlapsHandle {
+    fn read(&mut self, reader: &mut SimulatorReader) {
+        self.handle_position = reader.read("FLAPS_HANDLE_INDEX"); 
+    }
+}
+
+struct SlatFlapControlComputer {
+    flaps_angle: Angle,
+    slats_angle: Angle,
+
+    flaps_target_angle: Angle,
+    slats_target_angle: Angle,
+
+    flaps_state: FlapsState,
+    air_speed: f64,
+
+
+}
+
+impl SlatFlapControlComputer {
+
+    //Place holder until implementing Davy's model
+    const FLAPS_SPEED: f64 = 1.;
+    const SLATS_SPEED: f64 = 1.5;
+    const ANGLE_DELTA: f64 = 0.01;
+
+    fn new() -> Self {
+        Self {
+            flaps_angle: Angle::new::<degree>(0.),
+            slats_angle: Angle::new::<degree>(0.),
+            flaps_target_angle: Angle::new::<degree>(0.),
+            slats_target_angle: Angle::new::<degree>(0.),
+            flaps_state: FlapsState::State0,
+            air_speed: 0.,
+        }
+    }
+
+    fn set_flaps_angle_from_f64(&mut self, angle: f64) {
+        self.flaps_angle = Angle::new::<degree>(angle);
+    }
+
+    fn set_slats_angle_from_f64(&mut self, angle: f64) {
+        self.slats_angle = Angle::new::<degree>(angle);
+    }
+
+    fn set_target_flaps_angle(&mut self, angle: Angle) {
+        self.flaps_target_angle = angle;
+    }
+
+    fn set_target_slats_angle(&mut self, angle: Angle) {
+        self.slats_target_angle = angle;
+    }
+
+    fn set_target_flaps_angle_from_f64(&mut self, angle: f64) {
+        self.flaps_target_angle = Angle::new::<degree>(angle);
+    }
+
+    fn set_target_slats_angle_from_f64(&mut self, angle: f64) {
+        self.slats_target_angle = Angle::new::<degree>(angle);
+    }
+
+    fn get_target_flaps_angle_f64(&self) -> f64 {
+        self.flaps_target_angle.get::<degree>()
+    }
+    fn get_target_slats_angle_f64(&self) -> f64 {
+        self.slats_target_angle.get::<degree>()
+    }
+
+
+    fn get_flaps_angle_f64(&self) -> f64 {
+        self.flaps_angle.get::<degree>()
+    }
+    
+    fn get_slats_angle_f64(&self) -> f64 {
+        self.slats_angle.get::<degree>()
+    }
+
+    fn target_flaps_angle_from_state(flap_state: FlapsState) -> Angle {
+        match flap_state {
+            FlapsState::State0 => Angle::new::<degree>(0.),
+            FlapsState::State1 => Angle::new::<degree>(0.),
+            FlapsState::State1F => Angle::new::<degree>(10.),
+            FlapsState::State2 => Angle::new::<degree>(15.),
+            FlapsState::State3 => Angle::new::<degree>(20.),
+            FlapsState::StateFull => Angle::new::<degree>(40.),
+        }
+    }
+
+    fn target_slats_angle_from_state(flap_state: FlapsState) -> Angle {
+        match flap_state {
+            FlapsState::State0 => Angle::new::<degree>(0.),
+            FlapsState::State1 => Angle::new::<degree>(18.),
+            FlapsState::State1F => Angle::new::<degree>(18.),
+            FlapsState::State2 => Angle::new::<degree>(22.),
+            FlapsState::State3 => Angle::new::<degree>(22.),
+            FlapsState::StateFull => Angle::new::<degree>(27.),
+        }
+    }
+
+    pub fn update(
+        &mut self,
+        context: &UpdateContext,
+        transition: &str,
+    ) {
+
+        match transition {
+            "0->1" => {
+                if self.air_speed <= 100. {
+                    self.flaps_state = FlapsState::State1F;
+                } else {
+                    self.flaps_state = FlapsState::State1;
+                }
+            },
+            "2->1" => {
+                if self.air_speed <= 210. {
+                    self.flaps_state = FlapsState::State1F;
+                } else {
+                    self.flaps_state = FlapsState::State1;
+                }
+            },
+            "x->x" => {
+                if self.flaps_state == FlapsState::State1F 
+                    && self.air_speed > 210. {
+                        self.flaps_state = FlapsState::State1;
+                }
+            },
+            "x->y" => {
+                if self.flaps_state == FlapsState::State1 || self.flaps_state == FlapsState::State1F {
+                    self.flaps_state = FlapsState::State2;
+                } else {
+                    self.flaps_state = FlapsState::from(self.flaps_state as u8 + 1);
+                }
+            },
+            "y->x" => {
+                if self.flaps_state == FlapsState::State1 || self.flaps_state == FlapsState::State1F {
+                    self.flaps_state = FlapsState::State0;
+                } else {
+                    self.flaps_state = FlapsState::from(self.flaps_state as u8 - 1);
+                }
+            }
+            _ => {},
+        }
+
+        //Update target angle based on handle position
+        self.set_target_flaps_angle(Self::target_flaps_angle_from_state(self.flaps_state));
+        self.set_target_slats_angle(Self::target_slats_angle_from_state(self.flaps_state));
+
+        //The handle position signals the computer a desired
+        // flaps angle.
+        let flaps_actual_minus_target: f64 = 
+            self.flaps_target_angle.get::<degree>() - self.flaps_angle.get::<degree>();
+        let slats_actual_minus_target: f64 = 
+            self.slats_target_angle.get::<degree>() - self.slats_angle.get::<degree>();
+        
+
+        //Placeholder animation
+        if flaps_actual_minus_target.abs() > Self::ANGLE_DELTA {
+            self.flaps_angle += Angle::new::<degree>(
+                    flaps_actual_minus_target.signum()*context.delta_as_secs_f64()*Self::FLAPS_SPEED);
+            if self.flaps_angle < Angle::new::<degree>(0.) {
+                self.flaps_angle = Angle::new::<degree>(0.);
+            }
+        }
+        if slats_actual_minus_target.abs() > Self::ANGLE_DELTA {
+            self.slats_angle += Angle::new::<degree>(
+                    slats_actual_minus_target.signum()*context.delta_as_secs_f64()*Self::SLATS_SPEED);
+            if self.slats_angle < Angle::new::<degree>(0.) {
+                self.slats_angle = Angle::new::<degree>(0.);
+            }
+        }
+    }
+}
+
+impl SimulationElement for SlatFlapControlComputer {
+    fn read(&mut self, reader: &mut SimulatorReader) {
+        self.air_speed = reader.read("AIRSPEED INDICATED");
+    }
+
+    fn write(&self, writer: &mut SimulatorWriter) {
+        writer.write("FLAPS_CONF_HANDLE_INDEX_HELPER", self.flaps_state as u8 as f64);
+    }
+}
+
+pub struct SlatFlapComplex {
+    sfcc: [SlatFlapControlComputer; 2],
+    flaps_handle: FlapsHandle,
+    old_flaps_handle_position: f64,
+
+    flaps_handle_index: f64,
+}
+
+impl SlatFlapComplex {
+    const FLAPS_DEGREE_TO_PERCENT: f64 = 1./40.;
+    const FLAPS_PERCENT_TO_DEGREE: f64 = 40.;
+
+    const SLATS_DEGREE_TO_PERCENT: f64 = 1./27.;
+    const SLATS_PERCENT_TO_DEGREE: f64 = 27.;
+
+    pub fn new() -> Self {
+        Self {
+            sfcc: [SlatFlapControlComputer::new(),SlatFlapControlComputer::new()],
+            flaps_handle: FlapsHandle{ handle_position: 0. },
+            old_flaps_handle_position: 0.,
+            flaps_handle_index: 0.,
+        }
+    }
+
+    pub fn update(
+        &mut self,
+        context: &UpdateContext) {
+            for n in 0..2 {
+                if self.old_flaps_handle_position as u8 == self.flaps_handle.handle_position as u8 {
+                    self.sfcc[n].update(context,"x->x");
+                } else {
+                    if self.old_flaps_handle_position as u8 == 0 {
+                        self.sfcc[n].update(context,"0->1");
+                    } else if self.old_flaps_handle_position as u8 == 2
+                                && self.flaps_handle.handle_position as u8 == 1 {
+                        self.sfcc[n].update(context,"2->1");
+                    } else {
+                        if self.old_flaps_handle_position < self.flaps_handle.handle_position {
+                            self.sfcc[n].update(context,"x->y");
+                        } else {
+                            self.sfcc[n].update(context,"y->x");
+                        }
+                    }
+                }
+            }
+            self.old_flaps_handle_position = self.flaps_handle.handle_position;
+        }
+}
+
+impl SimulationElement for SlatFlapComplex {
+    fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) where Self: Sized, {
+        self.flaps_handle.accept(visitor);
+        for n in 0..2 {
+            self.sfcc[n].accept(visitor);
+        }
+
+        visitor.visit(self);
+    }
+
+    fn write(&self, writer: &mut SimulatorWriter) {
+        writer.write("LEFT_FLAPS_POSITION_PERCENT_DUMMY", self.sfcc[0].get_flaps_angle_f64()*Self::FLAPS_DEGREE_TO_PERCENT * 100.);
+        writer.write("DUMMY_HANDLE_POSITION", self.flaps_handle.handle_position);
+
+        writer.write("LEFT_FLAPS_POSITION_PERCENT", self.sfcc[0].get_flaps_angle_f64()*Self::FLAPS_DEGREE_TO_PERCENT * 100.);
+        writer.write("RIGHT_FLAPS_POSITION_PERCENT", self.sfcc[1].get_flaps_angle_f64()*Self::FLAPS_DEGREE_TO_PERCENT * 100.);
+        writer.write("LEFT_FLAPS_TARGET_ANGLE", self.sfcc[0].get_target_flaps_angle_f64());
+        writer.write("RIGHT_FLAPS_TARGET_ANGLE", self.sfcc[0].get_target_flaps_angle_f64());
+        writer.write("LEFT_FLAPS_ANGLE", self.sfcc[0].get_flaps_angle_f64());
+        writer.write("RIGHT_FLAPS_ANGLE", self.sfcc[1].get_flaps_angle_f64());
+
+        writer.write("LEFT_SLATS_POSITION_PERCENT", self.sfcc[0].get_slats_angle_f64()*Self::SLATS_DEGREE_TO_PERCENT * 100.);
+        writer.write("RIGHT_SLATS_POSITION_PERCENT", self.sfcc[1].get_slats_angle_f64()*Self::SLATS_DEGREE_TO_PERCENT * 100.);
+        writer.write("LEFT_SLATS_TARGET_ANGLE", self.sfcc[0].get_target_slats_angle_f64());
+        writer.write("RIGHT_SLATS_TARGET_ANGLE", self.sfcc[0].get_target_slats_angle_f64());
+        writer.write("LEFT_SLATS_ANGLE", self.sfcc[0].get_slats_angle_f64());
+        writer.write("RIGHT_SLATS_ANGLE", self.sfcc[1].get_slats_angle_f64());
+        
+
+    }
+
+    fn read(&mut self, reader: &mut SimulatorReader) {
+        let left_flaps_angle_percent: f64 = reader.read("LEFT_FLAPS_POSITION_PERCENT");
+        let right_flaps_angle_percent: f64 = reader.read("RIGHT_FLAPS_POSITION_PERCENT");
+        let left_slats_angle_percent: f64 = reader.read("LEFT_SLATS_POSITION_PERCENT");
+        let right_slats_angle_percent: f64 = reader.read("RIGHT_SLATS_POSITION_PERCENT");
+
+        // self.flaps_handle_index = reader.read("FLAPS HANDLE INDEX");
+
+        self.sfcc[0].set_flaps_angle_from_f64(
+            Self::FLAPS_PERCENT_TO_DEGREE*left_flaps_angle_percent/100.);
+        self.sfcc[1].set_flaps_angle_from_f64(
+            Self::FLAPS_PERCENT_TO_DEGREE*right_flaps_angle_percent/100.);
+
+
+        self.sfcc[0].set_slats_angle_from_f64(
+            Self::SLATS_PERCENT_TO_DEGREE*left_slats_angle_percent/100.);
+        self.sfcc[1].set_slats_angle_from_f64(
+            Self::SLATS_PERCENT_TO_DEGREE*right_slats_angle_percent/100.);
+    }
+}

--- a/src/systems/a320_systems/src/hydraulic.rs
+++ b/src/systems/a320_systems/src/hydraulic.rs
@@ -1473,8 +1473,8 @@ impl SimulationElement for A320BrakingForce {
     }
 
     fn read(&mut self, state: &mut SimulatorReader) {
-        let left_flap: f64 = state.read("TRAILING EDGE FLAPS LEFT PERCENT");
-        let right_flap: f64 = state.read("TRAILING EDGE FLAPS RIGHT PERCENT");
+        let left_flap: f64 = state.read("LEFT_FLAPS_POSITION_PERCENT");
+        let right_flap: f64 = state.read("RIGHT_FLAPS_POSITION_PERCENT");
         self.flap_position = (left_flap + right_flap) / 2.;
     }
 }

--- a/src/systems/a320_systems/src/lib.rs
+++ b/src/systems/a320_systems/src/lib.rs
@@ -5,6 +5,7 @@ mod fuel;
 mod hydraulic;
 mod pneumatic;
 mod power_consumption;
+mod flaps_computer;
 
 use self::{fuel::A320Fuel, pneumatic::A320PneumaticOverheadPanel};
 use electrical::{
@@ -12,6 +13,7 @@ use electrical::{
     APU_START_MOTOR_BUS_TYPE,
 };
 use hydraulic::{A320Hydraulic, A320HydraulicOverheadPanel};
+use flaps_computer::SlatFlapComplex;
 use power_consumption::A320PowerConsumption;
 use systems::{
     apu::{
@@ -53,6 +55,7 @@ pub struct A320 {
     autobrake_panel: AutobrakePanel,
     landing_gear: LandingGear,
     pressurization: Pressurization,
+    slat_flaps: SlatFlapComplex,
 }
 impl A320 {
     pub fn new(electricity: &mut Electricity) -> A320 {
@@ -85,6 +88,7 @@ impl A320 {
             autobrake_panel: AutobrakePanel::new(),
             landing_gear: LandingGear::new(),
             pressurization: Pressurization::new(),
+            slat_flaps: SlatFlapComplex::new(),
         }
     }
 }
@@ -162,6 +166,7 @@ impl Aircraft for A320 {
         self.adirs_overhead.update(context, &self.adirs);
 
         self.power_consumption.update(context);
+        self.slat_flaps.update(context);
     }
 }
 impl SimulationElement for A320 {
@@ -188,6 +193,7 @@ impl SimulationElement for A320 {
         self.hydraulic_overhead.accept(visitor);
         self.landing_gear.accept(visitor);
         self.pressurization.accept(visitor);
+        self.slat_flaps.accept(visitor);
 
         visitor.visit(self);
     }

--- a/src/systems/a320_systems_wasm/src/lib.rs
+++ b/src/systems/a320_systems_wasm/src/lib.rs
@@ -188,11 +188,9 @@ struct Flaps {
     //IDs of the flaps handle events
     id_flaps_incr: sys::DWORD,
     id_flaps_decr: sys::DWORD,
-    id_flaps_0: sys::DWORD,
     id_flaps_1: sys::DWORD,
     id_flaps_2: sys::DWORD,
     id_flaps_3: sys::DWORD,
-    id_flaps_4: sys::DWORD,
     id_flaps_set: sys::DWORD,
     id_axis_flaps_set: sys::DWORD,
     id_flaps_down: sys::DWORD,
@@ -228,11 +226,9 @@ impl Flaps {
             Self {
                 id_flaps_incr: sim_connect.map_client_event_to_sim_event("FLAPS_INCR", true)?,
                 id_flaps_decr: sim_connect.map_client_event_to_sim_event("FLAPS_DECR", true)?,
-                id_flaps_0: sim_connect.map_client_event_to_sim_event("FLAPS_0", true)?,
                 id_flaps_1: sim_connect.map_client_event_to_sim_event("FLAPS_1", true)?,
                 id_flaps_2: sim_connect.map_client_event_to_sim_event("FLAPS_2", true)?,
                 id_flaps_3: sim_connect.map_client_event_to_sim_event("FLAPS_3", true)?,
-                id_flaps_4: sim_connect.map_client_event_to_sim_event("FLAPS_4", true)?,
                 id_flaps_set: sim_connect.map_client_event_to_sim_event("FLAPS_SET", true)?,
                 id_axis_flaps_set: sim_connect.map_client_event_to_sim_event("AXIS_FLAPS_SET", true)?,
                 id_flaps_down: sim_connect.map_client_event_to_sim_event("FLAPS_DOWN", true)?,
@@ -323,12 +319,6 @@ impl Flaps {
             self.flaps_handle_index_simvar.set_value(self.flaps_handle_position_f64());
             self.flaps_handle_percent_simvar.set_value(self.flaps_handle_position_f64() / 4.);
             true
-
-        } else if event_id == self.id_flaps_0 {
-            self.flaps_handle_position = 0;
-            self.flaps_handle_index_simvar.set_value(self.flaps_handle_position_f64());
-            self.flaps_handle_percent_simvar.set_value(self.flaps_handle_position_f64() / 4.);
-            true
         } else if event_id == self.id_flaps_1 {
             self.flaps_handle_position = 1;
             self.flaps_handle_index_simvar.set_value(self.flaps_handle_position_f64());
@@ -341,11 +331,6 @@ impl Flaps {
             true
         } else if event_id == self.id_flaps_3 {
             self.flaps_handle_position = 3;
-            self.flaps_handle_index_simvar.set_value(self.flaps_handle_position_f64());
-            self.flaps_handle_percent_simvar.set_value(self.flaps_handle_position_f64() / 4.);
-            true
-        } else if event_id == self.id_flaps_4 {
-            self.flaps_handle_position = 4;
             self.flaps_handle_index_simvar.set_value(self.flaps_handle_position_f64());
             self.flaps_handle_percent_simvar.set_value(self.flaps_handle_position_f64() / 4.);
             true

--- a/src/systems/a320_systems_wasm/src/lib.rs
+++ b/src/systems/a320_systems_wasm/src/lib.rs
@@ -345,12 +345,12 @@ impl Flaps {
             self.flaps_handle_percent_simvar.set_value(self.flaps_handle_position_f64() / 4.);
             true
         } else if event_id == self.id_flaps_down {
-            self.flaps_handle_position = 0;
+            self.flaps_handle_position = 4;
             self.flaps_handle_index_simvar.set_value(self.flaps_handle_position_f64());
             self.flaps_handle_percent_simvar.set_value(self.flaps_handle_position_f64() / 4.);
             true
         } else if event_id == self.id_flaps_up {
-            self.flaps_handle_position = 4;
+            self.flaps_handle_position = 0;
             self.flaps_handle_index_simvar.set_value(self.flaps_handle_position_f64());
             self.flaps_handle_percent_simvar.set_value(self.flaps_handle_position_f64() / 4.);
             true

--- a/src/systems/a320_systems_wasm/src/lib.rs
+++ b/src/systems/a320_systems_wasm/src/lib.rs
@@ -120,8 +120,6 @@ fn create_aircraft_variable_reader(
     );
     reader.add("PLANE LATITUDE", "degree latitude", 0)?;
     reader.add("PLANE LONGITUDE", "degree longitude", 0)?;
-    reader.add("TRAILING EDGE FLAPS LEFT PERCENT", "Percent", 0)?;
-    reader.add("TRAILING EDGE FLAPS RIGHT PERCENT", "Percent", 0)?;
 
     // reader.add("FLAPS HANDLE INDEX", "Number", 0)?;
     Ok(reader)
@@ -185,12 +183,12 @@ struct SlatsSurface {
     right_slat: f64,
 }
 
-#[sim_connect::data_definition]
-struct FlapsHandleIndex{
-    #[name = "FLAPS HANDLE INDEX"]
-    #[unit = "Number"]
-    flaps_handle_index: f64,
-}
+// #[sim_connect::data_definition]
+// struct FlapsHandleIndex{
+//     #[name = "FLAPS HANDLE INDEX"]
+//     #[unit = "Number"]
+//     flaps_handle_index: f64,
+// }
 
 struct Flaps {
     //IDs of the flaps handle events
@@ -210,10 +208,11 @@ struct Flaps {
     right_flaps_position_simvar: NamedVariable,
     left_slats_position_simvar: NamedVariable,
     right_slats_position_simvar: NamedVariable,
+    // flaps_conf_handle_index_simvar: NamedVariable,
 
     flaps_surface_simobject: FlapsSurface,
     slats_surface_simobject: SlatsSurface,
-    flaps_handle_index_simobject: FlapsHandleIndex,
+    // flaps_handle_index_simobject: FlapsHandleIndex,
 
     flaps_handle_position: u8,
     left_flaps_position: f64,
@@ -244,6 +243,7 @@ impl Flaps {
                 right_flaps_position_simvar: NamedVariable::from("A32NX_RIGHT_FLAPS_POSITION_PERCENT"),
                 left_slats_position_simvar: NamedVariable::from("A32NX_LEFT_SLATS_POSITION_PERCENT"),
                 right_slats_position_simvar: NamedVariable::from("A32NX_RIGHT_SLATS_POSITION_PERCENT"),
+                // flaps_conf_handle_index_simvar: NamedVariable::from("A32NX_FLAPS_CONF_HANDLE_INDEX_HELPER"),
 
                 flaps_surface_simobject: FlapsSurface {
                     left_flap: 0.,
@@ -254,7 +254,7 @@ impl Flaps {
                     right_slat: 0.,
                 },
 
-                flaps_handle_index_simobject: FlapsHandleIndex { flaps_handle_index: 0.},
+                // flaps_handle_index_simobject: FlapsHandleIndex { flaps_handle_index: 0.},
 
                 flaps_handle_position: 0,
                 left_flaps_position: 0.,
@@ -333,6 +333,7 @@ impl Flaps {
         self.right_flaps_position_simvar.set_value(self.right_flaps_position);
         self.left_slats_position_simvar.set_value(self.left_slats_position);
         self.right_slats_position_simvar.set_value(self.right_slats_position);
+        // self.flaps_conf_handle_index_simvar.set_value(self.flaps_conf_helper);
     }
 }
 
@@ -366,10 +367,10 @@ impl SimulatorAspect for Flaps {
                 self.right_slats_position = value;
                 true
             },
-            "FLAPS_CONF_HANDLE_INDEX_HELPER" => {
-                self.flaps_conf_helper = value;
-                true
-            },
+            // "FLAPS_CONF_HANDLE_INDEX_HELPER" => {
+            //     self.flaps_conf_helper = value;
+            //     true
+            // },
             _ => false,
         }
     }
@@ -391,13 +392,13 @@ impl SimulatorAspect for Flaps {
         self.flaps_surface_simobject.right_flap = self.right_flaps_position;
         self.slats_surface_simobject.left_slat = self.left_slats_position;
         self.slats_surface_simobject.right_slat = self.right_slats_position;
-        self.flaps_handle_index_simobject.flaps_handle_index = self.flaps_conf_helper;
+        // self.flaps_handle_index_simobject.flaps_handle_index = self.flaps_conf_helper;
 
         self.write_simvars();
 
         sim_connect.set_data_on_sim_object(SIMCONNECT_OBJECT_ID_USER, &self.flaps_surface_simobject);
         sim_connect.set_data_on_sim_object(SIMCONNECT_OBJECT_ID_USER, &self.slats_surface_simobject);
-        sim_connect.set_data_on_sim_object(SIMCONNECT_OBJECT_ID_USER, &self.flaps_handle_index_simobject);
+        // sim_connect.set_data_on_sim_object(SIMCONNECT_OBJECT_ID_USER, &self.flaps_handle_index_simobject);
 
         Ok(())
     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
In order to more easily implement hydraulics to flaps and slats, a transition from the CPP module to Rust is needed.
This PR moved the flaps and slats logic and animation entirely to Rust.
**This does not yet implement hydraulics to flaps and slats**. The reason is that I wanted this to be tested since I have tempered with the FBW and autopilot modules. Since these are delicate systems and my CPP knowledge is limited, these change should be tested in order to see nothing has gone wrong.
For now, the animation is just linear.

There is also a fundamental change to what Simvars are relevant for the flaps configuration and angles. The CPP module controlled the flaps and slats position via the AVar `FLAPS HANDLE INDEX`. In this Rust implementation, this is completely removed, and instead `TRAILING EDGE FLAPS ...` and `LEADING EDGE FLAPS...` AVars are directly modified by the Rust module in order to move the actual flaps. This means that changes to ECAM pages and other places were made to accommodate the new Lvars.


## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): omryg#9274

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

The flaps operation should be the same. Things to test:

1. Autopilot and FBW operations - this is the most important test. Nothing should be different, and yet. Make sure that the `O,S,F` speeds during approach phase are correctly targeted according to the flaps position.
***If you encounter any unexpected `A.FLOOR` and `TOGA LK` modes, or unexpected `AP` disconnect, please indicate at what phase of flight this occurred, and what was the flap configuration***
2. ECAM indication - should be the same - when flaps are in transit it should animate in the upper ECAM, and the target configuration should be cyan while in transit and green when the flaps are in position.
3. Airspeed logic: 

     - If in Flaps 0 and transitioning to Flaps 1, ECAM should indicate `1+F` when KIAS < 100 and the flaps and slats should move to this configuration. If KIAS > 100, flaps should not expand.
     - If in Flaps 1 in configuration `1+F`, flaps should retract when KIAS > 210
     - If in Flaps 2 and moving to flaps 1, should go to `1+F` if KIAS < 210 and `1` if KIAS > 210.

4. Flaps axis operation - unfortunately I don't have an appropriate axis to test the operation of the events `AXIS_FLAPS_SET` and `FLAPS_SET`. Their logic was completely copied from the CPP module. If anyone has one of these axes, please test normal operation.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
