### PR TITLE
perf: LCD overlay causing excessive re-painting

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -279,7 +279,8 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
     onUpdate(_deltaTime) {
         super.onUpdate(_deltaTime);
 
-        this.lcdOverlay.style.opacity = SimVar.GetSimVarValue("L:A32NX_MFD_MASK_OPACITY", "number");
+        const opacityValue = SimVar.GetSimVarValue("L:A32NX_MFD_MASK_OPACITY", "number");
+        this.lcdOverlay.style.opacity = opacityValue.toFixed(2);
 
         if (this.minPageUpdateThrottler.canUpdate(_deltaTime) !== -1 && this.updateRequest) {
             this.updateRequest = false;

--- a/src/instruments/src/Common/displayUnit.tsx
+++ b/src/instruments/src/Common/displayUnit.tsx
@@ -1,3 +1,6 @@
+//  Copyright (c) 2021 FlyByWire Simulations
+//  SPDX-License-Identifier: GPL-3.0
+
 import React, { useEffect, useState } from 'react';
 import { NXDataStore } from '@shared/persistence';
 import { useSimVar } from './simVars';
@@ -27,6 +30,8 @@ export const DisplayUnit: React.FC<DisplayUnitProps> = (props) => {
     const [potentiometer] = useSimVar(`LIGHT POTENTIOMETER:${props.potentiometerIndex}`, 'percent over 100', 200);
     const [electricityState] = useSimVar(props.electricitySimvar, 'bool', 200);
     const [opacity] = useSimVar('L:A32NX_MFD_MASK_OPACITY', 'number', 200);
+
+    const fixedOpacity = opacity.toFixed(2);
 
     useUpdate((deltaTime) => {
         if (timer !== null) {
@@ -63,7 +68,7 @@ export const DisplayUnit: React.FC<DisplayUnitProps> = (props) => {
     if (state === DisplayUnitState.Selftest) {
         return (
             <>
-                <div className="LcdOverlay" style={{ opacity }} />
+                <div className="LcdOverlay" style={{ opacity: fixedOpacity }} />
                 <div className="BacklightBleed" />
                 <svg className="SelfTest" viewBox="0 0 600 600">
                     <rect className="SelfTestBackground" x="0" y="0" width="100%" height="100%" />
@@ -92,7 +97,7 @@ export const DisplayUnit: React.FC<DisplayUnitProps> = (props) => {
     }
     return (
         <>
-            <div className="LcdOverlay" style={{ opacity }} />
+            <div className="LcdOverlay" style={{ opacity: fixedOpacity }} />
             <div className="BacklightBleed" />
             <div style={{ display: state === DisplayUnitState.On ? 'block' : 'none' }}>{props.children}</div>
         </>

--- a/src/instruments/src/DCDU/index.jsx
+++ b/src/instruments/src/DCDU/index.jsx
@@ -1,3 +1,6 @@
+//  Copyright (c) 2021 FlyByWire Simulations
+//  SPDX-License-Identifier: GPL-3.0
+
 import ReactDOM from 'react-dom';
 import { useState } from 'react';
 
@@ -73,7 +76,8 @@ function DCDU() {
         } else if (!powerAvailable()) {
             setState('OFF');
         }
-        setOpacity(getSimVar('L:A32NX_MFD_MASK_OPACITY', 'number'));
+        const opacityValue = getSimVar('L:A32NX_MFD_MASK_OPACITY', 'number');
+        setOpacity(opacityValue.toFixed(2));
     });
 
     switch (state) {


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

This patch improves performance when the opacity filter is active on LCDs. Opacity values are fixed to two decimal places to avoid repaints every frame when the opacity is nonzero.

Frame drops are still present when moving or zooming (since that causes a lot of repaints), however, this will be addressed by the removal of our own pixel filter to instead use the native MSFS pixel filter (#6097).

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): someperson#4953

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
