### PR TITLE
fix(pfd): speed tape outline at low speeds

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -71,6 +71,7 @@
 1. [SOUND] Added ALT increment selector and fixed ISIS sounds - @ImenesFBW (Imenes)
 1. [AP] Added support for other default events to basically push/pull all FCU buttons - @aguther (Andreas Guther)
 1. [MCDU] Fix backlight, brightness - @tracernz (Mike)
+1. [PFD] Fixed speed tape outline at low speeds - @beheh (Benedict Etzel)
 
 ## 0.7.0
 

--- a/src/instruments/src/PFD/SpeedIndicator.tsx
+++ b/src/instruments/src/PFD/SpeedIndicator.tsx
@@ -201,10 +201,11 @@ export const AirspeedIndicatorOfftape = ({ airspeed, targetSpeed, speedIsManaged
 
     const clampedSpeed = Math.max(Math.min(airspeed, 660), 30);
     const clampedTargetSpeed = Math.max(Math.min(targetSpeed, 660), 30);
+    const showLower = clampedSpeed > 72;
     return (
         <g id="SpeedOfftapeGroup">
             <path id="SpeedTapeOutlineUpper" className="NormalStroke White" d="m1.9058 38.086h21.859" />
-            <path id="SpeedTapeOutlineLower" className="NormalStroke White" d="m1.9058 123.56h21.859" />
+            {showLower ? <path id="SpeedTapeOutlineLower" className="NormalStroke White" d="m1.9058 123.56h21.859" /> : null}
             <SpeedTarget airspeed={clampedSpeed} targetSpeed={clampedTargetSpeed} isManaged={speedIsManaged} />
             <path className="Fill Yellow SmallOutline" d="m13.994 80.46v0.7257h6.5478l3.1228 1.1491v-3.0238l-3.1228 1.1491z" />
             <path className="Fill Yellow SmallOutline" d="m0.092604 81.185v-0.7257h2.0147v0.7257z" />
@@ -231,7 +232,7 @@ const SpeedTarget = ({ airspeed, targetSpeed, isManaged }) => {
 };
 
 const SpeedTapeOutline = ({ airspeed, isRed = false }) => {
-    const length = Math.max(Math.min(airspeed, 72), 30) * 1.01754 + 12.2104;
+    const length = 42.9 + Math.max(Math.max(Math.min(airspeed, 72.1), 30) - 30, 0);
     const className = isRed ? 'NormalStroke Red' : 'NormalStroke White';
 
     return (


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR improves the behavior of the speed tape at speeds between 0 and 72 knots.
Specifically, it improves the alignment of the right speed tape edge with the 30 tick and hides the bottom speed tape until the bottom corner of the right edge passes it.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![image](https://user-images.githubusercontent.com/929769/142779953-e7bf1bd6-fc09-47a6-8ccc-6a581e2473e0.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

https://www.youtube.com/watch?v=TEi-WX08ov8#t=5m41s

![image](https://user-images.githubusercontent.com/929769/142779791-e7a89b93-81d6-470d-b567-b05e8b78e499.png)

![image](https://user-images.githubusercontent.com/929769/142780013-8e70cbea-c539-4bec-b983-02ec769a1d1c.png)

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BehEh#1234

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Start a flight without ADIRS aligned. Observe no changes to before when not aligned (see reference above)
2. Align the IRS. Check the white line is not visible.
3. Play close attention when taking off. Between 0 and 30 knots you should see no difference.
4. Above 30 you should see the right edge moving downwards, aligned with the tick (see above)
5. Around 72 knots you should see the right edge reaching reaching the bottom and the white edge at the bottom appearing
6. Nothing should have changed above 72 knots.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
