### PR TITLE
refactor(fms): stateful geometry+legs, improved pseudo waypoints

### DIFF
--- a/src/fmgc/src/guidance/GuidanceComponent.ts
+++ b/src/fmgc/src/guidance/GuidanceComponent.ts
@@ -6,6 +6,11 @@ export interface GuidanceComponent {
 
     update(deltaTime: number): void;
 
-    acceptNewMultipleLegGeometry(geometry: Geometry): void;
+    /**
+     * Callback invoked when the FMS decides to generate new multiple leg geometry
+     *
+     * @param geometry the new multiple leg geometry
+     */
+    acceptMultipleLegGeometry?(geometry: Geometry): void;
 
 }

--- a/src/fmgc/src/guidance/lnav/legs/TF.ts
+++ b/src/fmgc/src/guidance/lnav/legs/TF.ts
@@ -2,32 +2,28 @@ import { ControlLaw, GuidanceParameters } from '@fmgc/guidance/ControlLaws';
 import { MathUtils } from '@shared/MathUtils';
 import { EARTH_RADIUS_NM } from '@fmgc/guidance/Geometry';
 import {
-    Leg,
     AltitudeConstraint,
-    SpeedConstraint,
     getAltitudeConstraintFromWaypoint,
     getSpeedConstraintFromWaypoint,
+    Leg,
+    SpeedConstraint,
     waypointToLocation,
 } from '@fmgc/guidance/lnav/legs';
-import { WayPoint } from '@fmgc/types/fstypes/FSTypes';
 import { SegmentType } from '@fmgc/wtsdk';
 import { GeoMath } from '@fmgc/flightplanning/GeoMath';
 import { WaypointConstraintType } from '@fmgc/flightplanning/FlightPlanManager';
 
-export class TFLeg implements Leg {
+export class TFLeg extends Leg {
     public from: WayPoint;
 
     public to: WayPoint;
-
-    public segment: SegmentType;
-
-    public indexInFullPath: number;
 
     public constraintType: WaypointConstraintType;
 
     private mDistance: NauticalMiles;
 
     constructor(from: WayPoint, to: WayPoint, segment: SegmentType, indexInFullPath: number) {
+        super();
         this.from = from;
         this.to = to;
         this.mDistance = Avionics.Utils.computeGreatCircleDistance(this.from.infos.coordinates, this.to.infos.coordinates);
@@ -82,17 +78,13 @@ export class TFLeg implements Leg {
             this.to.infos.coordinates,
             this.from.infos.coordinates,
         );
-        const latLongAltResult = Avionics.Utils.bearingDistanceToCoordinates(
+
+        return Avionics.Utils.bearingDistanceToCoordinates(
             inverseBearing,
             distanceBeforeTerminator,
             this.terminatorLocation.lat,
             this.terminatorLocation.long,
         );
-        const loc: LatLongData = {
-            lat: latLongAltResult.lat,
-            long: latLongAltResult.long,
-        };
-        return loc;
     }
 
     getIntermediatePoint(start: LatLongData, end: LatLongData, fraction: number): LatLongData {

--- a/src/fmgc/src/guidance/lnav/legs/VM.ts
+++ b/src/fmgc/src/guidance/lnav/legs/VM.ts
@@ -4,7 +4,7 @@ import { SegmentType } from '@fmgc/wtsdk';
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
 
 // TODO needs updated with wind prediction, and maybe local magvar if following for longer distances
-export class VMLeg implements Leg {
+export class VMLeg extends Leg {
     // FIXME this is not really a thing, but it's temporary, ok ? I promise !
     public initialPosition: Coordinates;
 
@@ -12,11 +12,8 @@ export class VMLeg implements Leg {
 
     public initialCourse: Degrees;
 
-    public segment: SegmentType;
-
-    public indexInFullPath: number;
-
     constructor(heading: Degrees, initialPosition: Coordinates, initialCourse: Degrees, segment: SegmentType, indexInFullPath: number) {
+        super();
         this.heading = heading;
         this.initialPosition = initialPosition;
         this.initialCourse = initialCourse;

--- a/src/fmgc/src/guidance/lnav/legs/index.ts
+++ b/src/fmgc/src/guidance/lnav/legs/index.ts
@@ -25,7 +25,7 @@ export interface SpeedConstraint {
     speed: Knots,
 }
 
-export interface Leg extends Guidable {
+export abstract class Leg implements Guidable {
     segment: SegmentType;
 
     indexInFullPath: number;
@@ -44,20 +44,25 @@ export interface Leg extends Guidable {
 
     get terminatorLocation(): LatLongData | undefined;
 
-    getPseudoWaypointLocation(distanceBeforeTerminator: NauticalMiles): LatLongData | undefined;
+    abstract getPseudoWaypointLocation(distanceBeforeTerminator: NauticalMiles): LatLongData | undefined;
 
-    getGuidanceParameters(ppos: LatLongAlt, trueTrack: Degrees);
+    /** @inheritDoc */
+    recomputeWithParameters(_tas: Knots): void {
+        // Default impl.
+    }
 
-    getNominalRollAngle(gs): Degrees;
+    abstract getGuidanceParameters(ppos: LatLongAlt, trueTrack: Degrees);
+
+    abstract getNominalRollAngle(gs): Degrees;
 
     /**
      * Calculates directed DTG parameter
      *
      * @param ppos {LatLong} the current position of the aircraft
      */
-    getDistanceToGo(ppos: LatLongData): NauticalMiles;
+    abstract getDistanceToGo(ppos: LatLongData): NauticalMiles;
 
-    isAbeam(ppos);
+    abstract isAbeam(ppos);
 }
 
 export function getAltitudeConstraintFromWaypoint(wp: WayPoint): AltitudeConstraint | undefined {

--- a/src/fmgc/src/guidance/lnav/transitions.ts
+++ b/src/fmgc/src/guidance/lnav/transitions.ts
@@ -3,7 +3,13 @@ import { Guidable } from '@fmgc/guidance/Geometry';
 export abstract class Transition implements Guidable {
     abstract isAbeam(ppos: LatLongData): boolean;
 
+    recomputeWithParameters(_tas: Knots) {
+        // Default impl.
+    }
+
     abstract getGuidanceParameters(ppos: LatLongData, trueTrack: Degrees);
+
+    abstract getPseudoWaypointLocation(distanceBeforeTerminator: NauticalMiles): LatLongData | undefined;
 
     abstract getNominalRollAngle(gs): Degrees;
 
@@ -11,7 +17,7 @@ export abstract class Transition implements Guidable {
 
     abstract getDistanceToGo(ppos: LatLongData);
 
-    abstract getTrackDistanceToTerminationPoint(ppos: LatLongData): NauticalMiles;
+    abstract getTurningPoints(): [LatLongData, LatLongData];
 
-    abstract getTurningPoints(): [LatLongData, LatLongData]
+    abstract get distance(): NauticalMiles;
 }

--- a/src/fmgc/src/guidance/vnav/VnavDriver.ts
+++ b/src/fmgc/src/guidance/vnav/VnavDriver.ts
@@ -5,6 +5,7 @@ import { TheoreticalDescentPathCharacteristics } from '@fmgc/guidance/vnav/desce
 import { DecelPathBuilder, DecelPathCharacteristics } from '@fmgc/guidance/vnav/descent/DecelPathBuilder';
 import { DescentBuilder } from '@fmgc/guidance/vnav/descent/DescentBuilder';
 import { VnavConfig } from '@fmgc/guidance/vnav/VnavConfig';
+import { GuidanceController } from '@fmgc/guidance/GuidanceController';
 import { Geometry } from '../Geometry';
 import { GuidanceComponent } from '../GuidanceComponent';
 import { ClimbPathBuilder } from './climb/ClimbPathBuilder';
@@ -17,16 +18,32 @@ export class VnavDriver implements GuidanceComponent {
 
     currentApproachProfile: DecelPathCharacteristics;
 
-    acceptNewMultipleLegGeometry(geometry: Geometry) {
-        this.computeVerticalProfile(geometry);
+    constructor(
+        private readonly guidanceController: GuidanceController,
+    ) {
     }
 
     init(): void {
         console.log('[FMGC/Guidance] VnavDriver initialized!');
     }
 
+    acceptMultipleLegGeometry(geometry: Geometry) {
+        this.computeVerticalProfile(geometry);
+    }
+
+    lastCruiseAltitude: Feet = 0;
+
     update(_deltaTime: number): void {
-        // TODO stuff here ?
+        const newCruiseAltitude = SimVar.GetSimVarValue('L:AIRLINER_CRUISE_ALTITUDE', 'number');
+        if (newCruiseAltitude !== this.lastCruiseAltitude) {
+            this.lastCruiseAltitude = newCruiseAltitude;
+
+            if (DEBUG) {
+                console.log('[FMS/VNAV] Computed new vertical profile because of new cruise altitude.');
+            }
+
+            this.computeVerticalProfile(this.guidanceController.currentMultipleLegGeometry);
+        }
     }
 
     private computeVerticalProfile(geometry: Geometry) {
@@ -36,6 +53,8 @@ export class VnavDriver implements GuidanceComponent {
             }
             this.currentApproachProfile = DecelPathBuilder.computeDecelPath(geometry);
             this.currentDescentProfile = DescentBuilder.computeDescentPath(geometry, this.currentApproachProfile);
+
+            this.guidanceController.pseudoWaypoints.acceptVerticalProfile();
         } else if (DEBUG) {
             console.warn('[FMS/VNAV] Did not compute vertical profile. Reason: no legs in flight plan.');
         }

--- a/src/fmgc/src/guidance/vnav/descent/DescentBuilder.ts
+++ b/src/fmgc/src/guidance/vnav/descent/DescentBuilder.ts
@@ -16,7 +16,13 @@ export class DescentBuilder {
             console.log(verticalDistance);
         }
 
-        return { tod: decelPath.decel + (verticalDistance / Math.tan((fpa * Math.PI) / 180)) * 0.000164579 };
+        const tod = decelPath.decel + (verticalDistance / Math.tan((fpa * Math.PI) / 180)) * 0.000164579;
+
+        if (DEBUG) {
+            console.log(`[FMS/VNAV] T/D: ${tod.toFixed(1)}nm`);
+        }
+
+        return { tod };
 
         //     const decelPointDistance = DecelPathBuilder.computeDecelPath(geometry);
         //


### PR DESCRIPTION
## Summary of Changes

Part of cFMS v2 migration.

This patch changes the FMS architecture to keep geometry and legs object around until the flight plan changes. This not only allows (primarly) for stateful legs (useful for HX) and transitions, but is also less intensive.

Additionally, pseudo waypoints now work when they end up in the middle of a transition path.

### Principle

Guidables (so, legs and transitions) now have a `recomputeWithParameters` method which is called every X seconds. This re-computed the geometry of the guidable, without re-creating the entire instance, using new parameters (TAS, GS, etc.)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): someperson#4953

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
