### PR TITLE
fix(elec): connect captain dome and nav lights to gnd flt svc buses

### DIFF
--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -1562,7 +1562,7 @@
                     <POTENTIOMETER>7</POTENTIOMETER>
                     <FAILURE>1</FAILURE>
                     <SIMVAR_INDEX>1</SIMVAR_INDEX>
-                    <EMISSIVE_CODE>(L:A32NX_ELEC_DC_2_BUS_IS_POWERED, Bool)</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>(L:A32NX_ELEC_DC_GND_FLT_SVC_BUS_IS_POWERED, Bool)</EMISSIVE_CODE>
                 </UseTemplate>
 
                 <!-- F/O dome light -->

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/systems.cfg
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/systems.cfg
@@ -326,10 +326,10 @@ circuit.7 = Type:CIRCUIT_PITOT_HEAT#Connections:bus.1#Power:30, 40, 20.0#Name:Pi
 circuit.8 = Type:CIRCUIT_STARTER:1#Connections:bus.1#Power:20, 35, 20.0#Name:Starter_1 ; Bleed Air Starter 35W
 circuit.9 = Type:CIRCUIT_STARTER:2#Connections:bus.1#Power:20, 35, 20.0#Name:Starter_2 ; Bleed Air Starter 35W
 circuit.10 = Type:CIRCUIT_APU_STARTER:1#Connections:bus.11#Power:2000, 1500, 20.0#Name:Starter_APU ; APU Starter 1500W
-circuit.11 = Type:CIRCUIT_LIGHT_NAV:1#Connections:bus.2#Power:10, 15, 20.0#Name:Nav_Light_1 ; nav 1 light 15W
-circuit.12 = Type:CIRCUIT_LIGHT_NAV:2#Connections:bus.3#Power:10, 15, 20.0#Name:Nav_Light_2 ; nav 2 light 15W
-circuit.13 = Type:CIRCUIT_LIGHT_NAV:3#Connections:bus.3#Power:10, 15, 20.0#Name:Nav_Light_3 ; nav 3 light 15W
-circuit.14 = Type:CIRCUIT_LIGHT_NAV:4#Connections:bus.2#Power:10, 15, 20.0#Name:Nav_Light_3 ; nav 4 light 15W
+circuit.11 = Type:CIRCUIT_LIGHT_NAV:1#Connections:bus.14#Power:10, 15, 20.0#Name:Nav_Light_1 ; nav 1 light 15W
+circuit.12 = Type:CIRCUIT_LIGHT_NAV:2#Connections:bus.14#Power:10, 15, 20.0#Name:Nav_Light_2 ; nav 2 light 15W
+circuit.13 = Type:CIRCUIT_LIGHT_NAV:3#Connections:bus.14#Power:10, 15, 20.0#Name:Nav_Light_3 ; nav 3 light 15W
+circuit.14 = Type:CIRCUIT_LIGHT_NAV:4#Connections:bus.14#Power:10, 15, 20.0#Name:Nav_Light_4 ; nav 4 light 15W
 circuit.15 = Type:CIRCUIT_LIGHT_BEACON:1#Connections:bus.2#Power:6, 8, 20.0#Name:Beacon_Light ; Beacon light 28V @ 0.26A
 circuit.16 = Type:CIRCUIT_LIGHT_BEACON:2#Connections:bus.3#Power:6, 8, 20.0#Name:Beacon_Light ; Beacon light 28V @ 0.26A
 circuit.17 = Type:CIRCUIT_LIGHT_LANDING:1#Connections:bus.2#Power:80, 95, 20.0#Name:Landing_Light_Takeoff ; Landing light 95W
@@ -348,8 +348,8 @@ circuit.29 = Type:CIRCUIT_LIGHT_LOGO:1#Connections:bus.2#Power:10, 15, 20.0#Name
 circuit.30 = Type:CIRCUIT_LIGHT_LOGO:2#Connections:bus.3#Power:10, 15, 20.0#Name:Logo_Light ; logo light 15W
 circuit.31 = Type:CIRCUIT_LIGHT_PANEL:1#Connections:bus.1#Power:2, 5, 20.0#Name:Panel_Light_1 ; panel light 5W
 
-; Captain dome light: DC 2
-circuit.32 = Type:CIRCUIT_LIGHT_CABIN:1#Connections:bus.8#Power:30, 40, 20.0#Name:Cabin_Light_pilot ; Cabin light 40W
+; Captain dome light: DC GND FLT SVC
+circuit.32 = Type:CIRCUIT_LIGHT_CABIN:1#Connections:bus.15#Power:30, 40, 20.0#Name:Cabin_Light_pilot ; Cabin light 40W
 
 ; F/O dome light: DC ESS
 circuit.33 = Type:CIRCUIT_LIGHT_CABIN:2#Connections:bus.9#Power:30, 40, 20.0#Name:Cabin_Light_copilot ; Cabin light 40W


### PR DESCRIPTION
Fixes #6170
Fixes #6174

## Summary of Changes
When creating the electrical system initially (in #2582) I didn't add the AC GND FLT SVC BUS and DC GND FLT SVC BUS. As those buses were not available, the captain dome and nav lights were assigned to the wrong (often "parent") bus in #3980. #4544 added the GND FLT SVC BUSes and thus we can now assign lights to them.

The Capt. dome light is assigned to DC GND FLT SVC BUS.
The NAV lights are assigned to AC GND FLT SVC BUS.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

## Testing instructions
Aside from the information in the summary, it is useful to know that DC/AC GND FLT SVC BUS is powered when:
- AC BUS 2 is powered, and TR2 hasn't failed.
- AC BUS 2 is unpowered, and EXT PWR is AVAIL.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
