### PR TITLE
fix(model): Adjust heat effect on ENG1+2

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -70,6 +70,7 @@
 1. [AP] Added support for events AP_MACH_INC/DEC and AP_ALT_INC/DEC - @aguther (Andreas Guther)
 1. [SOUND] Added ALT increment selector and fixed ISIS sounds - @ImenesFBW (Imenes)
 1. [AP] Added support for other default events to basically push/pull all FCU buttons - @aguther (Andreas Guther)
+1. [MODEL] Adjust heat effect on ENG1+2 - @bouveng (Johan Bouveng)
 
 ## 0.7.0
 

--- a/src/model/models.json
+++ b/src/model/models.json
@@ -30917,6 +30917,20 @@
         ]
       },
       {
+        "node": "fx_exhaust_left",
+        "mods": {
+          "translation": [-3.045, 0.000683486462, -0.0133237839],
+          "scale": [0.5, 0.5, 0.5]
+        }
+      },
+      {
+        "node": "fx_exhaust_right",
+        "mods": {
+          "translation": [0.0284314156,1.00650072,0],
+          "scale": [0.5, 0.5, 0.5]
+        }
+      },
+      {
         "accessors": [
           "x0_LIVERY_OFFICIAL_WINGL_vertices#0_TEXCOORD_0",
           "x0_LIVERY_OFFICIAL_WINGL_vertices#0_TEXCOORD_1"


### PR DESCRIPTION
Fixes #5325
Fixes #1224 

## Summary of Changes
Adjust heat blur effect on `ENG1` + `ENG2` to more reasonable levels.

Blur effects are **moved back** slightly and **only 50%** so big.
Still visible from windows, just not as much as before, as a result of conversation in #2221 taken into account.

## Additional context
One could argue that this could/should be a setting, in EFB perhaps:

```
[ ] Default
[x] Minimal
[ ] Off 
```

Where `minimal` is the contents of this PR.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username: @bouveng 

## Testing instructions
1. Spawn on runway.
2. Observe blur on ENG1 and ENG2 from wing views.
3. Observe blur on ENG1 and ENG2 from external views / drone cam.
4. Take off, observe blur from wing views and external views / drone cam.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
