### PR TITLE
revert: remove pixels (after SU6)

### DIFF
--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -956,14 +956,6 @@
       0 | inactive
       1 | active
 
-- A32NX_MFD_MASK_OPACITY
-    - Number
-    - Current LCD mask opacity for MFDs, used for driving LCD display pixels effect
-
-- A32NX_MCDU_MASK_OPACITY
-    - Number
-    - Current LCD mask opacity for MCDU, used for driving MCDU display pixels effect
-
 - A32NX_ISIS_LS_ACTIVE
 	- Bool
 	- Indicates whether LS scales are shown on the ISIS

--- a/flybywire-aircraft-a320-neo/html_ui/CSS/A32NX_Display_Common.css
+++ b/flybywire-aircraft-a320-neo/html_ui/CSS/A32NX_Display_Common.css
@@ -46,25 +46,6 @@ text {
   fill: none;
 }
 
-
-/* LCD pixel effect for screens */
-#LcdOverlay {
-  content: '';
-  width: 100%;
-  height: 100%;
-  z-index: 999;
-  position: absolute;
-  /* custom svg */
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M0 0 V10 Z H10 Z' stroke='%23000' stroke-width='3' fill='none'/%3E%3C/svg%3E");
-  background-size: 2px;
-  opacity: 0;
-  transition: opacity 0.5s;
-  /*
-    TODO: This rule collectively affects CPT/FO ND, MCDU and ECAM screens
-    These screens should use the scss impl. some day, ideally.
-  */
-}
-
 /* Backlight Bleed*/
 #BacklightBleed {
   content: '';

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_LocalVarUpdater.js
@@ -16,13 +16,6 @@ class A32NX_LocalVarUpdater {
             "FWD":false,
             "AFT":false
         };
-        // Init for LCD effect
-        this.zoomLevel = SimVar.GetSimVarValue('COCKPIT CAMERA ZOOM', 'percent');
-        const camXyz = SimVar.GetGameVarValue('CAMERA POS IN PLANE', 'xyz');
-        this.camZ = camXyz.z;
-        this.camY = camXyz.y;
-        this.opacityMfd = 0;
-        this.opacityMcdu = 0;
 
         this.updaters = [
             {
@@ -97,18 +90,6 @@ class A32NX_LocalVarUpdater {
                 selector: this._areSlidesArmed.bind(this),
                 refreshInterval: 100,
             },
-            {
-                varName: "L:A32NX_MFD_MASK_OPACITY",
-                type: "number",
-                selector: this._mfdLcdEffectSelector.bind(this),
-                refreshInterval: 150,
-            },
-            {
-                varName: "L:A32NX_MCDU_MASK_OPACITY",
-                type: "number",
-                selector: this._mcduLcdEffectSelector.bind(this),
-                refreshInterval: 150,
-            }
             // New updaters go here...
         ];
 
@@ -264,44 +245,6 @@ class A32NX_LocalVarUpdater {
             SimVar.GetSimVarValue('INTERACTIVE POINT OPEN:3', 'percent') < 5 && // Rear door, FO side for catering
             SimVar.GetSimVarValue('L:A32NX_FWD_DOOR_CARGO_LOCKED', 'bool') // Cargo door FO side
         );
-    }
-
-    _mfdLcdEffectSelector() {
-        // Calculate opacity for MFD LCD effect
-        const zoomLevel = SimVar.GetSimVarValue('COCKPIT CAMERA ZOOM', 'percent');
-        const camXyz = SimVar.GetGameVarValue('CAMERA POS IN PLANE', 'xyz');
-
-        if (this.zoomLevel !== zoomLevel || this.camZ !== camXyz.z) {
-            // z-axis - away from screen >> -ve
-            // zTarget: Target zPos that marks max pixel effect point [11.625z @ 100%, 11.7z @ 75%]
-            const zTarget = (3975 - zoomLevel) / 333.33;
-            // zΔ: Diff between current zPos and zTarget
-            const zDelta = camXyz.z - zTarget;
-            // opacity: 0 < [4zΔ + 0.5] < 0.5
-            this.opacityMfd = Math.max(0, Math.min(0.5, 4 * (zDelta) + 0.5));
-
-            this.camZ = camXyz.z;
-            this.zoomLevel = zoomLevel;
-        }
-        return this.opacityMfd;
-    }
-
-    _mcduLcdEffectSelector() {
-        // Calculate opacity for MCDU LCD effect
-        const zoomLevel = SimVar.GetSimVarValue('COCKPIT CAMERA ZOOM', 'percent');
-        const camXyz = SimVar.GetGameVarValue('CAMERA POS IN PLANE', 'xyz');
-
-        if (this.zoomLevel !== zoomLevel || this.camY !== camXyz.y) {
-            // y-axis - away from screen >> +ve
-            const yTarget = (zoomLevel + 423.33) / 333.33;
-            const yDelta = yTarget - camXyz.y;
-            // opacity: 0 < [4yΔ + 0.5] < 1
-            this.opacityMcdu = Math.max(0, Math.min(1, 4 * (yDelta) + 0.5));
-
-            this.camY = camXyz.y;
-            this.zoomLevel = zoomLevel;
-        }
-        return this.opacityMcdu;
     }
 
     // New selectors go here...

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU.html
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU.html
@@ -2,7 +2,6 @@
 
 <script type="text/html" id="A320_Neo_CDU">
     <glasscockpit-highlight id="highlight"></glasscockpit-highlight>
-    <div id="LcdOverlay"></div>
     <div id="BacklightBleed"></div>
     <div id="Mainframe">
     </div>

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -108,9 +108,6 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         super.Init();
         Coherent.trigger('UNFOCUS_INPUT_FIELD');// note: without this, resetting mcdu kills camera
 
-        // LCD OVERLAY
-        this.lcdOverlay = document.querySelector("#LcdOverlay");
-
         this.minPageUpdateThrottler = new UpdateThrottler(100);
 
         this.generateHTMLLayout(this.getChildById("Mainframe") || this);
@@ -278,8 +275,6 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
 
     onUpdate(_deltaTime) {
         super.onUpdate(_deltaTime);
-
-        this.lcdOverlay.style.opacity = SimVar.GetSimVarValue("L:A32NX_MFD_MASK_OPACITY", "number");
 
         if (this.minPageUpdateThrottler.canUpdate(_deltaTime) !== -1 && this.updateRequest) {
             this.updateRequest = false;

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/A320_Neo_EICAS.html
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/A320_Neo_EICAS.html
@@ -5,7 +5,6 @@
     <glasscockpit-highlight id="highlight"></glasscockpit-highlight>
     <div id="Mainframe">
         <div id="Electricity" state="off">
-            <div id="LcdOverlay"></div>
             <div id="BacklightBleed"></div>
             <div style="height: 0;">
                 <svg>

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -136,9 +136,6 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
             this.isTopScreen ? 92 : 93,
             this.querySelector(`#${this.isTopScreen ? "Top" : "Bottom"}SelfTest`)
         );
-
-        // LCD OVERLAY
-        this.lcdOverlay = document.querySelector("#LcdOverlay");
     }
 
     onUpdate() {
@@ -151,7 +148,6 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         if (deltaTime === -1) {
             return;
         }
-        this.lcdOverlay.style.opacity = SimVar.GetSimVarValue("L:A32NX_MFD_MASK_OPACITY", "number");
 
         this.displayUnit.update(deltaTime);
 

--- a/src/instruments/src/Common/displayUnit.tsx
+++ b/src/instruments/src/Common/displayUnit.tsx
@@ -26,7 +26,6 @@ export const DisplayUnit: React.FC<DisplayUnitProps> = (props) => {
 
     const [potentiometer] = useSimVar(`LIGHT POTENTIOMETER:${props.potentiometerIndex}`, 'percent over 100', 200);
     const [electricityState] = useSimVar(props.electricitySimvar, 'bool', 200);
-    const [opacity] = useSimVar('L:A32NX_MFD_MASK_OPACITY', 'number', 200);
 
     useUpdate((deltaTime) => {
         if (timer !== null) {
@@ -63,7 +62,6 @@ export const DisplayUnit: React.FC<DisplayUnitProps> = (props) => {
     if (state === DisplayUnitState.Selftest) {
         return (
             <>
-                <div className="LcdOverlay" style={{ opacity }} />
                 <div className="BacklightBleed" />
                 <svg className="SelfTest" viewBox="0 0 600 600">
                     <rect className="SelfTestBackground" x="0" y="0" width="100%" height="100%" />
@@ -92,7 +90,6 @@ export const DisplayUnit: React.FC<DisplayUnitProps> = (props) => {
     }
     return (
         <>
-            <div className="LcdOverlay" style={{ opacity }} />
             <div className="BacklightBleed" />
             <div style={{ display: state === DisplayUnitState.On ? 'block' : 'none' }}>{props.children}</div>
         </>

--- a/src/instruments/src/Common/pixels.scss
+++ b/src/instruments/src/Common/pixels.scss
@@ -1,27 +1,3 @@
-/* LCD pixel effect for screens */
-@mixin pixels($density: 2, $spacing: 3, $bleed: true, $checkered: false) {
-  content: '';
-  width: 100%;
-  height: 100%;
-  z-index: 999;
-  position: absolute;
-  background-size: $density * 1px;
-  transition: opacity 0.5s;
-
-  @if $checkered {
-    background-image: url("data:image/svg+xml,%3Csvg width='2' height='2' xmlns='http://www.w3.org/2000/svg'%3E%3Crect height='1' width='1' y='0' x='0' /%3E%3Crect height='1' width='1' y='1' x='1' /%3E%3C/svg%3E");
-    background-position: 1px 0;
-    background-color: rgba(80, 80, 80, 0.2);
-  } @else {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M0 0 V10 Z H10 Z' stroke='%23000' stroke-width='#{$spacing}' fill='none'/%3E%3C/svg%3E");
-  }
-
-}
-
-.LcdOverlay {
-  @include pixels;
-}
-
 .BacklightBleed {
   content: '';
   width: 100%;

--- a/src/instruments/src/DCDU/index.jsx
+++ b/src/instruments/src/DCDU/index.jsx
@@ -63,7 +63,6 @@ function Idle() {
 }
 function DCDU() {
     const [state, setState] = useState('DEFAULT');
-    const [opacity, setOpacity] = useState('0');
 
     useUpdate((_deltaTime) => {
         if (state === 'OFF') {
@@ -73,7 +72,6 @@ function DCDU() {
         } else if (!powerAvailable()) {
             setState('OFF');
         }
-        setOpacity(getSimVar('L:A32NX_MFD_MASK_OPACITY', 'number'));
     });
 
     switch (state) {
@@ -96,7 +94,6 @@ function DCDU() {
         return (
             <>
                 <div className="BacklightBleed" />
-                <div className="LcdOverlayDcdu" style={{ opacity }} />
                 <SelfTest />
             </>
         );
@@ -110,7 +107,6 @@ function DCDU() {
         return (
             <>
                 <div className="BacklightBleed" />
-                <div className="LcdOverlayDcdu" style={{ opacity }} />
                 <WaitingForData />
             </>
         );
@@ -118,7 +114,6 @@ function DCDU() {
         return (
             <>
                 <div className="BacklightBleed" />
-                <div className="LcdOverlayDcdu" style={{ opacity }} />
                 <Idle />
             </>
         );

--- a/src/instruments/src/DCDU/style.scss
+++ b/src/instruments/src/DCDU/style.scss
@@ -12,12 +12,6 @@
   font-style: normal;
 }
 
-/* pixels for screen */
-@import "../Common/pixels";
-.LcdOverlayDcdu {
-  @include pixels($checkered: true);
-}
-
 .dcdu-lines {
   position: absolute;
   left: 10px !important;

--- a/src/instruments/src/ISIS/ISISDisplayUnit.tsx
+++ b/src/instruments/src/ISIS/ISISDisplayUnit.tsx
@@ -16,7 +16,6 @@ type ISISDisplayUnitProps = {
 export const ISISDisplayUnit: React.FC<ISISDisplayUnitProps> = ({ indicatedAirspeed, children }) => {
     const powerUpTime = 90;
     const [isColdAndDark] = useSimVar('L:A32NX_COLD_AND_DARK_SPAWN', 'Bool', 200);
-    const [opacity] = useSimVar('L:A32NX_MFD_MASK_OPACITY', 'number', 200);
 
     const [state, setState] = useState(isColdAndDark ? DisplayUnitState.Off : DisplayUnitState.Standby);
     const [timer, setTimer] = useState<number | null>(null);
@@ -59,7 +58,6 @@ export const ISISDisplayUnit: React.FC<ISISDisplayUnitProps> = ({ indicatedAirsp
     if (state === DisplayUnitState.Selftest) {
         return (
             <>
-                <div className="LcdOverlayISIS" style={{ opacity }} />
                 <svg id="SelfTest" className="SelfTest" version="1.1" viewBox="0 0 512 512">
                     <g id="AttFlag">
                         <rect id="AttTest" className="FillYellow" width="84" height="40" x="214" y="174" />
@@ -94,7 +92,6 @@ export const ISISDisplayUnit: React.FC<ISISDisplayUnitProps> = ({ indicatedAirsp
 
     return (
         <>
-            <div className="LcdOverlay" style={{ opacity }} />
             {children}
         </>
     );

--- a/src/instruments/src/ISIS/style.scss
+++ b/src/instruments/src/ISIS/style.scss
@@ -19,12 +19,6 @@
   font-family: "Ecam", monospace !important;
 }
 
-/* pixels for screen */
-@import "../Common/pixels";
-.LcdOverlayISIS {
-  @include pixels($bleed: false);
-}
-
 .sky {
   fill: #0698ff;
 }


### PR DESCRIPTION
## Summary of Changes
Fixes #6097

Reverts our pixels implementation because of the new subpixel LCD effect that was added in SU6. Keeps the bleed effect + tint.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username: 2Cas#1022

## Testing instructions
1, Spawn
2, Verify that the pixel filter is removed from PFD, ND, EICAS, MCDU and DCDU. (Subpixels should be there still).

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page