### PR TITLE
fix(apu): fix APU not shutting down properly

### DIFF
--- a/src/systems/systems/src/pneumatic/mod.rs
+++ b/src/systems/systems/src/pneumatic/mod.rs
@@ -287,7 +287,8 @@ pub enum EngineState {
     Off = 0,
     On = 1,
     Starting = 2,
-    Shutting = 3,
+    Restarting = 3,
+    Shutting = 4,
 }
 
 read_write_enum!(EngineState);
@@ -298,7 +299,8 @@ impl From<f64> for EngineState {
             0 | 10 => EngineState::Off,
             1 | 11 => EngineState::On,
             2 | 12 => EngineState::Starting,
-            3 | 13 => EngineState::Shutting,
+            3 | 13 => EngineState::Restarting,
+            4 | 14 => EngineState::Shutting,
             _ => panic!("EngineState value does not correspond to any enum member"),
         }
     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This fixes an issue where the APU AVAIL light would not turn off. This happened because the Rust process crashed when a new `EngineState` value introduced in #6284 was not recognized by the bleed system.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BlueberryKing#6641

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Start cold & dark
- Turn on APU
- Turn on engines
- Turn off engine number 2
- Make sure you can operate the hydraulic pumps on the overhead panel, i.e switch them off and back on.
- Make sure you can use the toe brakes and set the parking brake.
- Turn off engine number one and check the two items above again.
- Make sure you can turn off the APU. Observe APU shutting down properly and all of the APU lights turning off on the overhead panel.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
