### PR TITLE
refactor(fmgc): fix asobo flight plan syncing issues

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
@@ -104,6 +104,8 @@ class CDUAvailableArrivalsPage {
                         rows[2 * i + 1] = ["{sp}{sp}{sp}{sp}" + runwayCourse + "[color]cyan"];
                         mcdu.onLeftInput[i + 2] = () => {
                             mcdu.setApproachIndex(approach.index, () => {
+                                const apprRunwayIndex = mcdu.flightPlanManager.getRunwayIndex(airportInfo.oneWayRunways, approaches[approach.index].runway);
+                                mcdu.flightPlanManager.setDestinationRunwayIndex(apprRunwayIndex);
                                 CDUAvailableArrivalsPage.ShowPage(mcdu, airport, 0, true);
                             });
                         };

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
@@ -161,9 +161,9 @@ class CDUAvailableArrivalsPage {
                             rows[2 * i] = ["{" + star.name + "[color]" + color];
                             mcdu.onLeftInput[i + 2] = () => {
                                 const destinationRunway = mcdu.flightPlanManager.getDestinationRunway();
-                                const arrivalRunwayIndex = star.runwayTransitions.findIndex(t => {
-                                    return t.name.indexOf("RW" + destinationRunway.designation) != -1;
-                                });
+                                const arrivalRunwayIndex = destinationRunway ? star.runwayTransitions.findIndex(t => {
+                                    return t.name.indexOf("RW" + destinationRunway.designation) !== -1;
+                                }) : -1;
                                 if (arrivalRunwayIndex !== -1) {
                                     mcdu.flightPlanManager.setArrivalRunwayIndex(arrivalRunwayIndex);
                                 }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
@@ -104,8 +104,7 @@ class CDUAvailableArrivalsPage {
                         rows[2 * i + 1] = ["{sp}{sp}{sp}{sp}" + runwayCourse + "[color]cyan"];
                         mcdu.onLeftInput[i + 2] = () => {
                             mcdu.setApproachIndex(approach.index, () => {
-                                const apprRunwayIndex = mcdu.flightPlanManager.getRunwayIndex(airportInfo.oneWayRunways, approaches[approach.index].runway);
-                                mcdu.flightPlanManager.setDestinationRunwayIndex(apprRunwayIndex);
+                                mcdu.flightPlanManager.setDestinationRunwayIndexFromApproach();
                                 CDUAvailableArrivalsPage.ShowPage(mcdu, airport, 0, true);
                             });
                         };

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
@@ -161,9 +161,9 @@ class CDUAvailableArrivalsPage {
                             }
                             rows[2 * i] = ["{" + star.name + "[color]" + color];
                             mcdu.onLeftInput[i + 2] = () => {
-                                const approachRunway = mcdu.flightPlanManager.getApproachRunway();
+                                const destinationRunway = mcdu.flightPlanManager.getDestinationRunway();
                                 const arrivalRunwayIndex = star.runwayTransitions.findIndex(t => {
-                                    return t.name.indexOf("RW" + approachRunway.designation) != -1;
+                                    return t.name.indexOf("RW" + destinationRunway.designation) != -1;
                                 });
                                 if (arrivalRunwayIndex !== -1) {
                                     mcdu.flightPlanManager.setArrivalRunwayIndex(arrivalRunwayIndex);

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableDeparturesPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableDeparturesPage.js
@@ -6,7 +6,7 @@ class CDUAvailableDeparturesPage {
             mcdu.page.Current = mcdu.page.AvailableDeparturesPage;
             let selectedRunwayCell = "---";
             let selectedRunwayCellColor = "white";
-            const selectedRunway = mcdu.flightPlanManager.getDepartureRunway();
+            const selectedRunway = mcdu.flightPlanManager.getOriginRunway();
             if (selectedRunway) {
                 selectedRunwayCell = Avionics.Utils.formatRunway(selectedRunway.designation);
                 selectedRunwayCellColor = mcdu.flightPlanManager.getCurrentFlightPlanIndex() === 1 ? "yellow" : "green";

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -176,8 +176,8 @@ class CDUFlightPlanPage {
                 // Fix Header
                 let fixAnnotation;
                 const currentApproach = fpm.getApproach();
-                if (fpm.getDepartureRunway() && wpPrev === fpm.getOrigin() && prevFpIndex === 0) {
-                    fixAnnotation = `${wpPrev.ident.substring(0,3)}${fpm.getDepartureRunway().direction.toFixed(0)}`;
+                if (fpm.getOriginRunway() && wpPrev === fpm.getOrigin() && prevFpIndex === 0) {
+                    fixAnnotation = `${wpPrev.ident.substring(0,3)}${fpm.getOriginRunway().direction.toFixed(0)}`;
                 } else if (fpm.getDepartureProcIndex() !== -1 && fpm.getDepartureWaypoints().some(fix => fix === wp)) {
                     const departureName = fpm.getDepartureName();
                     fixAnnotation = departureName ? departureName : undefined;
@@ -296,7 +296,7 @@ class CDUFlightPlanPage {
                     // Only for destination waypoint, show runway elevation.
                     altColor = "white";
                     spdColor = "white";
-                    const [rwTxt, rwAlt] = getRunwayInfo(fpm.getApproachRunway());
+                    const [rwTxt, rwAlt] = getRunwayInfo(fpm.getDestinationRunway());
                     if (rwTxt && rwAlt) {
                         altPrefix = "{magenta}*{end}";
                         ident += rwTxt;
@@ -306,7 +306,7 @@ class CDUFlightPlanPage {
                     altitudeConstraint = altitudeConstraint.padStart(5,"\xa0");
 
                 } else if (wp === fpm.getOrigin() && fpIndex === 0) {
-                    const [rwTxt, rwAlt] = getRunwayInfo(fpm.getDepartureRunway());
+                    const [rwTxt, rwAlt] = getRunwayInfo(fpm.getOriginRunway());
                     if (rwTxt && rwAlt) {
                         ident += rwTxt;
                         altitudeConstraint = rwAlt;
@@ -614,12 +614,12 @@ class CDUFlightPlanPage {
             });
         } else {
             let destCell = "----";
-            let approachRunway = null;
+            let destinationRunway = null;
             if (fpm.getDestination()) {
                 destCell = fpm.getDestination().ident;
-                approachRunway = fpm.getApproachRunway();
-                if (approachRunway) {
-                    destCell += Avionics.Utils.formatRunway(approachRunway.designation);
+                destinationRunway = fpm.getDestinationRunway();
+                if (destinationRunway) {
+                    destCell += Avionics.Utils.formatRunway(destinationRunway.designation);
                 }
             }
             let destTimeCell = "----";

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -503,7 +503,7 @@ class CDUFlightPlanPage {
                     fpIndex: fpIndex,
                     active: false,
                     ident: pwp.ident,
-                    color: "green",
+                    color: (fpm.isCurrentFlightPlanTemporary()) ? "yellow" : "green",
                     distance: Math.round(pwp.stats.distanceInFP).toString(),
                     spdColor: "white",
                     speedConstraint: "---",

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
@@ -19,14 +19,14 @@ class CDULateralRevisionPage {
         if (waypoint) {
             waypointIdent = waypoint.ident;
             if (isDeparture) {
-                const departureRunway = mcdu.flightPlanManager.getDepartureRunway();
-                if (departureRunway) {
-                    waypointIdent += Avionics.Utils.formatRunway(departureRunway.designation);
+                const originRunway = mcdu.flightPlanManager.getOriginRunway();
+                if (originRunway) {
+                    waypointIdent += Avionics.Utils.formatRunway(originRunway.designation);
                 }
             } else if (isDestination) {
-                const approachRunway = mcdu.flightPlanManager.getApproachRunway();
-                if (approachRunway) {
-                    waypointIdent += Avionics.Utils.formatRunway(approachRunway.designation);
+                const destinationRunway = mcdu.flightPlanManager.getDestinationRunway();
+                if (destinationRunway) {
+                    waypointIdent += Avionics.Utils.formatRunway(destinationRunway.designation);
                 }
             }
         }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -40,7 +40,7 @@ class CDUPerformancePage {
         let runway = "";
         let hasRunway = false;
         if (hasOrigin) {
-            const runwayObj = mcdu.flightPlanManager.getDepartureRunway();
+            const runwayObj = mcdu.flightPlanManager.getOriginRunway();
             if (runwayObj) {
                 runway = Avionics.Utils.formatRunway(runwayObj.designation);
                 hasRunway = true;

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
@@ -44,12 +44,6 @@ class A320_Neo_FCU extends BaseAirliners {
     }
     onEvent(_event) {
     }
-    onFlightStart() {
-        super.onFlightStart();
-        if (this.mainPage) {
-            this.mainPage.onFlightStart();
-        }
-    }
 }
 
 class A320_Neo_FCU_MainElement extends NavSystemElement {
@@ -84,10 +78,6 @@ class A320_Neo_FCU_MainPage extends NavSystemPage {
     reboot() {
         this.largeScreen.reboot();
         this.smallScreen.reboot();
-    }
-    onFlightStart() {
-        this.largeScreen.onFlightStart();
-        this.smallScreen.onFlightStart();
     }
 }
 
@@ -133,13 +123,9 @@ class A320_Neo_FCU_Component {
         this.gps = _gps;
         this.divRef = _gps.getChildById(_divName);
         this.textValue = this.getTextElement("Value");
-        this.init();
-        this.update(0);
     }
     reboot() {
         this.init();
-    }
-    onFlightStart() {
     }
 }
 
@@ -170,8 +156,8 @@ class A320_Neo_FCU_Speed extends A320_Neo_FCU_Component {
         this._rotaryEncoderTimeout = 300;
         this._rotaryEncoderIncrement = 0.15;
         this._rotaryEncoderPreviousTimestamp = 0;
-
-        this.onPull();
+        this.init();
+        this.update(0);
     }
 
     init() {
@@ -188,11 +174,6 @@ class A320_Neo_FCU_Speed extends A320_Neo_FCU_Component {
         Coherent.call("AP_SPD_VAR_SET", 0, this.MIN_SPEED).catch(console.error);
         SimVar.SetSimVarValue("K:AP_MANAGED_SPEED_IN_MACH_OFF", "number", 0);
         this.onPull();
-    }
-
-    onFlightStart() {
-        super.onFlightStart();
-        this.init();
     }
 
     update(_deltaTime) {
@@ -494,6 +475,8 @@ class A320_Neo_FCU_Speed extends A320_Neo_FCU_Component {
 class A320_Neo_FCU_Autopilot extends A320_Neo_FCU_Component {
     constructor() {
         super(...arguments);
+        this.init();
+        this.update(0);
     }
 
     init() {
@@ -528,6 +511,8 @@ class A320_Neo_FCU_Heading extends A320_Neo_FCU_Component {
         this._rotaryEncoderTimeout = 350;
         this._rotaryEncoderIncrement = 0.1;
         this._rotaryEncoderPreviousTimestamp = 0;
+        this.init();
+        this.update(0);
     }
 
     init() {
@@ -540,11 +525,6 @@ class A320_Neo_FCU_Heading extends A320_Neo_FCU_Component {
         this.isSelectedValueActive = true;
         this.isPreselectionModeActive = false;
         this.refresh(true, false, false, false, true, 0, false, true);
-    }
-
-    onFlightStart() {
-        super.onFlightStart();
-        this.init();
     }
 
     onRotate() {
@@ -814,6 +794,12 @@ class A320_Neo_FCU_Heading extends A320_Neo_FCU_Component {
 }
 
 class A320_Neo_FCU_Mode extends A320_Neo_FCU_Component {
+    constructor() {
+        super(...arguments);
+        this.init();
+        this.update(0);
+    }
+
     init() {
         this.textHDG = this.getTextElement("HDG");
         this.textVS = this.getTextElement("VS");
@@ -848,6 +834,12 @@ class A320_Neo_FCU_Mode extends A320_Neo_FCU_Component {
 }
 
 class A320_Neo_FCU_Altitude extends A320_Neo_FCU_Component {
+    constructor() {
+        super(...arguments);
+        this.init();
+        this.update(0);
+    }
+
     init() {
         this.illuminator = this.getElement("circle", "Illuminator");
         this.isActive = false;
@@ -859,11 +851,6 @@ class A320_Neo_FCU_Altitude extends A320_Neo_FCU_Component {
         }
         Coherent.call("AP_ALT_VAR_SET_ENGLISH", 3, initValue, true).catch(console.error);
         this.refresh(false, false, initValue, 0, true);
-    }
-
-    onFlightStart() {
-        super.onFlightStart();
-        this.init();
     }
 
     reboot() {
@@ -933,6 +920,8 @@ class A320_Neo_FCU_VerticalSpeed extends A320_Neo_FCU_Component {
         this.ABS_MINMAX_VS = 6000;
         this.backToIdleTimeout = 45000;
         this.previousVerticalMode = 0;
+        this.init();
+        this.update(0);
     }
     get currentState() {
         return this._currentState;
@@ -951,11 +940,6 @@ class A320_Neo_FCU_VerticalSpeed extends A320_Neo_FCU_Component {
         this.selectedVs = 0;
         this.selectedFpa = 0;
         this.refresh(false, false, 0, 0, true);
-    }
-
-    onFlightStart() {
-        super.onFlightStart();
-        this.init();
     }
 
     onPush() {
@@ -1226,15 +1210,6 @@ class A320_Neo_FCU_LargeScreen extends NavSystemElement {
             }
         }
     }
-    onFlightStart() {
-        if (this.components != null) {
-            for (let i = 0; i < this.components.length; ++i) {
-                if (this.components[i] != null) {
-                    this.components[i].onFlightStart();
-                }
-            }
-        }
-    }
     onUpdate(_deltaTime) {
         if (this.components != null) {
             for (let i = 0; i < this.components.length; ++i) {
@@ -1256,6 +1231,11 @@ class A320_Neo_FCU_LargeScreen extends NavSystemElement {
 }
 
 class A320_Neo_FCU_Pressure extends A320_Neo_FCU_Component {
+    constructor() {
+        super(...arguments);
+        this.init();
+        this.update(0);
+    }
     init() {
         this.selectedElem = this.getDivElement("Selected");
         this.standardElem = this.getDivElement("Standard");
@@ -1328,8 +1308,6 @@ class A320_Neo_FCU_SmallScreen extends NavSystemElement {
         if (this.pressure) {
             this.pressure.reboot();
         }
-    }
-    onFlightStart() {
     }
 }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -1688,7 +1688,7 @@ class FMCMainDisplay extends BaseAirliners {
 
     setDepartureIndex(departureIndex, callback = EmptyCallback.Boolean) {
         this.ensureCurrentFlightPlanIsTemporary(() => {
-            const currentRunway = this.flightPlanManager.getDepartureRunway();
+            const currentRunway = this.flightPlanManager.getOriginRunway();
             this.flightPlanManager.setDepartureProcIndex(departureIndex, () => {
                 if (currentRunway) {
                     SimVar.SetSimVarValue("L:A32NX_DEPARTURE_ELEVATION", "feet", A32NX_Util.meterToFeet(currentRunway.elevation));
@@ -1745,7 +1745,7 @@ class FMCMainDisplay extends BaseAirliners {
             this.flightPlanManager.setApproachIndex(approachIndex, () => {
                 const approach = this.flightPlanManager.getApproach();
                 if (approach) {
-                    const runway = this.flightPlanManager.getApproachRunway();
+                    const runway = this.flightPlanManager.getDestinationRunway();
                     if (runway) {
                         SimVar.SetSimVarValue("L:A32NX_PRESS_AUTO_LANDING_ELEVATION", "feet", A32NX_Util.meterToFeet(runway.elevation));
                     }
@@ -1811,7 +1811,7 @@ class FMCMainDisplay extends BaseAirliners {
                     return;
                 }
                 airport = this.flightPlanManager.getDestination();
-                runway = this.flightPlanManager.getApproachRunway();
+                runway = this.flightPlanManager.getDestinationRunway();
 
                 const planeLla = new LatLongAlt(
                     SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude"),
@@ -1830,7 +1830,7 @@ class FMCMainDisplay extends BaseAirliners {
             }
             this.ilsAutoTuned = false;
             airport = this.flightPlanManager.getOrigin();
-            runway = this.flightPlanManager.getDepartureRunway();
+            runway = this.flightPlanManager.getOriginRunway();
         }
 
         // If the airport has correct navdata, the ILS will be listed as the reference navaid (originIcao in MSFS land) on at least the last leg of the
@@ -3077,7 +3077,7 @@ class FMCMainDisplay extends BaseAirliners {
             return true;
         } else if (s.match(/^[0-9]{1,5}$/) !== null) {
             const value = parseInt(s);
-            let ldgRwy = this.flightPlanManager.getApproachRunway();
+            let ldgRwy = this.flightPlanManager.getDestinationRunway();
             if (!ldgRwy) {
                 const dest = this.flightPlanManager.getDestination();
                 if (dest && dest.infos && dest.infos.runways.length > 0) {
@@ -3524,7 +3524,7 @@ class FMCMainDisplay extends BaseAirliners {
 
     updateTowerHeadwind() {
         if (isFinite(this.perfApprWindSpeed) && isFinite(this.perfApprWindHeading)) {
-            const rwy = this.flightPlanManager.getApproachRunway();
+            const rwy = this.flightPlanManager.getDestinationRunway();
             if (rwy) {
                 this._towerHeadwind = NXSpeedsUtils.getHeadwind(this.perfApprWindSpeed, this.perfApprWindHeading, rwy.direction);
             }
@@ -3560,7 +3560,7 @@ class FMCMainDisplay extends BaseAirliners {
      *   Only prompt the confirmation of FLEX TEMP when the TO runway was changed, not on initial insertion of the runway
      */
     onToRwyChanged() {
-        const selectedRunway = this.flightPlanManager.getDepartureRunway();
+        const selectedRunway = this.flightPlanManager.getOriginRunway();
         if (!!selectedRunway) {
             const toRunway = Avionics.Utils.formatRunway(selectedRunway.designation);
             if (toRunway === this.toRunway) {

--- a/src/fmgc/src/flightplanning/FlightPlanAsoboSync.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanAsoboSync.ts
@@ -127,6 +127,29 @@ export class FlightPlanAsoboSync {
                                     console.error(`[FP LOAD] Setting Departure En Route Transition ${data.departureEnRouteTransitionIndex} ... FAILED`);
                                     console.error(e);
                                 });
+                             // set approach
+                            //  rwy index
+                            await fpln.setArrivalRunwayIndex(data.arrivalRunwayIndex)
+                            // .then(() => console.log(`[FP LOAD] Setting Arrival Runway ${data.arrivalRunwayIndex} ... SUCCESS`))
+                            .catch((e) => {
+                                console.error(`[FP LOAD] Setting Arrival Runway ${data.arrivalRunwayIndex} ... FAILED`);
+                                console.error(e);
+                            });
+                            //  approach index
+                            await fpln.setApproachIndex(data.approachIndex)
+                                // .then(() => console.log(`[FP LOAD] Setting Approach ${data.approachIndex} ... SUCCESS`))
+                                .catch((e) => {
+                                    console.error(`[FP LOAD] Setting Approach ${data.approachIndex} ... FAILED`);
+                                    console.error(e);
+                                });
+                            //  approachtrans index
+                            await fpln.setApproachTransitionIndex(data.approachTransitionIndex)
+                                // .then(() => console.log(`[FP LOAD] Setting Approach Transition ${data.approachTransitionIndex} ... SUCCESS`))
+                                .catch((e) => {
+                                    console.error(`[FP LOAD] Setting Approach Transition ${data.approachTransitionIndex} ... FAILED`);
+                                    console.error(e);
+                                });
+
                             // set arrival
                             //  arrivalproc index
                             await fpln.setArrivalProcIndex(data.arrivalProcIndex)
@@ -142,28 +165,6 @@ export class FlightPlanAsoboSync {
                                     console.error(`[FP LOAD] Setting En Route Transition ${data.arrivalEnRouteTransitionIndex} ... FAILED`);
                                     console.error(e);
                                 });
-                             // set approach
-                            //  rwy index
-                            await fpln.setArrivalRunwayIndex(data.arrivalRunwayIndex)
-                            // .then(() => console.log(`[FP LOAD] Setting Arrival Runway ${data.arrivalRunwayIndex} ... SUCCESS`))
-                            .catch((e) => {
-                                console.error(`[FP LOAD] Setting Arrival Runway ${data.arrivalRunwayIndex} ... FAILED`);
-                                console.error(e);
-                            });
-                            //  approach index
-                            await fpln.setApproachIndex(data.approachIndex)
-                                .catch((e) => {
-                                    console.error(`[FP LOAD] Setting Approach ${data.approachIndex} ... FAILED`);
-                                    console.error(e);
-                                });
-                            // .then(() => console.log(`[FP LOAD] Setting Approach ${data.approachIndex} ... SUCCESS`));
-                            //  approachtrans index
-                            await fpln.setApproachTransitionIndex(data.approachTransitionIndex)
-                                .catch((e) => {
-                                    console.error(`[FP LOAD] Setting Approach Transition ${data.approachTransitionIndex} ... FAILED`);
-                                    console.error(e);
-                                });
-                            // .then(() => console.log(`[FP LOAD] Setting Approach Transition ${data.approachTransitionIndex} ... SUCCESS`));
 
                             await fpln.setDestinationRunwayIndexFromApproach()
                             // .then(() => console.log(`[FP LOAD] Setting Destination Runway using ${data.approachIndex} ... SUCCESS`))

--- a/src/fmgc/src/flightplanning/FlightPlanAsoboSync.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanAsoboSync.ts
@@ -197,7 +197,7 @@ export class FlightPlanAsoboSync {
                 const plan = fpln.getCurrentFlightPlan();
                 if ((plan.checksum !== this.fpChecksum)) {
                     // await Coherent.call("CREATE_NEW_FLIGHTPLAN").catch(console.error);
-                    yield Coherent.call('SET_CURRENT_FLIGHTPLAN_INDEX', 0).catch(console.error);
+                    yield Coherent.call('SET_CURRENT_FLIGHTPLAN_INDEX', 0, false).catch(console.error);
                     yield Coherent.call('CLEAR_CURRENT_FLIGHT_PLAN').catch(console.error);
                     if (plan.hasPersistentOrigin && plan.hasDestination) {
                         yield Coherent.call('SET_ORIGIN', plan.persistentOriginAirfield.icao, false).catch(console.error);

--- a/src/fmgc/src/flightplanning/FlightPlanAsoboSync.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanAsoboSync.ts
@@ -28,259 +28,255 @@ import { FlightPlanManager } from './FlightPlanManager';
 
 /** A class for syncing a flight plan with the game */
 export class FlightPlanAsoboSync {
-  static fpChecksum = 0;
+    static fpChecksum = 0;
 
-  static fpListenerInitialized = false;
+    static fpListenerInitialized = false;
 
-  public static init() {
-      if (!this.fpListenerInitialized) {
-          RegisterViewListener('JS_LISTENER_FLIGHTPLAN');
-          this.fpListenerInitialized = true;
-      }
-  }
+    public static init() {
+        if (!this.fpListenerInitialized) {
+            RegisterViewListener('JS_LISTENER_FLIGHTPLAN');
+            this.fpListenerInitialized = true;
+        }
+    }
 
-  public static async LoadFromGame(fpln: FlightPlanManager): Promise<void> {
-      return new Promise((resolve) => {
-          this.init();
-          setTimeout(() => {
-              Coherent.call('LOAD_CURRENT_GAME_FLIGHT').catch(console.error);
-              Coherent.call('LOAD_CURRENT_ATC_FLIGHTPLAN').catch(console.error);
-              setTimeout(() => {
-                  Coherent.call('GET_FLIGHTPLAN').then(async (data: Record<string, any>) => {
-                      console.log('COHERENT GET_FLIGHTPLAN received');
-                      const { isDirectTo } = data;
+    public static async LoadFromGame(fpln: FlightPlanManager): Promise<void> {
+        return new Promise((resolve) => {
+            this.init();
+            setTimeout(() => {
+                Coherent.call('LOAD_CURRENT_GAME_FLIGHT').catch(console.error);
+                Coherent.call('LOAD_CURRENT_ATC_FLIGHTPLAN').catch(console.error);
+                setTimeout(() => {
+                    Coherent.call('GET_FLIGHTPLAN').then(async (data: Record<string, any>) => {
+                        console.log('COHERENT GET_FLIGHTPLAN received');
+                        const { isDirectTo } = data;
 
-                      // TODO: talk to matt about dirto
-                      if (!isDirectTo) {
-                          // TODO FIXME: better handling of mid-air spawning and syncing fpln
-                          if (data.waypoints.length === 0 || data.waypoints[0].icao[0] !== 'A') {
-                              fpln.resumeSync();
-                              resolve();
-                              return;
-                          }
+                        // TODO: talk to matt about dirto
+                        if (!isDirectTo) {
+                            // TODO FIXME: better handling of mid-air spawning and syncing fpln
+                            if (data.waypoints.length === 0 || data.waypoints[0].icao[0] !== 'A') {
+                                fpln.resumeSync();
+                                resolve();
+                                return;
+                            }
 
-                          await fpln._parentInstrument.facilityLoader.getFacilityRaw(data.waypoints[0].icao, 10000).catch((e) => {
-                              console.error('[FP LOAD] Error getting first wp data');
-                              console.error(e);
-                          });
-
-                          // set origin
-                          await fpln.setOrigin(data.waypoints[0].icao).catch((e) => {
-                              console.error('[FP LOAD] Error setting origin');
-                              console.error(e);
-                          });
-
-                          // set dest
-                          await fpln.setDestination(data.waypoints[data.waypoints.length - 1].icao).catch((e) => {
-                              console.error('[FP LOAD] Error setting Destination');
-                              console.error(e);
-                          });
-
-                          // set route
-
-                          const enrouteStart = (data.departureWaypointsSize === -1) ? 1 : data.departureWaypointsSize;
-                          // Find out first approach waypoint, - 1 to skip destination
-                          const enrouteEnd = data.waypoints.length - ((data.arrivalWaypointsSize === -1) ? 1 : data.arrivalWaypointsSize) - 1;
-                          const enroute = data.waypoints.slice(enrouteStart, enrouteEnd - 1);
-                          for (let i = 0; i < enroute.length - 1; i++) {
-                              const wpt = enroute[i];
-                              if (wpt.icao.trim() !== '') {
-                                  fpln.addWaypoint(wpt.icao, Infinity, () => console.log(`[FP LOAD] Adding [${wpt.icao}]... SUCCESS`)).catch(console.error);
-                              }
-                          }
-
-                          // set departure
-                          //  rwy index
-                          await fpln.setDepartureRunwayIndex(data.departureRunwayIndex)
-                              // .then(() => console.log(`[FP LOAD] Setting Departure Runway ${data.departureRunwayIndex} ... SUCCESS`))
-                              .catch((e) => {
-                                  console.error(`[FP LOAD] Setting Departure Runway ${data.departureRunwayIndex} ... FAILED`);
-                                  console.error(e);
-                              });
-                          // proc index
-                          await fpln.setDepartureProcIndex(data.departureProcIndex)
-                              // .then(() => console.log(`[FP LOAD] Setting Departure Procedure  ${data.departureProcIndex} ... SUCCESS`))
-                              .catch((e) => {
-                                  console.error(`[FP LOAD] Setting Departure Procedure ${data.departureProcIndex} ... FAILED`);
-                                  console.error(e);
-                              });
-                          // origin runway
-                          if (data.originRunwayIndex !== -1) {
-                              await fpln.setOriginRunwayIndex(data.originRunwayIndex)
-                                  // .then(() => console.log(`[FP LOAD] Setting Origin  ${data.originRunwayIndex} ... SUCCESS`))
-                                  .catch((e) => {
-                                      console.error(`[FP LOAD] Setting Origin ${data.originRunwayIndex} ... FAILED`);
-                                      console.error(e);
-                                  });
-                          } else if (data.departureRunwayIndex !== -1 && data.departureProcIndex !== -1) {
-                            await fpln.setOriginRunwayIndex(fpln.getDepartureRunwayIndex())
-                            // .then(() => console.log(`[FP LOAD] Setting Origin  ${fpln.getDepartureRunwayIndex()} ... SUCCESS`))
-                              .catch((e) => {
-                                console.error(`[FP LOAD] Setting Origin ${fpln.getDepartureRunwayIndex()} ... FAILED`);
+                            await fpln._parentInstrument.facilityLoader.getFacilityRaw(data.waypoints[0].icao, 10000).catch((e) => {
+                                console.error('[FP LOAD] Error getting first wp data');
                                 console.error(e);
                             });
-                          }
-                          //  enroutetrans index
-                          await fpln.setDepartureEnRouteTransitionIndex(data.departureEnRouteTransitionIndex)
-                              // .then(() => console.log(`[FP LOAD] Setting Departure En Route Transition ${data.departureEnRouteTransitionIndex} ... SUCCESS`))
-                              .catch((e) => {
-                                  console.error(`[FP LOAD] Setting Departure En Route Transition ${data.departureEnRouteTransitionIndex} ... FAILED`);
-                                  console.error(e);
-                              });
-                          // set arrival
-                          //  arrivalproc index
-                          await fpln.setArrivalProcIndex(data.arrivalProcIndex)
-                              // .then(() => console.log(`[FP LOAD] Setting Arrival Procedure ${data.arrivalProcIndex} ... SUCCESS`))
-                              .catch((e) => {
-                                  console.error(`[FP LOAD] Setting Arrival Procedure ${data.arrivalProcIndex} ... FAILED`);
-                                  console.error(e);
-                              });
-                          //  arrivaltrans index
-                          await fpln.setArrivalEnRouteTransitionIndex(data.arrivalEnRouteTransitionIndex)
-                              // .then(() => console.log(`[FP LOAD] Setting En Route Transition ${data.arrivalEnRouteTransitionIndex} ... SUCCESS`))
-                              .catch((e) => {
-                                  console.error(`[FP LOAD] Setting En Route Transition ${data.arrivalEnRouteTransitionIndex} ... FAILED`);
-                                  console.error(e);
-                              });
-                          // set approach
-                          //  rwy index
-                          /*
-                           * FIXME this is obviously bogus...
-                           * should be an index into the destination airport runway array...
-                           * but arrivalRunwayIndex is an index into the STAR runwayTransitions array
-                           */
-                          /*await fpln.setDestinationRunwayIndex(data.arrivalRunwayIndex)
-                              // .then(() => console.log(`[FP LOAD] Setting Destination Runway ${data.arrivalRunwayIndex} ... SUCCESS`))
-                              .catch((e) => {
-                                  console.error(`[FP LOAD] Setting Destination Runway ${data.arrivalRunwayIndex} ... FAILED`);
-                                  console.error(e);
-                              });*/
-                          await fpln.setArrivalRunwayIndex(data.arrivalRunwayIndex)
-                              // .then(() => console.log(`[FP LOAD] Setting Arrival Runway ${data.arrivalRunwayIndex} ... SUCCESS`))
-                              .catch((e) => {
-                                  console.error(`[FP LOAD] Setting Arrival Runway ${data.arrivalRunwayIndex} ... FAILED`);
-                                  console.error(e);
-                              });
-                          //  approach index
-                          await fpln.setApproachIndex(data.approachIndex)
-                              .catch((e) => {
-                                  console.error(`[FP LOAD] Setting Approach ${data.approachIndex} ... FAILED`);
-                                  console.error(e);
-                              });
-                          // .then(() => console.log(`[FP LOAD] Setting Approach ${data.approachIndex} ... SUCCESS`));
-                          //  approachtrans index
-                          await fpln.setApproachTransitionIndex(data.approachTransitionIndex)
-                              .catch((e) => {
-                                  console.error(`[FP LOAD] Setting Approach Transition ${data.approachTransitionIndex} ... FAILED`);
-                                  console.error(e);
-                              });
-                          // .then(() => console.log(`[FP LOAD] Setting Approach Transition ${data.approachTransitionIndex} ... SUCCESS`));
 
-                          fpln.resumeSync();
+                            // set origin
+                            await fpln.setOrigin(data.waypoints[0].icao).catch((e) => {
+                                console.error('[FP LOAD] Error setting origin');
+                                console.error(e);
+                            });
 
-                          this.fpChecksum = fpln.getCurrentFlightPlan().checksum;
-                          // Potential CTD source?
-                          Coherent.call('SET_ACTIVE_WAYPOINT_INDEX', 0)
-                              .catch((e) => console.error('[FP LOAD] Error when setting Active WP'));
-                          Coherent.call('RECOMPUTE_ACTIVE_WAYPOINT_INDEX')
-                              .catch((e) => console.error('[FP LOAD] Error when recomputing Active WP'));
-                          resolve();
-                      }
-                  }).catch(console.error);
-              }, 500);
-          }, 200);
-      });
-  }
+                            // set dest
+                            await fpln.setDestination(data.waypoints[data.waypoints.length - 1].icao).catch((e) => {
+                                console.error('[FP LOAD] Error setting Destination');
+                                console.error(e);
+                            });
 
-  public static async SaveToGame(fpln) {
-      return __awaiter(this, 0, 0, function* () {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          return new Promise((resolve, reject) => __awaiter(this, 0, 0, function* () {
-              FlightPlanAsoboSync.init();
-              const plan = fpln.getCurrentFlightPlan();
-              if ((plan.checksum !== this.fpChecksum)) {
-                  // await Coherent.call("CREATE_NEW_FLIGHTPLAN").catch(console.error);
-                  yield Coherent.call('SET_CURRENT_FLIGHTPLAN_INDEX', 0).catch(console.error);
-                  yield Coherent.call('CLEAR_CURRENT_FLIGHT_PLAN').catch(console.error);
-                  if (plan.hasPersistentOrigin && plan.hasDestination) {
-                      yield Coherent.call('SET_ORIGIN', plan.persistentOriginAirfield.icao, false).catch(console.error);
-                      // .then(() => console.log('[FP SAVE] Setting Origin Airfield... SUCCESS'));
-                      yield Coherent.call('SET_DESTINATION', plan.destinationAirfield.icao, false).catch(console.error);
-                      // .then(() => console.log('[FP SAVE] Setting Destination Airfield... SUCCESS'));
-                      let coIndex = 1;
-                      for (let i = 0; i < plan.enroute.waypoints.length; i++) {
-                          const wpt = plan.enroute.waypoints[i];
-                          if (wpt.icao.trim() !== '') {
-                              yield Coherent.call('ADD_WAYPOINT', wpt.icao, coIndex, false).catch(console.error);
-                              // .then(() => console.log(`[FP SAVE] Adding Waypoint [${wpt.icao}]... SUCCESS`));
-                              coIndex++;
-                          }
-                      }
-                      yield Coherent.call('SET_ORIGIN_RUNWAY_INDEX', plan.procedureDetails.originRunwayIndex)
-                          // .then(() => console.log(`[FP SAVE] Setting Origin Runway ${plan.procedureDetails.originRunwayIndex} ... SUCCESS`))
-                          .catch((e) => {
-                              console.error(`[FP SAVE] Setting Origin Runway ${plan.procedureDetails.originRunwayIndex} ... FAILED`);
-                              console.error(e);
-                          });
-                      yield Coherent.call('SET_DEPARTURE_RUNWAY_INDEX', plan.procedureDetails.departureRunwayIndex)
-                          // .then(() => console.log(`[FP SAVE] Setting Departure Runway ${plan.procedureDetails.departureRunwayIndex} ... SUCCESS`))
-                          .catch((e) => {
-                              console.error(`[FP SAVE] Setting Departure Runway ${plan.procedureDetails.departureRunwayIndex} ... FAILED`);
-                              console.error(e);
-                          });
-                      yield Coherent.call('SET_DEPARTURE_PROC_INDEX', plan.procedureDetails.departureIndex)
-                          // .then(() => console.log(`[FP SAVE] Setting Departure Procedure ${plan.procedureDetails.departureIndex} ... SUCCESS`))
-                          .catch((e) => {
-                              console.error(`[FP SAVE] Setting Departure Procedure ${plan.procedureDetails.departureIndex} ... FAILED`);
-                              console.error(e);
-                          });
-                      yield Coherent.call('SET_DEPARTURE_ENROUTE_TRANSITION_INDEX', plan.procedureDetails.departureTransitionIndex)
-                          // .then(() => console.log(`[FP SAVE] Setting Departure Transition ${plan.procedureDetails.departureTransitionIndex} ... SUCCESS`))
-                          .catch((e) => {
-                              console.error(`[FP SAVE] Setting Departure Transition ${plan.procedureDetails.departureTransitionIndex} ... FAILED`);
-                              console.error(e);
-                          });
-                      yield Coherent.call('SET_ARRIVAL_RUNWAY_INDEX', plan.procedureDetails.arrivalRunwayIndex)
-                          // .then(() => console.log(`[FP SAVE] Setting Arrival Runway ${plan.procedureDetails.arrivalRunwayIndex} ... SUCCESS`))
-                          .catch((e) => {
-                              console.error(`[FP SAVE] Setting  Arrival Runway ${plan.procedureDetails.arrivalRunwayIndex} ... FAILED`);
-                              console.error(e);
-                          });
-                      yield Coherent.call('SET_ARRIVAL_PROC_INDEX', plan.procedureDetails.arrivalIndex)
-                          // .then(() => console.log(`[FP SAVE] Setting Arrival Procedure ${plan.procedureDetails.arrivalIndex} ... SUCCESS`))
-                          .catch((e) => {
-                              console.error(`[FP SAVE] Setting Arrival Procedure ${plan.procedureDetails.arrivalIndex} ... FAILED`);
-                              console.error(e);
-                          });
-                      yield Coherent.call('SET_ARRIVAL_ENROUTE_TRANSITION_INDEX', plan.procedureDetails.arrivalTransitionIndex)
-                          // .then(() => console.log(`[FP SAVE] Setting Arrival En Route Transition ${plan.procedureDetails.arrivalTransitionIndex} ... SUCCESS`))
-                          .catch((e) => {
-                              console.error(`[FP SAVE] Setting Arrival En Route Transition ${plan.procedureDetails.arrivalTransitionIndex} ... FAILED`);
-                              console.error(e);
-                          });
-                      yield Coherent.call('SET_APPROACH_INDEX', plan.procedureDetails.approachIndex)
-                          .then(() => {
-                              // console.log(`[FP SAVE] Setting Approach ${plan.procedureDetails.approachIndex} ... SUCCESS`);
-                              Coherent.call('SET_APPROACH_TRANSITION_INDEX', plan.procedureDetails.approachTransitionIndex)
-                                  // .then(() => console.log(`[FP SAVE] Setting Approach Transition ${plan.procedureDetails.approachTransitionIndex} ... SUCCESS`))
-                                  .catch((e) => {
-                                      console.error(`[FP SAVE] Setting Approach Transition ${plan.procedureDetails.approachTransitionIndex} ... FAILED`);
-                                      console.error(e);
-                                  });
-                          })
-                          .catch((e) => {
-                              console.error(`[FP SAVE] Setting Approach ${plan.procedureDetails.approachIndex} ... FAILED`);
-                              console.error(e);
-                          });
-                  }
-                  this.fpChecksum = plan.checksum;
-              }
-              Coherent.call('RECOMPUTE_ACTIVE_WAYPOINT_INDEX')
-                  .catch((e) => console.log('[FP SAVE] Setting Active Waypoint... FAILED'))
-                  .then(() => console.log('[FP SAVE] Setting Active Waypoint... SUCCESS'));
-          }));
-      });
-  }
+                            // set route
+
+                            const enrouteStart = (data.departureWaypointsSize === -1) ? 1 : data.departureWaypointsSize;
+                            // Find out first approach waypoint, - 1 to skip destination
+                            const enrouteEnd = data.waypoints.length - ((data.arrivalWaypointsSize === -1) ? 1 : data.arrivalWaypointsSize) - 1;
+                            const enroute = data.waypoints.slice(enrouteStart, enrouteEnd - 1);
+                            for (let i = 0; i < enroute.length - 1; i++) {
+                                const wpt = enroute[i];
+                                if (wpt.icao.trim() !== '') {
+                                    fpln.addWaypoint(wpt.icao, Infinity, () => console.log(`[FP LOAD] Adding [${wpt.icao}]... SUCCESS`)).catch(console.error);
+                                }
+                            }
+
+                            // set departure
+                            //  rwy index
+                            await fpln.setDepartureRunwayIndex(data.departureRunwayIndex)
+                                // .then(() => console.log(`[FP LOAD] Setting Departure Runway ${data.departureRunwayIndex} ... SUCCESS`))
+                                .catch((e) => {
+                                    console.error(`[FP LOAD] Setting Departure Runway ${data.departureRunwayIndex} ... FAILED`);
+                                    console.error(e);
+                                });
+                            // proc index
+                            await fpln.setDepartureProcIndex(data.departureProcIndex)
+                                // .then(() => console.log(`[FP LOAD] Setting Departure Procedure  ${data.departureProcIndex} ... SUCCESS`))
+                                .catch((e) => {
+                                    console.error(`[FP LOAD] Setting Departure Procedure ${data.departureProcIndex} ... FAILED`);
+                                    console.error(e);
+                                });
+                            // origin runway
+                            if (data.originRunwayIndex !== -1) {
+                                await fpln.setOriginRunwayIndex(data.originRunwayIndex)
+                                    // .then(() => console.log(`[FP LOAD] Setting Origin  ${data.originRunwayIndex} ... SUCCESS`))
+                                    .catch((e) => {
+                                        console.error(`[FP LOAD] Setting Origin ${data.originRunwayIndex} ... FAILED`);
+                                        console.error(e);
+                                    });
+                            } else if (data.departureRunwayIndex !== -1 && data.departureProcIndex !== -1) {
+                              await fpln.setOriginRunwayIndex(fpln.getDepartureRunwayIndex())
+                              // .then(() => console.log(`[FP LOAD] Setting Origin  ${fpln.getDepartureRunwayIndex()} ... SUCCESS`))
+                                .catch((e) => {
+                                  console.error(`[FP LOAD] Setting Origin ${fpln.getDepartureRunwayIndex()} ... FAILED`);
+                                  console.error(e);
+                              });
+                            }
+                            //  enroutetrans index
+                            await fpln.setDepartureEnRouteTransitionIndex(data.departureEnRouteTransitionIndex)
+                                // .then(() => console.log(`[FP LOAD] Setting Departure En Route Transition ${data.departureEnRouteTransitionIndex} ... SUCCESS`))
+                                .catch((e) => {
+                                    console.error(`[FP LOAD] Setting Departure En Route Transition ${data.departureEnRouteTransitionIndex} ... FAILED`);
+                                    console.error(e);
+                                });
+                            // set arrival
+                            //  arrivalproc index
+                            await fpln.setArrivalProcIndex(data.arrivalProcIndex)
+                                // .then(() => console.log(`[FP LOAD] Setting Arrival Procedure ${data.arrivalProcIndex} ... SUCCESS`))
+                                .catch((e) => {
+                                    console.error(`[FP LOAD] Setting Arrival Procedure ${data.arrivalProcIndex} ... FAILED`);
+                                    console.error(e);
+                                });
+                            //  arrivaltrans index
+                            await fpln.setArrivalEnRouteTransitionIndex(data.arrivalEnRouteTransitionIndex)
+                                // .then(() => console.log(`[FP LOAD] Setting En Route Transition ${data.arrivalEnRouteTransitionIndex} ... SUCCESS`))
+                                .catch((e) => {
+                                    console.error(`[FP LOAD] Setting En Route Transition ${data.arrivalEnRouteTransitionIndex} ... FAILED`);
+                                    console.error(e);
+                                });
+                             // set approach
+                            //  rwy index
+                            await fpln.setArrivalRunwayIndex(data.arrivalRunwayIndex)
+                            // .then(() => console.log(`[FP LOAD] Setting Arrival Runway ${data.arrivalRunwayIndex} ... SUCCESS`))
+                            .catch((e) => {
+                                console.error(`[FP LOAD] Setting Arrival Runway ${data.arrivalRunwayIndex} ... FAILED`);
+                                console.error(e);
+                            });
+                            //  approach index
+                            await fpln.setApproachIndex(data.approachIndex)
+                                .catch((e) => {
+                                    console.error(`[FP LOAD] Setting Approach ${data.approachIndex} ... FAILED`);
+                                    console.error(e);
+                                });
+                            // .then(() => console.log(`[FP LOAD] Setting Approach ${data.approachIndex} ... SUCCESS`));
+                            //  approachtrans index
+                            await fpln.setApproachTransitionIndex(data.approachTransitionIndex)
+                                .catch((e) => {
+                                    console.error(`[FP LOAD] Setting Approach Transition ${data.approachTransitionIndex} ... FAILED`);
+                                    console.error(e);
+                                });
+                            // .then(() => console.log(`[FP LOAD] Setting Approach Transition ${data.approachTransitionIndex} ... SUCCESS`));
+
+                            await fpln.setDestinationRunwayIndex(fpln.getApproachRunwayIndex())
+                            // .then(() => console.log(`[FP LOAD] Setting Destination Runway ${fpln.getApproachRunwayIndex()} ... SUCCESS`))
+                            .catch((e) => {
+                                console.error(`[FP LOAD] Setting Destination Runway ${fpln.getApproachRunwayIndex()} ... FAILED`);
+                                console.error(e);
+                            });
+
+                            fpln.resumeSync();
+
+                            this.fpChecksum = fpln.getCurrentFlightPlan().checksum;
+                            // Potential CTD source?
+                            Coherent.call('SET_ACTIVE_WAYPOINT_INDEX', 0)
+                                .catch((e) => console.error('[FP LOAD] Error when setting Active WP'));
+                            Coherent.call('RECOMPUTE_ACTIVE_WAYPOINT_INDEX')
+                                .catch((e) => console.error('[FP LOAD] Error when recomputing Active WP'));
+                            resolve();
+                        }
+                    }).catch(console.error);
+                }, 500);
+            }, 200);
+        });
+    }
+
+    public static async SaveToGame(fpln) {
+        return __awaiter(this, 0, 0, function* () {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            return new Promise((resolve, reject) => __awaiter(this, 0, 0, function* () {
+                FlightPlanAsoboSync.init();
+                const plan = fpln.getCurrentFlightPlan();
+                if ((plan.checksum !== this.fpChecksum)) {
+                    // await Coherent.call("CREATE_NEW_FLIGHTPLAN").catch(console.error);
+                    yield Coherent.call('SET_CURRENT_FLIGHTPLAN_INDEX', 0).catch(console.error);
+                    yield Coherent.call('CLEAR_CURRENT_FLIGHT_PLAN').catch(console.error);
+                    if (plan.hasPersistentOrigin && plan.hasDestination) {
+                        yield Coherent.call('SET_ORIGIN', plan.persistentOriginAirfield.icao, false).catch(console.error);
+                        // .then(() => console.log('[FP SAVE] Setting Origin Airfield... SUCCESS'));
+                        yield Coherent.call('SET_DESTINATION', plan.destinationAirfield.icao, false).catch(console.error);
+                        // .then(() => console.log('[FP SAVE] Setting Destination Airfield... SUCCESS'));
+                        let coIndex = 1;
+                        for (let i = 0; i < plan.enroute.waypoints.length; i++) {
+                            const wpt = plan.enroute.waypoints[i];
+                            if (wpt.icao.trim() !== '') {
+                                yield Coherent.call('ADD_WAYPOINT', wpt.icao, coIndex, false).catch(console.error);
+                                // .then(() => console.log(`[FP SAVE] Adding Waypoint [${wpt.icao}]... SUCCESS`));
+                                coIndex++;
+                            }
+                        }
+                        yield Coherent.call('SET_ORIGIN_RUNWAY_INDEX', plan.procedureDetails.originRunwayIndex)
+                            // .then(() => console.log(`[FP SAVE] Setting Origin Runway ${plan.procedureDetails.originRunwayIndex} ... SUCCESS`))
+                            .catch((e) => {
+                                console.error(`[FP SAVE] Setting Origin Runway ${plan.procedureDetails.originRunwayIndex} ... FAILED`);
+                                console.error(e);
+                            });
+                        yield Coherent.call('SET_DEPARTURE_RUNWAY_INDEX', plan.procedureDetails.departureRunwayIndex)
+                            // .then(() => console.log(`[FP SAVE] Setting Departure Runway ${plan.procedureDetails.departureRunwayIndex} ... SUCCESS`))
+                            .catch((e) => {
+                                console.error(`[FP SAVE] Setting Departure Runway ${plan.procedureDetails.departureRunwayIndex} ... FAILED`);
+                                console.error(e);
+                            });
+                        yield Coherent.call('SET_DEPARTURE_PROC_INDEX', plan.procedureDetails.departureIndex)
+                            // .then(() => console.log(`[FP SAVE] Setting Departure Procedure ${plan.procedureDetails.departureIndex} ... SUCCESS`))
+                            .catch((e) => {
+                                console.error(`[FP SAVE] Setting Departure Procedure ${plan.procedureDetails.departureIndex} ... FAILED`);
+                                console.error(e);
+                            });
+                        yield Coherent.call('SET_DEPARTURE_ENROUTE_TRANSITION_INDEX', plan.procedureDetails.departureTransitionIndex)
+                            // .then(() => console.log(`[FP SAVE] Setting Departure Transition ${plan.procedureDetails.departureTransitionIndex} ... SUCCESS`))
+                            .catch((e) => {
+                                console.error(`[FP SAVE] Setting Departure Transition ${plan.procedureDetails.departureTransitionIndex} ... FAILED`);
+                                console.error(e);
+                            });
+                        yield Coherent.call('SET_ARRIVAL_RUNWAY_INDEX', plan.procedureDetails.arrivalRunwayIndex)
+                            // .then(() => console.log(`[FP SAVE] Setting Arrival Runway ${plan.procedureDetails.arrivalRunwayIndex} ... SUCCESS`))
+                            .catch((e) => {
+                                console.error(`[FP SAVE] Setting  Arrival Runway ${plan.procedureDetails.arrivalRunwayIndex} ... FAILED`);
+                                console.error(e);
+                            });
+                        yield Coherent.call('SET_ARRIVAL_PROC_INDEX', plan.procedureDetails.arrivalIndex)
+                            // .then(() => console.log(`[FP SAVE] Setting Arrival Procedure ${plan.procedureDetails.arrivalIndex} ... SUCCESS`))
+                            .catch((e) => {
+                                console.error(`[FP SAVE] Setting Arrival Procedure ${plan.procedureDetails.arrivalIndex} ... FAILED`);
+                                console.error(e);
+                            });
+                        yield Coherent.call('SET_ARRIVAL_ENROUTE_TRANSITION_INDEX', plan.procedureDetails.arrivalTransitionIndex)
+                            // .then(() => console.log(`[FP SAVE] Setting Arrival En Route Transition ${plan.procedureDetails.arrivalTransitionIndex} ... SUCCESS`))
+                            .catch((e) => {
+                                console.error(`[FP SAVE] Setting Arrival En Route Transition ${plan.procedureDetails.arrivalTransitionIndex} ... FAILED`);
+                                console.error(e);
+                            });
+                        yield Coherent.call('SET_APPROACH_INDEX', plan.procedureDetails.approachIndex)
+                            .then(() => {
+                                // console.log(`[FP SAVE] Setting Approach ${plan.procedureDetails.approachIndex} ... SUCCESS`);
+                                Coherent.call('SET_APPROACH_TRANSITION_INDEX', plan.procedureDetails.approachTransitionIndex)
+                                    // .then(() => console.log(`[FP SAVE] Setting Approach Transition ${plan.procedureDetails.approachTransitionIndex} ... SUCCESS`))
+                                    .catch((e) => {
+                                        console.error(`[FP SAVE] Setting Approach Transition ${plan.procedureDetails.approachTransitionIndex} ... FAILED`);
+                                        console.error(e);
+                                    });
+                            })
+                            .catch((e) => {
+                                console.error(`[FP SAVE] Setting Approach ${plan.procedureDetails.approachIndex} ... FAILED`);
+                                console.error(e);
+                            });
+                    }
+                    this.fpChecksum = plan.checksum;
+                }
+                Coherent.call('RECOMPUTE_ACTIVE_WAYPOINT_INDEX')
+                    .catch((e) => console.log('[FP SAVE] Setting Active Waypoint... FAILED'))
+                    .then(() => console.log('[FP SAVE] Setting Active Waypoint... SUCCESS'));
+            }));
+        });
+    }
 }
 
 function __awaiter(thisArg, _arguments, P, generator) {

--- a/src/fmgc/src/flightplanning/FlightPlanAsoboSync.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanAsoboSync.ts
@@ -113,10 +113,10 @@ export class FlightPlanAsoboSync {
                                         console.error(e);
                                     });
                             } else if (data.departureRunwayIndex !== -1 && data.departureProcIndex !== -1) {
-                              await fpln.setOriginRunwayIndex(fpln.getDepartureRunwayIndex())
-                              // .then(() => console.log(`[FP LOAD] Setting Origin  ${fpln.getDepartureRunwayIndex()} ... SUCCESS`))
+                              await fpln.setOriginRunwayIndexFromDeparture()
+                              // .then(() => console.log(`[FP LOAD] Setting Origin using ${data.departureProcIndex}/${data.departureRunwayIndex}... SUCCESS`))
                                 .catch((e) => {
-                                  console.error(`[FP LOAD] Setting Origin ${fpln.getDepartureRunwayIndex()} ... FAILED`);
+                                  console.error(`[FP LOAD] Setting Origin using ${data.departureProcIndex}/${data.departureRunwayIndex} ... FAILED`);
                                   console.error(e);
                               });
                             }
@@ -165,10 +165,10 @@ export class FlightPlanAsoboSync {
                                 });
                             // .then(() => console.log(`[FP LOAD] Setting Approach Transition ${data.approachTransitionIndex} ... SUCCESS`));
 
-                            await fpln.setDestinationRunwayIndex(fpln.getApproachRunwayIndex())
-                            // .then(() => console.log(`[FP LOAD] Setting Destination Runway ${fpln.getApproachRunwayIndex()} ... SUCCESS`))
+                            await fpln.setDestinationRunwayIndexFromApproach()
+                            // .then(() => console.log(`[FP LOAD] Setting Destination Runway using ${data.approachIndex} ... SUCCESS`))
                             .catch((e) => {
-                                console.error(`[FP LOAD] Setting Destination Runway ${fpln.getApproachRunwayIndex()} ... FAILED`);
+                                console.error(`[FP LOAD] Setting Destination Runway using ${data.approachIndex} ... FAILED`);
                                 console.error(e);
                             });
 

--- a/src/fmgc/src/flightplanning/FlightPlanAsoboSync.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanAsoboSync.ts
@@ -91,25 +91,35 @@ export class FlightPlanAsoboSync {
 
                           // set departure
                           //  rwy index
-                          await fpln.setOriginRunwayIndex(data.originRunwayIndex)
-                              // .then(() => console.log(`[FP LOAD] Setting Origin  ${data.originRunwayIndex} ... SUCCESS`))
-                              .catch((e) => {
-                                  console.error(`[FP LOAD] Setting Origin ${data.originRunwayIndex} ... FAILED`);
-                                  console.error(e);
-                              });
                           await fpln.setDepartureRunwayIndex(data.departureRunwayIndex)
                               // .then(() => console.log(`[FP LOAD] Setting Departure Runway ${data.departureRunwayIndex} ... SUCCESS`))
                               .catch((e) => {
                                   console.error(`[FP LOAD] Setting Departure Runway ${data.departureRunwayIndex} ... FAILED`);
                                   console.error(e);
                               });
-                          //  proc index
+                          // proc index
                           await fpln.setDepartureProcIndex(data.departureProcIndex)
                               // .then(() => console.log(`[FP LOAD] Setting Departure Procedure  ${data.departureProcIndex} ... SUCCESS`))
                               .catch((e) => {
                                   console.error(`[FP LOAD] Setting Departure Procedure ${data.departureProcIndex} ... FAILED`);
                                   console.error(e);
                               });
+                          // origin runway
+                          if (data.originRunwayIndex !== -1) {
+                              await fpln.setOriginRunwayIndex(data.originRunwayIndex)
+                                  // .then(() => console.log(`[FP LOAD] Setting Origin  ${data.originRunwayIndex} ... SUCCESS`))
+                                  .catch((e) => {
+                                      console.error(`[FP LOAD] Setting Origin ${data.originRunwayIndex} ... FAILED`);
+                                      console.error(e);
+                                  });
+                          } else if (data.departureRunwayIndex !== -1 && data.departureProcIndex !== -1) {
+                            await fpln.setOriginRunwayIndex(fpln.getDepartureRunwayIndex())
+                            // .then(() => console.log(`[FP LOAD] Setting Origin  ${fpln.getDepartureRunwayIndex()} ... SUCCESS`))
+                              .catch((e) => {
+                                console.error(`[FP LOAD] Setting Origin ${fpln.getDepartureRunwayIndex()} ... FAILED`);
+                                console.error(e);
+                            });
+                          }
                           //  enroutetrans index
                           await fpln.setDepartureEnRouteTransitionIndex(data.departureEnRouteTransitionIndex)
                               // .then(() => console.log(`[FP LOAD] Setting Departure En Route Transition ${data.departureEnRouteTransitionIndex} ... SUCCESS`))

--- a/src/fmgc/src/flightplanning/FlightPlanManager.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanManager.ts
@@ -517,13 +517,8 @@ export class FlightPlanManager {
     /**
      * Gets the destination airfield of the current flight plan, if any.
      */
-    public getDestination(flightPlanIndex = NaN): WayPoint | undefined {
-        if (isNaN(flightPlanIndex)) {
-            flightPlanIndex = this._currentFlightPlanIndex;
-        }
-
-        const currentFlightPlan = this._flightPlans[flightPlanIndex];
-        return currentFlightPlan.destinationAirfield;
+    public getDestination(): WayPoint | undefined {
+        return this._flightPlans[this._currentFlightPlanIndex].destinationAirfield;
     }
 
     /**
@@ -531,9 +526,9 @@ export class FlightPlanManager {
      * @param flightPlanIndex flight plan index
      * @returns Index of destination
      */
-    public getDestinationIndex(flightPlanIndex = NaN): number {
-        if (this.getDestination(flightPlanIndex)) {
-            return this.getWaypointsCount(flightPlanIndex) - 1;
+    public getDestinationIndex(): number {
+        if (this.getDestination()) {
+            return this.getWaypointsCount() - 1;
         }
         return -1;
     }

--- a/src/fmgc/src/flightplanning/FlightPlanManager.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanManager.ts
@@ -1557,12 +1557,12 @@ export class FlightPlanManager {
         }
         const currentFlightPlan = this._flightPlans[flightPlanIndex];
 
-        if (currentFlightPlan.procedureDetails.arrivalRunwayIndex !== -1 && currentFlightPlan.destinationAirfield) {
-            return currentFlightPlan.procedureDetails.arrivalRunwayIndex;
+        if (currentFlightPlan.procedureDetails.destinationRunwayIndex !== -1 && currentFlightPlan.destinationAirfield) {
+            return currentFlightPlan.procedureDetails.destinationRunwayIndex;
         }
 
         if (currentFlightPlan.hasDestination && currentFlightPlan.procedureDetails.approachIndex !== -1) {
-            console.error(`Arrival runway index is -1 with valid STAR`);
+            console.error(`Destination runway index is -1 with valid STAR`);
             const approachRunwayName = (currentFlightPlan.destinationAirfield.infos as AirportInfo).approaches[currentFlightPlan.procedureDetails.approachIndex].runway;
 
             return this.getRunwayIndex((currentFlightPlan.destinationAirfield.infos as AirportInfo).oneWayRunways, approachRunwayName);

--- a/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
+++ b/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
@@ -969,12 +969,7 @@ export class ManagedFlightPlan {
                 }
             }
 
-            let runway: OneWayRunway;
-            if (approachIndex !== -1) {
-                runway = this.getRunway(destinationInfo.oneWayRunways, destinationInfo.approaches[approachIndex].runway);
-            } else if (destinationRunwayIndex !== -1) {
-                runway = destinationInfo.oneWayRunways[destinationRunwayIndex];
-            }
+            let runway: OneWayRunway | null = this.getDestinationRunway();
 
             const procedure = new LegsProcedure(legs, this.getWaypoint(_startIndex - 1), this._parentInstrument);
 

--- a/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
+++ b/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
@@ -1070,40 +1070,6 @@ export class ManagedFlightPlan {
     }
 
     /**
-     * Gets the runway information from a given runway name.
-     * To be deprecated.
-     * @param runways The collection of runways to search.
-     * @param runwayName The runway name.
-     * @returns The found runway, if any.
-     */
-    public getRunway(runways: OneWayRunway[], runwayName: string): OneWayRunway | null {
-        if (runways.length > 0) {
-            let runwayIndex;
-            const match = runwayName.match(/^(RW)?([0-9]{1,2})([LCRT ])?$/);
-            if (match === null) {
-                return null;
-            }
-            const runwayLetter = match[3] ?? ' ';
-            if (runwayLetter === ' ' || runwayLetter === 'C') {
-                const runwayDirection = runwayName.trim();
-                runwayIndex = runways.findIndex((r) =>
-                r.designation === runwayDirection
-                || r.designation === `${runwayDirection}C`
-                || `RW${r.designation}` === runwayDirection
-                || `RW${r.designation}` === `${runwayDirection}C`);
-            } else {
-                runwayIndex = runways.findIndex((r) => r.designation === runwayName || `RW${r.designation}` === runwayName);
-            }
-
-            if (runwayIndex !== -1) {
-                return runways[runwayIndex];
-            }
-        }
-
-        return null;
-    }
-
-    /**
      * Converts a plain object into a ManagedFlightPlan.
      * @param flightPlanObject The object to convert.
      * @param parentInstrument The parent instrument attached to this flight plan.
@@ -1194,28 +1160,20 @@ export class ManagedFlightPlan {
         this.addWaypoint(waypoint, waypointIndex, segment.type);
     }
 
-    // TODO: Deprecate
     public getOriginRunway(): OneWayRunway | null {
         if (this.originAirfield) {
             if (this.procedureDetails.originRunwayIndex !== -1) {
                 return this.originAirfield.infos.oneWayRunways[this.procedureDetails.originRunwayIndex];
-            } /* else if (this.procedureDetails.departureRunwayIndex !== -1 && this.procedureDetails.departureIndex !== -1) {
-                // TODO: Remove
-                //return this.getRunway(this.originAirfield.infos.oneWayRunways, this.originAirfield.infos.departures[this.procedureDetails.departureIndex].runwayTransitions[this.procedureDetails.departureRunwayIndex].name);
-            } */
+            }
         }
         return null;
     }
 
-    // TODO: Deprecate
     public getDestinationRunway(): OneWayRunway | null{
         if (this.destinationAirfield) {
             if (this.procedureDetails.arrivalRunwayIndex !== -1) {
                 return this.destinationAirfield.infos.oneWayRunways[this.procedureDetails.destinationRunwayIndex];
-            } /* else if (this.procedureDetails.approachIndex !== -1) {
-                // TODO: Remove
-                //return this.getRunway(this.destinationAirfield.infos.oneWayRunways, this.destinationAirfield.infos.approaches[this.procedureDetails.approachIndex].runway);
-            } */
+            }
         }
         return null;
     }

--- a/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
+++ b/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
@@ -1171,7 +1171,7 @@ export class ManagedFlightPlan {
 
     public getDestinationRunway(): OneWayRunway | null{
         if (this.destinationAirfield) {
-            if (this.procedureDetails.arrivalRunwayIndex !== -1) {
+            if (this.procedureDetails.destinationRunwayIndex !== -1) {
                 return this.destinationAirfield.infos.oneWayRunways[this.procedureDetails.destinationRunwayIndex];
             }
         }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes flight plan syncing from world map issues in Experimental branch where runway symbol would not be displayed on the ND.

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Refactor of index values to properly set originRunwayIndex and destinationRunwayIndex, and to use these index values to retrieve onewayRunway objects where needed.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

You will need to test several permutations of the following:

1. Loading in from the world map using MSFS flight planning
2. Manual entry in the MCDU
3. Loading flight plan from SimBrief
4. Loading flight plan from a .PLN save file (saved route from the world map menu)

AND

1. Flight plan with no SID/STAR but departing/arriving to a runway, test at least between 2 different routes*
2. Flight plan with SID but not STAR, test at least between 2 different routes
3. Flight plan with both SID and STAR, test at least between 2 different routes
4. Flight plan with STAR and no approach.

Ensure that the correct SID/STAR is selected (where applicable) the correct approach is displayed on both the MCDU and ND. 

Known Issues: 

Loading with no SID/STAR results in origin and destination runways not being entered - bug with returned values from the sim, no fix.

Sometimes old flight plan will reload from the previous flight if the flight was not started/fully completed. Workaround this by reentering a new Origin/Dest pair before returning to the main menu for now. 

Spawning in mid-air will not show a flight plan. Not addressed by this PR.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
