### PR TITLE
fix: Flap settings and lighting in runway.flt and final.flt files

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -108,6 +108,7 @@
 1. [AP] Further improved ALT CST* and ALT CST conditions - @aguther (Andreas Guther)
 1. [MCDU] Added support for connecting MCDU to external devices - @tyler58546 (tyler58546)
 1. [ATHR] Improvement of ATHR laws - @IbrahimK42(IbrahimK42), @aguther (Andreas Guther)
+1. [MISC] Fixed flap configuration in final.flt and runway.flt files -  @donstim (donbikes#4084)
 
 ## 0.7.0
 

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/final.FLT
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/final.FLT
@@ -1,6 +1,6 @@
 [SimVarForSpawningInTheAir.0]
 IAS=248
-FlapsDegree=0035.00
+FlapsDegree=0040.00
 
 [Avionics.0]
 Comm1Active=122.800
@@ -101,11 +101,7 @@ AutoFeatherSwitch=False
 FlightDirector=True
 PanelLights=False
 LaunchBarSwitch=False
-LaunchBarState=0
-TailhookHandle=False
-TailhookState=0
-FoldingWingsHandle=False
-FoldingWingsState=0, 0
+SeatBeltsSwitch = True
 
 [LocalVars.0]
 A32NX_RMP_L_TOGGLE_SWITCH=1
@@ -262,6 +258,9 @@ A32NX_ISIS_BUGS_SPD_ACTIVE:2=0
 A32NX_ISIS_BUGS_SPD_ACTIVE:3=0
 A32NX_OVHD_PRESS_MODE_SEL_PB_IS_AUTO = 1
 A32NX_OVHD_PRESS_MAN_VS_CTL_SWITCH = 1
+A32NX_FLAPS_HANDLE_PERCENT = 1
+A32NX_FLAPS_HANDLE_INDEX = 4
+A32NX_SPOILERS_ARMED = 1
 
 [Gauges.0]
 KollsmanSetting=29.921342849731445313
@@ -295,8 +294,8 @@ Potentiometer.8=0
 Potentiometer.9=0
 Potentiometer.10=0
 Potentiometer.11=0
-Potentiometer.76=0
-Potentiometer.83=0
+Potentiometer.76=0.5
+Potentiometer.83=0.5
 Potentiometer.84=0.5
 Potentiometer.85=0.5
 Potentiometer.87=0.5

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/runway.FLT
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/runway.FLT
@@ -109,11 +109,7 @@ PanelLights=False
 AutoFeatherSwitch=False
 FlightDirector=True
 LaunchBarSwitch=False
-LaunchBarState=0
-TailhookHandle=False
-TailhookState=0
-FoldingWingsHandle=False
-FoldingWingsState=0, 0
+SeatBeltsSwitch = True
 
 [LocalVars.0]
 A32NX_RMP_L_TOGGLE_SWITCH=1
@@ -270,6 +266,9 @@ A32NX_ISIS_BUGS_SPD_ACTIVE:2=0
 A32NX_ISIS_BUGS_SPD_ACTIVE:3=0
 A32NX_OVHD_PRESS_MODE_SEL_PB_IS_AUTO = 1
 A32NX_OVHD_PRESS_MAN_VS_CTL_SWITCH = 1
+A32NX_FLAPS_HANDLE_PERCENT = 0.25
+A32NX_FLAPS_HANDLE_INDEX = 1
+A32NX_SPOILERS_ARMED = 1
 
 [Gauges.0]
 KollsmanSetting=29.921342849731445313
@@ -304,8 +303,8 @@ Potentiometer.8=0
 Potentiometer.9=0
 Potentiometer.10=0
 Potentiometer.11=0
-Potentiometer.76=0
-Potentiometer.83=0
+Potentiometer.76=0.5
+Potentiometer.83=0.5
 Potentiometer.84=0.5
 Potentiometer.85=0.5
 Potentiometer.86=0.5
@@ -352,9 +351,6 @@ VSSlotIndex=2
 [Controls.0]
 SpoilersHandle=000.00
 SpoilersArmed=True
-FlapsHandle=020.00
-LeftFlap=014.28
-RightFlap=014.28
 GearsHandle=000.01
 Gear1=100.00
 Gear2=100.00

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -640,7 +640,7 @@ bool FlyByWireInterface::updateAdditionalData(double sampleTime) {
   additionalData.autobrake_decel_light = idAutobrakeDecelLight->get();
   additionalData.spoilers_handle_pos = idSpoilersHandlePosition->get();
   additionalData.spoilers_armed = idSpoilersArmed->get();
-  additionalData.spoilers_handle_sim_pos = simData.spoilerHandlePosition;
+  additionalData.spoilers_handle_sim_pos = simData.spoilers_handle_position;
   additionalData.ground_spoilers_active = idSpoilersGroundSpoilersActive->get();
   additionalData.flaps_handle_percent = idFlapsHandlePercent->get();
   additionalData.flaps_handle_index = idFlapsHandleIndex->get();
@@ -1725,7 +1725,7 @@ bool FlyByWireInterface::updateSpoilers(double sampleTime) {
 
   // initialize position if needed
   if (!spoilersHandler->getIsInitialized()) {
-    spoilersHandler->setInitialPosition(simData.spoilers_handle_position);
+    spoilersHandler->setInitialPosition(idSpoilersArmed->get(), simData.spoilers_handle_position);
   }
 
   // update simulation variables

--- a/src/fbw/src/SpoilersHandler.cpp
+++ b/src/fbw/src/SpoilersHandler.cpp
@@ -26,7 +26,7 @@ double SpoilersHandler::getSimPosition() const {
   return simPosition;
 }
 
-void SpoilersHandler::setInitialPosition(double position) {
+void SpoilersHandler::setInitialPosition(bool isArmed, double position) {
   if (isInitialized) {
     return;
   }

--- a/src/fbw/src/SpoilersHandler.h
+++ b/src/fbw/src/SpoilersHandler.h
@@ -8,7 +8,7 @@ class SpoilersHandler {
   double getSimPosition() const;
   bool getIsGroundSpoilersActive() const;
 
-  void setInitialPosition(double position);
+  void setInitialPosition(bool isArmed, double position);
   void setSimulationVariables(double simulationTime_new,
                               bool isAutopilotEngaged_new,
                               double groundSpeed_new,

--- a/src/fbw/src/interface/SimConnectData.h
+++ b/src/fbw/src/interface/SimConnectData.h
@@ -123,7 +123,6 @@ struct SimData {
   SIMCONNECT_DATA_LATLONALT nav_gs_pos;
   double brakeLeftPosition;
   double brakeRightPosition;
-  double spoilerHandlePosition;
   double flapsHandleIndex;
   double gearHandlePosition;
 };

--- a/src/fbw/src/interface/SimConnectInterface.cpp
+++ b/src/fbw/src/interface/SimConnectInterface.cpp
@@ -239,7 +239,6 @@ bool SimConnectInterface::prepareSimDataSimConnectDataDefinitions() {
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_LATLONALT, "NAV GS LATLONALT:3", "STRUCT");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "BRAKE LEFT POSITION", "POSITION");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "BRAKE RIGHT POSITION", "POSITION");
-  result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "SPOILERS HANDLE POSITION", "POSITION");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "FLAPS HANDLE INDEX", "NUMBER");
   result &= addDataDefinition(hSimConnect, 0, SIMCONNECT_DATATYPE_FLOAT64, "GEAR HANDLE POSITION", "POSITION");
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

Fixes #6442 
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

**Revised to add changes to runway,flt file in addition to final.flt file**

The runway.flt file is used when starting the airplane on the runway. The final.flt file is used when starting the airplane with only the destination airport/runway set in the MSFS Flight Planner. 

Due to changes in how flap/slat configurations are handled in the FBW A32NX, these files no longer start the airplane in the appropriate configuration (a takeoff flap in the runway.flt file and landing flaps in the final.flt file). The default airplane starts in CONF 1+F when starting on the runway and CONF 4 when starting at the final approach phase. This PR makes changes to restore starting with CONF 1+F on the runway and in the full landing configuration for the final approach. There are also other minor changes.

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
1. CONF 1+F  for starting on the runway and CONF 4 (Full landing configuration for starting in the final approach phase
2. Panel and pedestal flood lights on
3. Functional MSFS Fuel and Payload Weights UI when starting in the final approach phase  **[Removed]**
4. Seatbelt switch in the "on" position in either starting position.
5. Auto-spoilers armed
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
The lighting changes were made to make it easier to see the panel and pedestal if starting in the dark. [Removed:  Enabling the MSFS Fuel and Payload UI was done because there is simply not enough time to change weights using the EFB and MCDU when starting the flight at the beginning of the final approach.]

Attempts were made to arm the autospoilers and set the autobrake to the low setting when starting in the final approach phase, but these were unsuccessful. These parameters would initially be loaded as intended, but just before the "READY TO FLY" selector appears, they are reset.
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): donbikes#4084

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Start a flight with only the destination airport selected. (You can let MSFS select the runway or select it yourself).
2. Verify that the airplane starts in CONF FULL with auto-spoilers armed (and starts at a speed that does not immediately activate an envelope protection mode).
3. Start a flight at night to verify that lighting is sufficient.
4. Verify that the seatbelt annunciator in the overhead panel is set to "on" and that the "Seatbelts" message is shown on the upper ECAM.
5. Start a flight on the runway
6. Verify that the airplane starts in CONF 1+F with auto-spoilers armed.
7. Start a flight at night to verify that lighting is sufficient.
8. Verify that the seatbelt annunciator in the overhead panel is set to "on" and that the "Seatbelts" message is shown on the upper ECAM.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
