### PR TITLE
fix: transition alt/level

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -318,7 +318,7 @@ class CDUFlightPlanPage {
                     const lastRouteIndex = fpm.getLastIndexBeforeApproach();
                     //const departureWp = firstRouteIndex > 1 && fpm.getDepartureWaypoints().indexOf(wp) !== -1;
 
-                    if (mcdu.transitionAltitude >= 100 && wp.legAltitude1 > mcdu.transitionAltitude) {
+                    if (mcdu.flightPlanManager.getOriginTransitionAltitude() >= 100 && wp.legAltitude1 > mcdu.flightPlanManager.getOriginTransitionAltitude()) {
                         altitudeConstraint = (wp.legAltitude1 / 100).toFixed(0).toString();
                         altitudeConstraint = `FL${altitudeConstraint.padStart(3,"0")}`;
                     } else {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -188,7 +188,7 @@ class CDUPerformancePage {
             transAltCell = "[\xa0".padEnd(4, "\xa0") + "]";
             if (mcdu.flightPlanManager.originTransitionAltitude !== undefined) {
                 transAltCell = `{cyan}${mcdu.flightPlanManager.originTransitionAltitude}{end}`;
-                if (mcdu.flightPlanManager.originTransitionAltitudeFromDb) {
+                if (mcdu.flightPlanManager.originTransitionAltitudeIsFromDb) {
                     transAltCell += "[s-text]";
                 }
             }
@@ -762,7 +762,7 @@ class CDUPerformancePage {
         if (hasDestination) {
             if (mcdu.flightPlanManager.destinationTransitionLevel !== undefined) {
                 transAltCell = (mcdu.flightPlanManager.destinationTransitionLevel * 100).toFixed(0).padEnd(5, "\xa0");
-                if (mcdu.flightPlanManager.destinationTransitionLevelFromDb) {
+                if (mcdu.flightPlanManager.destinationTransitionLevelIsFromDb) {
                     transAltCell = `{small}${transAltCell}{end}`;
                 }
             } else {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
@@ -21,26 +21,27 @@ class CDUVerticalRevisionPage {
                 speedConstraint = waypoint.speedConstraint.toFixed(0);
             }
             let altitudeConstraint = "";
+            const transAltLevel = waypoint.constraintType === 2 /* DES */ ? mcdu.flightPlanManager.destinationTransitionLevel : mcdu.flightPlanManager.originTransitionAltitude;
             switch (waypoint.legAltitudeDescription) {
                 case 1: {
-                    altitudeConstraint = this.formatFl(Math.round(waypoint.legAltitude1), mcdu.transitionAltitude);
+                    altitudeConstraint = this.formatFl(Math.round(waypoint.legAltitude1), transAltLevel);
                     break;
                 }
                 case 2: {
-                    altitudeConstraint = "+" + this.formatFl(Math.round(waypoint.legAltitude1), mcdu.transitionAltitude);
+                    altitudeConstraint = "+" + this.formatFl(Math.round(waypoint.legAltitude1), transAltLevel);
                     break;
                 }
                 case 3: {
-                    altitudeConstraint = "-" + this.formatFl(Math.round(waypoint.legAltitude1), mcdu.transitionAltitude);
+                    altitudeConstraint = "-" + this.formatFl(Math.round(waypoint.legAltitude1), transAltLevel);
                     break;
                 }
                 case 4: {
                     if (waypoint.legAltitude1 < waypoint.legAltitude2) {
-                        altitudeConstraint = "+" + this.formatFl(Math.round(waypoint.legAltitude1), mcdu.transitionAltitude)
-                            + "/-" + this.formatFl(Math.round(waypoint.legAltitude2), mcdu.transitionAltitude);
+                        altitudeConstraint = "+" + this.formatFl(Math.round(waypoint.legAltitude1), transAltLevel)
+                            + "/-" + this.formatFl(Math.round(waypoint.legAltitude2), transAltLevel);
                     } else {
-                        altitudeConstraint = "+" + this.formatFl(Math.round(waypoint.legAltitude2), mcdu.transitionAltitude)
-                            + "/-" + this.formatFl(Math.round(waypoint.legAltitude1), mcdu.transitionAltitude);
+                        altitudeConstraint = "+" + this.formatFl(Math.round(waypoint.legAltitude2), transAltLevel)
+                            + "/-" + this.formatFl(Math.round(waypoint.legAltitude1), transAltLevel);
                     }
                     break;
                 }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -80,8 +80,6 @@ class FMCMainDisplay extends BaseAirliners {
         this.engineOutAccelerationAltitude = undefined;
         this.engineOutAccelerationAltitudeGoaround = undefined;
         this.engineOutAccelerationAltitudeIsPilotEntered = undefined;
-        this.transitionAltitude = undefined;
-        this.transitionAltitudeIsPilotEntered = undefined;
         this._windDirections = undefined;
         this._fuelPlanningPhases = undefined;
         this._zeroFuelWeightZFWCGEntered = undefined;
@@ -296,7 +294,6 @@ class FMCMainDisplay extends BaseAirliners {
         this.routeIndex = 0;
         this.coRoute = "";
         this.tmpOrigin = "";
-        this.transitionAltitude = undefined;
         this.perfTOTemp = NaN;
         this._overridenFlapApproachSpeed = NaN;
         this._overridenSlatApproachSpeed = NaN;
@@ -348,7 +345,6 @@ class FMCMainDisplay extends BaseAirliners {
         this.engineOutAccelerationAltitude = NaN;
         this.engineOutAccelerationAltitudeGoaround = NaN;
         this.engineOutAccelerationAltitudeIsPilotEntered = false;
-        this.transitionAltitudeIsPilotEntered = false;
 
         this._windDirections = {
             TAILWIND : "TL",
@@ -495,8 +491,6 @@ class FMCMainDisplay extends BaseAirliners {
         SimVar.SetSimVarValue("L:AIRLINER_V1_SPEED", "Knots", NaN);
         SimVar.SetSimVarValue("L:AIRLINER_V2_SPEED", "Knots", NaN);
         SimVar.SetSimVarValue("L:AIRLINER_VR_SPEED", "Knots", NaN);
-        SimVar.SetSimVarValue("L:AIRLINER_TRANS_ALT", "Number", this.transitionAltitude);
-        SimVar.SetSimVarValue("L:AIRLINER_APPR_TRANS_ALT", "Number", this.perfApprTransAlt);
 
         CDUPerformancePage.UpdateThrRedAccFromOrigin(this, true, true);
         CDUPerformancePage.UpdateEngOutAccFromOrigin(this);
@@ -2222,10 +2216,7 @@ class FMCMainDisplay extends BaseAirliners {
     trySetTakeOffTransAltitude(s) {
         if (s === FMCMainDisplay.clrValue) {
             // TODO when possible fetch default from database
-            this.transitionAltitude = this.transitionAltitudeIsPilotEntered ? 10000 : NaN;
-            this.transitionAltitudeIsPilotEntered = false;
             this.flightPlanManager.setOriginTransitionAltitude();
-            SimVar.SetSimVarValue("L:AIRLINER_TRANS_ALT", "Number", 0);
             return true;
         }
 
@@ -2241,10 +2232,7 @@ class FMCMainDisplay extends BaseAirliners {
             return false;
         }
 
-        this.transitionAltitude = value;
-        this.transitionAltitudeIsPilotEntered = true;
         this.flightPlanManager.setOriginTransitionAltitude(value);
-        SimVar.SetSimVarValue("L:AIRLINER_TRANS_ALT", "Number", value);
         return true;
     }
 
@@ -3009,7 +2997,6 @@ class FMCMainDisplay extends BaseAirliners {
     setPerfApprTransAlt(s) {
         if (s === FMCMainDisplay.clrValue) {
             this.flightPlanManager.setDestinationTransitionLevel();
-            SimVar.SetSimVarValue("L:AIRLINER_APPR_TRANS_ALT", "Number", 0);
             return true;
         }
 
@@ -3024,7 +3011,6 @@ class FMCMainDisplay extends BaseAirliners {
         }
 
         this.flightPlanManager.setDestinationTransitionLevel(Math.round(value / 100));
-        SimVar.SetSimVarValue("L:AIRLINER_APPR_TRANS_ALT", "Number", value);
         return true;
     }
 

--- a/src/fmgc/src/components/EfisLabels.ts
+++ b/src/fmgc/src/components/EfisLabels.ts
@@ -9,9 +9,8 @@ export class EfisLabels implements FmgcComponent {
 
     private flightPlanManager: FlightPlanManager;
 
-    init(): void {
-        // FIXME we need a better way to fetch this... maybe just make it a singleton
-        this.flightPlanManager = FlightPlanManager.DEBUG_INSTANCE;
+    init(flightPlanManager: FlightPlanManager): void {
+        this.flightPlanManager = flightPlanManager;
     }
 
     update(_deltaTime: number): void {

--- a/src/fmgc/src/components/EfisLabels.ts
+++ b/src/fmgc/src/components/EfisLabels.ts
@@ -1,0 +1,32 @@
+import { FlightLevel } from '@fmgc/guidance/vnav/verticalFlightPlan/VerticalFlightPlan';
+import { FmgcComponent } from '@fmgc/lib/FmgcComponent';
+import { FlightPlanManager } from '@fmgc/wtsdk';
+
+export class EfisLabels implements FmgcComponent {
+    private lastTransitionAltitude: Feet;
+
+    private lastTransitionLevel: FlightLevel;
+
+    private flightPlanManager: FlightPlanManager;
+
+    init(): void {
+        // FIXME we need a better way to fetch this... maybe just make it a singleton
+        this.flightPlanManager = FlightPlanManager.DEBUG_INSTANCE;
+    }
+
+    update(_deltaTime: number): void {
+        const transitionAltitude = this.flightPlanManager.originTransitionAltitude;
+        const transitionLevel = this.flightPlanManager.destinationTransitionLevel;
+
+        // FIXME ARINC429 when the PR adding a TS impl. lands...
+        if (transitionAltitude !== this.lastTransitionAltitude) {
+            SimVar.SetSimVarValue('L:AIRLINER_TRANS_ALT', 'Number', transitionAltitude ?? 0);
+            this.lastTransitionAltitude = transitionAltitude;
+        }
+
+        if (transitionLevel !== this.lastTransitionLevel) {
+            SimVar.SetSimVarValue('L:AIRLINER_APPR_TRANS_ALT', 'Number', (transitionLevel ?? 0) * 100);
+            this.lastTransitionLevel = transitionLevel;
+        }
+    }
+}

--- a/src/fmgc/src/flightplanning/FlightPlanManager.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanManager.ts
@@ -30,6 +30,7 @@ import { FlightPlanSegment } from './FlightPlanSegment';
 import { FlightPlanAsoboSync } from './FlightPlanAsoboSync';
 import { FixInfo } from './FixInfo';
 import { OneWayRunway } from '@fmgc/types/fstypes/FSTypes';
+import { FlightLevel } from '@fmgc/guidance/vnav/verticalFlightPlan/VerticalFlightPlan';
 
 export enum WaypointConstraintType {
     CLB = 1,
@@ -1774,18 +1775,38 @@ export class FlightPlanManager {
         return this._currentFlightPlanVersion;
     }
 
-    get originTransitionAltitude(): number | undefined {
-        const currentFlightPlan = this._flightPlans[this._currentFlightPlanIndex];
+    public getOriginTransitionAltitude(flightPlanIndex: number = this._currentFlightPlanIndex): Feet | undefined {
+        const currentFlightPlan = this._flightPlans[flightPlanIndex];
         return currentFlightPlan.originTransitionAltitudePilot ?? currentFlightPlan.originTransitionAltitudeDb;
     }
 
-    get originTransitionAltitudeFromDb(): boolean {
-        const currentFlightPlan = this._flightPlans[this._currentFlightPlanIndex];
+    /**
+     * The transition altitude for the origin in the *active* flight plan
+     */
+    get originTransitionAltitude(): number | undefined {
+        return this.getOriginTransitionAltitude(0);
+    }
+
+    public getOriginTransitionAltitudeIsFromDb(flightPlanIndex: number = 0): boolean {
+        const currentFlightPlan = this._flightPlans[flightPlanIndex];
         return currentFlightPlan.originTransitionAltitudePilot === undefined;
     }
 
-    public setOriginTransitionAltitude(altitude?: number, database: boolean = false) {
-        const currentFlightPlan = this._flightPlans[this._currentFlightPlanIndex];
+    /**
+     * Is the transition altitude for the origin in the *active* flight plan from the database?
+     */
+    get originTransitionAltitudeIsFromDb(): boolean {
+        return this.getOriginTransitionAltitudeIsFromDb(0);
+    }
+
+    /**
+     * Set the transition altitude for the origin
+     * @param altitude transition altitude
+     * @param database is this value from the database, or pilot?
+     * @param flightPlanIndex index of flight plan to be edited, defaults to current plan being edited (not active!)
+     */
+    public setOriginTransitionAltitude(altitude?: number, database: boolean = false, flightPlanIndex = this._currentFlightPlanIndex) {
+        const currentFlightPlan = this._flightPlans[flightPlanIndex];
         if (database) {
             currentFlightPlan.originTransitionAltitudeDb = altitude;
         } else {
@@ -1794,18 +1815,38 @@ export class FlightPlanManager {
         this.updateFlightPlanVersion();
     }
 
-    get destinationTransitionLevel(): number | undefined {
-        const currentFlightPlan = this._flightPlans[this._currentFlightPlanIndex];
+    public getDestinationTransitionLevel(flightPlanIndex: number = this._currentFlightPlanIndex): FlightLevel | undefined {
+        const currentFlightPlan = this._flightPlans[flightPlanIndex];
         return currentFlightPlan.destinationTransitionLevelPilot ?? currentFlightPlan.destinationTransitionLevelDb;
     }
 
-    get destinationTransitionLevelFromDb(): boolean {
-        const currentFlightPlan = this._flightPlans[this._currentFlightPlanIndex];
+    /**
+     * The transition level for the destination in the *active* flight plan
+     */
+    get destinationTransitionLevel(): FlightLevel | undefined {
+        return this.getDestinationTransitionLevel(0);
+    }
+
+    public getDestinationTransitionLevelIsFromDb(flightPlanIndex: number = this._currentFlightPlanIndex): boolean {
+        const currentFlightPlan = this._flightPlans[flightPlanIndex];
         return currentFlightPlan.destinationTransitionLevelPilot === undefined;
     }
 
-    public setDestinationTransitionLevel(flightLevel?: number, database: boolean = false) {
-        const currentFlightPlan = this._flightPlans[this._currentFlightPlanIndex];
+    /**
+     * Is the transition level for the destination in the *active* flight plan from the database?
+     */
+    get destinationTransitionLevelIsFromDb(): boolean {
+        return this.getDestinationTransitionLevelIsFromDb(0);
+    }
+
+    /**
+     * Set the transition level for the destination
+     * @param flightLevel transition level
+     * @param database is this value from the database, or pilot?
+     * @param flightPlanIndex index of flight plan to be edited, defaults to current plan being edited (not active!)
+     */
+    public setDestinationTransitionLevel(flightLevel?: FlightLevel, database: boolean = false, flightPlanIndex = this._currentFlightPlanIndex) {
+        const currentFlightPlan = this._flightPlans[flightPlanIndex];
         if (database) {
             currentFlightPlan.destinationTransitionLevelDb = flightLevel;
         } else {

--- a/src/fmgc/src/lib/FmgcComponent.ts
+++ b/src/fmgc/src/lib/FmgcComponent.ts
@@ -1,6 +1,8 @@
+import { FlightPlanManager } from '@fmgc/wtsdk';
+
 export interface FmgcComponent {
 
-    init(): void;
+    init(flightPlanManager: FlightPlanManager): void;
 
     update(deltaTime: number): void;
 

--- a/src/fmgc/src/loop.ts
+++ b/src/fmgc/src/loop.ts
@@ -1,6 +1,7 @@
 import { FmgcComponent } from '@fmgc/lib/FmgcComponent';
 import { FmsMessages } from '@fmgc/components/FmsMessages';
 import { EfisLabels } from '@fmgc/components/EfisLabels';
+import { FlightPlanManager } from '@fmgc/wtsdk';
 
 const components: FmgcComponent[] = [
     FmsMessages.instance,
@@ -8,7 +9,10 @@ const components: FmgcComponent[] = [
 ];
 
 export function initFmgcLoop(): void {
-    components.forEach((component) => component.init());
+    // FIXME we need a better way to fetch this... maybe just make it a singleton
+    const flightPlanManager = FlightPlanManager.DEBUG_INSTANCE;
+
+    components.forEach((component) => component.init(flightPlanManager));
 }
 
 export function updateFmgcLoop(deltaTime: number): void {

--- a/src/fmgc/src/loop.ts
+++ b/src/fmgc/src/loop.ts
@@ -1,8 +1,10 @@
 import { FmgcComponent } from '@fmgc/lib/FmgcComponent';
 import { FmsMessages } from '@fmgc/components/FmsMessages';
+import { EfisLabels } from '@fmgc/components/EfisLabels';
 
 const components: FmgcComponent[] = [
     FmsMessages.instance,
+    new EfisLabels(),
 ];
 
 export function initFmgcLoop(): void {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Refactor transition altitude and level handling a little to accomodate secondary and alternate flight plan (future). Fix trans alt and level not being sent to EFIS when from DB (currently only Navigraph OFPs).

Note: no changelog as there are no user visible changes since the previous stable release.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Fetch an OFP from SimBrief and note the transition altitude and level are automatically filled from the database. Climb through the transition altitude and ensure QNH blinks on the PFD. Activate STD, reach cruise, then descend through the transition level and ensure STD blinks on the PFD.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
