### PR TITLE
build: retry uploads to Bunny CDN if required

### DIFF
--- a/scripts/cdn.sh
+++ b/scripts/cdn.sh
@@ -4,12 +4,28 @@ CDN_URL="storage.bunnycdn.com/flybywiresim-cdn"
 CDN_PURGE_LINK="https://bunnycdn.com/api/purge?url=http://flybywiresim.b-cdn.net"
 CDN_DIR=${1:-"addons/a32nx/test"}
 
-for FILE in ./build-modules/*; do
-    DEST="$CDN_URL/$CDN_DIR/$(basename -- "$FILE")"
-    echo "Syncing file: $FILE"
+MAX_RETRY=5
+
+upload () {
+    DEST="$CDN_URL/$CDN_DIR/$(basename -- "$1")"
+    echo "Syncing file: $1"
     echo "Destination: $DEST"
-    curl -X PUT -H "AccessKey: $BUNNY_BUCKET_PASSWORD" --data-binary "@$FILE" "$DEST"
+
+    # Try to upload the file up to MAX_RETRY times before failing
+    counter=0
+    until curl --fail -X PUT -H "AccessKey: $BUNNY_BUCKET_PASSWORD" --data-binary "@$1" "$DEST"
+    do
+        sleep 1
+        [[ counter -eq $MAX_RETRY ]] && echo "Failed to upload file '$1'" >&2 && exit 1
+        echo "Trying again. Try #$counter"
+        ((counter++))
+    done
     echo ""; echo ""
+}
+
+# Upload all files
+for FILE in ./build-modules/*; do
+    upload "$FILE"
 done
 
 # Purge after all uploads that the files are somewhat in sync


### PR DESCRIPTION
Fixes #[issue_no]

## Summary of Changes
The CDN script now fails after 5 retries per file and will let the GH action fail if the file can not be uploaded.

## Screenshots (if necessary)
N/A

## References
N/A

## Additional context
N/A

Discord username (if different from GitHub): nistei#1362

## Testing instructions
None. Only CI changes that will not impact the addon itself.


## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
