### PR TITLE
fix: Pounds - kilograms units conversion

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -26,6 +26,7 @@
 1. [AP] Improved ROLL OUT law - @aguther (Andreas Guther)
 1. [ENGINE] Refactor FADEC and fuel consumption code (comments, variable nomenclature and overall clean-up) - @Taz5150 (TazX [Z+2]#0405)
 1. [ARCH] Support ARINC 429 communication between aircraft components - @davidwalschots (David Walschots)
+1. [UTILS] Fix lbs to kgs units conversion to match MSFS - @donstim (donbikes#4084)
 
 ## 0.7.0
 1. [HYD] First building block, more to come. Hydraulics do not impact the sim YET. - @crocket6 (crocket)

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Utils/NXUnits.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Utils/NXUnits.js
@@ -15,11 +15,11 @@ class NXUnits {
     }
 
     static userToKg(value) {
-        return NXUnits.metricWeight ? value : value / 2.20462;
+        return NXUnits.metricWeight ? value : value / 2.204625;
     }
 
     static kgToUser(value) {
-        return NXUnits.metricWeight ? value : value * 2.20462;
+        return NXUnits.metricWeight ? value : value * 2.204625;
     }
 
     static userWeightUnit() {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Changes kilograms per pound units conversion in our utilities coding to better match what MSFS uses internally. This PR is intended to complement PR #5895 (although that PR is not necessary for this one to be merged).
## Screenshots (if necessary)
The current conversion in the NX Utilities package is 2.20462 kg/lb. This PR changes it to 2.204625 lb/kg. Although that is not the exact conversion you will find in any online converters ( 2.2046226218 kg/lb), it is what is necessary to match MSFS weights. See the following screenshots with weights in pounds and then with kilograms:

![Screenshot (1215)](https://user-images.githubusercontent.com/70166617/134587685-1fcd9a53-38be-4ab4-be2b-afcfe24a2853.png)
![Screenshot (1214)](https://user-images.githubusercontent.com/70166617/134587702-36909489-2d10-4cb9-b22b-dd94978c3938.png)

I filled each loading station and fuel tank with the max allowed by the slider in order to maximize the weights and therefore the accuracy of this check.

Here is a screenshot of a spreadsheet I used to find a conversion, starting with the weight in pounds (which is what MSFS uses as its base) and converting it to kilograms. First, I tried different conversions to match the 198856 lbs fully loaded weight in kg. Starting with the current utils conversion factor of 2.20462, you can see that this would round off to 90200 kg, whereas the MSFS weight is 90199 kg. I then tried several conversions until finding the one that matched. 

After that, I checked each loading station using that conversion (2.204625) and comparing it to the MSFS weight in kg to the same precision level as the MSFS weights are shown.) Lastly, as a final check on the original 2.20462 conversion, I compared it to the MSFS kg weight for the center and inner fuel tanks. With that conversion, the kg weights were not converted to the exact MSFS weights. (They are off by a whopping 0.01 kg! xD)

![Screenshot (1219)](https://user-images.githubusercontent.com/70166617/134589488-4a01c7c4-9e07-45cc-b4c0-4d04b74bcf53.png)

Anyway, in the interest of exact matching of MSFS weight conversions, I propose this PR.
## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): donbikes#4084

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
