### PR TITLE
fix(fcu): autopilot button integ light brightness

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -56,6 +56,7 @@
 1. [FBW] Improved roll stability in turbulence or with performance issues - @IbrahimK42 (IbrahimK42) and @aguther (Andreas Guther)
 1. [MCDU] Hide POSITION UPDATE AT field on PROG page when GPS is available - @BlueberryKing (BlueberryKing)
 1. [MCDU] Sort approaches by type - @tracernz (Mike)
+1. [FCU] Autopilot button integ light brightness corrected - @tracernz (Mike)
 
 ## 0.7.0
 

--- a/flybywire-aircraft-a320-neo/ModelBehaviorDefs/A32NX/Airbus.xml
+++ b/flybywire-aircraft-a320-neo/ModelBehaviorDefs/A32NX/Airbus.xml
@@ -1253,10 +1253,10 @@
                 <Case Check="POTENTIOMETER">
                     <Condition Check="SEQ2_POWERED">
                         <True>
-                            <EMISSIVE_CODE>(A:LIGHT POTENTIOMETER:#POTENTIOMETER#, Percent over 100) #SEQ2_POWERED# *</EMISSIVE_CODE>
+                            <EMISSIVE_CODE>#SEQ2_POWERED#</EMISSIVE_CODE>
                         </True>
                         <False>
-                            <EMISSIVE_CODE>(A:LIGHT POTENTIOMETER:#POTENTIOMETER#, Percent over 100)</EMISSIVE_CODE>
+                            <EMISSIVE_CODE>1</EMISSIVE_CODE>
                         </False>
                     </Condition>
                 </Case>


### PR DESCRIPTION
The asobo sub template already applies the potentiometer, so we don't need to

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The integ lighting brightness on the autopilot buttons was double multiplying the potentiometer setting. Fixed.

Asobo template code:
```xml
<EMISSIVE_CODE>#EMISSIVE_CODE# (A:LIGHT POTENTIOMETER:#POTENTIOMETER#, Percent over 100) *</EMISSIVE_CODE>
```

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/9995998/139516202-73281dfa-22f4-4f29-b975-16ea49b62d12.png)

![image](https://user-images.githubusercontent.com/9995998/139516860-cb28a731-4b81-4d93-a517-44b183e5b9bd.png)




## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Check brightness of button integ lighting on glareshield/FCU.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
