### PR TITLE
feat(efb): EFB Dashboard Weather Widget uses selected barometer setting

### DIFF
--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -75,6 +75,26 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
         const getBaroTypeForAirport = (icao: string) => (['K', 'C', 'M', 'P', 'RJ', 'RO', 'TI', 'TJ'].some((r) => icao.startsWith(r)) ? 'IN HG' : 'HPA');
 
 
+    const getBaroValue = () => {
+        if (baroType === 'IN HG') {
+            return (
+                <>
+                    {metar.barometer.hg.toFixed(2)}
+                    {' '}
+                    inHg
+                </>
+            );
+        }
+
+        return (
+            <>
+                {metar.barometer.mb.toFixed(0)}
+                {' '}
+                mb
+            </>
+        );
+    };
+
     let [baroType] = usePersistentProperty('CONFIG_INIT_BARO_UNIT', 'HPA');
     let [metarSource] = usePersistentProperty('CONFIG_METAR_SRC', 'MSFS');
 
@@ -141,20 +161,7 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
                                 <div className="flex justify-center">
                                     <IconGauge className="mb-2" size={35} stroke={1.5} strokeLinejoin="miter" />
                                 </div>
-                                {metar.barometer ? baroType === 'IN HG'? (
-                                    <>
-                                        {metar.barometer.hg.toFixed(2)}
-                                        {' '}
-                                        inHg
-                                    </>
-                                ) : (
-                                    <>
-                                        {metar.barometer.mb.toFixed(0)}
-                                        {' '}
-                                        mb
-                                    </>
-                                )
-                                : 'N/A'}
+                                {metar.barometer ? (getBaroValue(baroType)) : 'N/A'}
                             </div>
                             <div className="text-lg text-center">
                                 <div className="flex justify-center">

--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -69,13 +69,10 @@ const MetarParserTypeProp: MetarParserType = {
 
 type WeatherWidgetProps = { name: string, editIcao: string, icao: string};
 
-function getBaroTypeForAirport(icao) {
-    const inchOfMercuryRegions = ["K", "C", "M", "P", "RJ", "RO", "TI", "TJ"];
-    return inchOfMercuryRegions.some(r => icao.startsWith(r)) ? "IN HG" : "HPA";
-}
-
 const WeatherWidget = (props: WeatherWidgetProps) => {
     const [metar, setMetar] = useState<MetarParserType>(MetarParserTypeProp);
+
+    let getBaroTypeForAirport: string = icao: string => ["K", "C", "M", "P", "RJ", "RO", "TI", "TJ"].some(r => icao.startsWith(r)) ? "IN HG" : "HPA";
 
     let [baroType] = usePersistentProperty('CONFIG_INIT_BARO_UNIT', 'HPA');
     let [metarSource] = usePersistentProperty('CONFIG_METAR_SRC', 'MSFS');

--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -75,7 +75,7 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
         const getBaroTypeForAirport = (icao: string) => (['K', 'C', 'M', 'P', 'RJ', 'RO', 'TI', 'TJ'].some((r) => icao.startsWith(r)) ? 'IN HG' : 'HPA');
 
 
-    const getBaroValue = () => {
+    const BaroValue = () => {
         if (baroType === 'IN HG') {
             return (
                 <>

--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -161,7 +161,7 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
                                 <div className="flex justify-center">
                                     <IconGauge className="mb-2" size={35} stroke={1.5} strokeLinejoin="miter" />
                                 </div>
-                                {metar.barometer ? (getBaroValue(baroType)) : 'N/A'}
+                                {metar.barometer ? <BaroValue /> : 'N/A'}
                             </div>
                             <div className="text-lg text-center">
                                 <div className="flex justify-center">

--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -72,9 +72,8 @@ type WeatherWidgetProps = { name: string, editIcao: string, icao: string};
 const WeatherWidget = (props: WeatherWidgetProps) => {
     const [metar, setMetar] = useState<MetarParserType>(MetarParserTypeProp);
 
-    const getBaroTypeForAirport = (icao: string) => {
-        return ["K", "C", "M", "P", "RJ", "RO", "TI", "TJ"].some(r => icao.startsWith(r)) ? "IN HG" : "HPA"
-    };
+        const getBaroTypeForAirport = (icao: string) => (['K', 'C', 'M', 'P', 'RJ', 'RO', 'TI', 'TJ'].some((r) => icao.startsWith(r)) ? 'IN HG' : 'HPA');
+
 
     let [baroType] = usePersistentProperty('CONFIG_INIT_BARO_UNIT', 'HPA');
     let [metarSource] = usePersistentProperty('CONFIG_METAR_SRC', 'MSFS');

--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -72,6 +72,7 @@ type WeatherWidgetProps = { name: string, editIcao: string, icao: string};
 const WeatherWidget = (props: WeatherWidgetProps) => {
     const [metar, setMetar] = useState<MetarParserType>(MetarParserTypeProp);
 
+    let [baroType] = usePersistentProperty('CONFIG_INIT_BARO_UNIT', 'HPA');
     let [metarSource] = usePersistentProperty('CONFIG_METAR_SRC', 'MSFS');
 
     if (metarSource === 'MSFS') {
@@ -133,13 +134,20 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
                                 <div className="flex justify-center">
                                     <IconGauge className="mb-2" size={35} stroke={1.5} strokeLinejoin="miter" />
                                 </div>
-                                {metar.barometer ? (
+                                {metar.barometer ? baroType === 'IN HG'? (
+                                    <>
+                                        {metar.barometer.hg.toFixed(2)}
+                                        {' '}
+                                        inHg
+                                    </>
+                                ) : (
                                     <>
                                         {metar.barometer.mb.toFixed(0)}
                                         {' '}
                                         mb
                                     </>
-                                ) : 'N/A'}
+                                )
+                                : 'N/A'}
                             </div>
                             <div className="text-lg text-center">
                                 <div className="flex justify-center">

--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -108,7 +108,7 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
             });
     }
 
-    if(baroType === "AUTO") {
+    if (baroType === 'AUTO') {
         baroType = getBaroTypeForAirport(props.icao);
     }
 

--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -69,6 +69,11 @@ const MetarParserTypeProp: MetarParserType = {
 
 type WeatherWidgetProps = { name: string, editIcao: string, icao: string};
 
+function getBaroTypeForAirport(icao) {
+    const inchOfMercuryRegions = ["K", "C", "M", "P", "RJ", "RO", "TI", "TJ"];
+    return inchOfMercuryRegions.some(r => icao.startsWith(r)) ? "IN HG" : "HPA";
+}
+
 const WeatherWidget = (props: WeatherWidgetProps) => {
     const [metar, setMetar] = useState<MetarParserType>(MetarParserTypeProp);
 
@@ -103,6 +108,10 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
             .catch(() => {
                 setMetar(MetarParserTypeProp);
             });
+    }
+
+    if(baroType === "AUTO") {
+        baroType = getBaroTypeForAirport(props.icao);
     }
 
     useEffect(() => {

--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -72,7 +72,9 @@ type WeatherWidgetProps = { name: string, editIcao: string, icao: string};
 const WeatherWidget = (props: WeatherWidgetProps) => {
     const [metar, setMetar] = useState<MetarParserType>(MetarParserTypeProp);
 
-    let getBaroTypeForAirport: string = icao: string => ["K", "C", "M", "P", "RJ", "RO", "TI", "TJ"].some(r => icao.startsWith(r)) ? "IN HG" : "HPA";
+    const getBaroTypeForAirport = (icao: string) => {
+        return ["K", "C", "M", "P", "RJ", "RO", "TI", "TJ"].some(r => icao.startsWith(r)) ? "IN HG" : "HPA"
+    };
 
     let [baroType] = usePersistentProperty('CONFIG_INIT_BARO_UNIT', 'HPA');
     let [metarSource] = usePersistentProperty('CONFIG_METAR_SRC', 'MSFS');


### PR DESCRIPTION
Fixes #[5634]

## Summary of Changes
Adjusted dashboard weather widget to use selected barometer from sim options page.

## Screenshots (if necessary)

## References

## Additional context
Discord username (if different from GitHub): bdepz#1564

## Testing instructions
Load various flight plans into the EFB and switch barometer in sim settings menu. The weather widget on the dashboard should change accordingly.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
