### PR TITLE
fix(typings): add boolean SetSimVarValue overload

### DIFF
--- a/typings/fs-base-ui/html_ui/JS/simvar.d.ts
+++ b/typings/fs-base-ui/html_ui/JS/simvar.d.ts
@@ -2,9 +2,11 @@
 /// <reference path="./Simplane.d.ts" />
 /// <reference path="../../../types.d.ts" />
 
-type NumberVarUnit = ("number" | "Number") | "position 32k" | ("SINT32") | ("bool" | "Bool" | "Boolean" | "boolean") | "Enum" | "lbs" | "kg" | ("Degrees" | "degree" | "Radians")
+type NumberVarUnit = ("number" | "Number") | "position 32k" | ("SINT32") | BooleanVarUnit | "Enum" | "lbs" | "kg" | ("Degrees" | "degree" | "Radians")
     | "radians" | ("Percent" | "percent") | ("Feet" | "feet" | "feets" | "Feets") | "Volts" | "Amperes" | "Hertz" | "PSI" | "celsius" | "degree latitude"
     | "degree longitude" | "meters per second" | "Meters per second" | "Position" | ("Knots" | "knots") | "Seconds" | "seconds" | "kilograms per second" | "nautical miles" | "degrees"
+
+type BooleanVarUnit = 'Bool' | 'bool' | 'Boolean' | 'boolean'
 
 type TextVarUnit = "Text" | "string"
 
@@ -86,6 +88,7 @@ declare global {
         function GetSimVarValue(name: string, unit: XYZVarUnit, dataSource?: string): XYZ | null;
 
         function SetSimVarValue(name: string, unit: NumberVarUnit, value: number, dataSource?: string): Promise<void>;
+        function SetSimVarValue(name: string, unit: BooleanVarUnit, value: boolean, dataSource?: string): Promise<void>;
         function SetSimVarValue(name: string, unit: TextVarUnit, value: string, dataSource?: string): Promise<void>;
         function SetSimVarValue(name: string, unit: LatLongAltVarUnit, value: LatLongAlt, dataSource?: string): Promise<void>;
         function SetSimVarValue(name: string, unit: LatLongAltPBHVarUnit, value: LatLongAltPBH, dataSource?: string): Promise<void>;


### PR DESCRIPTION
## Summary of Changes

This patch fixes type checking errors that would reject boolean values being used in `SetSimVarValue` with boolean units, which is a valid operation. The same is not done on `GetSimVarValue` because that function does not return a boolean, even with the right unit.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): someperson#4953

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

N/A. No runtime changes.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
