### PR TITLE
fix(ecam): fix gross weight being shown without engines running

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -86,6 +86,7 @@
 1. [PFD] Added new messages and modes for TCAS - @lukecologne (lukecologne#1156)
 1. [FDR] Added additional data to the FDR - @aguther (Andreas Guther)
 1. [ATHR] Fixed ATHR being armed in flight when TOGA applied without GA condition - @aguther (Andreas Guther)
+1. [ECAM] Fixed gross weight being shown without engines running - @BlueberryKing (BlueberryKing)
 
 ## 0.7.0
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/EICAS_Common.css
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/EICAS_Common.css
@@ -47,6 +47,9 @@ eicas-common-display text {
   font-size: 20px;
   font-family: "ECAMFontRegular";
 }
+eicas-common-display text.Cyan {
+  fill: var(--displayCyan) !important;
+}
 eicas-common-display text.Title {
   fill: var(--displayWhite) !important;
 }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/EICAS_Common.html
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/EICAS_Common.html
@@ -42,7 +42,7 @@
         <g id="GW">
             <text class="Title" x="445" y="63" text-anchor="end">GW</text>
 
-            <text id="GWValue" class="Value" x="542" y="63" text-anchor="end">--</text>
+            <text id="GWValue" class="Value" x="512" y="63" text-anchor="middle">--</text>
             <text id="GWUnit" class="Unit" x="562" y="61" text-anchor="start">KG</text>
         </g>
     </svg>

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/EICAS_Common.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/EICAS_Common.js
@@ -168,7 +168,7 @@ class EICASCommonDisplay extends Airliners.EICASTemplateElement {
             } else {
                 this.gwValue.classList.remove("Value");
                 this.gwValue.classList.add("Cyan");
-                this.gwValue.textContent = "--"
+                this.gwValue.textContent = "--";
             }
         }
         if (gwUnit != this.currentGwUnit) {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/EICAS_Common.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/EICAS_Common.js
@@ -153,13 +153,22 @@ class EICASCommonDisplay extends Airliners.EICASTemplateElement {
         const fuelWeight = SimVar.GetSimVarValue("FUEL TOTAL QUANTITY WEIGHT", "kg");
         const emptyWeight = SimVar.GetSimVarValue("EMPTY WEIGHT", "kg");
         const payloadWeight = this.getPayloadWeight("kg");
+        const isOneEngineRunning = SimVar.GetSimVarValue("ENG COMBUSTION:1", "bool") || SimVar.GetSimVarValue("ENG COMBUSTION:2", "bool");
         const gw = Math.round(NXUnits.kgToUser(emptyWeight + fuelWeight + payloadWeight));
         const gwUnit = NXUnits.userWeightUnit();
-        if ((gw != this.currentGW) || _force) {
+        if ((gw != this.currentGW) || (this.isOneEngineRunning != isOneEngineRunning) || _force) {
             this.currentGW = gw;
-            if (this.gwValue != null) {
+            this.isOneEngineRunning = isOneEngineRunning;
+
+            if (isOneEngineRunning && this.gwValue != null) {
                 // Lower EICAS displays GW in increments of 100
+                this.gwValue.classList.add("Value");
+                this.gwValue.classList.remove("Cyan");
                 this.gwValue.textContent = (Math.floor(this.currentGW / 100) * 100).toString();
+            } else {
+                this.gwValue.classList.remove("Value");
+                this.gwValue.classList.add("Cyan");
+                this.gwValue.textContent = "--"
             }
         }
         if (gwUnit != this.currentGwUnit) {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #6305 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Show cyan dashes in place of gross weight when no engine is running.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![Screenshot 2021-12-08 005553](https://user-images.githubusercontent.com/22713769/145124316-f5a80688-1851-4ac0-a04d-8aba344ea613.png)
![Screenshot 2021-12-08 005501](https://user-images.githubusercontent.com/22713769/145124322-aa65e318-ff64-4b57-a8b0-e128d7999c09.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
- With timestamp: https://youtu.be/uz5HT8K-g8I?t=235

- FBW-31-04

- FCOM:

![image](https://user-images.githubusercontent.com/22713769/144724665-9c8e903d-3654-4c79-9e6c-63e545b3277d.png)

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BlueberryKing#6641

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Load up cold and dark
- Power up
- Observe gross cyan dashes in place of gross weight value
- Start one engine
- Observe gross weight value showing

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
