### PR TITLE
feat: Manual ILS Tuning by Ident, Course

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -94,6 +94,7 @@
 1. [FM] Stored waypoints - @tracernz (Mike)
 1. [ATSU] Import lat/lon waypoints correctly from SimBrief - @tracernz (Mike)
 1. [MCDU] Added manual ILS tuning by ident on RAD NAV page - @tracernz (Mike)
+1. [MCDU] Support manual entry of forward LS course - @tracernz (Mike)
 
 ## 0.7.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -93,6 +93,7 @@
 1. [ENGINE/ MODEL] Implement engine shutdown and realistic engine animation - @Taz5150 (TazX [Z+2]#0405)
 1. [FM] Stored waypoints - @tracernz (Mike)
 1. [ATSU] Import lat/lon waypoints correctly from SimBrief - @tracernz (Mike)
+1. [MCDU] Added manual ILS tuning by ident on RAD NAV page - @tracernz (Mike)
 
 ## 0.7.0
 

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -908,6 +908,14 @@
     - Bool
     - Auto brake panel push button for MAX mode is pressed
 
+- A32NX_FM_LS_COURSE
+    - Number
+    - Landing system course. Values, in priority order:
+        - Pilot entered course
+        - Database course
+        - Course received from LOC when LOC available
+        - -1 when invalid
+
 - A32NX_FMGC_FLIGHT_PHASE
     - Enum
     - Holds the FMGCs current flight phase

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -909,7 +909,7 @@
     - Auto brake panel push button for MAX mode is pressed
 
 - A32NX_FM_LS_COURSE
-    - Number
+    - Number<Degrees | -1>
     - Landing system course. Values, in priority order:
         - Pilot entered course
         - Database course

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Utils/NXSystemMessages.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Utils/NXSystemMessages.js
@@ -35,6 +35,7 @@ const NXSystemMessages = {
     awyWptMismatch:         new McduMessage("AWY/WPT MISMATCH", false, false),
     checkMinDestFob:        new McduMessage("CHECK MIN DEST FOB", false, true),
     checkToData:            new McduMessage("CHECK TAKE OFF DATA", true, true),
+    databaseCodingError:    new McduMessage("DATABASE CODING ERROR", false, true),
     destEfobBelowMin:       new McduMessage("DEST EFOB BELOW MIN", true, true),
     enterDestData:          new McduMessage("ENTER DEST DATA", true, true),
     entryOutOfRange:        new McduMessage("ENTRY OUT OF RANGE", false, false),

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Utils/NXSystemMessages.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Utils/NXSystemMessages.js
@@ -47,6 +47,7 @@ const NXSystemMessages = {
     noIntersectionFound:    new McduMessage("NO INTERSECTION FOUND", false, false),
     notAllowed:             new McduMessage("NOT ALLOWED", false, false),
     notInDatabase:          new McduMessage("NOT IN DATABASE", false, false),
+    rwyLsMismatch:          new McduMessage("RWY/LS MISMATCH", true, true),
     selectDesiredSystem:    new McduMessage("SELECT DESIRED SYSTEM", false, false),
     uplinkInsertInProg:     new McduMessage("UPLINK INSERT IN PROG", false, true),
     vToDisagree:            new McduMessage("V1/VR/V2 DISAGREE", true, true),

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -124,17 +124,25 @@ class CDUNavRadioPage {
                     const ilsIdent = mcdu.radioNav.getILSBeacon(1);
                     ilsFrequencyCell = `{small}${ilsIdent.ident.trim().padStart(4, "\xa0")}{end}/${mcdu.ilsFrequency.toFixed(2)}`;
                     ilsCourseCell = "{small}F" + ilsIdent.course.toFixed(0).padStart(3, "0") + "{end}";
+                } else if (mcdu._ilsIdentPilotEntered) {
+                    const ilsIdent = mcdu.radioNav.getILSBeacon(1);
+                    ilsFrequencyCell = `${mcdu._ilsIdent.trim().padStart(4, "\xa0")}/{small}${mcdu.ilsFrequency.toFixed(2)}{end}`;
+                    ilsCourseCell = "{small}F" + ilsIdent.course.toFixed(0).padStart(3, "0") + "{end}";
                 } else if (mcdu.ilsAutoTuned) {
                     ilsFrequencyCell = `{small}${mcdu.ilsAutoIdent.padStart(4, "\xa0")}/${mcdu.ilsFrequency.toFixed(2)}{end}`;
                     ilsCourseCell = `{small}F${mcdu.ilsAutoCourse.toFixed(0).padStart(3, "0")}{end}`;
                 }
             }
             mcdu.onLeftInput[2] = (value, scratchpadCallback) => {
-                if (mcdu.setIlsFrequency(value)) {
-                    CDUNavRadioPage.ShowPage(mcdu);
-                } else {
-                    scratchpadCallback();
-                }
+                mcdu.setIlsFrequency(value, (result) => {
+                    if (result) {
+                        mcdu.requestCall(() => {
+                            CDUNavRadioPage.ShowPage(mcdu);
+                        });
+                    } else {
+                        scratchpadCallback();
+                    }
+                });
             };
             adf1FrequencyCell = "[\xa0]/[\xa0\xa0\xa0.]";
             const adf1Ident = SimVar.GetSimVarValue(`ADF IDENT:1`, "string");

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -13,7 +13,7 @@ class CDUNavRadioPage {
         let vor1FrequencyCell = "";
         let vor1CourseCell = "";
         let ilsFrequencyCell = "";
-        let ilsCourseCell = "";
+        let ilsCourseCell = "[  ]";
         let adf1FrequencyCell = "";
         let adf1BfoOption = "";
         let vor2FrequencyCell = "";
@@ -118,23 +118,36 @@ class CDUNavRadioPage {
                 }
             };
             ilsFrequencyCell = "[\xa0\xa0]/[\xa0\xa0.\xa0]";
-            ilsCourseCell = "";
             if (mcdu.ilsFrequency != 0) {
                 if (mcdu._ilsFrequencyPilotEntered) {
                     const ilsIdent = mcdu.radioNav.getILSBeacon(1);
                     ilsFrequencyCell = `{small}${ilsIdent.ident.trim().padStart(4, "\xa0")}{end}/${mcdu.ilsFrequency.toFixed(2)}`;
-                    ilsCourseCell = "{small}F" + ilsIdent.course.toFixed(0).padStart(3, "0") + "{end}";
                 } else if (mcdu._ilsIdentPilotEntered) {
-                    const ilsIdent = mcdu.radioNav.getILSBeacon(1);
                     ilsFrequencyCell = `${mcdu._ilsIdent.trim().padStart(4, "\xa0")}/{small}${mcdu.ilsFrequency.toFixed(2)}{end}`;
-                    ilsCourseCell = "{small}F" + ilsIdent.course.toFixed(0).padStart(3, "0") + "{end}";
                 } else if (mcdu.ilsAutoTuned) {
                     ilsFrequencyCell = `{small}${mcdu.ilsAutoIdent.padStart(4, "\xa0")}/${mcdu.ilsFrequency.toFixed(2)}{end}`;
-                    ilsCourseCell = `{small}F${mcdu.ilsAutoCourse.toFixed(0).padStart(3, "0")}{end}`;
+                }
+
+                const lsCourse = SimVar.GetSimVarValue('L:A32NX_FM_LS_COURSE', 'number');
+                if (lsCourse >= 0) {
+                    ilsCourseCell = `{${mcdu.ilsCourse !== undefined ? 'big' : 'small'}}F${lsCourse.toFixed(0).padStart(3, "0")}{end}`;
+                } else {
+                    ilsCourseCell = "{amber}____{end}";
                 }
             }
             mcdu.onLeftInput[2] = (value, scratchpadCallback) => {
                 mcdu.setIlsFrequency(value, (result) => {
+                    if (result) {
+                        mcdu.requestCall(() => {
+                            CDUNavRadioPage.ShowPage(mcdu);
+                        });
+                    } else {
+                        scratchpadCallback();
+                    }
+                });
+            };
+            mcdu.onLeftInput[3] = (value, scratchpadCallback) => {
+                mcdu.setLsCourse(value, (result) => {
                     if (result) {
                         mcdu.requestCall(() => {
                             CDUNavRadioPage.ShowPage(mcdu);

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCDataManager.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCDataManager.js
@@ -4,6 +4,14 @@ const StoredWaypointType = Object.freeze({
     LatLon: 3,
 });
 
+const IcaoSearchFilter = Object.freeze({
+    None: 0,
+    Airports: 1,
+    Intersections: 2,
+    Vors: 3,
+    Ndbs: 4,
+});
+
 class FMCDataManager {
     constructor(_fmc) {
         this.fmc = _fmc;
@@ -77,59 +85,35 @@ class FMCDataManager {
     }
 
     async GetWaypointsByIdent(ident) {
-        const waypoints = [];
-        const intersections = await this.GetWaypointsByIdentAndType(ident, "W").catch(console.error);
-        waypoints.push(...intersections);
-        const vors = await this.GetWaypointsByIdentAndType(ident, "V").catch(console.error);
-        waypoints.push(...vors);
-        const ndbs = await this.GetWaypointsByIdentAndType(ident, "N").catch(console.error);
-        waypoints.push(...ndbs);
-        const airports = await this.GetWaypointsByIdentAndType(ident, "A").catch(console.error);
-        waypoints.push(...airports);
+        const waypoints = [...await this.GetWaypointsByIdentAndType(ident, IcaoSearchFilter.None)];
         return this._filterDuplicateWaypoints(waypoints);
     }
     async GetVORsByIdent(ident) {
         const navaids = [];
-        const vors = await this.GetWaypointsByIdentAndType(ident, "V");
+        const vors = await this.GetWaypointsByIdentAndType(ident, IcaoSearchFilter.Vors);
         navaids.push(...vors.filter((vor) => vor.infos.type !== 6 /* ILS */));
         return navaids;
     }
     async GetILSsByIdent(ident) {
         const navaids = [];
-        const vors = await this.GetWaypointsByIdentAndType(ident, "V");
+        const vors = await this.GetWaypointsByIdentAndType(ident, IcaoSearchFilter.Vors);
         navaids.push(...vors.filter((vor) => vor.infos.type === 6 /* ILS */));
         return navaids;
     }
     async GetNDBsByIdent(ident) {
         const navaids = [];
-        const ndbs = await this.GetWaypointsByIdentAndType(ident, "N").catch(console.error);
+        const ndbs = await this.GetWaypointsByIdentAndType(ident, IcaoSearchFilter.Ndbs);
         navaids.push(...ndbs);
         return navaids;
     }
-    async GetWaypointsByIdentAndType(ident, wpType = "W", maxItems = 40) {
-        let filter = 0;
-        switch (wpType) {
-            case 'A':
-                filter = 1;
-                break;
-            case 'W':
-                filter = 2;
-                break;
-            case 'V':
-                filter = 3;
-                break;
-            case 'N':
-                filter = 4;
-                break;
-            default:
-        }
-
+    async GetWaypointsByIdentAndType(ident, filter = 0, maxItems = 40) {
         // fetch results from the nav database
+        // we filter for equal idents, because the search returns everything starting with the given string
         const results = (await Coherent.call('SEARCH_BY_IDENT', ident, filter, maxItems)).filter((icao) => ident === icao.substr(7, 5).trim());
         const waypoints = await Promise.all(results.map(async (icao) => await this.fmc.facilityLoader.getFacility(icao)));
 
         // fetch pilot stored waypoints
-        if (wpType === 'W') {
+        if (filter === IcaoSearchFilter.None || (filter & IcaoSearchFilter.Intersections) > 0) {
             waypoints.push(...this.storedWaypoints.filter((wp) => wp && wp.ident === ident));
         }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCDataManager.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCDataManager.js
@@ -94,6 +94,12 @@ class FMCDataManager {
         navaids.push(...vors.filter((vor) => vor.infos.type !== 6 /* ILS */));
         return navaids;
     }
+    async GetILSsByIdent(ident) {
+        const navaids = [];
+        const vors = await this.GetWaypointsByIdentAndType(ident, "V");
+        navaids.push(...vors.filter((vor) => vor.infos.type === 6 /* ILS */));
+        return navaids;
+    }
     async GetNDBsByIdent(ident) {
         const navaids = [];
         const ndbs = await this.GetWaypointsByIdentAndType(ident, "N").catch(console.error);

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -1438,6 +1438,7 @@ class FMCMainDisplay extends BaseAirliners {
                     if (airportTo) {
                         this.eraseTemporaryFlightPlan(() => {
                             this.flightPlanManager.clearFlightPlan(() => {
+                                this.tempFpPendingAutoTune = true;
                                 this.flightPlanManager.setOrigin(airportFrom.icao, () => {
                                     this.tmpOrigin = airportFrom.ident;
                                     this.flightPlanManager.setDestination(airportTo.icao, () => {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -1910,6 +1910,9 @@ class FMCMainDisplay extends BaseAirliners {
         });
     }
 
+    getOrSelectILSsByIdent(ident, callback) {
+        this._getOrSelectWaypoints(this.dataManager.GetILSsByIdent.bind(this.dataManager), ident, callback);
+    }
     getOrSelectVORsByIdent(ident, callback) {
         this._getOrSelectWaypoints(this.dataManager.GetVORsByIdent.bind(this.dataManager), ident, callback);
     }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -3171,16 +3171,7 @@ class FMCMainDisplay extends BaseAirliners {
 
     connectIlsFrequency(_freq) {
         if (_freq >= 108 && _freq <= 111.95 && RadioNav.isHz50Compliant(_freq)) {
-            switch (this.radioNav.mode) {
-                case NavMode.FOUR_SLOTS: {
-                    this.ilsFrequency = _freq;
-                    break;
-                }
-                case NavMode.TWO_SLOTS: {
-                    this.vor1Frequency = _freq;
-                    break;
-                }
-            }
+            this.ilsFrequency = _freq;
             this.connectIls();
             return true;
         }
@@ -3198,22 +3189,9 @@ class FMCMainDisplay extends BaseAirliners {
         setTimeout(() => {
             this._lockConnectIls = false;
         }, 1000);
-        switch (this.radioNav.mode) {
-            case NavMode.FOUR_SLOTS: {
-                if (Math.abs(this.radioNav.getILSActiveFrequency(1) - this.ilsFrequency) > 0.005) {
-                    this.radioNav.setILSActiveFrequency(1, this.ilsFrequency);
-                }
-                break;
-            }
-            case NavMode.TWO_SLOTS: {
-                if (Math.abs(this.radioNav.getVORActiveFrequency(1) - this.vor1Frequency) > 0.005) {
-                    this.radioNav.setVORActiveFrequency(1, this.vor1Frequency);
-                }
-                break;
-            }
-            default:
-                console.error("Unknown RadioNav operating mode");
-                break;
+
+        if (Math.abs(this.radioNav.getILSActiveFrequency(1) - this.ilsFrequency) > 0.005) {
+            this.radioNav.setILSActiveFrequency(1, this.ilsFrequency);
         }
     }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -1887,21 +1887,33 @@ class FMCMainDisplay extends BaseAirliners {
         return SimVar.SetSimVarValue('L:A32NX_FM_LS_COURSE', 'number', course);
     }
 
-    checkRunwayLsMismatch() {
+    isRunwayLsMismatched() {
         if (!this.ilsAutoTuned || this.currentFlightPhase === FmgcFlightPhases.DONE) {
             return false;
         }
 
-        if ((this._ilsFrequencyPilotEntered && Math.abs(this.ilsFrequency - this.ilsAutoFrequency) >= 0.05) || (this._ilsIdentPilotEntered && this._ilsIcao !== this.ilsAutoIcao)) {
-            this.addNewMessage(NXSystemMessages.rwyLsMismatch);
+        return (this._ilsFrequencyPilotEntered && Math.abs(this.ilsFrequency - this.ilsAutoFrequency) >= 0.05) || (this._ilsIdentPilotEntered && this._ilsIcao !== this.ilsAutoIcao);
+    }
+
+    isRunwayLsCourseMismatched() {
+        if (!this.ilsAutoTuned || this.ilsCourse === undefined) {
+            return false;
+        }
+
+        return Math.abs(Avionics.Utils.diffAngle(this.ilsCourse, this.ilsAutoCourse)) > 3;
+    }
+
+    checkRunwayLsMismatch() {
+        if (this.isRunwayLsMismatched()) {
+            this.addNewMessage(NXSystemMessages.rwyLsMismatch, () => !(this.isRunwayLsMismatched() || this.isRunwayLsCourseMismatched()));
         }
 
         // manually entered course mismatch is handled separately to avoid unwanted messages
     }
 
     checkRunwayLsCourseMismatch() {
-        if (this.ilsAutoTuned && !this._ilsFrequencyPilotEntered && (!this._ilsIdentPilotEntered || this._ilsIcao === this.ilsAutoIcao) && this.ilsCourse !== undefined && Math.abs(Avionics.Utils.diffAngle(this.ilsCourse, this.ilsAutoCourse)) > 3) {
-            this.addNewMessage(NXSystemMessages.rwyLsMismatch);
+        if (this.isRunwayLsCourseMismatched()) {
+            this.addNewMessage(NXSystemMessages.rwyLsMismatch, () => !(this.isRunwayLsMismatched() || this.isRunwayLsCourseMismatched()));
         }
     }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/FlightElements/A32NX_Waypoint.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/FlightElements/A32NX_Waypoint.js
@@ -32,6 +32,7 @@ class WayPoint {
         this.liveETATo = 0;
         this.liveUTCTo = 0;
         this.waypointReachedAt = 0;
+        this.additionalData = {};
     }
     getSvgElement(index) {
         if (this.infos) {

--- a/src/instruments/src/ND/pages/ArcMode.tsx
+++ b/src/instruments/src/ND/pages/ArcMode.tsx
@@ -31,7 +31,7 @@ export const ArcMode: React.FC<ArcModeProps> = ({ symbols, adirsAlign, rangeSett
     const [tcasMode] = useSimVar('L:A32NX_SWITCH_TCAS_Position', 'number');
     const [fmgcFlightPhase] = useSimVar('L:A32NX_FMGC_FLIGHT_PHASE', 'enum');
     const [selectedHeading] = useSimVar('L:A32NX_AUTOPILOT_HEADING_SELECTED', 'degrees');
-    const [ilsCourse] = useSimVar('NAV LOCALIZER:3', 'degrees');
+    const [lsCourse] = useSimVar('L:A32NX_FM_LS_COURSE', 'number');
     const [lsDisplayed] = useSimVar(`L:BTN_LS_${side === 'L' ? 1 : 2}_FILTER_ACTIVE`, 'bool'); // TODO rename simvar
     const [showTmpFplan] = useSimVar('L:MAP_SHOW_TEMPORARY_FLIGHT_PLAN', 'bool');
     const [fmaLatMode] = useSimVar('L:A32NX_FMA_LATERAL_MODE', 'enum', 200);
@@ -112,7 +112,7 @@ export const ArcMode: React.FC<ArcModeProps> = ({ symbols, adirsAlign, rangeSett
                 <ToWaypointIndicator info={flightPlanManager.getCurrentFlightPlan().computeActiveWaypointStatistics(ppos)} />
                 <ApproachMessage info={flightPlanManager.getAirportApproach()} flightPhase={fmgcFlightPhase} />
                 <TrackBug heading={heading} track={track} />
-                { lsDisplayed && <IlsCourseBug heading={heading} ilsCourse={ilsCourse} /> }
+                { lsDisplayed && <LsCourseBug heading={heading} lsCourse={lsCourse} /> }
                 <SelectedHeadingBug heading={heading} selected={selectedHeading} />
                 <Plane />
                 <CrossTrack x={390} y={646} />
@@ -637,9 +637,9 @@ const TrackBug: React.FC<{heading: number, track: number}> = memo(({ heading, tr
     );
 });
 
-const IlsCourseBug: React.FC<{heading: number, ilsCourse: number}> = ({ heading, ilsCourse }) => {
-    const diff = getSmallestAngle(ilsCourse, heading);
-    if (ilsCourse < 0 || Math.abs(diff) > 48) {
+const LsCourseBug: React.FC<{heading: number, lsCourse: number}> = ({ heading, lsCourse }) => {
+    const diff = getSmallestAngle(lsCourse, heading);
+    if (lsCourse < 0 || Math.abs(diff) > 48) {
         return null;
     }
 
@@ -649,13 +649,13 @@ const IlsCourseBug: React.FC<{heading: number, ilsCourse: number}> = ({ heading,
                 d="M384,122 L384,74 M376,114 L392,114"
                 transform={`rotate(${diff} 384 620)`}
                 className="shadow rounded"
-                strokeWidth={1.5}
+                strokeWidth={2.5}
             />
             <path
                 d="M384,122 L384,74 M376,114 L392,114"
                 transform={`rotate(${diff} 384 620)`}
                 className="Magenta rounded"
-                strokeWidth={1}
+                strokeWidth={2}
             />
         </>
     );

--- a/src/instruments/src/ND/pages/RoseMode.tsx
+++ b/src/instruments/src/ND/pages/RoseMode.tsx
@@ -33,7 +33,7 @@ export const RoseMode: FC<RoseModeProps> = ({ symbols, adirsAlign, rangeSetting,
     const [tcasMode] = useSimVar('L:A32NX_SWITCH_TCAS_Position', 'number');
     const [fmgcFlightPhase] = useSimVar('L:A32NX_FMGC_FLIGHT_PHASE', 'enum');
     const [selectedHeading] = useSimVar('L:A32NX_AUTOPILOT_HEADING_SELECTED', 'degrees');
-    const [ilsCourse] = useSimVar('NAV LOCALIZER:3', 'degrees');
+    const [lsCourse] = useSimVar('L:A32NX_FM_LS_COURSE', 'number');
     const [lsDisplayed] = useSimVar(`L:BTN_LS_${side === 'L' ? 1 : 2}_FILTER_ACTIVE`, 'bool'); // TODO rename simvar
     const [showTmpFplan] = useSimVar('L:MAP_SHOW_TEMPORARY_FLIGHT_PLAN', 'bool');
     const [fmaLatMode] = useSimVar('L:A32NX_FMA_LATERAL_MODE', 'enum', 200);
@@ -124,7 +124,7 @@ export const RoseMode: FC<RoseModeProps> = ({ symbols, adirsAlign, rangeSetting,
 
                 <ApproachMessage info={flightPlanManager.getAirportApproach()} flightPhase={fmgcFlightPhase} />
                 <TrackBug heading={heading} track={track} />
-                { mode === Mode.ROSE_NAV && lsDisplayed && <IlsCourseBug heading={heading} ilsCourse={ilsCourse} /> }
+                { mode === Mode.ROSE_NAV && lsDisplayed && <LsCourseBug heading={heading} lsCourse={lsCourse} /> }
                 <SelectedHeadingBug heading={heading} selected={selectedHeading} />
                 { mode === Mode.ROSE_ILS && <GlideSlope /> }
                 <Plane />
@@ -735,25 +735,25 @@ const TrackBug: React.FC<{heading: number, track: number}> = memo(({ heading, tr
     );
 });
 
-const IlsCourseBug: React.FC<{heading: number, ilsCourse: number}> = ({ heading, ilsCourse }) => {
-    if (ilsCourse < 0) {
+const LsCourseBug: React.FC<{heading: number, lsCourse: number}> = ({ heading, lsCourse }) => {
+    if (lsCourse < 0) {
         return null;
     }
 
-    const diff = getSmallestAngle(ilsCourse, heading);
+    const diff = getSmallestAngle(lsCourse, heading);
     return (
         <>
             <path
                 d="M384,128 L384,96 M376,120 L392,120"
                 transform={`rotate(${diff} 384 384)`}
                 className="shadow rounded"
-                strokeWidth={1.5}
+                strokeWidth={2.5}
             />
             <path
                 d="M384,128 L384,96 M376,120 L392,120"
                 transform={`rotate(${diff} 384 384)`}
                 className="Magenta rounded"
-                strokeWidth={1}
+                strokeWidth={2}
             />
         </>
     );

--- a/src/instruments/src/PFD/HeadingIndicator.tsx
+++ b/src/instruments/src/PFD/HeadingIndicator.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Arinc429Word } from '@shared/arinc429';
 import { getSmallestAngle } from '@instruments/common/utils';
 import { HorizontalTape } from './PFDUtils';
-import { getSimVar } from '../util.js';
 
 const DisplayRange = 24;
 const DistanceSpacing = 7.555;

--- a/src/instruments/src/PFD/HeadingIndicator.tsx
+++ b/src/instruments/src/PFD/HeadingIndicator.tsx
@@ -144,7 +144,7 @@ interface QFUIndicatorProps {
 }
 
 const QFUIndicator = ({ ILSCourse, heading }: QFUIndicatorProps) => {
-    if (Number.isNaN(ILSCourse) || !getSimVar('NAV HAS LOCALIZER:3', 'Bool')) {
+    if (ILSCourse < 0) {
         return null;
     }
 

--- a/src/instruments/src/PFD/index.tsx
+++ b/src/instruments/src/PFD/index.tsx
@@ -148,9 +148,9 @@ export const PFD: React.FC = () => {
         selectedHeading = Simplane.getAutoPilotSelectedHeadingLockValue(false) || 0;
     }
 
-    let ILSCourse = NaN;
+    let ILSCourse = -1;
     if (lsButtonPressed) {
-        ILSCourse = getSimVar('NAV LOCALIZER:3', 'degrees');
+        ILSCourse = getSimVar('L:A32NX_FM_LS_COURSE', 'number');
     }
 
     return (


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #2568 
Fixes #5788

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
ILS' can now be tuned by ident on the rad nav page. ILS course can now be entered on the RAD NAV page. The course dagger on the ND and PFD is sourced from the correct data depending on entry, and availability of database or radio info. The `RWY/LS MISMATCH` scratchpad message is implemented, and is generated when the ILS/LOC manually tuned doesn't match the database one for the runway, or the entered course does not match the database.

The new facility search API introduced in SU6 returns ILS in the VOR search results, making this possible. This PR switches the data manager from the old FS9GPS search API to the new one for all search types, yielding a substantial improvement in performance for all database searches for idents.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/9995998/138021530-bb61c4d5-3872-46f2-967b-6d86e7eac6f0.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

Honeywell manual.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Ensure ILS auto-tuning works properly (departure runway when at origin airport, approach frequency when within 300 NM of destination during cruise phase or later).
- Check manual ILS tuning by frequency, including clearing... should revert to autotuned ILS when available.
- Check manual ILS tuning by identifier, including clearing... should revert to autotuned ILS when available.
- Tune the wrong ILS for the runway selected, and ensure `RWY/LS MISMATCH` is generated.
- Check VOR and NDB tuning by frequency and ident
- Enter waypoints etc. into the flightplan and/or PROG BRG/DIST from the scratchpad
- Enter correct course on the RAD NAV page, and check no scratchpad message is generated
- Enter incorrect course (more than 3 degrees off proper course) and check that `RWY/LS MISMATCH` is generated.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
