### PR TITLE
fix: Co-pilot not showing

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -87,6 +87,7 @@
 1. [FDR] Added additional data to the FDR - @aguther (Andreas Guther)
 1. [ATHR] Fixed ATHR being armed in flight when TOGA applied without GA condition - @aguther (Andreas Guther)
 1. [ECAM] Fixed gross weight being shown without engines running - @BlueberryKing (BlueberryKing)
+1. [FLIGHT MODEL] Fixes co-pilot not being shown in external view -  @donstim (donbikes#4084)
 
 ## 0.7.0
 

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/flight_model.cfg
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/flight_model.cfg
@@ -42,7 +42,7 @@ activate_cg_limit_based_on_mach = 0 ; Activate cg limitation depending on mach v
 ; Average Adult pax assumed to be 185lbs/84kg
 ; Passenger baggage weight of 20 kg/pax is also added, making total pax + baggage weight = 104 kg/pax (i.e. Passenger weight on Simbrief)
 ; Starting load is 50% of capacity
-max_number_of_stations = 8 ; Number of payload stations
+max_number_of_stations = 10 ; Number of payload stations
 station_load.0 = 3300, 21.98, 0, 5, ECONOMY ROWS 1-6 (seats: 36 max: 6670lbs/3024kg), 0
 station_load.1 = 3850, 2.86, 0, 5.1, ECONOMY ROWS 7-13 (seats: 42 max: 7780lb/3530kg), 0
 station_load.2 = 4400, -15.34, 0, 5.3, ECONOMY ROWS 14-21 (seats: 48 max: 8880lb/4032kg), 0
@@ -51,6 +51,8 @@ station_load.4 = 2800, 18.28, 0, 0.9, FWD BAGGAGE/CONTAINER (max: 5600lb/2540kg)
 station_load.5 = 1950, -15.96, 0, 1, AFT CONTAINER (max: 4000lb/1815kg), 0
 station_load.6 = 1700, -27.10, 0, 1.2, AFT BAGGAGE (max: 3500lb/1585kg), 0
 station_load.7 = 1300, -37.35, 0, 1.4, AFT BULK/LOOSE (max: 2750lb/1245kg), 0
+station_load.8 = 1, 42.36, 0, 0, PILOT, 1
+station_load.9 = 1, 42.36, 0, 0, CO-PILOT, 2
 
 [CONTACT_POINTS]
 static_pitch = -0.2 ; degrees, pitch when at rest on the ground (+=Up, -=Dn)


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #6264 

## Summary of Changes
The Pilot and Co-pilot weights were removed from the flight_model.cfg weight-and-balance section by PR #5895 since the flightcrew are included in the operating empty weight of the airplane. An unintended side effect was that the co-pilot (and for some people, the pilot) no longer appears in the external view. (It was not known that the pilot and co-pilot entries in the weight-and-balance section of the flight_model.cfg file affected the appearance of their avatars in the external view. This is not mentioned in the MSFS SDK.)

This PR adds the pilot and co-pilot entries back into the weight-and-balance section of the flight_model.cfg file. It assigns them weights of 1 pound each so that it does not materially affect the weight-and-balance distribution. (I tried using 0 pounds each, but that did not work.)

## Screenshots (if necessary)
Before PR:
![Screenshot (1379)](https://user-images.githubusercontent.com/70166617/145498019-3bba288a-4cde-4fd0-98bb-4d0e251facbc.png)

After PR:
![Screenshot (1381)](https://user-images.githubusercontent.com/70166617/145498030-a49f9923-dd3b-4cae-aa6a-c5e1bd3df4f9.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): donbikes#4084

## Testing instructions
1. Verify that the pilot and co-pilot avatars appear in the external view
2. I suppose you could also check that weight and cg are unaffected by this change. It should add 2 pounds of weight in the cockpit.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
