### PR TITLE
feat(nd): Add XTE display in PLAN mode, reduce XTE display precision

### DIFF
--- a/src/instruments/src/ND/elements/CrossTrack.tsx
+++ b/src/instruments/src/ND/elements/CrossTrack.tsx
@@ -15,8 +15,8 @@ export const CrossTrack: React.FC<CrossTrackProps> = memo(({ x, y, isPlanMode })
     let crossTrackX = x;
     const crossTrackAbs = Math.abs(crossTrackError);
 
-    if (crossTrackAbs > 0.02) {
-        crossTrackText = crossTrackAbs.toFixed(crossTrackAbs < 0.3 ? 2 : 1);
+    if (crossTrackAbs >= 0.1) {
+        crossTrackText = crossTrackAbs.toFixed(1);
         if (crossTrackError < 0) {
             crossTrackText += 'R';
             crossTrackAnchor = 'start';

--- a/src/instruments/src/ND/elements/CrossTrack.tsx
+++ b/src/instruments/src/ND/elements/CrossTrack.tsx
@@ -1,7 +1,13 @@
 import { useSimVar } from '@instruments/common/simVars';
 import React, { memo } from 'react';
 
-export const CrossTrack: React.FC<{ x: number, y: number}> = memo(({ x, y }) => {
+interface CrossTrackProps {
+    x: number,
+    y: number,
+    isPlanMode?: boolean;
+}
+
+export const CrossTrack: React.FC<CrossTrackProps> = memo(({ x, y, isPlanMode }) => {
     const [crossTrackError] = useSimVar('L:A32NX_FG_CROSS_TRACK_ERROR', 'nautical miles', 250);
 
     let crossTrackText = '';
@@ -23,7 +29,7 @@ export const CrossTrack: React.FC<{ x: number, y: number}> = memo(({ x, y }) => 
     }
 
     return (
-        <text x={crossTrackX} y={y} textAnchor={crossTrackAnchor} fontSize={24} className="Green shadow">
+        <text x={isPlanMode ? x : crossTrackX} y={y} textAnchor={isPlanMode ? 'start' : crossTrackAnchor} fontSize={24} className="Green shadow">
             {crossTrackText}
         </text>
     );

--- a/src/instruments/src/ND/pages/PlanMode.tsx
+++ b/src/instruments/src/ND/pages/PlanMode.tsx
@@ -5,6 +5,7 @@ import { useSimVar } from '@instruments/common/simVars';
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
 import { NdSymbol } from '@shared/NavigationDisplay';
 import { LateralMode } from '@shared/autopilot';
+import { CrossTrack } from '../elements/CrossTrack';
 import { ToWaypointIndicator } from '../elements/ToWaypointIndicator';
 import { FlightPlan, FlightPlanType } from '../elements/FlightPlan';
 import { MapParameters } from '../utils/MapParameters';
@@ -89,6 +90,8 @@ export const PlanMode: FC<PlanModeProps> = ({ symbols, adirsAlign, rangeSetting,
             )}
 
             <ToWaypointIndicator info={flightPlanManager.getCurrentFlightPlan().computeActiveWaypointStatistics(ppos)} />
+
+            <CrossTrack x={44} y={690} isPlanMode />
         </>
     );
 };


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR adds the XTE indication, which was missing in PLAN mode, and also changes the XTE in all modes to only display 1 digit of precision.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
Image credit: @tshomas 
![IMG_2187](https://user-images.githubusercontent.com/39596827/146289900-6e06120a-a384-4e8b-8d23-9312ec65a324.jpg)

![grafik](https://user-images.githubusercontent.com/39596827/146290711-9ea88d34-5b65-4bcf-8ea5-c92452c0a102.png)



<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Make sure that the XTE indication shows correctly, both in PLAN and also in the other ND modes.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
