### PR TITLE
fix: su7 fpm SET_CURRENT_FLIGHTPLAN_INDEX fix

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/NavSystems/LogicElements/A32NX_FlightPlanManager.js
@@ -661,7 +661,7 @@ class FlightPlanManager {
         return this._currentFlightPlanIndex;
     }
     setCurrentFlightPlanIndex(index, callback = EmptyCallback.Boolean) {
-        Coherent.call("SET_CURRENT_FLIGHTPLAN_INDEX", index).then(() => {
+        Coherent.call("SET_CURRENT_FLIGHTPLAN_INDEX", index, false).then(() => {
             let attempts = 0;
             const checkTrueFlightPlanIndex = () => {
                 Coherent.call("GET_CURRENT_FLIGHTPLAN_INDEX").then((value) => {


### PR DESCRIPTION
Fixes #6196 ?

## Summary of Changes

Add `false` as `SET_CURRENT_FLIGHTPLAN_INDEX ` second argument

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): someperson#4953

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
