### PR TITLE
feat(pfd): Improve behaviour of the speed trend on the PFD

### DIFF
--- a/src/instruments/src/PFD/index.tsx
+++ b/src/instruments/src/PFD/index.tsx
@@ -34,7 +34,7 @@ export const PFD: React.FC = () => {
     const [clampedAirspeed, setClampedAirspeed] = useState(0);
     const [filteredAirspeedAcc, setfilteredAirspeedAcc] = useState(0);
 
-    const [airspeedAccFilter] = useState(() => new LagFilter(1.2));
+    const [airspeedAccFilter] = useState(() => new LagFilter(1.6));
     const [airspeedAccRateLimiter] = useState(() => new RateLimiter(1.2, -1.2));
 
     const [isAttExcessive, setIsAttExcessive] = useState(false);
@@ -61,8 +61,8 @@ export const PFD: React.FC = () => {
         setPreviousAirspeed(clamped);
         setClampedAirspeed(clamped);
 
-        const rateLimitedAirspeedAcc = airspeedAccRateLimiter.step(airspeedAcc, deltaTime / 1000);
-        setfilteredAirspeedAcc(airspeedAccFilter.step(rateLimitedAirspeedAcc, deltaTime / 1000));
+        const filteredAirspeedAcc = airspeedAccFilter.step(airspeedAcc, deltaTime / 1000);
+        setfilteredAirspeedAcc(airspeedAccRateLimiter.step(filteredAirspeedAcc, deltaTime / 1000));
 
         if (isOnGround) {
             setShowSpeedBars(false);


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->


## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR improves the behaviour of the speed trend arrow on the PFD, by making it more reactive. It also swaps the order of filters that are applied.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
Example for the speed trend behaviour: https://www.youtube.com/watch?v=bjGT9aJU6jo

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
This PR only affects the yellow speed trend arrow on the PFD, on the speed scale. It is a very subtle change, and you should mostly make sure nothing has broken.

Fly a few circuits and observe the speed arrow. It should generally increase when the speed is increasing, and decrease when the speed is decreasing. However when the speed change is very extreme, the arrow will intentionally take a moment to catch up.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
