### PR TITLE
feat(atsu): get trans alt and level from simbrief

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -70,6 +70,7 @@
 1. [AP] Added support for events AP_MACH_INC/DEC and AP_ALT_INC/DEC - @aguther (Andreas Guther)
 1. [SOUND] Added ALT increment selector and fixed ISIS sounds - @ImenesFBW (Imenes)
 1. [AP] Added support for other default events to basically push/pull all FCU buttons - @aguther (Andreas Guther)
+1. [FM] Fetch transition alt and level from SimBrief - @tracernz (Mike)
 
 ## 0.7.0
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_ATSU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_ATSU.js
@@ -149,7 +149,11 @@ const getSimBriefOfp = (mcdu, updateView, callback = () => {}) => {
             mcdu.simbrief["route"] = data.general.route;
             mcdu.simbrief["cruiseAltitude"] = data.general.initial_altitude;
             mcdu.simbrief["originIcao"] = data.origin.icao_code;
+            mcdu.simbrief["originTransAlt"] = parseInt(data.origin.trans_alt, 10);
+            mcdu.simbrief["originTransLevel"] = parseInt(data.origin.trans_level, 10);
             mcdu.simbrief["destinationIcao"] = data.destination.icao_code;
+            mcdu.simbrief["destinationTransAlt"] = parseInt(data.destination.trans_alt, 10);
+            mcdu.simbrief["destinationTransLevel"] = parseInt(data.destination.trans_level, 10);
             mcdu.simbrief["blockFuel"] = mcdu.simbrief["units"] === 'kgs' ? data.fuel.plan_ramp : lbsToKg(data.fuel.plan_ramp);
             mcdu.simbrief["payload"] = mcdu.simbrief["units"] === 'kgs' ? data.weights.payload : lbsToKg(data.weights.payload);
             mcdu.simbrief["estZfw"] = mcdu.simbrief["units"] === 'kgs' ? data.weights.est_zfw : lbsToKg(data.weights.est_zfw);
@@ -161,6 +165,8 @@ const getSimBriefOfp = (mcdu, updateView, callback = () => {}) => {
             mcdu.simbrief["icao_airline"] = typeof data.general.icao_airline === 'string' ? data.general.icao_airline : "";
             mcdu.simbrief["flight_number"] = data.general.flight_number;
             mcdu.simbrief["alternateIcao"] = data.alternate.icao_code;
+            mcdu.simbrief["alternateTransAlt"] = parseInt(data.alternate.trans_alt, 10);
+            mcdu.simbrief["alternateTransLevel"] = parseInt(data.alternate.trans_level, 10);
             mcdu.simbrief["avgTropopause"] = data.general.avg_tropopause;
             mcdu.simbrief["ete"] = data.times.est_time_enroute;
             mcdu.simbrief["blockTime"] = data.times.est_block;
@@ -192,7 +198,9 @@ const getSimBriefOfp = (mcdu, updateView, callback = () => {}) => {
 const insertUplink = (mcdu) => {
     const {
         originIcao,
+        originTransAlt,
         destinationIcao,
+        destinationTransLevel,
         cruiseAltitude,
         costIndex,
         alternateIcao,
@@ -213,6 +221,13 @@ const insertUplink = (mcdu) => {
         if (result) {
             CDUPerformancePage.UpdateThrRedAccFromOrigin(mcdu);
             CDUPerformancePage.UpdateEngOutAccFromOrigin(mcdu);
+
+            if (originTransAlt > 0) {
+                mcdu.flightPlanManager.setOriginTransitionAltitude(originTransAlt, true);
+            }
+            if (destinationTransLevel > 0) {
+                mcdu.flightPlanManager.setDestinationTransitionLevel(destinationTransLevel / 100, true);
+            }
 
             await mcdu.tryUpdateAltDestination(alternateIcao);
 

--- a/src/fmgc/src/flightplanning/FlightPlanManager.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanManager.ts
@@ -288,6 +288,7 @@ export class FlightPlanManager {
      * @param callback A callback to call when the operation has completed.
      */
     public async setOrigin(icao: string, callback = () => { }): Promise<void> {
+        const sameAirport = this.getOrigin()?.ident === icao;
         const currentFlightPlan = this._flightPlans[this._currentFlightPlanIndex];
         const airport = await this._parentInstrument.facilityLoader.getFacilityRaw(icao).catch(console.error);
         if (airport) {
@@ -296,7 +297,10 @@ export class FlightPlanManager {
             // clear pilot trans alt
             this.setOriginTransitionAltitude(undefined, false);
             // TODO get origin trans alt from database
-            this.setOriginTransitionAltitude(undefined, true);
+            // until then, don't erase the database value from ATSU if same airport as before
+            if (!sameAirport) {
+                this.setOriginTransitionAltitude(undefined, true);
+            }
             this.updateFlightPlanVersion().catch(console.error);
         }
         callback();
@@ -711,6 +715,7 @@ export class FlightPlanManager {
      * @param callback A callback to call once the operation completes.
      */
     public async setDestination(icao: string, callback = () => { }): Promise<void> {
+        const sameAirport = this.getDestination()?.ident === icao;
         const waypoint = await this._parentInstrument.facilityLoader.getFacilityRaw(icao);
         const currentFlightPlan = this._flightPlans[this._currentFlightPlanIndex];
         const destinationIndex = currentFlightPlan.length - 1;
@@ -736,7 +741,10 @@ export class FlightPlanManager {
         // clear pilot trans level
         this.setDestinationTransitionLevel(undefined, false);
         // TODO get destination trans level from database
-        this.setDestinationTransitionLevel(undefined, true);
+        // until then, don't erase the database value from ATSU if same airport as before
+        if (!sameAirport) {
+            this.setDestinationTransitionLevel(undefined, true);
+        }
 
         this.updateFlightPlanVersion().catch(console.error);
         callback();


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Partial #2068

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Transition altitude and level are not available yet in the MSFS navdata, so we weren't able to populate them until now. I asked Navigraph if they could include the transition altitude and level in the OFP, and they very speedily obliged, so thanks very much to them. When you retreive a navigraph OFP via ATSU, the transition altitude and level will be used as database values.

Needs #4953, and then retargeted onto `master`.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/9995998/142587922-b0bdd916-4673-4316-a482-a55cf9da506c.png)
![image](https://user-images.githubusercontent.com/9995998/142587951-8926c1e7-77ce-4df0-b8a9-9d6f75adc1c1.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Check that trans alt and level are filled by ATSU.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
