### PR TITLE
refactor(ap): Move FD smoothing from C++ Interface to model

### DIFF
--- a/docs/Configuration/ModelConfiguration.ini
+++ b/docs/Configuration/ModelConfiguration.ini
@@ -18,19 +18,6 @@
 ; (only applies when using default flight plan manager)
 ;gps_course_to_steer_enabled = true
 
-; !! WARNING ONLY FOR DEVELOPMENT !!
-; enable smoothing of flight director
-;flight_director_smoothing_enabled = true
-
-; !! WARNING ONLY FOR DEVELOPMENT !!
-; flight director smoothing factor
-;flight_director_smoothing_factor = 2.5
-
-; !! WARNING ONLY FOR DEVELOPMENT !!
-; flight director smoothing limit
-; (limits the difference before applying smoothing)
-;flight_director_smoothing_limit = 20
-
 ; !! WARNING CHANGE AT YOUR OWN RISK !!
 ; maximum allowed simulation rate
 ;maximum_simulation_rate = 4

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -47,9 +47,6 @@ class FlyByWireInterface {
   double targetSimulationRate = 1;
   bool targetSimulationRateModified = false;
 
-  bool flightDirectorSmoothingEnabled = false;
-  double flightDirectorSmoothingFactor = 0;
-  double flightDirectorSmoothingLimit = 0;
   bool customFlightGuidanceEnabled = false;
   bool gpsCourseToSteerEnabled = false;
   bool autopilotStateMachineEnabled = false;
@@ -327,8 +324,6 @@ class FlyByWireInterface {
   bool updateSpoilers(double sampleTime);
 
   bool updateAltimeterSetting(double sampleTime);
-
-  double smoothFlightDirector(double sampleTime, double factor, double limit, double currentValue, double targetValue);
 
   double getHeadingAngleError(double u1, double u2);
 

--- a/src/fbw/src/model/AutopilotLaws.cpp
+++ b/src/fbw/src/model/AutopilotLaws.cpp
@@ -356,26 +356,28 @@ void AutopilotLawsModelClass::step()
   real_T b_R;
   real_T distance_m;
   real_T limit;
-  real_T rtb_Add3_d;
-  real_T rtb_Add3_fm;
-  real_T rtb_Add3_l;
-  real_T rtb_Add3_n;
+  real_T rtb_Add3_d1;
+  real_T rtb_Add3_gy;
+  real_T rtb_Add3_n2;
   real_T rtb_Cos1_k;
   real_T rtb_Cos1_pk;
-  real_T rtb_Cos_k;
-  real_T rtb_Gain4_m;
+  real_T rtb_Cos_f2;
   real_T rtb_Gain5_n;
   real_T rtb_GainTheta;
   real_T rtb_GainTheta1;
+  real_T rtb_Gain_ar0;
   real_T rtb_Gain_dn;
-  real_T rtb_Gain_ij;
+  real_T rtb_Gain_n1;
   real_T rtb_Saturation;
   real_T rtb_Saturation_c;
   real_T rtb_Sum2_p;
   real_T rtb_Sum_ae;
-  real_T rtb_Y_k;
+  real_T rtb_Y_h;
+  real_T rtb_Y_hc;
+  real_T rtb_Y_n0;
   real_T rtb_dme;
   real_T rtb_error_d;
+  int32_T i;
   int32_T low_i;
   int32_T low_ip1;
   int32_T rtb_on_ground;
@@ -385,6 +387,7 @@ void AutopilotLawsModelClass::step()
   boolean_T rtb_Delay_j;
   boolean_T rtb_valid;
   boolean_T rtb_valid_d;
+  rtb_Saturation_c = ((AutopilotLaws_U.in.input.enabled_AP1 != 0.0) || (AutopilotLaws_U.in.input.enabled_AP2 != 0.0));
   rtb_GainTheta = AutopilotLaws_P.GainTheta_Gain * AutopilotLaws_U.in.data.Theta_deg;
   rtb_GainTheta1 = AutopilotLaws_P.GainTheta1_Gain * AutopilotLaws_U.in.data.Phi_deg;
   rtb_dme = 0.017453292519943295 * rtb_GainTheta;
@@ -399,10 +402,10 @@ void AutopilotLawsModelClass::step()
   result_tmp[4] = b_R;
   result_tmp[7] = -a;
   result_tmp[2] = 0.0;
-  R = std::cos(rtb_dme);
-  distance_m = 1.0 / R;
-  result_tmp[5] = distance_m * a;
-  result_tmp[8] = distance_m * b_R;
+  distance_m = std::cos(rtb_dme);
+  rtb_Y_hc = 1.0 / distance_m;
+  result_tmp[5] = rtb_Y_hc * a;
+  result_tmp[8] = rtb_Y_hc * b_R;
   rtb_error_d = AutopilotLaws_P.Gain_Gain_de * AutopilotLaws_U.in.data.p_rad_s * AutopilotLaws_P.Gainpk_Gain;
   rtb_Saturation = AutopilotLaws_P.Gain_Gain_d * AutopilotLaws_U.in.data.q_rad_s * AutopilotLaws_P.Gainqk_Gain;
   Phi2 = AutopilotLaws_P.Gain_Gain_m * AutopilotLaws_U.in.data.r_rad_s;
@@ -412,15 +415,15 @@ void AutopilotLawsModelClass::step()
   }
 
   rtb_error_d = std::sin(rtb_dme);
-  result_tmp[0] = R;
+  result_tmp[0] = distance_m;
   result_tmp[3] = 0.0;
   result_tmp[6] = -rtb_error_d;
   result_tmp[1] = a * rtb_error_d;
   result_tmp[4] = b_R;
-  result_tmp[7] = R * a;
+  result_tmp[7] = distance_m * a;
   result_tmp[2] = b_R * rtb_error_d;
   result_tmp[5] = 0.0 - a;
-  result_tmp[8] = b_R * R;
+  result_tmp[8] = b_R * distance_m;
   for (rtb_on_ground = 0; rtb_on_ground < 3; rtb_on_ground++) {
     result_0[rtb_on_ground] = (result_tmp[rtb_on_ground + 3] * AutopilotLaws_U.in.data.by_m_s2 +
       result_tmp[rtb_on_ground] * AutopilotLaws_U.in.data.bx_m_s2) + result_tmp[rtb_on_ground + 6] *
@@ -453,8 +456,8 @@ void AutopilotLawsModelClass::step()
   a = std::cos(rtb_error_d) * std::cos(Phi2) * distance_m * distance_m + a * a;
   distance_m = std::atan2(std::sqrt(a), std::sqrt(1.0 - a)) * 2.0 * 6.371E+6;
   a = AutopilotLaws_U.in.data.aircraft_position.alt - AutopilotLaws_U.in.data.nav_loc_position.alt;
-  R = std::cos(Phi2);
-  L = 0.017453292519943295 * AutopilotLaws_U.in.data.nav_loc_position.lon - rtb_Saturation;
+  L = std::cos(Phi2);
+  R = 0.017453292519943295 * AutopilotLaws_U.in.data.nav_loc_position.lon - rtb_Saturation;
   b_L = mod_mvZvttxs((mod_mvZvttxs(mod_mvZvttxs(360.0) + 360.0) - (mod_mvZvttxs(mod_mvZvttxs
     (AutopilotLaws_U.in.data.nav_loc_magvar_deg) + 360.0) + 360.0)) + 360.0);
   b_R = mod_mvZvttxs(360.0 - b_L);
@@ -462,16 +465,16 @@ void AutopilotLawsModelClass::step()
     b_R = -b_L;
   }
 
-  b_L = std::cos(rtb_error_d);
+  rtb_Y_hc = std::cos(rtb_error_d);
   rtb_error_d = std::sin(rtb_error_d);
-  R = mod_mvZvttxs(mod_mvZvttxs(mod_mvZvttxs(std::atan2(std::sin(L) * R, b_L * std::sin(Phi2) - rtb_error_d * R * std::
-    cos(L)) * 57.295779513082323 + 360.0)) + 360.0) + 360.0;
+  L = mod_mvZvttxs(mod_mvZvttxs(mod_mvZvttxs(std::atan2(std::sin(R) * L, rtb_Y_hc * std::sin(Phi2) - rtb_error_d * L *
+    std::cos(R)) * 57.295779513082323 + 360.0)) + 360.0) + 360.0;
   Phi2 = mod_mvZvttxs((mod_mvZvttxs(mod_mvZvttxs(mod_mvZvttxs(mod_mvZvttxs(AutopilotLaws_U.in.data.nav_loc_deg - b_R) +
-    360.0)) + 360.0) - R) + 360.0);
+    360.0)) + 360.0) - L) + 360.0);
   b_R = mod_mvZvttxs(360.0 - Phi2);
   guard1 = false;
   if (std::abs(std::sqrt(distance_m * distance_m + a * a) / 1852.0) < 30.0) {
-    L = mod_mvZvttxs((mod_mvZvttxs(mod_mvZvttxs(AutopilotLaws_U.in.data.nav_loc_deg) + 360.0) - R) + 360.0);
+    L = mod_mvZvttxs((mod_mvZvttxs(mod_mvZvttxs(AutopilotLaws_U.in.data.nav_loc_deg) + 360.0) - L) + 360.0);
     R = mod_mvZvttxs(360.0 - L);
     if (std::abs(L) < std::abs(R)) {
       R = -L;
@@ -506,14 +509,14 @@ void AutopilotLawsModelClass::step()
                0.017453292519943295 / 2.0);
   distance_m = std::sin((AutopilotLaws_U.in.data.nav_gs_position.lon - AutopilotLaws_U.in.data.aircraft_position.lon) *
                         0.017453292519943295 / 2.0);
-  R = std::cos(Phi2);
-  L = b_L;
-  a = b_L * R * distance_m * distance_m + a * a;
+  L = std::cos(Phi2);
+  R = rtb_Y_hc;
+  a = rtb_Y_hc * L * distance_m * distance_m + a * a;
   distance_m = std::atan2(std::sqrt(a), std::sqrt(1.0 - a)) * 2.0 * 6.371E+6;
   a = AutopilotLaws_U.in.data.aircraft_position.alt - AutopilotLaws_U.in.data.nav_gs_position.alt;
   distance_m = std::sqrt(distance_m * distance_m + a * a);
   rtb_Saturation = 0.017453292519943295 * AutopilotLaws_U.in.data.nav_gs_position.lon - rtb_Saturation;
-  rtb_Saturation = std::atan2(std::sin(rtb_Saturation) * R, b_L * std::sin(Phi2) - rtb_error_d * R * std::cos
+  rtb_Saturation = std::atan2(std::sin(rtb_Saturation) * L, rtb_Y_hc * std::sin(Phi2) - rtb_error_d * L * std::cos
     (rtb_Saturation)) * 57.295779513082323;
   if (rtb_Saturation + 360.0 == 0.0) {
     rtb_error_d = 0.0;
@@ -562,14 +565,14 @@ void AutopilotLawsModelClass::step()
       Phi2 = std::fmod(Phi2 + 360.0, 360.0);
     }
 
-    R = (rtb_Saturation - (Phi2 + 360.0)) + 360.0;
-    if (R == 0.0) {
+    rtb_Saturation = (rtb_Saturation - (Phi2 + 360.0)) + 360.0;
+    if (rtb_Saturation == 0.0) {
       L = 0.0;
     } else {
-      L = std::fmod(R, 360.0);
+      L = std::fmod(rtb_Saturation, 360.0);
       if (L == 0.0) {
         L = 0.0;
-      } else if (R < 0.0) {
+      } else if (rtb_Saturation < 0.0) {
         L += 360.0;
       }
     }
@@ -643,8 +646,7 @@ void AutopilotLawsModelClass::step()
   rtb_Compare_jy = (AutopilotLaws_U.in.data.altimeter_setting_left_mbar != AutopilotLaws_DWork.DelayInput1_DSTATE);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_DWork.DelayInput1_DSTATE_g;
   AutopilotLaws_Y.out = AutopilotLaws_P.ap_laws_output_MATLABStruct;
-  AutopilotLaws_Y.out.output.ap_on = ((AutopilotLaws_U.in.input.enabled_AP1 != 0.0) ||
-    (AutopilotLaws_U.in.input.enabled_AP2 != 0.0));
+  AutopilotLaws_Y.out.output.ap_on = rtb_Saturation_c;
   AutopilotLaws_Y.out.time = AutopilotLaws_U.in.time;
   AutopilotLaws_Y.out.data.aircraft_position = AutopilotLaws_U.in.data.aircraft_position;
   AutopilotLaws_Y.out.data.Theta_deg = rtb_GainTheta;
@@ -720,13 +722,13 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_U.in.data.Psi_true_deg + AutopilotLaws_P.Constant3_Value_e;
   AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_U.in.data.Psi_magnetic_deg -
     AutopilotLaws_DWork.DelayInput1_DSTATE) + AutopilotLaws_P.Constant3_Value_e;
-  rtb_GainTheta = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_e);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant3_Value_e - rtb_GainTheta;
   b_R = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_e);
-  if (rtb_GainTheta < b_R) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_h * rtb_GainTheta;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant3_Value_e - b_R;
+  rtb_error_d = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_e);
+  if (b_R < rtb_error_d) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_h * b_R;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain_Gain_e * b_R;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain_Gain_e * rtb_error_d;
   }
 
   AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
@@ -735,12 +737,12 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_P.Constant3_Value_b;
   AutopilotLaws_DWork.DelayInput1_DSTATE = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE,
     AutopilotLaws_P.Constant3_Value_b);
-  rtb_GainTheta = AutopilotLaws_U.in.data.nav_loc_deg - AutopilotLaws_U.in.data.nav_loc_magvar_deg;
-  distance_m = rt_modd(rt_modd(rtb_GainTheta, AutopilotLaws_P.Constant3_Value_n) + AutopilotLaws_P.Constant3_Value_n,
-                       AutopilotLaws_P.Constant3_Value_n);
-  b_R = rt_modd((AutopilotLaws_DWork.DelayInput1_DSTATE - (distance_m + AutopilotLaws_P.Constant3_Value_i)) +
-                AutopilotLaws_P.Constant3_Value_i, AutopilotLaws_P.Constant3_Value_i);
-  rtb_Saturation = rt_modd(AutopilotLaws_P.Constant3_Value_i - b_R, AutopilotLaws_P.Constant3_Value_i);
+  b_R = AutopilotLaws_U.in.data.nav_loc_deg - AutopilotLaws_U.in.data.nav_loc_magvar_deg;
+  rtb_Saturation = rt_modd(rt_modd(b_R, AutopilotLaws_P.Constant3_Value_n) + AutopilotLaws_P.Constant3_Value_n,
+    AutopilotLaws_P.Constant3_Value_n);
+  Phi2 = rt_modd((AutopilotLaws_DWork.DelayInput1_DSTATE - (rtb_Saturation + AutopilotLaws_P.Constant3_Value_i)) +
+                 AutopilotLaws_P.Constant3_Value_i, AutopilotLaws_P.Constant3_Value_i);
+  a = rt_modd(AutopilotLaws_P.Constant3_Value_i - Phi2, AutopilotLaws_P.Constant3_Value_i);
   if (AutopilotLaws_P.ManualSwitch_CurrentSetting == 1) {
     rtb_error_d = AutopilotLaws_P.Constant_Value;
   } else {
@@ -748,61 +750,61 @@ void AutopilotLawsModelClass::step()
   }
 
   rtb_valid = (rtb_error_d == AutopilotLaws_P.CompareToConstant2_const);
-  if (b_R < rtb_Saturation) {
-    b_R *= AutopilotLaws_P.Gain1_Gain;
+  if (Phi2 < a) {
+    Phi2 *= AutopilotLaws_P.Gain1_Gain;
   } else {
-    b_R = AutopilotLaws_P.Gain_Gain * rtb_Saturation;
+    Phi2 = AutopilotLaws_P.Gain_Gain * a;
   }
 
-  b_R = std::abs(b_R);
+  Phi2 = std::abs(Phi2);
   if (!AutopilotLaws_DWork.limit_not_empty) {
-    AutopilotLaws_DWork.limit = b_R;
+    AutopilotLaws_DWork.limit = Phi2;
     AutopilotLaws_DWork.limit_not_empty = true;
   }
 
   if (!rtb_valid) {
-    AutopilotLaws_DWork.limit = std::fmin(std::fmax(b_R, 15.0), 115.0);
+    AutopilotLaws_DWork.limit = std::fmin(std::fmax(Phi2, 15.0), 115.0);
   }
 
-  if (rtb_valid && (b_R < 15.0)) {
+  if (rtb_valid && (Phi2 < 15.0)) {
     AutopilotLaws_DWork.limit = 15.0;
   }
 
-  AutopilotLaws_MATLABFunction(AutopilotLaws_P.tau_Value, AutopilotLaws_P.zeta_Value, &R, &b_L);
+  AutopilotLaws_MATLABFunction(AutopilotLaws_P.tau_Value, AutopilotLaws_P.zeta_Value, &L, &rtb_Y_n0);
   if (rtb_dme > AutopilotLaws_P.Saturation_UpperSat_b) {
-    b_R = AutopilotLaws_P.Saturation_UpperSat_b;
+    Phi2 = AutopilotLaws_P.Saturation_UpperSat_b;
   } else if (rtb_dme < AutopilotLaws_P.Saturation_LowerSat_n) {
-    b_R = AutopilotLaws_P.Saturation_LowerSat_n;
+    Phi2 = AutopilotLaws_P.Saturation_LowerSat_n;
   } else {
-    b_R = rtb_dme;
+    Phi2 = rtb_dme;
   }
 
-  b_R = std::sin(AutopilotLaws_P.Gain1_Gain_f * AutopilotLaws_U.in.data.nav_loc_error_deg) * b_R *
-    AutopilotLaws_P.Gain_Gain_h * b_L / AutopilotLaws_U.in.data.V_gnd_kn;
+  Phi2 = std::sin(AutopilotLaws_P.Gain1_Gain_f * AutopilotLaws_U.in.data.nav_loc_error_deg) * Phi2 *
+    AutopilotLaws_P.Gain_Gain_h * rtb_Y_n0 / AutopilotLaws_U.in.data.V_gnd_kn;
   AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_DWork.DelayInput1_DSTATE - (rt_modd(rt_modd
-    (AutopilotLaws_U.in.data.nav_loc_error_deg + distance_m, AutopilotLaws_P.Constant3_Value_c) +
+    (AutopilotLaws_U.in.data.nav_loc_error_deg + rtb_Saturation, AutopilotLaws_P.Constant3_Value_c) +
     AutopilotLaws_P.Constant3_Value_c, AutopilotLaws_P.Constant3_Value_c) + AutopilotLaws_P.Constant3_Value_p)) +
     AutopilotLaws_P.Constant3_Value_p;
   rtb_Saturation = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_p);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant3_Value_p - rtb_Saturation;
-  Phi2 = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_p);
-  if (rtb_Saturation < Phi2) {
+  a = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_p);
+  if (rtb_Saturation < a) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_p * rtb_Saturation;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain_Gain_a * Phi2;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain_Gain_a * a;
   }
 
-  if (b_R > AutopilotLaws_DWork.limit) {
-    b_R = AutopilotLaws_DWork.limit;
-  } else if (b_R < -AutopilotLaws_DWork.limit) {
-    b_R = -AutopilotLaws_DWork.limit;
+  if (Phi2 > AutopilotLaws_DWork.limit) {
+    Phi2 = AutopilotLaws_DWork.limit;
+  } else if (Phi2 < -AutopilotLaws_DWork.limit) {
+    Phi2 = -AutopilotLaws_DWork.limit;
   }
 
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_P.Gain2_Gain_i * AutopilotLaws_DWork.DelayInput1_DSTATE + b_R)
-    * R;
-  rtb_Saturation = AutopilotLaws_DWork.DelayInput1_DSTATE * AutopilotLaws_U.in.data.V_gnd_kn;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_P.Gain2_Gain_i * AutopilotLaws_DWork.DelayInput1_DSTATE + Phi2)
+    * L;
+  Phi2 = AutopilotLaws_DWork.DelayInput1_DSTATE * AutopilotLaws_U.in.data.V_gnd_kn;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_nr * AutopilotLaws_U.in.data.nav_loc_error_deg;
-  b_R = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
+  rtb_Saturation = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
   if (rtb_dme > AutopilotLaws_P.Saturation_UpperSat_o) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_o;
   } else if (rtb_dme < AutopilotLaws_P.Saturation_LowerSat_o) {
@@ -811,7 +813,8 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_dme;
   }
 
-  AutopilotLaws_DWork.DelayInput1_DSTATE = b_R * AutopilotLaws_DWork.DelayInput1_DSTATE * AutopilotLaws_P.Gain2_Gain_g;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Saturation * AutopilotLaws_DWork.DelayInput1_DSTATE *
+    AutopilotLaws_P.Gain2_Gain_g;
   if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation1_UpperSat_g) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation1_UpperSat_g;
   } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation1_LowerSat_k) {
@@ -833,13 +836,13 @@ void AutopilotLawsModelClass::step()
 
   rtb_dme = AutopilotLaws_DWork.DelayInput1_DSTATE * look1_binlxpw(AutopilotLaws_U.in.data.V_gnd_kn,
     AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1, AutopilotLaws_P.ScheduledGain_Table, 2U);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_GainTheta;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = b_R;
   AutopilotLaws_DWork.DelayInput1_DSTATE = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE,
     AutopilotLaws_P.Constant3_Value_d);
   AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_P.Constant3_Value_d;
   AutopilotLaws_storevalue(rtb_Compare_jy, rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE,
-    AutopilotLaws_P.Constant3_Value_d), &b_L, &AutopilotLaws_DWork.sf_storevalue);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_U.in.data.nav_loc_error_deg + b_L;
+    AutopilotLaws_P.Constant3_Value_d), &rtb_Y_n0, &AutopilotLaws_DWork.sf_storevalue);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_U.in.data.nav_loc_error_deg + rtb_Y_n0;
   AutopilotLaws_DWork.DelayInput1_DSTATE = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE,
     AutopilotLaws_P.Constant3_Value_o);
   AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_P.Constant3_Value_o;
@@ -848,13 +851,13 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_P.Constant3_Value_n1;
   AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_U.in.data.Psi_true_deg -
     AutopilotLaws_DWork.DelayInput1_DSTATE) + AutopilotLaws_P.Constant3_Value_n1;
-  b_R = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_n1);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant3_Value_n1 - b_R;
-  Phi2 = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_n1);
-  if (b_R < Phi2) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_j * b_R;
+  rtb_Saturation = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_n1);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant3_Value_n1 - rtb_Saturation;
+  a = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_n1);
+  if (rtb_Saturation < a) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_j * rtb_Saturation;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain_Gain_i * Phi2;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain_Gain_i * a;
   }
 
   AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_DWork.Delay_DSTATE + rtb_dme) + AutopilotLaws_P.Gain1_Gain_fq *
@@ -872,22 +875,22 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_DWork.DelayInput1_DSTATE = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE,
     AutopilotLaws_P.Constant3_Value_nr);
   AutopilotLaws_Chart_h(rtb_dme, AutopilotLaws_P.Gain_Gain_oc * AutopilotLaws_DWork.DelayInput1_DSTATE,
-                        AutopilotLaws_P.Constant1_Value_e, &Phi2, &AutopilotLaws_DWork.sf_Chart_b);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_GainTheta;
+                        AutopilotLaws_P.Constant1_Value_e, &a, &AutopilotLaws_DWork.sf_Chart_b);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = b_R;
   AutopilotLaws_DWork.DelayInput1_DSTATE = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE,
     AutopilotLaws_P.Constant3_Value_if);
   AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_P.Constant3_Value_if;
   AutopilotLaws_DWork.DelayInput1_DSTATE = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE,
     AutopilotLaws_P.Constant3_Value_if);
-  distance_m = AutopilotLaws_U.in.data.Psi_true_deg + AutopilotLaws_P.Constant3_Value_m;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_DWork.DelayInput1_DSTATE - distance_m) +
+  rtb_Saturation = AutopilotLaws_U.in.data.Psi_true_deg + AutopilotLaws_P.Constant3_Value_m;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_DWork.DelayInput1_DSTATE - rtb_Saturation) +
     AutopilotLaws_P.Constant3_Value_m;
   rtb_dme = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_m);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant3_Value_m - rtb_dme;
   AutopilotLaws_DWork.DelayInput1_DSTATE = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE,
     AutopilotLaws_P.Constant3_Value_m);
   AutopilotLaws_Chart_h(rtb_dme, AutopilotLaws_P.Gain_Gain_fn * AutopilotLaws_DWork.DelayInput1_DSTATE,
-                        AutopilotLaws_P.Constant2_Value_l, &a, &AutopilotLaws_DWork.sf_Chart_h);
+                        AutopilotLaws_P.Constant2_Value_l, &distance_m, &AutopilotLaws_DWork.sf_Chart_h);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_U.in.data.Psi_magnetic_deg + AutopilotLaws_P.Constant3_Value_cd;
   AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_U.in.input.Psi_c_deg - AutopilotLaws_DWork.DelayInput1_DSTATE)
     + AutopilotLaws_P.Constant3_Value_cd;
@@ -896,27 +899,27 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_DWork.DelayInput1_DSTATE = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE,
     AutopilotLaws_P.Constant3_Value_cd);
   rtb_valid = ((rtb_error_d == AutopilotLaws_P.CompareToConstant5_const) == AutopilotLaws_P.CompareToConstant_const_hx);
-  rtb_GainTheta = AutopilotLaws_P.Subsystem_Value / AutopilotLaws_U.in.time.dt;
+  b_R = AutopilotLaws_P.Subsystem_Value / AutopilotLaws_U.in.time.dt;
   if (!rtb_valid) {
-    for (rtb_on_ground = 0; rtb_on_ground < 100; rtb_on_ground++) {
-      AutopilotLaws_DWork.Delay_DSTATE_l[rtb_on_ground] = AutopilotLaws_P.Delay_InitialCondition;
+    for (i = 0; i < 100; i++) {
+      AutopilotLaws_DWork.Delay_DSTATE_l[i] = AutopilotLaws_P.Delay_InitialCondition;
     }
   }
 
-  if (rtb_GainTheta < 1.0) {
+  if (b_R < 1.0) {
     rtb_valid_d = rtb_valid;
   } else {
-    if (rtb_GainTheta > 100.0) {
-      rtb_on_ground = 100;
+    if (b_R > 100.0) {
+      i = 100;
     } else {
-      rtb_on_ground = static_cast<int32_T>(static_cast<uint32_T>(std::fmod(std::trunc(rtb_GainTheta), 4.294967296E+9)));
+      i = static_cast<int32_T>(static_cast<uint32_T>(std::fmod(std::trunc(b_R), 4.294967296E+9)));
     }
 
-    rtb_valid_d = AutopilotLaws_DWork.Delay_DSTATE_l[100U - rtb_on_ground];
+    rtb_valid_d = AutopilotLaws_DWork.Delay_DSTATE_l[100U - i];
   }
 
   AutopilotLaws_Chart(rtb_dme, AutopilotLaws_P.Gain_Gain_cy * AutopilotLaws_DWork.DelayInput1_DSTATE, rtb_valid !=
-                      rtb_valid_d, &rtb_GainTheta, &AutopilotLaws_DWork.sf_Chart);
+                      rtb_valid_d, &R, &AutopilotLaws_DWork.sf_Chart);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_U.in.data.Psi_magnetic_track_deg +
     AutopilotLaws_P.Constant3_Value_k;
   AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_U.in.input.Psi_c_deg - AutopilotLaws_DWork.DelayInput1_DSTATE)
@@ -928,8 +931,8 @@ void AutopilotLawsModelClass::step()
   rtb_valid_d = ((rtb_error_d == AutopilotLaws_P.CompareToConstant4_const) == AutopilotLaws_P.CompareToConstant_const_e);
   b_R = AutopilotLaws_P.Subsystem_Value_n / AutopilotLaws_U.in.time.dt;
   if (!rtb_valid_d) {
-    for (rtb_on_ground = 0; rtb_on_ground < 100; rtb_on_ground++) {
-      AutopilotLaws_DWork.Delay_DSTATE_h5[rtb_on_ground] = AutopilotLaws_P.Delay_InitialCondition_b;
+    for (i = 0; i < 100; i++) {
+      AutopilotLaws_DWork.Delay_DSTATE_h5[i] = AutopilotLaws_P.Delay_InitialCondition_b;
     }
   }
 
@@ -937,29 +940,29 @@ void AutopilotLawsModelClass::step()
     rtb_Delay_j = rtb_valid_d;
   } else {
     if (b_R > 100.0) {
-      rtb_on_ground = 100;
+      i = 100;
     } else {
-      rtb_on_ground = static_cast<int32_T>(static_cast<uint32_T>(std::fmod(std::trunc(b_R), 4.294967296E+9)));
+      i = static_cast<int32_T>(static_cast<uint32_T>(std::fmod(std::trunc(b_R), 4.294967296E+9)));
     }
 
-    rtb_Delay_j = AutopilotLaws_DWork.Delay_DSTATE_h5[100U - rtb_on_ground];
+    rtb_Delay_j = AutopilotLaws_DWork.Delay_DSTATE_h5[100U - i];
   }
 
   AutopilotLaws_Chart(rtb_dme, AutopilotLaws_P.Gain_Gain_p * AutopilotLaws_DWork.DelayInput1_DSTATE, rtb_valid_d !=
-                      rtb_Delay_j, &L, &AutopilotLaws_DWork.sf_Chart_ba);
-  AutopilotLaws_MATLABFunction(AutopilotLaws_P.tau_Value_c, AutopilotLaws_P.zeta_Value_h, &b_R, &distance_m);
+                      rtb_Delay_j, &b_L, &AutopilotLaws_DWork.sf_Chart_ba);
+  AutopilotLaws_MATLABFunction(AutopilotLaws_P.tau_Value_c, AutopilotLaws_P.zeta_Value_h, &b_R, &rtb_Saturation);
   AutopilotLaws_RateLimiter(AutopilotLaws_U.in.data.flight_guidance_phi_deg, AutopilotLaws_P.RateLimiterVariableTs_up,
     AutopilotLaws_P.RateLimiterVariableTs_lo, AutopilotLaws_U.in.time.dt,
-    AutopilotLaws_P.RateLimiterVariableTs_InitialCondition, &R, &AutopilotLaws_DWork.sf_RateLimiter);
-  AutopilotLaws_LagFilter(R, AutopilotLaws_P.LagFilter_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_k,
+    AutopilotLaws_P.RateLimiterVariableTs_InitialCondition, &L, &AutopilotLaws_DWork.sf_RateLimiter);
+  AutopilotLaws_LagFilter(L, AutopilotLaws_P.LagFilter_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_h,
     &AutopilotLaws_DWork.sf_LagFilter);
   AutopilotLaws_LagFilter(AutopilotLaws_U.in.data.nav_loc_error_deg, AutopilotLaws_P.LagFilter2_C1,
-    AutopilotLaws_U.in.time.dt, &R, &AutopilotLaws_DWork.sf_LagFilter_h);
-  rtb_dme = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain * R;
+    AutopilotLaws_U.in.time.dt, &L, &AutopilotLaws_DWork.sf_LagFilter_h);
+  rtb_dme = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain * L;
   AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_dme - AutopilotLaws_DWork.Delay_DSTATE_e;
   AutopilotLaws_DWork.DelayInput1_DSTATE /= AutopilotLaws_U.in.time.dt;
-  AutopilotLaws_LagFilter(R + AutopilotLaws_P.Gain3_Gain_i * AutopilotLaws_DWork.DelayInput1_DSTATE,
-    AutopilotLaws_P.LagFilter_C1_n, AutopilotLaws_U.in.time.dt, &b_L, &AutopilotLaws_DWork.sf_LagFilter_m);
+  AutopilotLaws_LagFilter(L + AutopilotLaws_P.Gain3_Gain_i * AutopilotLaws_DWork.DelayInput1_DSTATE,
+    AutopilotLaws_P.LagFilter_C1_n, AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_LagFilter_m);
   rtb_Delay_j = (AutopilotLaws_U.in.data.H_radio_ft <= AutopilotLaws_P.CompareToConstant_const_d);
   switch (static_cast<int32_T>(rtb_error_d)) {
    case 0:
@@ -967,45 +970,45 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 1:
-    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_GainTheta * look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn,
+    AutopilotLaws_DWork.DelayInput1_DSTATE = R * look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn,
       AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_h, AutopilotLaws_P.ScheduledGain_Table_o, 6U) *
       AutopilotLaws_P.Gain1_Gain_o + AutopilotLaws_P.Gain_Gain_o * result[2];
     break;
 
    case 2:
-    AutopilotLaws_DWork.DelayInput1_DSTATE = L * look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn,
+    AutopilotLaws_DWork.DelayInput1_DSTATE = b_L * look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn,
       AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_o, AutopilotLaws_P.ScheduledGain_Table_e, 6U) *
       AutopilotLaws_P.Gain1_Gain_i + AutopilotLaws_P.Gain_Gain_l * result[2];
     break;
 
    case 3:
-    rtb_Saturation_c = AutopilotLaws_P.Gain_Gain_c * AutopilotLaws_U.in.data.flight_guidance_xtk_nmi * distance_m /
+    rtb_Gain_ar0 = AutopilotLaws_P.Gain_Gain_c * AutopilotLaws_U.in.data.flight_guidance_xtk_nmi * rtb_Saturation /
       AutopilotLaws_U.in.data.V_gnd_kn;
-    if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat) {
-      rtb_Saturation_c = AutopilotLaws_P.Saturation_UpperSat;
-    } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat) {
-      rtb_Saturation_c = AutopilotLaws_P.Saturation_LowerSat;
+    if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat) {
+      rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat;
+    } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat) {
+      rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat;
     }
 
-    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_k - (AutopilotLaws_P.Gain2_Gain *
-      AutopilotLaws_U.in.data.flight_guidance_tae_deg + rtb_Saturation_c) * b_R * AutopilotLaws_U.in.data.V_gnd_kn;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_h - (AutopilotLaws_P.Gain2_Gain *
+      AutopilotLaws_U.in.data.flight_guidance_tae_deg + rtb_Gain_ar0) * b_R * AutopilotLaws_U.in.data.V_gnd_kn;
     break;
 
    case 4:
-    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Saturation;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = Phi2;
     break;
 
    case 5:
     if (rtb_Delay_j) {
-      rtb_GainTheta = AutopilotLaws_P.k_beta_Phi_Gain * AutopilotLaws_U.in.data.beta_deg;
+      L = AutopilotLaws_P.k_beta_Phi_Gain * AutopilotLaws_U.in.data.beta_deg;
     } else {
-      rtb_GainTheta = AutopilotLaws_P.Constant1_Value_fk;
+      L = AutopilotLaws_P.Constant1_Value_fk;
     }
 
-    AutopilotLaws_DWork.DelayInput1_DSTATE = b_L * look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft,
+    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_n0 * look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft,
       AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_e, AutopilotLaws_P.ScheduledGain_Table_p, 4U) *
       look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn, AutopilotLaws_P.ScheduledGain2_BreakpointsForDimension1,
-                    AutopilotLaws_P.ScheduledGain2_Table, 6U) + rtb_GainTheta;
+                    AutopilotLaws_P.ScheduledGain2_Table, 6U) + L;
     break;
 
    default:
@@ -1013,37 +1016,38 @@ void AutopilotLawsModelClass::step()
     break;
   }
 
-  R = std::abs(AutopilotLaws_U.in.data.V_tas_kn);
-  rtb_on_ground = 5;
+  rtb_Saturation = std::abs(AutopilotLaws_U.in.data.V_tas_kn);
+  i = 5;
   low_i = 1;
   low_ip1 = 2;
-  while (rtb_on_ground > low_ip1) {
+  while (i > low_ip1) {
     int32_T mid_i;
-    mid_i = (low_i + rtb_on_ground) >> 1;
-    if (R >= (static_cast<real_T>(mid_i) - 1.0) * 150.0) {
+    mid_i = (low_i + i) >> 1;
+    if (rtb_Saturation >= (static_cast<real_T>(mid_i) - 1.0) * 150.0) {
       low_i = mid_i;
       low_ip1 = mid_i + 1;
     } else {
-      rtb_on_ground = mid_i;
+      i = mid_i;
     }
   }
 
-  rtb_GainTheta = R - (static_cast<real_T>(low_i) - 1.0) * 150.0;
-  b_R = std::abs(AutopilotLaws_U.in.data.flight_guidance_phi_limit_deg);
-  if ((AutopilotLaws_U.in.input.lateral_mode != 20.0) || (b_R <= 0.0)) {
-    b_R = ((b[low_i - 1] * rtb_GainTheta + b[low_i + 3]) * rtb_GainTheta + b[low_i + 7]) * rtb_GainTheta + b[low_i + 11];
+  b_R = rtb_Saturation - (static_cast<real_T>(low_i) - 1.0) * 150.0;
+  rtb_Saturation = std::abs(AutopilotLaws_U.in.data.flight_guidance_phi_limit_deg);
+  if ((AutopilotLaws_U.in.input.lateral_mode != 20.0) || (rtb_Saturation <= 0.0)) {
+    rtb_Saturation = ((b[low_i - 1] * b_R + b[low_i + 3]) * b_R + b[low_i + 7]) * b_R + b[low_i + 11];
   }
 
-  if (AutopilotLaws_DWork.DelayInput1_DSTATE > b_R) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = b_R;
+  if (AutopilotLaws_DWork.DelayInput1_DSTATE > rtb_Saturation) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Saturation;
   } else {
-    rtb_GainTheta = AutopilotLaws_P.Gain1_Gain_l * b_R;
-    if (AutopilotLaws_DWork.DelayInput1_DSTATE < rtb_GainTheta) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_GainTheta;
+    b_R = AutopilotLaws_P.Gain1_Gain_l * rtb_Saturation;
+    if (AutopilotLaws_DWork.DelayInput1_DSTATE < b_R) {
+      AutopilotLaws_DWork.DelayInput1_DSTATE = b_R;
     }
   }
 
-  distance_m = (AutopilotLaws_DWork.DelayInput1_DSTATE - rtb_GainTheta1) * AutopilotLaws_P.Gain_Gain_lu;
+  AutopilotLaws_LagFilter(AutopilotLaws_P.Gain_Gain_lu * (AutopilotLaws_DWork.DelayInput1_DSTATE - rtb_GainTheta1),
+    AutopilotLaws_P.LagFilter_C1_a, AutopilotLaws_U.in.time.dt, &b_R, &AutopilotLaws_DWork.sf_LagFilter_mp);
   if (!AutopilotLaws_DWork.pY_not_empty) {
     AutopilotLaws_DWork.pY = AutopilotLaws_P.RateLimiterVariableTs_InitialCondition_i;
     AutopilotLaws_DWork.pY_not_empty = true;
@@ -1053,94 +1057,94 @@ void AutopilotLawsModelClass::step()
     (AutopilotLaws_P.RateLimiterVariableTs_up_n) * AutopilotLaws_U.in.time.dt), -std::abs
     (AutopilotLaws_P.RateLimiterVariableTs_lo_k) * AutopilotLaws_U.in.time.dt);
   if (AutopilotLaws_DWork.pY > AutopilotLaws_P.Saturation_UpperSat_k) {
-    rtb_GainTheta = AutopilotLaws_P.Saturation_UpperSat_k;
+    rtb_Y_hc = AutopilotLaws_P.Saturation_UpperSat_k;
   } else if (AutopilotLaws_DWork.pY < AutopilotLaws_P.Saturation_LowerSat_f3) {
-    rtb_GainTheta = AutopilotLaws_P.Saturation_LowerSat_f3;
+    rtb_Y_hc = AutopilotLaws_P.Saturation_LowerSat_f3;
   } else {
-    rtb_GainTheta = AutopilotLaws_DWork.pY;
+    rtb_Y_hc = AutopilotLaws_DWork.pY;
   }
 
-  b_R = (AutopilotLaws_P.Gain_Gain_b * result[2] * rtb_GainTheta + (AutopilotLaws_P.Constant_Value_a - rtb_GainTheta) *
-         (AutopilotLaws_P.Gain4_Gain * AutopilotLaws_U.in.data.beta_deg)) + AutopilotLaws_P.Gain5_Gain_o * Phi2;
-  if (AutopilotLaws_Y.out.output.ap_on > AutopilotLaws_P.Switch_Threshold_n) {
+  a = (AutopilotLaws_P.Gain_Gain_b * result[2] * rtb_Y_hc + (AutopilotLaws_P.Constant_Value_a - rtb_Y_hc) *
+       (AutopilotLaws_P.Gain4_Gain * AutopilotLaws_U.in.data.beta_deg)) + AutopilotLaws_P.Gain5_Gain_o * a;
+  if (rtb_Saturation_c > AutopilotLaws_P.Switch_Threshold_n) {
     switch (static_cast<int32_T>(rtb_error_d)) {
      case 0:
-      rtb_Saturation_c = AutopilotLaws_P.beta1_Value;
+      rtb_Saturation = AutopilotLaws_P.beta1_Value;
       break;
 
      case 1:
-      rtb_Saturation_c = AutopilotLaws_P.beta1_Value_h;
+      rtb_Saturation = AutopilotLaws_P.beta1_Value_h;
       break;
 
      case 2:
-      rtb_Saturation_c = AutopilotLaws_P.beta1_Value_l;
+      rtb_Saturation = AutopilotLaws_P.beta1_Value_l;
       break;
 
      case 3:
-      rtb_Saturation_c = AutopilotLaws_P.beta1_Value_m;
+      rtb_Saturation = AutopilotLaws_P.beta1_Value_m;
       break;
 
      case 4:
-      rtb_Saturation_c = AutopilotLaws_P.beta1_Value_d;
+      rtb_Saturation = AutopilotLaws_P.beta1_Value_d;
       break;
 
      case 5:
-      rtb_Saturation_c = AutopilotLaws_P.beta1_Value_hy;
+      rtb_Saturation = AutopilotLaws_P.beta1_Value_hy;
       break;
 
      default:
-      rtb_Saturation_c = AutopilotLaws_P.Gain3_Gain * b_R;
+      rtb_Saturation = AutopilotLaws_P.Gain3_Gain * a;
       break;
     }
   } else {
-    rtb_Saturation_c = AutopilotLaws_P.Constant1_Value;
+    rtb_Saturation = AutopilotLaws_P.Constant1_Value;
   }
 
   if (rtb_Delay_j) {
-    rtb_GainTheta = AutopilotLaws_P.Gain_Gain_ae * a + AutopilotLaws_P.Gain1_Gain_k * AutopilotLaws_U.in.data.beta_deg;
+    L = AutopilotLaws_P.Gain_Gain_ae * distance_m + AutopilotLaws_P.Gain1_Gain_k * AutopilotLaws_U.in.data.beta_deg;
   } else {
-    rtb_GainTheta = AutopilotLaws_P.Constant1_Value_fk;
+    L = AutopilotLaws_P.Constant1_Value_fk;
   }
 
-  AutopilotLaws_LagFilter(rtb_GainTheta, AutopilotLaws_P.LagFilter1_C1, AutopilotLaws_U.in.time.dt, &b_L,
+  AutopilotLaws_LagFilter(L, AutopilotLaws_P.LagFilter1_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_n0,
     &AutopilotLaws_DWork.sf_LagFilter_c);
   switch (static_cast<int32_T>(rtb_error_d)) {
    case 0:
-    rtb_GainTheta = AutopilotLaws_P.beta_Value;
+    rtb_Y_hc = AutopilotLaws_P.beta_Value;
     break;
 
    case 1:
-    rtb_GainTheta = AutopilotLaws_P.beta_Value_e;
+    rtb_Y_hc = AutopilotLaws_P.beta_Value_e;
     break;
 
    case 2:
-    rtb_GainTheta = AutopilotLaws_P.beta_Value_b;
+    rtb_Y_hc = AutopilotLaws_P.beta_Value_b;
     break;
 
    case 3:
-    rtb_GainTheta = AutopilotLaws_P.beta_Value_i;
+    rtb_Y_hc = AutopilotLaws_P.beta_Value_i;
     break;
 
    case 4:
-    rtb_GainTheta = AutopilotLaws_P.beta_Value_c;
+    rtb_Y_hc = AutopilotLaws_P.beta_Value_c;
     break;
 
    case 5:
-    if (b_L > AutopilotLaws_P.Saturation_UpperSat_e) {
-      rtb_GainTheta = AutopilotLaws_P.Saturation_UpperSat_e;
-    } else if (b_L < AutopilotLaws_P.Saturation_LowerSat_f) {
-      rtb_GainTheta = AutopilotLaws_P.Saturation_LowerSat_f;
+    if (rtb_Y_n0 > AutopilotLaws_P.Saturation_UpperSat_e) {
+      rtb_Y_hc = AutopilotLaws_P.Saturation_UpperSat_e;
+    } else if (rtb_Y_n0 < AutopilotLaws_P.Saturation_LowerSat_f) {
+      rtb_Y_hc = AutopilotLaws_P.Saturation_LowerSat_f;
     } else {
-      rtb_GainTheta = b_L;
+      rtb_Y_hc = rtb_Y_n0;
     }
     break;
 
    default:
-    rtb_GainTheta = AutopilotLaws_P.Gain7_Gain * b_R;
+    rtb_Y_hc = AutopilotLaws_P.Gain7_Gain * a;
     break;
   }
 
-  AutopilotLaws_DWork.icLoad = ((AutopilotLaws_Y.out.output.ap_on == 0.0) || AutopilotLaws_DWork.icLoad);
+  AutopilotLaws_DWork.icLoad = ((rtb_Saturation_c == 0.0) || AutopilotLaws_DWork.icLoad);
   if (AutopilotLaws_DWork.icLoad) {
     AutopilotLaws_DWork.Delay_DSTATE_h = rtb_GainTheta1;
   }
@@ -1151,925 +1155,895 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_DWork.Delay_DSTATE_h += std::fmax(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Gain1_Gain_kf *
     AutopilotLaws_P.Constant2_Value_h * AutopilotLaws_U.in.time.dt);
   AutopilotLaws_LagFilter(AutopilotLaws_DWork.Delay_DSTATE_h, AutopilotLaws_P.LagFilter_C1_l, AutopilotLaws_U.in.time.dt,
-    &rtb_Y_k, &AutopilotLaws_DWork.sf_LagFilter_o);
-  AutopilotLaws_RateLimiter(AutopilotLaws_Y.out.output.ap_on, AutopilotLaws_P.RateLimiterVariableTs_up_b,
+    &rtb_Y_h, &AutopilotLaws_DWork.sf_LagFilter_o);
+  AutopilotLaws_RateLimiter(rtb_Saturation_c, AutopilotLaws_P.RateLimiterVariableTs_up_b,
     AutopilotLaws_P.RateLimiterVariableTs_lo_b, AutopilotLaws_U.in.time.dt,
-    AutopilotLaws_P.RateLimiterVariableTs_InitialCondition_il, &b_L, &AutopilotLaws_DWork.sf_RateLimiter_d);
-  if (b_L > AutopilotLaws_P.Saturation_UpperSat_m) {
-    b_R = AutopilotLaws_P.Saturation_UpperSat_m;
-  } else if (b_L < AutopilotLaws_P.Saturation_LowerSat_fw) {
-    b_R = AutopilotLaws_P.Saturation_LowerSat_fw;
+    AutopilotLaws_P.RateLimiterVariableTs_InitialCondition_il, &rtb_Y_n0, &AutopilotLaws_DWork.sf_RateLimiter_d);
+  if (rtb_Y_n0 > AutopilotLaws_P.Saturation_UpperSat_m) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_m;
+  } else if (rtb_Y_n0 < AutopilotLaws_P.Saturation_LowerSat_fw) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_fw;
   } else {
-    b_R = b_L;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_n0;
   }
 
-  AutopilotLaws_Y.out.output.Phi_loc_c = rtb_Saturation;
-  rtb_Saturation_c *= AutopilotLaws_P.Gain_Gain_m3;
-  if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat_c) {
+  rtb_error_d = rtb_Y_h * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_ii - AutopilotLaws_DWork.DelayInput1_DSTATE;
+  AutopilotLaws_DWork.DelayInput1_DSTATE *= rtb_GainTheta1;
+  AutopilotLaws_DWork.DelayInput1_DSTATE += rtb_error_d;
+  AutopilotLaws_Y.out.output.Phi_loc_c = Phi2;
+  rtb_Gain_ar0 = AutopilotLaws_P.Gain_Gain_m3 * rtb_Saturation;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_c) {
     AutopilotLaws_Y.out.output.Nosewheel_c = AutopilotLaws_P.Saturation_UpperSat_c;
-  } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat_d) {
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_d) {
     AutopilotLaws_Y.out.output.Nosewheel_c = AutopilotLaws_P.Saturation_LowerSat_d;
   } else {
-    AutopilotLaws_Y.out.output.Nosewheel_c = rtb_Saturation_c;
+    AutopilotLaws_Y.out.output.Nosewheel_c = rtb_Gain_ar0;
   }
 
-  AutopilotLaws_Y.out.output.flight_director.Beta_c_deg = rtb_GainTheta;
-  AutopilotLaws_Y.out.output.autopilot.Beta_c_deg = rtb_GainTheta;
-  AutopilotLaws_Y.out.output.flight_director.Phi_c_deg = distance_m;
-  AutopilotLaws_Y.out.output.autopilot.Phi_c_deg = (AutopilotLaws_P.Constant_Value_ii - b_R) * rtb_GainTheta1 + rtb_Y_k *
-    b_R;
-  AutopilotLaws_WashoutFilter(AutopilotLaws_Y.out.data.Theta_deg, AutopilotLaws_P.WashoutFilter_C1,
-    AutopilotLaws_Y.out.time.dt, &rtb_GainTheta, &AutopilotLaws_DWork.sf_WashoutFilter_fo);
+  AutopilotLaws_Y.out.output.flight_director.Beta_c_deg = rtb_Y_hc;
+  AutopilotLaws_Y.out.output.autopilot.Beta_c_deg = rtb_Y_hc;
+  AutopilotLaws_Y.out.output.flight_director.Phi_c_deg = b_R;
+  AutopilotLaws_Y.out.output.autopilot.Phi_c_deg = AutopilotLaws_DWork.DelayInput1_DSTATE;
+  AutopilotLaws_WashoutFilter(rtb_GainTheta, AutopilotLaws_P.WashoutFilter_C1, AutopilotLaws_U.in.time.dt, &b_R,
+    &AutopilotLaws_DWork.sf_WashoutFilter_fo);
   if (AutopilotLaws_P.ManualSwitch_CurrentSetting_b == 1) {
-    rtb_GainTheta1 = AutopilotLaws_P.Constant_Value_m;
+    rtb_error_d = AutopilotLaws_P.Constant_Value_m;
   } else {
-    rtb_GainTheta1 = AutopilotLaws_Y.out.input.vertical_law;
+    rtb_error_d = AutopilotLaws_U.in.input.vertical_law;
   }
 
-  if (AutopilotLaws_Y.out.input.ALT_soft_mode_active) {
-    b_R = (AutopilotLaws_Y.out.input.V_c_kn - AutopilotLaws_Y.out.data.V_ias_kn) * AutopilotLaws_P.Gain1_Gain_b;
-    if (b_R > AutopilotLaws_P.Saturation1_UpperSat) {
-      b_R = AutopilotLaws_P.Saturation1_UpperSat;
-    } else if (b_R < AutopilotLaws_P.Saturation1_LowerSat) {
-      b_R = AutopilotLaws_P.Saturation1_LowerSat;
+  if (AutopilotLaws_U.in.input.ALT_soft_mode_active) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_U.in.input.V_c_kn - AutopilotLaws_U.in.data.V_ias_kn) *
+      AutopilotLaws_P.Gain1_Gain_b;
+    if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation1_UpperSat) {
+      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation1_UpperSat;
+    } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation1_LowerSat) {
+      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation1_LowerSat;
     }
   } else {
-    b_R = AutopilotLaws_P.Constant1_Value_h;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant1_Value_h;
   }
 
-  if (rtb_GainTheta1 != AutopilotLaws_P.CompareToConstant5_const_e) {
-    AutopilotLaws_B.u = (AutopilotLaws_Y.out.input.H_c_ft + AutopilotLaws_Y.out.data.H_ft) -
-      AutopilotLaws_Y.out.data.H_ind_ft;
+  if (rtb_error_d != AutopilotLaws_P.CompareToConstant5_const_e) {
+    AutopilotLaws_B.u = (AutopilotLaws_U.in.input.H_c_ft + AutopilotLaws_U.in.data.H_ft) -
+      AutopilotLaws_U.in.data.H_ind_ft;
   }
 
-  AutopilotLaws_LagFilter(AutopilotLaws_B.u - AutopilotLaws_Y.out.data.H_ft, AutopilotLaws_P.LagFilter_C1_a,
-    AutopilotLaws_Y.out.time.dt, &b_L, &AutopilotLaws_DWork.sf_LagFilter_g);
-  rtb_Saturation_c = AutopilotLaws_P.Gain_Gain_ft * b_L + b_R;
-  b_R = AutopilotLaws_P.kntoms_Gain * AutopilotLaws_Y.out.data.V_tas_kn;
-  if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat_n) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_UpperSat_n;
-  } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat_d4) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_LowerSat_d4;
+  AutopilotLaws_LagFilter(AutopilotLaws_B.u - AutopilotLaws_U.in.data.H_ft, AutopilotLaws_P.LagFilter_C1_ai,
+    AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_LagFilter_g);
+  AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_P.Gain_Gain_ft * rtb_Y_n0;
+  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_n) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_n;
+  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_d4) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_d4;
   }
 
-  if (b_R > AutopilotLaws_P.Saturation_UpperSat_a) {
-    b_R = AutopilotLaws_P.Saturation_UpperSat_a;
-  } else if (b_R < AutopilotLaws_P.Saturation_LowerSat_n5) {
-    b_R = AutopilotLaws_P.Saturation_LowerSat_n5;
+  AutopilotLaws_DWork.DelayInput1_DSTATE -= AutopilotLaws_U.in.data.H_dot_ft_min;
+  rtb_Saturation = AutopilotLaws_P.ftmintoms_Gain * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain * AutopilotLaws_U.in.data.V_tas_kn;
+  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_a) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_a;
+  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_n5) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_n5;
   }
 
-  rtb_Saturation_c = (rtb_Saturation_c - AutopilotLaws_Y.out.data.H_dot_ft_min) * AutopilotLaws_P.ftmintoms_Gain / b_R;
-  if (rtb_Saturation_c > 1.0) {
-    rtb_Saturation_c = 1.0;
-  } else if (rtb_Saturation_c < -1.0) {
-    rtb_Saturation_c = -1.0;
+  rtb_Gain_ar0 = rtb_Saturation / AutopilotLaws_DWork.DelayInput1_DSTATE;
+  if (rtb_Gain_ar0 > 1.0) {
+    rtb_Gain_ar0 = 1.0;
+  } else if (rtb_Gain_ar0 < -1.0) {
+    rtb_Gain_ar0 = -1.0;
   }
 
-  rtb_error_d = AutopilotLaws_P.Gain_Gain_k * std::asin(rtb_Saturation_c);
-  rtb_Compare_jy = (rtb_GainTheta1 == AutopilotLaws_P.CompareToConstant1_const);
+  Phi2 = AutopilotLaws_P.Gain_Gain_k * std::asin(rtb_Gain_ar0);
+  rtb_Compare_jy = (rtb_error_d == AutopilotLaws_P.CompareToConstant1_const);
   if (!AutopilotLaws_DWork.wasActive_not_empty_p) {
     AutopilotLaws_DWork.wasActive_c = rtb_Compare_jy;
     AutopilotLaws_DWork.wasActive_not_empty_p = true;
   }
 
-  rtb_Saturation = AutopilotLaws_Y.out.input.H_c_ft - AutopilotLaws_Y.out.data.H_ind_ft;
-  if (rtb_Saturation < 0.0) {
-    b_R = -1.0;
-  } else if (rtb_Saturation > 0.0) {
-    b_R = 1.0;
+  a = AutopilotLaws_U.in.input.H_c_ft - AutopilotLaws_U.in.data.H_ind_ft;
+  if (a < 0.0) {
+    rtb_Saturation = -1.0;
+  } else if (a > 0.0) {
+    rtb_Saturation = 1.0;
   } else {
-    b_R = rtb_Saturation;
+    rtb_Saturation = a;
   }
 
-  b_R = b_R * AutopilotLaws_DWork.dH_offset + rtb_Saturation;
+  rtb_Saturation = rtb_Saturation * AutopilotLaws_DWork.dH_offset + a;
   if ((!AutopilotLaws_DWork.wasActive_c) && rtb_Compare_jy) {
-    AutopilotLaws_DWork.k = AutopilotLaws_Y.out.data.H_dot_ft_min / b_R;
+    AutopilotLaws_DWork.k = AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Saturation;
     AutopilotLaws_DWork.dH_offset = std::abs(500.0 / std::abs(AutopilotLaws_DWork.k) - 100.0);
-    if (b_R < 0.0) {
-      Phi2 = -1.0;
-    } else if (b_R > 0.0) {
-      Phi2 = 1.0;
+    if (rtb_Saturation < 0.0) {
+      rtb_Saturation_c = -1.0;
+    } else if (rtb_Saturation > 0.0) {
+      rtb_Saturation_c = 1.0;
     } else {
-      Phi2 = b_R;
+      rtb_Saturation_c = rtb_Saturation;
     }
 
-    b_R += Phi2 * AutopilotLaws_DWork.dH_offset;
-    AutopilotLaws_DWork.k = AutopilotLaws_Y.out.data.H_dot_ft_min / b_R;
-    AutopilotLaws_DWork.maxH_dot = std::abs(AutopilotLaws_Y.out.data.H_dot_ft_min);
+    rtb_Saturation += rtb_Saturation_c * AutopilotLaws_DWork.dH_offset;
+    AutopilotLaws_DWork.k = AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Saturation;
+    AutopilotLaws_DWork.maxH_dot = std::abs(AutopilotLaws_U.in.data.H_dot_ft_min);
   }
 
-  b_R *= AutopilotLaws_DWork.k;
-  if (std::abs(b_R) > AutopilotLaws_DWork.maxH_dot) {
-    if (b_R < 0.0) {
-      b_R = -1.0;
-    } else if (b_R > 0.0) {
-      b_R = 1.0;
+  rtb_Saturation *= AutopilotLaws_DWork.k;
+  if (std::abs(rtb_Saturation) > AutopilotLaws_DWork.maxH_dot) {
+    if (rtb_Saturation < 0.0) {
+      rtb_Saturation = -1.0;
+    } else if (rtb_Saturation > 0.0) {
+      rtb_Saturation = 1.0;
     }
 
-    b_R *= AutopilotLaws_DWork.maxH_dot;
+    rtb_Saturation *= AutopilotLaws_DWork.maxH_dot;
   }
 
   AutopilotLaws_DWork.wasActive_c = rtb_Compare_jy;
-  rtb_Saturation_c = AutopilotLaws_P.kntoms_Gain_h * AutopilotLaws_Y.out.data.V_tas_kn;
-  if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat_d) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_UpperSat_d;
-  } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat_nr) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_LowerSat_nr;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Saturation - AutopilotLaws_U.in.data.H_dot_ft_min;
+  rtb_Saturation = AutopilotLaws_P.ftmintoms_Gain_c * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_h * AutopilotLaws_U.in.data.V_tas_kn;
+  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_d) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_d;
+  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_nr) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_nr;
   }
 
-  rtb_Saturation_c = (b_R - AutopilotLaws_Y.out.data.H_dot_ft_min) * AutopilotLaws_P.ftmintoms_Gain_c / rtb_Saturation_c;
-  if (rtb_Saturation_c > 1.0) {
-    rtb_Saturation_c = 1.0;
-  } else if (rtb_Saturation_c < -1.0) {
-    rtb_Saturation_c = -1.0;
+  rtb_Gain_ar0 = rtb_Saturation / AutopilotLaws_DWork.DelayInput1_DSTATE;
+  if (rtb_Gain_ar0 > 1.0) {
+    rtb_Gain_ar0 = 1.0;
+  } else if (rtb_Gain_ar0 < -1.0) {
+    rtb_Gain_ar0 = -1.0;
   }
 
-  R = AutopilotLaws_P.Gain_Gain_es * std::asin(rtb_Saturation_c);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_m * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_j) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_j;
-  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_i) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_i;
+  rtb_Saturation_c = AutopilotLaws_P.Gain_Gain_es * std::asin(rtb_Gain_ar0);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain * AutopilotLaws_U.in.data.H_dot_ft_min;
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_m * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_j) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_j;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_i) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_i;
   }
 
-  b_R = std::atan(AutopilotLaws_P.fpmtoms_Gain * AutopilotLaws_Y.out.data.H_dot_ft_min /
-                  AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_e3;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_g * AutopilotLaws_Y.out.data.Theta_deg;
-  rtb_Saturation_c = AutopilotLaws_P.kntoms_Gain_b * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat_ei) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_UpperSat_ei;
-  } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat_dz) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_LowerSat_dz;
-  }
-
-  Phi2 = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_g *
-    AutopilotLaws_Y.out.data.H_dot_ft_min / rtb_Saturation_c) * AutopilotLaws_P.Gain_Gain_c1 *
-    AutopilotLaws_P.Gain1_Gain_lx;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_c * AutopilotLaws_Y.out.data.Phi_deg;
-  a = std::cos(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  distance_m = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_e * AutopilotLaws_Y.out.data.Psi_magnetic_deg;
-  L = AutopilotLaws_P.Gain1_Gain_pf * AutopilotLaws_Y.out.data.Psi_magnetic_track_deg -
-    AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.ktstomps_Gain * AutopilotLaws_Y.out.data.V_gnd_kn;
-  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain * (AutopilotLaws_P.GStoGS_CAS_Gain *
-    AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.WashoutFilter_C1_e, AutopilotLaws_Y.out.time.dt, &b_L,
+  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Gain_ar0) *
+    AutopilotLaws_P.Gain_Gain_e3;
+  rtb_Saturation = AutopilotLaws_P.Gain1_Gain_c * rtb_GainTheta1;
+  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain * (AutopilotLaws_P.GStoGS_CAS_Gain * (AutopilotLaws_P.ktstomps_Gain *
+    AutopilotLaws_U.in.data.V_gnd_kn)), AutopilotLaws_P.WashoutFilter_C1_e, AutopilotLaws_U.in.time.dt, &rtb_Y_n0,
     &AutopilotLaws_DWork.sf_WashoutFilter);
-  AutopilotLaws_LeadLagFilter(b_L - AutopilotLaws_P.g_Gain * (AutopilotLaws_P.Gain1_Gain_lp *
-    (AutopilotLaws_P.Gain_Gain_am * (Phi2 * (AutopilotLaws_P.Constant_Value_dy - a) + distance_m * std::sin(L)))),
-    AutopilotLaws_P.HighPassFilter_C1, AutopilotLaws_P.HighPassFilter_C2, AutopilotLaws_P.HighPassFilter_C3,
-    AutopilotLaws_P.HighPassFilter_C4, AutopilotLaws_Y.out.time.dt, &rtb_Y_k, &AutopilotLaws_DWork.sf_LeadLagFilter);
-  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_b * AutopilotLaws_Y.out.data.V_ias_kn,
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_b * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_ei) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_ei;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_dz) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_dz;
+  }
+
+  AutopilotLaws_LeadLagFilter(rtb_Y_n0 - AutopilotLaws_P.g_Gain * (AutopilotLaws_P.Gain1_Gain_lp *
+    (AutopilotLaws_P.Gain_Gain_am * ((AutopilotLaws_P.Gain1_Gain_g * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_lx *
+    (AutopilotLaws_P.Gain_Gain_c1 * std::atan(AutopilotLaws_P.fpmtoms_Gain_g * AutopilotLaws_U.in.data.H_dot_ft_min /
+    rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_dy - std::cos(rtb_Saturation)) + std::sin(rtb_Saturation) * std::
+    sin(AutopilotLaws_P.Gain1_Gain_pf * AutopilotLaws_U.in.data.Psi_magnetic_track_deg - AutopilotLaws_P.Gain1_Gain_e *
+        AutopilotLaws_U.in.data.Psi_magnetic_deg)))), AutopilotLaws_P.HighPassFilter_C1,
+    AutopilotLaws_P.HighPassFilter_C2, AutopilotLaws_P.HighPassFilter_C3, AutopilotLaws_P.HighPassFilter_C4,
+    AutopilotLaws_U.in.time.dt, &rtb_Y_h, &AutopilotLaws_DWork.sf_LeadLagFilter);
+  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_b * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1, AutopilotLaws_P.LowPassFilter_C2, AutopilotLaws_P.LowPassFilter_C3,
-    AutopilotLaws_P.LowPassFilter_C4, AutopilotLaws_Y.out.time.dt, &b_L, &AutopilotLaws_DWork.sf_LeadLagFilter_o);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (rtb_Y_k + b_L) * AutopilotLaws_P.ug_Gain;
-  distance_m = AutopilotLaws_P.Gain1_Gain_bf * b_R;
-  Phi2 = AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m;
-  a = AutopilotLaws_P.Constant3_Value_nq - AutopilotLaws_P.Constant4_Value;
-  distance_m = (AutopilotLaws_P.Gain1_Gain_ik * AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m) *
-    AutopilotLaws_P.Gain_Gain_aj;
-  if (a > AutopilotLaws_P.Switch_Threshold_l) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant1_Value_g;
+    AutopilotLaws_P.LowPassFilter_C4, AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_LeadLagFilter_o);
+  rtb_Saturation = (rtb_Y_h + rtb_Y_n0) * AutopilotLaws_P.ug_Gain;
+  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_bf * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  distance_m = rtb_Saturation + rtb_Y_hc;
+  L = AutopilotLaws_P.Constant3_Value_nq - AutopilotLaws_P.Constant4_Value;
+  R = (AutopilotLaws_P.Gain1_Gain_ik * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_aj;
+  if (L > AutopilotLaws_P.Switch_Threshold_l) {
+    rtb_Saturation = AutopilotLaws_P.Constant1_Value_g;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain * distance_m;
+    rtb_Saturation = AutopilotLaws_P.Gain5_Gain * R;
   }
 
-  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_Y.out.input.V_c_kn, AutopilotLaws_Y.out.data.VLS_kn, &b_L);
-  L = (AutopilotLaws_Y.out.data.V_ias_kn - b_L) * AutopilotLaws_P.Gain1_Gain_oz;
-  if (L <= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-    if (a > AutopilotLaws_P.Switch1_Threshold) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_g;
+  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &rtb_Y_n0);
+  b_L = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_n0) * AutopilotLaws_P.Gain1_Gain_oz;
+  if (b_L <= rtb_Saturation) {
+    if (L > AutopilotLaws_P.Switch1_Threshold) {
+      rtb_Saturation = AutopilotLaws_P.Constant_Value_g;
     } else {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain * distance_m;
+      rtb_Saturation = AutopilotLaws_P.Gain6_Gain * R;
     }
 
-    if (L >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = L;
+    if (b_L >= rtb_Saturation) {
+      rtb_Saturation = b_L;
     }
   }
 
-  L = (AutopilotLaws_P.Gain_Gain_b0 * Phi2 - b_R) + AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_p * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_h) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_h;
-  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_e) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_e;
+  R = (AutopilotLaws_P.Gain_Gain_b0 * distance_m - AutopilotLaws_DWork.DelayInput1_DSTATE) + rtb_Saturation;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain_a * AutopilotLaws_U.in.data.H_dot_ft_min;
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_p * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_h) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_h;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_e) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_e;
   }
 
-  b_R = std::atan(AutopilotLaws_P.fpmtoms_Gain_a * AutopilotLaws_Y.out.data.H_dot_ft_min /
-                  AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_d4;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_kd * AutopilotLaws_Y.out.data.Theta_deg;
-  rtb_Saturation_c = AutopilotLaws_P.kntoms_Gain_l * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat_i) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_UpperSat_i;
-  } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat_h) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_LowerSat_h;
-  }
-
-  Phi2 = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_c *
-    AutopilotLaws_Y.out.data.H_dot_ft_min / rtb_Saturation_c) * AutopilotLaws_P.Gain_Gain_bs *
-    AutopilotLaws_P.Gain1_Gain_o4;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_j0 * AutopilotLaws_Y.out.data.Phi_deg;
-  a = std::cos(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  distance_m = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_lxx * AutopilotLaws_Y.out.data.Psi_magnetic_deg;
-  rtb_Add3_d = AutopilotLaws_P.Gain1_Gain_bk * AutopilotLaws_Y.out.data.Psi_magnetic_track_deg -
-    AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.ktstomps_Gain_g * AutopilotLaws_Y.out.data.V_gnd_kn;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Gain_ar0) *
+    AutopilotLaws_P.Gain_Gain_d4;
+  rtb_Saturation = AutopilotLaws_P.Gain1_Gain_j0 * rtb_GainTheta1;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_h * (AutopilotLaws_P.GStoGS_CAS_Gain_m *
-    AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.WashoutFilter_C1_e4, AutopilotLaws_Y.out.time.dt, &b_L,
-    &AutopilotLaws_DWork.sf_WashoutFilter_d);
-  AutopilotLaws_LeadLagFilter(b_L - AutopilotLaws_P.g_Gain_h * (AutopilotLaws_P.Gain1_Gain_dv *
-    (AutopilotLaws_P.Gain_Gain_id * (Phi2 * (AutopilotLaws_P.Constant_Value_cg - a) + distance_m * std::sin(rtb_Add3_d)))),
-    AutopilotLaws_P.HighPassFilter_C1_e, AutopilotLaws_P.HighPassFilter_C2_c, AutopilotLaws_P.HighPassFilter_C3_f,
-    AutopilotLaws_P.HighPassFilter_C4_c, AutopilotLaws_Y.out.time.dt, &rtb_Y_k, &AutopilotLaws_DWork.sf_LeadLagFilter_h);
-  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_i * AutopilotLaws_Y.out.data.V_ias_kn,
+    (AutopilotLaws_P.ktstomps_Gain_g * AutopilotLaws_U.in.data.V_gnd_kn)), AutopilotLaws_P.WashoutFilter_C1_e4,
+    AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_WashoutFilter_d);
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_l * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_i) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_i;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_h) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_h;
+  }
+
+  AutopilotLaws_LeadLagFilter(rtb_Y_n0 - AutopilotLaws_P.g_Gain_h * (AutopilotLaws_P.Gain1_Gain_dv *
+    (AutopilotLaws_P.Gain_Gain_id * ((AutopilotLaws_P.Gain1_Gain_kd * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_o4 *
+    (AutopilotLaws_P.Gain_Gain_bs * std::atan(AutopilotLaws_P.fpmtoms_Gain_c * AutopilotLaws_U.in.data.H_dot_ft_min /
+    rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_cg - std::cos(rtb_Saturation)) + std::sin(rtb_Saturation) * std::
+    sin(AutopilotLaws_P.Gain1_Gain_bk * AutopilotLaws_U.in.data.Psi_magnetic_track_deg - AutopilotLaws_P.Gain1_Gain_lxx *
+        AutopilotLaws_U.in.data.Psi_magnetic_deg)))), AutopilotLaws_P.HighPassFilter_C1_e,
+    AutopilotLaws_P.HighPassFilter_C2_c, AutopilotLaws_P.HighPassFilter_C3_f, AutopilotLaws_P.HighPassFilter_C4_c,
+    AutopilotLaws_U.in.time.dt, &rtb_Y_h, &AutopilotLaws_DWork.sf_LeadLagFilter_h);
+  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_i * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_n, AutopilotLaws_P.LowPassFilter_C2_a, AutopilotLaws_P.LowPassFilter_C3_o,
-    AutopilotLaws_P.LowPassFilter_C4_o, AutopilotLaws_Y.out.time.dt, &b_L, &AutopilotLaws_DWork.sf_LeadLagFilter_m);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (rtb_Y_k + b_L) * AutopilotLaws_P.ug_Gain_a;
-  distance_m = AutopilotLaws_P.Gain1_Gain_hm * b_R;
-  Phi2 = AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m;
-  a = AutopilotLaws_P.Constant1_Value_b4 - AutopilotLaws_P.Constant2_Value_c;
-  distance_m = (AutopilotLaws_P.Gain1_Gain_mz * AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m) *
-    AutopilotLaws_P.Gain_Gain_ie;
-  if (a > AutopilotLaws_P.Switch_Threshold_b) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant1_Value_a;
+    AutopilotLaws_P.LowPassFilter_C4_o, AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_LeadLagFilter_m);
+  rtb_Saturation = (rtb_Y_h + rtb_Y_n0) * AutopilotLaws_P.ug_Gain_a;
+  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_hm * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  distance_m = rtb_Saturation + rtb_Y_hc;
+  L = AutopilotLaws_P.Constant1_Value_b4 - AutopilotLaws_P.Constant2_Value_c;
+  b_L = (AutopilotLaws_P.Gain1_Gain_mz * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_ie;
+  if (L > AutopilotLaws_P.Switch_Threshold_b) {
+    rtb_Saturation = AutopilotLaws_P.Constant1_Value_a;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain_l * distance_m;
+    rtb_Saturation = AutopilotLaws_P.Gain5_Gain_l * b_L;
   }
 
-  b_L = AutopilotLaws_Y.out.data.V_ias_kn - AutopilotLaws_Y.out.data.VMAX_kn;
-  rtb_Add3_d = b_L * AutopilotLaws_P.Gain1_Gain_f1;
-  if (rtb_Add3_d <= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-    if (a > AutopilotLaws_P.Switch1_Threshold_f) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_p;
+  rtb_Y_n0 = AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.data.VMAX_kn;
+  rtb_Y_hc = rtb_Y_n0 * AutopilotLaws_P.Gain1_Gain_f1;
+  if (rtb_Y_hc <= rtb_Saturation) {
+    if (L > AutopilotLaws_P.Switch1_Threshold_f) {
+      rtb_Saturation = AutopilotLaws_P.Constant_Value_p;
     } else {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain_j * distance_m;
+      rtb_Saturation = AutopilotLaws_P.Gain6_Gain_j * b_L;
     }
 
-    if (rtb_Add3_d >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Add3_d;
+    if (rtb_Y_hc >= rtb_Saturation) {
+      rtb_Saturation = rtb_Y_hc;
     }
   }
 
-  b_R = (AutopilotLaws_P.Gain_Gain_kj * Phi2 - b_R) + AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_SpeedProtectionSignalSelection(&AutopilotLaws_Y.out, R, AutopilotLaws_P.VS_Gain * R, L,
-    AutopilotLaws_P.Gain_Gain_m0 * L, b_R, AutopilotLaws_P.Gain_Gain_lr * b_R, AutopilotLaws_P.Constant_Value_ig, &a,
-    &Phi2);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_hx * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_nd) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_nd;
-  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_a) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_a;
+  rtb_Saturation += AutopilotLaws_P.Gain_Gain_kj * distance_m - AutopilotLaws_DWork.DelayInput1_DSTATE;
+  AutopilotLaws_SpeedProtectionSignalSelection(&AutopilotLaws_Y.out, rtb_Saturation_c, AutopilotLaws_P.VS_Gain *
+    rtb_Saturation_c, R, AutopilotLaws_P.Gain_Gain_m0 * R, rtb_Saturation, AutopilotLaws_P.Gain_Gain_lr * rtb_Saturation,
+    AutopilotLaws_P.Constant_Value_ig, &distance_m, &L);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain_i * AutopilotLaws_U.in.data.H_dot_ft_min;
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_hx * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_nd) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_nd;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_a) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_a;
   }
 
-  b_R = std::atan(AutopilotLaws_P.fpmtoms_Gain_i * AutopilotLaws_Y.out.data.H_dot_ft_min /
-                  AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_hm;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_fv * AutopilotLaws_Y.out.data.Theta_deg;
-  rtb_Saturation_c = AutopilotLaws_P.kntoms_Gain_d * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat_g) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_UpperSat_g;
-  } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat_aw) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_LowerSat_aw;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Gain_ar0) *
+    AutopilotLaws_P.Gain_Gain_hm;
+  rtb_Saturation = AutopilotLaws_P.Gain1_Gain_fm * rtb_GainTheta1;
+  rtb_Saturation_c = std::cos(rtb_Saturation);
+  R = std::sin(rtb_Saturation);
+  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_hy * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
+  b_L = rtb_Y_hc - AutopilotLaws_P.Gain1_Gain_j2 * AutopilotLaws_U.in.data.Psi_magnetic_deg;
+  rtb_Saturation = AutopilotLaws_P.ktstomps_Gain_c * AutopilotLaws_U.in.data.V_gnd_kn;
+  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_m * (AutopilotLaws_P.GStoGS_CAS_Gain_o * rtb_Saturation),
+    AutopilotLaws_P.WashoutFilter_C1_l, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
+    &AutopilotLaws_DWork.sf_WashoutFilter_j);
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_d * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_g) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_g;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_aw) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_aw;
   }
 
-  R = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_e *
-    AutopilotLaws_Y.out.data.H_dot_ft_min / rtb_Saturation_c) * AutopilotLaws_P.Gain_Gain_ho *
-    AutopilotLaws_P.Gain1_Gain_i0;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_fm * AutopilotLaws_Y.out.data.Phi_deg;
-  L = std::cos(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  rtb_Add3_d = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_j2 * AutopilotLaws_Y.out.data.Psi_magnetic_deg;
-  distance_m = AutopilotLaws_P.Gain1_Gain_hy * AutopilotLaws_Y.out.data.Psi_magnetic_track_deg;
-  rtb_Add3_l = distance_m - AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.ktstomps_Gain_c * AutopilotLaws_Y.out.data.V_gnd_kn;
-  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_m * (AutopilotLaws_P.GStoGS_CAS_Gain_o *
-    AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.WashoutFilter_C1_l, AutopilotLaws_Y.out.time.dt,
-    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_WashoutFilter_j);
-  AutopilotLaws_LeadLagFilter(AutopilotLaws_DWork.DelayInput1_DSTATE - AutopilotLaws_P.g_Gain_g *
-    (AutopilotLaws_P.Gain1_Gain_be * (AutopilotLaws_P.Gain_Gain_db * (R * (AutopilotLaws_P.Constant_Value_j - L) +
-    rtb_Add3_d * std::sin(rtb_Add3_l)))), AutopilotLaws_P.HighPassFilter_C1_l, AutopilotLaws_P.HighPassFilter_C2_co,
-    AutopilotLaws_P.HighPassFilter_C3_b, AutopilotLaws_P.HighPassFilter_C4_j, AutopilotLaws_Y.out.time.dt, &distance_m,
-    &AutopilotLaws_DWork.sf_LeadLagFilter_l);
-  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_n * AutopilotLaws_Y.out.data.V_ias_kn,
+  AutopilotLaws_LeadLagFilter(rtb_Saturation - AutopilotLaws_P.g_Gain_g * (AutopilotLaws_P.Gain1_Gain_be *
+    (AutopilotLaws_P.Gain_Gain_db * ((AutopilotLaws_P.Gain1_Gain_fv * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_i0 *
+    (AutopilotLaws_P.Gain_Gain_ho * std::atan(AutopilotLaws_P.fpmtoms_Gain_e * AutopilotLaws_U.in.data.H_dot_ft_min /
+    rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_j - rtb_Saturation_c) + R * std::sin(b_L)))),
+    AutopilotLaws_P.HighPassFilter_C1_l, AutopilotLaws_P.HighPassFilter_C2_co, AutopilotLaws_P.HighPassFilter_C3_b,
+    AutopilotLaws_P.HighPassFilter_C4_j, AutopilotLaws_U.in.time.dt, &rtb_Y_hc, &AutopilotLaws_DWork.sf_LeadLagFilter_l);
+  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_n * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_f, AutopilotLaws_P.LowPassFilter_C2_p, AutopilotLaws_P.LowPassFilter_C3_a,
-    AutopilotLaws_P.LowPassFilter_C4_g, AutopilotLaws_Y.out.time.dt, &AutopilotLaws_DWork.DelayInput1_DSTATE,
+    AutopilotLaws_P.LowPassFilter_C4_g, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
     &AutopilotLaws_DWork.sf_LeadLagFilter_as);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (distance_m + AutopilotLaws_DWork.DelayInput1_DSTATE) *
-    AutopilotLaws_P.ug_Gain_l;
-  distance_m = AutopilotLaws_P.Gain1_Gain_g1 * b_R;
-  R = AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m;
-  distance_m = (AutopilotLaws_P.Gain1_Gain_ov * AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m) *
-    AutopilotLaws_P.Gain_Gain_a2;
-  AutopilotLaws_Voter1(AutopilotLaws_Y.out.data.VLS_kn, AutopilotLaws_Y.out.input.V_c_kn,
-                       AutopilotLaws_Y.out.data.VMAX_kn, &L);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_Y.out.data.V_ias_kn - L;
-  AutopilotLaws_DWork.DelayInput1_DSTATE *= AutopilotLaws_P.Gain1_Gain_lxw;
-  if ((rtb_Saturation > AutopilotLaws_P.CompareToConstant_const_a) && (distance_m <
-       AutopilotLaws_P.CompareToConstant1_const_n) && (AutopilotLaws_DWork.DelayInput1_DSTATE <
-       AutopilotLaws_P.CompareToConstant2_const_b)) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_c;
+  rtb_Saturation = (rtb_Y_hc + rtb_Saturation) * AutopilotLaws_P.ug_Gain_l;
+  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_g1 * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Saturation_c = rtb_Saturation + rtb_Y_hc;
+  R = (AutopilotLaws_P.Gain1_Gain_ov * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_a2;
+  AutopilotLaws_Voter1(AutopilotLaws_U.in.data.VLS_kn, AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VMAX_kn,
+                       &rtb_Saturation);
+  rtb_Saturation = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Saturation) * AutopilotLaws_P.Gain1_Gain_lxw;
+  if ((a > AutopilotLaws_P.CompareToConstant_const_a) && (R < AutopilotLaws_P.CompareToConstant1_const_n) &&
+      (rtb_Saturation < AutopilotLaws_P.CompareToConstant2_const_b)) {
+    rtb_Saturation = AutopilotLaws_P.Constant_Value_c;
   } else {
-    if (rtb_Saturation > AutopilotLaws_P.Switch2_Threshold) {
-      L = AutopilotLaws_P.Constant1_Value_mf;
+    if (a > AutopilotLaws_P.Switch2_Threshold) {
+      b_L = AutopilotLaws_P.Constant1_Value_mf;
     } else {
-      L = AutopilotLaws_P.Gain5_Gain_f * distance_m;
+      b_L = AutopilotLaws_P.Gain5_Gain_f * R;
     }
 
-    if (AutopilotLaws_DWork.DelayInput1_DSTATE > L) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = L;
+    if (rtb_Saturation > b_L) {
+      rtb_Saturation = b_L;
     } else {
-      if (rtb_Saturation > AutopilotLaws_P.Switch1_Threshold_o) {
-        distance_m = std::fmax(AutopilotLaws_P.Constant2_Value, AutopilotLaws_P.Gain1_Gain_lt * distance_m);
+      if (a > AutopilotLaws_P.Switch1_Threshold_o) {
+        R = std::fmax(AutopilotLaws_P.Constant2_Value, AutopilotLaws_P.Gain1_Gain_lt * R);
       } else {
-        distance_m *= AutopilotLaws_P.Gain6_Gain_l;
+        R *= AutopilotLaws_P.Gain6_Gain_l;
       }
 
-      if (AutopilotLaws_DWork.DelayInput1_DSTATE < distance_m) {
-        AutopilotLaws_DWork.DelayInput1_DSTATE = distance_m;
+      if (rtb_Saturation < R) {
+        rtb_Saturation = R;
       }
     }
   }
 
-  R = (AutopilotLaws_P.Gain_Gain_ce * R - b_R) + AutopilotLaws_DWork.DelayInput1_DSTATE;
-  rtb_Saturation_c = AutopilotLaws_P.kntoms_Gain_a * AutopilotLaws_Y.out.data.V_tas_kn;
-  if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat_l) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_UpperSat_l;
-  } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat_hm) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_LowerSat_hm;
+  R = (AutopilotLaws_P.Gain_Gain_ce * rtb_Saturation_c - AutopilotLaws_DWork.DelayInput1_DSTATE) + rtb_Saturation;
+  b_L = AutopilotLaws_U.in.input.H_dot_c_fpm - AutopilotLaws_U.in.data.H_dot_ft_min;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = b_L;
+  rtb_Saturation = AutopilotLaws_P.ftmintoms_Gain_l * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_a * AutopilotLaws_U.in.data.V_tas_kn;
+  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_l) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_l;
+  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_hm) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_hm;
   }
 
-  L = AutopilotLaws_Y.out.input.H_dot_c_fpm - AutopilotLaws_Y.out.data.H_dot_ft_min;
-  rtb_Saturation_c = L * AutopilotLaws_P.ftmintoms_Gain_l / rtb_Saturation_c;
-  if (rtb_Saturation_c > 1.0) {
-    rtb_Saturation_c = 1.0;
-  } else if (rtb_Saturation_c < -1.0) {
-    rtb_Saturation_c = -1.0;
+  rtb_Gain_ar0 = rtb_Saturation / AutopilotLaws_DWork.DelayInput1_DSTATE;
+  if (rtb_Gain_ar0 > 1.0) {
+    rtb_Gain_ar0 = 1.0;
+  } else if (rtb_Gain_ar0 < -1.0) {
+    rtb_Gain_ar0 = -1.0;
   }
 
-  rtb_Gain_dn = AutopilotLaws_P.Gain_Gain_ey * std::asin(rtb_Saturation_c);
-  if (AutopilotLaws_Y.out.input.vertical_mode == 50.0) {
-    distance_m = 0.3;
+  rtb_Gain_dn = AutopilotLaws_P.Gain_Gain_ey * std::asin(rtb_Gain_ar0);
+  if (AutopilotLaws_U.in.input.vertical_mode == 50.0) {
+    rtb_Y_hc = 0.3;
   } else {
-    distance_m = 0.1;
+    rtb_Y_hc = 0.1;
   }
 
-  rtb_Y_k = 9.81 / (AutopilotLaws_Y.out.data.V_tas_kn * 0.51444444444444448);
-  limit = rtb_Y_k * distance_m * 57.295779513082323;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_o * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_f) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_f;
-  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_c) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_c;
+  rtb_Saturation_c = 9.81 / (AutopilotLaws_U.in.data.V_tas_kn * 0.51444444444444448);
+  limit = rtb_Saturation_c * rtb_Y_hc * 57.295779513082323;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain_o * AutopilotLaws_U.in.data.H_dot_ft_min;
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_o * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_f) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_f;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_c) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_c;
   }
 
-  b_R = std::atan(AutopilotLaws_P.fpmtoms_Gain_o * AutopilotLaws_Y.out.data.H_dot_ft_min /
-                  AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_lx;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_jn * AutopilotLaws_Y.out.data.Theta_deg;
-  rtb_Saturation_c = AutopilotLaws_P.kntoms_Gain_db * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat_hb) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_UpperSat_hb;
-  } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat_k) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_LowerSat_k;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Gain_ar0) *
+    AutopilotLaws_P.Gain_Gain_lx;
+  rtb_Saturation = AutopilotLaws_P.Gain1_Gain_hi * rtb_GainTheta1;
+  rtb_Cos_f2 = std::cos(rtb_Saturation);
+  rtb_Cos1_pk = std::sin(rtb_Saturation);
+  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_hg * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
+  rtb_Add3_gy = rtb_Y_hc - AutopilotLaws_P.Gain1_Gain_da * AutopilotLaws_U.in.data.Psi_magnetic_deg;
+  rtb_Saturation = AutopilotLaws_P.ktstomps_Gain_m * AutopilotLaws_U.in.data.V_gnd_kn;
+  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_k * (AutopilotLaws_P.GStoGS_CAS_Gain_k * rtb_Saturation),
+    AutopilotLaws_P.WashoutFilter_C1_o, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
+    &AutopilotLaws_DWork.sf_WashoutFilter_fs);
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_db * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_hb) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_hb;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_k) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_k;
   }
 
-  rtb_Add3_d = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_ey *
-    AutopilotLaws_Y.out.data.H_dot_ft_min / rtb_Saturation_c) * AutopilotLaws_P.Gain_Gain_in *
-    AutopilotLaws_P.Gain1_Gain_ps;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_hi * AutopilotLaws_Y.out.data.Phi_deg;
-  rtb_Add3_l = std::cos(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  rtb_Cos1_pk = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_da * AutopilotLaws_Y.out.data.Psi_magnetic_deg;
-  distance_m = AutopilotLaws_P.Gain1_Gain_hg * AutopilotLaws_Y.out.data.Psi_magnetic_track_deg;
-  rtb_Add3_n = distance_m - AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.ktstomps_Gain_m * AutopilotLaws_Y.out.data.V_gnd_kn;
-  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_k * (AutopilotLaws_P.GStoGS_CAS_Gain_k *
-    AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.WashoutFilter_C1_o, AutopilotLaws_Y.out.time.dt,
-    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_WashoutFilter_fs);
-  AutopilotLaws_LeadLagFilter(AutopilotLaws_DWork.DelayInput1_DSTATE - AutopilotLaws_P.g_Gain_m *
-    (AutopilotLaws_P.Gain1_Gain_kdq * (AutopilotLaws_P.Gain_Gain_b5 * (rtb_Add3_d * (AutopilotLaws_P.Constant_Value_od -
-    rtb_Add3_l) + rtb_Cos1_pk * std::sin(rtb_Add3_n)))), AutopilotLaws_P.HighPassFilter_C1_g,
-    AutopilotLaws_P.HighPassFilter_C2_l, AutopilotLaws_P.HighPassFilter_C3_j, AutopilotLaws_P.HighPassFilter_C4_i,
-    AutopilotLaws_Y.out.time.dt, &distance_m, &AutopilotLaws_DWork.sf_LeadLagFilter_b);
-  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_c2 * AutopilotLaws_Y.out.data.V_ias_kn,
+  AutopilotLaws_LeadLagFilter(rtb_Saturation - AutopilotLaws_P.g_Gain_m * (AutopilotLaws_P.Gain1_Gain_kdq *
+    (AutopilotLaws_P.Gain_Gain_b5 * ((AutopilotLaws_P.Gain1_Gain_jn * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_ps *
+    (AutopilotLaws_P.Gain_Gain_in * std::atan(AutopilotLaws_P.fpmtoms_Gain_ey * AutopilotLaws_U.in.data.H_dot_ft_min /
+    rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_od - rtb_Cos_f2) + rtb_Cos1_pk * std::sin(rtb_Add3_gy)))),
+    AutopilotLaws_P.HighPassFilter_C1_g, AutopilotLaws_P.HighPassFilter_C2_l, AutopilotLaws_P.HighPassFilter_C3_j,
+    AutopilotLaws_P.HighPassFilter_C4_i, AutopilotLaws_U.in.time.dt, &rtb_Y_hc, &AutopilotLaws_DWork.sf_LeadLagFilter_b);
+  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_c2 * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_m, AutopilotLaws_P.LowPassFilter_C2_l, AutopilotLaws_P.LowPassFilter_C3_i,
-    AutopilotLaws_P.LowPassFilter_C4_k, AutopilotLaws_Y.out.time.dt, &AutopilotLaws_DWork.DelayInput1_DSTATE,
+    AutopilotLaws_P.LowPassFilter_C4_k, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
     &AutopilotLaws_DWork.sf_LeadLagFilter_kq);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (distance_m + AutopilotLaws_DWork.DelayInput1_DSTATE) *
-    AutopilotLaws_P.ug_Gain_aa;
-  distance_m = AutopilotLaws_P.Gain1_Gain_gf * b_R;
-  rtb_Add3_d = AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m;
-  rtb_Add3_l = AutopilotLaws_P.Constant3_Value_h1 - AutopilotLaws_P.Constant4_Value_f;
-  rtb_Cos1_pk = (AutopilotLaws_P.Gain1_Gain_ovr * AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m) *
-    AutopilotLaws_P.Gain_Gain_jy;
-  if (rtb_Add3_l > AutopilotLaws_P.Switch_Threshold_o) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant1_Value_m5;
+  rtb_Saturation = (rtb_Y_hc + rtb_Saturation) * AutopilotLaws_P.ug_Gain_aa;
+  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_gf * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Cos_f2 = rtb_Saturation + rtb_Y_hc;
+  rtb_Cos1_pk = AutopilotLaws_P.Constant3_Value_h1 - AutopilotLaws_P.Constant4_Value_f;
+  rtb_Gain_ar0 = (AutopilotLaws_P.Gain1_Gain_ovr * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_jy;
+  if (rtb_Cos1_pk > AutopilotLaws_P.Switch_Threshold_o) {
+    rtb_Saturation = AutopilotLaws_P.Constant1_Value_m5;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain_h * rtb_Cos1_pk;
+    rtb_Saturation = AutopilotLaws_P.Gain5_Gain_h * rtb_Gain_ar0;
   }
 
-  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_Y.out.input.V_c_kn, AutopilotLaws_Y.out.data.VLS_kn, &distance_m);
-  distance_m = (AutopilotLaws_Y.out.data.V_ias_kn - distance_m) * AutopilotLaws_P.Gain1_Gain_dvi;
-  if (distance_m <= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-    if (rtb_Add3_l > AutopilotLaws_P.Switch1_Threshold_c) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_b;
+  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &rtb_Y_hc);
+  rtb_Y_hc = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_hc) * AutopilotLaws_P.Gain1_Gain_dvi;
+  if (rtb_Y_hc <= rtb_Saturation) {
+    if (rtb_Cos1_pk > AutopilotLaws_P.Switch1_Threshold_c) {
+      rtb_Saturation = AutopilotLaws_P.Constant_Value_b;
     } else {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain_a * rtb_Cos1_pk;
+      rtb_Saturation = AutopilotLaws_P.Gain6_Gain_a * rtb_Gain_ar0;
     }
 
-    if (distance_m >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = distance_m;
+    if (rtb_Y_hc >= rtb_Saturation) {
+      rtb_Saturation = rtb_Y_hc;
     }
   }
 
-  rtb_Cos1_pk = (AutopilotLaws_P.Gain_Gain_j * rtb_Add3_d - b_R) + AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_bq * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_ba) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_ba;
-  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_p) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_p;
+  rtb_Add3_gy = (AutopilotLaws_P.Gain_Gain_j * rtb_Cos_f2 - AutopilotLaws_DWork.DelayInput1_DSTATE) + rtb_Saturation;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain_p * AutopilotLaws_U.in.data.H_dot_ft_min;
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_bq * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_ba) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_ba;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_p) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_p;
   }
 
-  b_R = std::atan(AutopilotLaws_P.fpmtoms_Gain_p * AutopilotLaws_Y.out.data.H_dot_ft_min /
-                  AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_py;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_hk * AutopilotLaws_Y.out.data.Theta_deg;
-  rtb_Saturation_c = AutopilotLaws_P.kntoms_Gain_l5 * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat_b3) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_UpperSat_b3;
-  } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat_es) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_LowerSat_es;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Gain_ar0) *
+    AutopilotLaws_P.Gain_Gain_py;
+  rtb_Saturation = AutopilotLaws_P.Gain1_Gain_er * rtb_GainTheta1;
+  rtb_Cos_f2 = std::cos(rtb_Saturation);
+  rtb_Cos1_pk = std::sin(rtb_Saturation);
+  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_ero * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
+  rtb_Add3_n2 = rtb_Y_hc - AutopilotLaws_P.Gain1_Gain_fl * AutopilotLaws_U.in.data.Psi_magnetic_deg;
+  rtb_Saturation = AutopilotLaws_P.ktstomps_Gain_a * AutopilotLaws_U.in.data.V_gnd_kn;
+  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_i * (AutopilotLaws_P.GStoGS_CAS_Gain_n * rtb_Saturation),
+    AutopilotLaws_P.WashoutFilter_C1_p, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
+    &AutopilotLaws_DWork.sf_WashoutFilter_jh);
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_l5 * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_b3) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_b3;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_es) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_es;
   }
 
-  rtb_Add3_d = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_j *
-    AutopilotLaws_Y.out.data.H_dot_ft_min / rtb_Saturation_c) * AutopilotLaws_P.Gain_Gain_e5 *
-    AutopilotLaws_P.Gain1_Gain_ja;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_er * AutopilotLaws_Y.out.data.Phi_deg;
-  rtb_Add3_l = std::cos(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  rtb_Add3_n = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_fl * AutopilotLaws_Y.out.data.Psi_magnetic_deg;
-  distance_m = AutopilotLaws_P.Gain1_Gain_ero * AutopilotLaws_Y.out.data.Psi_magnetic_track_deg;
-  rtb_Saturation_c = distance_m - AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.ktstomps_Gain_a * AutopilotLaws_Y.out.data.V_gnd_kn;
-  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_i * (AutopilotLaws_P.GStoGS_CAS_Gain_n *
-    AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.WashoutFilter_C1_p, AutopilotLaws_Y.out.time.dt,
-    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_WashoutFilter_jh);
-  AutopilotLaws_LeadLagFilter(AutopilotLaws_DWork.DelayInput1_DSTATE - AutopilotLaws_P.g_Gain_gr *
-    (AutopilotLaws_P.Gain1_Gain_hv * (AutopilotLaws_P.Gain_Gain_mx * (rtb_Add3_d * (AutopilotLaws_P.Constant_Value_ia -
-    rtb_Add3_l) + rtb_Add3_n * std::sin(rtb_Saturation_c)))), AutopilotLaws_P.HighPassFilter_C1_n,
-    AutopilotLaws_P.HighPassFilter_C2_m, AutopilotLaws_P.HighPassFilter_C3_k, AutopilotLaws_P.HighPassFilter_C4_h,
-    AutopilotLaws_Y.out.time.dt, &distance_m, &AutopilotLaws_DWork.sf_LeadLagFilter_c);
-  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_o * AutopilotLaws_Y.out.data.V_ias_kn,
+  AutopilotLaws_LeadLagFilter(rtb_Saturation - AutopilotLaws_P.g_Gain_gr * (AutopilotLaws_P.Gain1_Gain_hv *
+    (AutopilotLaws_P.Gain_Gain_mx * ((AutopilotLaws_P.Gain1_Gain_hk * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_ja *
+    (AutopilotLaws_P.Gain_Gain_e5 * std::atan(AutopilotLaws_P.fpmtoms_Gain_j * AutopilotLaws_U.in.data.H_dot_ft_min /
+    rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_ia - rtb_Cos_f2) + rtb_Cos1_pk * std::sin(rtb_Add3_n2)))),
+    AutopilotLaws_P.HighPassFilter_C1_n, AutopilotLaws_P.HighPassFilter_C2_m, AutopilotLaws_P.HighPassFilter_C3_k,
+    AutopilotLaws_P.HighPassFilter_C4_h, AutopilotLaws_U.in.time.dt, &rtb_Y_hc, &AutopilotLaws_DWork.sf_LeadLagFilter_c);
+  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_o * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_l, AutopilotLaws_P.LowPassFilter_C2_c, AutopilotLaws_P.LowPassFilter_C3_g,
-    AutopilotLaws_P.LowPassFilter_C4_d, AutopilotLaws_Y.out.time.dt, &AutopilotLaws_DWork.DelayInput1_DSTATE,
+    AutopilotLaws_P.LowPassFilter_C4_d, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
     &AutopilotLaws_DWork.sf_LeadLagFilter_p);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (distance_m + AutopilotLaws_DWork.DelayInput1_DSTATE) *
-    AutopilotLaws_P.ug_Gain_f;
-  distance_m = AutopilotLaws_P.Gain1_Gain_ot * b_R;
-  rtb_Add3_d = AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m;
-  rtb_Add3_l = AutopilotLaws_P.Constant1_Value_d - AutopilotLaws_P.Constant2_Value_k;
-  distance_m = (AutopilotLaws_P.Gain1_Gain_ou * AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m) *
-    AutopilotLaws_P.Gain_Gain_jg;
-  if (rtb_Add3_l > AutopilotLaws_P.Switch_Threshold_a) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant1_Value_mi;
+  rtb_Saturation = (rtb_Y_hc + rtb_Saturation) * AutopilotLaws_P.ug_Gain_f;
+  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_ot * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Cos_f2 = rtb_Saturation + rtb_Y_hc;
+  rtb_Cos1_pk = AutopilotLaws_P.Constant1_Value_d - AutopilotLaws_P.Constant2_Value_k;
+  rtb_Y_hc = (AutopilotLaws_P.Gain1_Gain_ou * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_jg;
+  if (rtb_Cos1_pk > AutopilotLaws_P.Switch_Threshold_a) {
+    rtb_Saturation = AutopilotLaws_P.Constant1_Value_mi;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain_g * distance_m;
+    rtb_Saturation = AutopilotLaws_P.Gain5_Gain_g * rtb_Y_hc;
   }
 
-  rtb_Add3_n = b_L * AutopilotLaws_P.Gain1_Gain_gy;
-  if (rtb_Add3_n <= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-    if (rtb_Add3_l > AutopilotLaws_P.Switch1_Threshold_b) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_o;
+  rtb_Gain_ar0 = rtb_Y_n0 * AutopilotLaws_P.Gain1_Gain_gy;
+  if (rtb_Gain_ar0 <= rtb_Saturation) {
+    if (rtb_Cos1_pk > AutopilotLaws_P.Switch1_Threshold_b) {
+      rtb_Saturation = AutopilotLaws_P.Constant_Value_o;
     } else {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain_c * distance_m;
+      rtb_Saturation = AutopilotLaws_P.Gain6_Gain_c * rtb_Y_hc;
     }
 
-    if (rtb_Add3_n >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Add3_n;
+    if (rtb_Gain_ar0 >= rtb_Saturation) {
+      rtb_Saturation = rtb_Gain_ar0;
     }
   }
 
-  b_R = (AutopilotLaws_P.Gain_Gain_dm * rtb_Add3_d - b_R) + AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Saturation += AutopilotLaws_P.Gain_Gain_dm * rtb_Cos_f2 - AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_SpeedProtectionSignalSelection(&AutopilotLaws_Y.out, rtb_Gain_dn, std::fmax(-limit, std::fmin(limit,
-    AutopilotLaws_P.VS_Gain_h * rtb_Gain_dn)), rtb_Cos1_pk, AutopilotLaws_P.Gain_Gain_h4 * rtb_Cos1_pk, b_R,
-    AutopilotLaws_P.Gain_Gain_eq * b_R, AutopilotLaws_P.Constant_Value_ga, &rtb_Add3_l, &rtb_Add3_d);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_c * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_oz) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_oz;
-  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_ou) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_ou;
+    AutopilotLaws_P.VS_Gain_h * rtb_Gain_dn)), rtb_Add3_gy, AutopilotLaws_P.Gain_Gain_h4 * rtb_Add3_gy, rtb_Saturation,
+    AutopilotLaws_P.Gain_Gain_eq * rtb_Saturation, AutopilotLaws_P.Constant_Value_ga, &rtb_Cos_f2, &rtb_Cos1_pk);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain_ps * AutopilotLaws_U.in.data.H_dot_ft_min;
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_c * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_oz) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_oz;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_ou) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_ou;
   }
 
-  rtb_Cos1_pk = AutopilotLaws_Y.out.input.FPA_c_deg - std::atan(AutopilotLaws_P.fpmtoms_Gain_ps *
-    AutopilotLaws_Y.out.data.H_dot_ft_min / AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_g;
-  limit = rtb_Y_k * 0.1 * 57.295779513082323;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_cv * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_bb) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_bb;
-  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_a4) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_a4;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Gain_ar0) *
+    AutopilotLaws_P.Gain_Gain_g;
+  rtb_Add3_n2 = AutopilotLaws_U.in.input.FPA_c_deg - AutopilotLaws_DWork.DelayInput1_DSTATE;
+  limit = rtb_Saturation_c * 0.1 * 57.295779513082323;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain_d * AutopilotLaws_U.in.data.H_dot_ft_min;
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_cv * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_bb) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_bb;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_a4) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_a4;
   }
 
-  b_R = std::atan(AutopilotLaws_P.fpmtoms_Gain_d * AutopilotLaws_Y.out.data.H_dot_ft_min /
-                  AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_hv;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_ej * AutopilotLaws_Y.out.data.Theta_deg;
-  rtb_Saturation_c = AutopilotLaws_P.kntoms_Gain_k * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat_pj) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_UpperSat_pj;
-  } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat_py) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_LowerSat_py;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Gain_ar0) *
+    AutopilotLaws_P.Gain_Gain_hv;
+  rtb_Saturation = AutopilotLaws_P.Gain1_Gain_gfa * rtb_GainTheta1;
+  rtb_Saturation_c = std::cos(rtb_Saturation);
+  rtb_Y_hc = std::sin(rtb_Saturation);
+  rtb_Saturation = AutopilotLaws_P.ktstomps_Gain_j * AutopilotLaws_U.in.data.V_gnd_kn;
+  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_kb * (AutopilotLaws_P.GStoGS_CAS_Gain_o5 * rtb_Saturation),
+    AutopilotLaws_P.WashoutFilter_C1_j, AutopilotLaws_U.in.time.dt, &rtb_Y_h, &AutopilotLaws_DWork.sf_WashoutFilter_h);
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_k * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_pj) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_pj;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_py) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_py;
   }
 
-  distance_m = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_f *
-    AutopilotLaws_Y.out.data.H_dot_ft_min / rtb_Saturation_c) * AutopilotLaws_P.Gain_Gain_bf *
-    AutopilotLaws_P.Gain1_Gain_jv;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_gfa * AutopilotLaws_Y.out.data.Phi_deg;
-  rtb_Gain_dn = std::cos(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  rtb_Add3_n = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_kw * AutopilotLaws_Y.out.data.Psi_magnetic_deg;
-  rtb_Saturation_c = AutopilotLaws_P.Gain1_Gain_j4 * AutopilotLaws_Y.out.data.Psi_magnetic_track_deg -
-    AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.ktstomps_Gain_j * AutopilotLaws_Y.out.data.V_gnd_kn;
-  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_kb * (AutopilotLaws_P.GStoGS_CAS_Gain_o5 *
-    AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.WashoutFilter_C1_j, AutopilotLaws_Y.out.time.dt, &rtb_Y_k,
-    &AutopilotLaws_DWork.sf_WashoutFilter_h);
-  AutopilotLaws_LeadLagFilter(rtb_Y_k - AutopilotLaws_P.g_Gain_l * (AutopilotLaws_P.Gain1_Gain_n4 *
-    (AutopilotLaws_P.Gain_Gain_bc * (distance_m * (AutopilotLaws_P.Constant_Value_l - rtb_Gain_dn) + rtb_Add3_n * std::
-    sin(rtb_Saturation_c)))), AutopilotLaws_P.HighPassFilter_C1_i, AutopilotLaws_P.HighPassFilter_C2_h,
-    AutopilotLaws_P.HighPassFilter_C3_m, AutopilotLaws_P.HighPassFilter_C4_n, AutopilotLaws_Y.out.time.dt,
-    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_LeadLagFilter_e);
-  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_k * AutopilotLaws_Y.out.data.V_ias_kn,
+  AutopilotLaws_LeadLagFilter(rtb_Y_h - AutopilotLaws_P.g_Gain_l * (AutopilotLaws_P.Gain1_Gain_n4 *
+    (AutopilotLaws_P.Gain_Gain_bc * ((AutopilotLaws_P.Gain1_Gain_ej * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_jv *
+    (AutopilotLaws_P.Gain_Gain_bf * std::atan(AutopilotLaws_P.fpmtoms_Gain_f * AutopilotLaws_U.in.data.H_dot_ft_min /
+    rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_l - rtb_Saturation_c) + rtb_Y_hc * std::sin
+    (AutopilotLaws_P.Gain1_Gain_j4 * AutopilotLaws_U.in.data.Psi_magnetic_track_deg - AutopilotLaws_P.Gain1_Gain_kw *
+     AutopilotLaws_U.in.data.Psi_magnetic_deg)))), AutopilotLaws_P.HighPassFilter_C1_i,
+    AutopilotLaws_P.HighPassFilter_C2_h, AutopilotLaws_P.HighPassFilter_C3_m, AutopilotLaws_P.HighPassFilter_C4_n,
+    AutopilotLaws_U.in.time.dt, &rtb_Saturation, &AutopilotLaws_DWork.sf_LeadLagFilter_e);
+  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_k * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_l4, AutopilotLaws_P.LowPassFilter_C2_po, AutopilotLaws_P.LowPassFilter_C3_f,
-    AutopilotLaws_P.LowPassFilter_C4_dt, AutopilotLaws_Y.out.time.dt, &rtb_Y_k, &AutopilotLaws_DWork.sf_LeadLagFilter_k);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_Y_k) *
-    AutopilotLaws_P.ug_Gain_n;
-  distance_m = AutopilotLaws_P.Gain1_Gain_b1 * b_R;
-  rtb_Gain_dn = AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m;
-  rtb_Add3_n = AutopilotLaws_P.Constant3_Value_nk - AutopilotLaws_P.Constant4_Value_o;
-  distance_m = (AutopilotLaws_P.Gain1_Gain_on * AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m) *
-    AutopilotLaws_P.Gain_Gain_hy;
-  if (rtb_Add3_n > AutopilotLaws_P.Switch_Threshold_d) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant1_Value_m;
+    AutopilotLaws_P.LowPassFilter_C4_dt, AutopilotLaws_U.in.time.dt, &rtb_Y_h, &AutopilotLaws_DWork.sf_LeadLagFilter_k);
+  rtb_Saturation = (rtb_Saturation + rtb_Y_h) * AutopilotLaws_P.ug_Gain_n;
+  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_b1 * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Saturation_c = rtb_Saturation + rtb_Y_hc;
+  rtb_Gain_ar0 = AutopilotLaws_P.Constant3_Value_nk - AutopilotLaws_P.Constant4_Value_o;
+  rtb_Y_hc = (AutopilotLaws_P.Gain1_Gain_on * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_hy;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Switch_Threshold_d) {
+    rtb_Saturation = AutopilotLaws_P.Constant1_Value_m;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain_b * distance_m;
+    rtb_Saturation = AutopilotLaws_P.Gain5_Gain_b * rtb_Y_hc;
   }
 
-  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_Y.out.input.V_c_kn, AutopilotLaws_Y.out.data.VLS_kn, &rtb_Y_k);
-  rtb_Y_k = (AutopilotLaws_Y.out.data.V_ias_kn - rtb_Y_k) * AutopilotLaws_P.Gain1_Gain_m1;
-  if (rtb_Y_k <= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-    if (rtb_Add3_n > AutopilotLaws_P.Switch1_Threshold_d) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_p0;
+  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &rtb_Y_h);
+  rtb_Gain_dn = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_h) * AutopilotLaws_P.Gain1_Gain_m1;
+  if (rtb_Gain_dn <= rtb_Saturation) {
+    if (rtb_Gain_ar0 > AutopilotLaws_P.Switch1_Threshold_d) {
+      rtb_Saturation = AutopilotLaws_P.Constant_Value_p0;
     } else {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain_n * distance_m;
+      rtb_Saturation = AutopilotLaws_P.Gain6_Gain_n * rtb_Y_hc;
     }
 
-    if (rtb_Y_k >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_k;
+    if (rtb_Gain_dn >= rtb_Saturation) {
+      rtb_Saturation = rtb_Gain_dn;
     }
   }
 
-  rtb_Sum2_p = (AutopilotLaws_P.Gain_Gain_d0 * rtb_Gain_dn - b_R) + AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_hi * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_cv) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_cv;
-  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_hd) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_hd;
+  rtb_Sum2_p = (AutopilotLaws_P.Gain_Gain_d0 * rtb_Saturation_c - AutopilotLaws_DWork.DelayInput1_DSTATE) +
+    rtb_Saturation;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain_o2 * AutopilotLaws_U.in.data.H_dot_ft_min;
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_hi * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_cv) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_cv;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_hd) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_hd;
   }
 
-  b_R = std::atan(AutopilotLaws_P.fpmtoms_Gain_o2 * AutopilotLaws_Y.out.data.H_dot_ft_min /
-                  AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_pp;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_iw * AutopilotLaws_Y.out.data.Theta_deg;
-  rtb_Saturation_c = AutopilotLaws_P.kntoms_Gain_i * AutopilotLaws_Y.out.data.V_gnd_kn;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Gain_ar0) *
+    AutopilotLaws_P.Gain_Gain_pp;
+  rtb_Saturation_c = AutopilotLaws_P.kntoms_Gain_i * AutopilotLaws_U.in.data.V_gnd_kn;
   if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat_nu) {
     rtb_Saturation_c = AutopilotLaws_P.Saturation_UpperSat_nu;
   } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat_ae) {
     rtb_Saturation_c = AutopilotLaws_P.Saturation_LowerSat_ae;
   }
 
-  distance_m = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_h *
-    AutopilotLaws_Y.out.data.H_dot_ft_min / rtb_Saturation_c) * AutopilotLaws_P.Gain_Gain_ej *
-    AutopilotLaws_P.Gain1_Gain_lw;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_ky * AutopilotLaws_Y.out.data.Phi_deg;
-  rtb_Gain_dn = std::cos(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  rtb_Add3_n = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_nrn * AutopilotLaws_Y.out.data.Psi_magnetic_deg;
-  rtb_Saturation_c = AutopilotLaws_P.Gain1_Gain_ip * AutopilotLaws_Y.out.data.Psi_magnetic_track_deg -
-    AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.ktstomps_Gain_l * AutopilotLaws_Y.out.data.V_gnd_kn;
-  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_ip * (AutopilotLaws_P.GStoGS_CAS_Gain_e *
-    AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.WashoutFilter_C1_c, AutopilotLaws_Y.out.time.dt, &rtb_Y_k,
-    &AutopilotLaws_DWork.sf_WashoutFilter_g5);
-  AutopilotLaws_LeadLagFilter(rtb_Y_k - AutopilotLaws_P.g_Gain_hq * (AutopilotLaws_P.Gain1_Gain_mx *
-    (AutopilotLaws_P.Gain_Gain_d3 * (distance_m * (AutopilotLaws_P.Constant_Value_f - rtb_Gain_dn) + rtb_Add3_n * std::
-    sin(rtb_Saturation_c)))), AutopilotLaws_P.HighPassFilter_C1_d, AutopilotLaws_P.HighPassFilter_C2_i,
-    AutopilotLaws_P.HighPassFilter_C3_d, AutopilotLaws_P.HighPassFilter_C4_nr, AutopilotLaws_Y.out.time.dt,
-    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_LeadLagFilter_j);
-  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_mh * AutopilotLaws_Y.out.data.V_ias_kn,
+  rtb_Saturation = AutopilotLaws_P.Gain1_Gain_ky * rtb_GainTheta1;
+  rtb_Y_hc = std::cos(rtb_Saturation);
+  rtb_Gain_ar0 = std::sin(rtb_Saturation);
+  rtb_Saturation = AutopilotLaws_P.ktstomps_Gain_l * AutopilotLaws_U.in.data.V_gnd_kn;
+  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_ip * (AutopilotLaws_P.GStoGS_CAS_Gain_e * rtb_Saturation),
+    AutopilotLaws_P.WashoutFilter_C1_c, AutopilotLaws_U.in.time.dt, &rtb_Y_h, &AutopilotLaws_DWork.sf_WashoutFilter_g5);
+  AutopilotLaws_LeadLagFilter(rtb_Y_h - AutopilotLaws_P.g_Gain_hq * (AutopilotLaws_P.Gain1_Gain_mx *
+    (AutopilotLaws_P.Gain_Gain_d3 * ((AutopilotLaws_P.Gain1_Gain_iw * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_lw *
+    (AutopilotLaws_P.Gain_Gain_ej * std::atan(AutopilotLaws_P.fpmtoms_Gain_h * AutopilotLaws_U.in.data.H_dot_ft_min /
+    rtb_Saturation_c))) * (AutopilotLaws_P.Constant_Value_f - rtb_Y_hc) + rtb_Gain_ar0 * std::sin
+    (AutopilotLaws_P.Gain1_Gain_ip * AutopilotLaws_U.in.data.Psi_magnetic_track_deg - AutopilotLaws_P.Gain1_Gain_nrn *
+     AutopilotLaws_U.in.data.Psi_magnetic_deg)))), AutopilotLaws_P.HighPassFilter_C1_d,
+    AutopilotLaws_P.HighPassFilter_C2_i, AutopilotLaws_P.HighPassFilter_C3_d, AutopilotLaws_P.HighPassFilter_C4_nr,
+    AutopilotLaws_U.in.time.dt, &rtb_Saturation, &AutopilotLaws_DWork.sf_LeadLagFilter_j);
+  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_mh * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_e, AutopilotLaws_P.LowPassFilter_C2_i, AutopilotLaws_P.LowPassFilter_C3_o5,
-    AutopilotLaws_P.LowPassFilter_C4_f, AutopilotLaws_Y.out.time.dt, &rtb_Y_k, &AutopilotLaws_DWork.sf_LeadLagFilter_a);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_Y_k) *
-    AutopilotLaws_P.ug_Gain_e;
-  distance_m = AutopilotLaws_P.Gain1_Gain_be1 * b_R;
-  rtb_Y_k = AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m;
-  rtb_Gain_dn = AutopilotLaws_P.Constant1_Value_o - AutopilotLaws_P.Constant2_Value_hd;
-  rtb_Add3_n = (AutopilotLaws_P.Gain1_Gain_nj * AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m) *
-    AutopilotLaws_P.Gain_Gain_aq;
-  if (rtb_Gain_dn > AutopilotLaws_P.Switch_Threshold_g) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant1_Value_f;
+    AutopilotLaws_P.LowPassFilter_C4_f, AutopilotLaws_U.in.time.dt, &rtb_Y_h, &AutopilotLaws_DWork.sf_LeadLagFilter_a);
+  rtb_Saturation = (rtb_Saturation + rtb_Y_h) * AutopilotLaws_P.ug_Gain_e;
+  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_be1 * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Saturation_c = rtb_Saturation + rtb_Y_hc;
+  rtb_Gain_ar0 = AutopilotLaws_P.Constant1_Value_o - AutopilotLaws_P.Constant2_Value_hd;
+  rtb_Gain_dn = (AutopilotLaws_P.Gain1_Gain_nj * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_aq;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Switch_Threshold_g) {
+    rtb_Saturation = AutopilotLaws_P.Constant1_Value_f;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain_a * rtb_Add3_n;
+    rtb_Saturation = AutopilotLaws_P.Gain5_Gain_a * rtb_Gain_dn;
   }
 
-  distance_m = AutopilotLaws_P.Gain1_Gain_fle * b_L;
-  if (distance_m <= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-    if (rtb_Gain_dn > AutopilotLaws_P.Switch1_Threshold_h) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_i;
+  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_fle * rtb_Y_n0;
+  if (rtb_Y_hc <= rtb_Saturation) {
+    if (rtb_Gain_ar0 > AutopilotLaws_P.Switch1_Threshold_h) {
+      rtb_Saturation = AutopilotLaws_P.Constant_Value_i;
     } else {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain_g * rtb_Add3_n;
+      rtb_Saturation = AutopilotLaws_P.Gain6_Gain_g * rtb_Gain_dn;
     }
 
-    if (distance_m >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = distance_m;
+    if (rtb_Y_hc >= rtb_Saturation) {
+      rtb_Saturation = rtb_Y_hc;
     }
   }
 
-  b_R = (AutopilotLaws_P.Gain_Gain_gx * rtb_Y_k - b_R) + AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_SpeedProtectionSignalSelection(&AutopilotLaws_Y.out, rtb_Cos1_pk, std::fmax(-limit, std::fmin(limit,
-    AutopilotLaws_P.Gain_Gain_c3 * rtb_Cos1_pk)), rtb_Sum2_p, AutopilotLaws_P.Gain_Gain_fnw * rtb_Sum2_p, b_R,
-    AutopilotLaws_P.Gain_Gain_ko * b_R, AutopilotLaws_P.Constant_Value_fo, &rtb_Add3_n, &rtb_Gain_dn);
-  limit = AutopilotLaws_P.Gain2_Gain_m * AutopilotLaws_Y.out.data.H_dot_ft_min *
-    AutopilotLaws_P.DiscreteDerivativeVariableTs1_Gain;
-  b_R = limit - AutopilotLaws_DWork.Delay_DSTATE_hi;
-  AutopilotLaws_LagFilter(b_R / AutopilotLaws_Y.out.time.dt, AutopilotLaws_P.LagFilter2_C1_k,
-    AutopilotLaws_Y.out.time.dt, &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_LagFilter_b);
-  AutopilotLaws_WashoutFilter(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.WashoutFilter1_C1,
-    AutopilotLaws_Y.out.time.dt, &b_R, &AutopilotLaws_DWork.sf_WashoutFilter_n);
-  rtb_Compare_jy = ((AutopilotLaws_Y.out.input.vertical_mode == AutopilotLaws_P.CompareGSTRACK_const) ||
-                    (AutopilotLaws_Y.out.input.vertical_mode == AutopilotLaws_P.CompareGSTRACK2_const));
-  AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain4_Gain_g * b_R, rtb_Compare_jy,
-    &AutopilotLaws_DWork.DelayInput1_DSTATE);
-  AutopilotLaws_LagFilter(AutopilotLaws_Y.out.data.nav_gs_error_deg, AutopilotLaws_P.LagFilter1_C1_p,
-    AutopilotLaws_Y.out.time.dt, &rtb_Y_k, &AutopilotLaws_DWork.sf_LagFilter_cu);
-  rtb_Cos1_pk = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain_o * rtb_Y_k;
-  AutopilotLaws_LagFilter(rtb_Y_k + AutopilotLaws_P.Gain3_Gain_n * ((rtb_Cos1_pk - AutopilotLaws_DWork.Delay_DSTATE_n) /
-    AutopilotLaws_Y.out.time.dt), AutopilotLaws_P.LagFilter_C1_m, AutopilotLaws_Y.out.time.dt, &distance_m,
-    &AutopilotLaws_DWork.sf_LagFilter_j);
-  b_R = look1_binlxpw(AutopilotLaws_Y.out.data.H_radio_ft, AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_ec,
-                      AutopilotLaws_P.ScheduledGain_Table_l, 5U);
-  AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain3_Gain_c * (AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m
-    * b_R), (AutopilotLaws_Y.out.data.H_radio_ft > AutopilotLaws_P.CompareToConstant_const_k) &&
-    AutopilotLaws_Y.out.data.nav_gs_valid, &rtb_Saturation_c);
-  AutopilotLaws_storevalue(rtb_GainTheta1 == AutopilotLaws_P.CompareToConstant6_const,
-    AutopilotLaws_Y.out.data.nav_gs_deg, &b_R, &AutopilotLaws_DWork.sf_storevalue_g);
-  if (b_R > AutopilotLaws_P.Saturation_UpperSat_e0) {
-    b_R = AutopilotLaws_P.Saturation_UpperSat_e0;
-  } else if (b_R < AutopilotLaws_P.Saturation_LowerSat_ph) {
-    b_R = AutopilotLaws_P.Saturation_LowerSat_ph;
+  rtb_Saturation += AutopilotLaws_P.Gain_Gain_gx * rtb_Saturation_c - AutopilotLaws_DWork.DelayInput1_DSTATE;
+  AutopilotLaws_SpeedProtectionSignalSelection(&AutopilotLaws_Y.out, rtb_Add3_n2, std::fmax(-limit, std::fmin(limit,
+    AutopilotLaws_P.Gain_Gain_c3 * rtb_Add3_n2)), rtb_Sum2_p, AutopilotLaws_P.Gain_Gain_fnw * rtb_Sum2_p, rtb_Saturation,
+    AutopilotLaws_P.Gain_Gain_ko * rtb_Saturation, AutopilotLaws_P.Constant_Value_fo, &rtb_Gain_dn, &rtb_Add3_gy);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain2_Gain_m * AutopilotLaws_U.in.data.H_dot_ft_min;
+  limit = AutopilotLaws_P.DiscreteDerivativeVariableTs1_Gain * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = limit - AutopilotLaws_DWork.Delay_DSTATE_hi;
+  AutopilotLaws_LagFilter(AutopilotLaws_DWork.DelayInput1_DSTATE / AutopilotLaws_U.in.time.dt,
+    AutopilotLaws_P.LagFilter2_C1_k, AutopilotLaws_U.in.time.dt, &rtb_Saturation, &AutopilotLaws_DWork.sf_LagFilter_b);
+  AutopilotLaws_WashoutFilter(rtb_Saturation, AutopilotLaws_P.WashoutFilter1_C1, AutopilotLaws_U.in.time.dt,
+    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_WashoutFilter_n);
+  rtb_Compare_jy = ((AutopilotLaws_U.in.input.vertical_mode == AutopilotLaws_P.CompareGSTRACK_const) ||
+                    (AutopilotLaws_U.in.input.vertical_mode == AutopilotLaws_P.CompareGSTRACK2_const));
+  AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain4_Gain_g * AutopilotLaws_DWork.DelayInput1_DSTATE,
+    rtb_Compare_jy, &rtb_Saturation);
+  AutopilotLaws_LagFilter(AutopilotLaws_U.in.data.nav_gs_error_deg, AutopilotLaws_P.LagFilter1_C1_p,
+    AutopilotLaws_U.in.time.dt, &rtb_Y_h, &AutopilotLaws_DWork.sf_LagFilter_cu);
+  rtb_Add3_n2 = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain_o * rtb_Y_h;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Add3_n2 - AutopilotLaws_DWork.Delay_DSTATE_n;
+  AutopilotLaws_DWork.DelayInput1_DSTATE /= AutopilotLaws_U.in.time.dt;
+  AutopilotLaws_LagFilter(rtb_Y_h + AutopilotLaws_P.Gain3_Gain_n * AutopilotLaws_DWork.DelayInput1_DSTATE,
+    AutopilotLaws_P.LagFilter_C1_m, AutopilotLaws_U.in.time.dt, &rtb_Y_hc, &AutopilotLaws_DWork.sf_LagFilter_j);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft,
+    AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_ec, AutopilotLaws_P.ScheduledGain_Table_l, 5U);
+  AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain3_Gain_c * (rtb_Saturation + rtb_Y_hc *
+    AutopilotLaws_DWork.DelayInput1_DSTATE), (AutopilotLaws_U.in.data.H_radio_ft >
+    AutopilotLaws_P.CompareToConstant_const_k) && AutopilotLaws_U.in.data.nav_gs_valid, &rtb_Saturation_c);
+  AutopilotLaws_storevalue(rtb_error_d == AutopilotLaws_P.CompareToConstant6_const, AutopilotLaws_Y.out.data.nav_gs_deg,
+    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_storevalue_g);
+  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_e0) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_e0;
+  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_ph) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_ph;
   }
 
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain_g4 * AutopilotLaws_Y.out.data.H_dot_ft_min;
-  distance_m = AutopilotLaws_P.kntoms_Gain_k4 * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (distance_m > AutopilotLaws_P.Saturation_UpperSat_eb) {
-    distance_m = AutopilotLaws_P.Saturation_UpperSat_eb;
-  } else if (distance_m < AutopilotLaws_P.Saturation_LowerSat_gk) {
-    distance_m = AutopilotLaws_P.Saturation_LowerSat_gk;
+  rtb_Y_hc = AutopilotLaws_P.kntoms_Gain_k4 * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Y_hc > AutopilotLaws_P.Saturation_UpperSat_eb) {
+    rtb_Y_hc = AutopilotLaws_P.Saturation_UpperSat_eb;
+  } else if (rtb_Y_hc < AutopilotLaws_P.Saturation_LowerSat_gk) {
+    rtb_Y_hc = AutopilotLaws_P.Saturation_LowerSat_gk;
   }
 
-  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / distance_m) *
+  rtb_Saturation = std::atan(AutopilotLaws_P.fpmtoms_Gain_g4 * AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Y_hc) *
     AutopilotLaws_P.Gain_Gain_ow;
-  AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain2_Gain_l * (b_R - AutopilotLaws_DWork.DelayInput1_DSTATE),
-    rtb_Compare_jy, &distance_m);
-  AutopilotLaws_Voter1(rtb_Saturation_c + distance_m, AutopilotLaws_P.Gain1_Gain_d4 * ((b_R + AutopilotLaws_P.Bias_Bias)
-    - AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.Gain_Gain_eyl * ((b_R + AutopilotLaws_P.Bias1_Bias) -
-    AutopilotLaws_DWork.DelayInput1_DSTATE), &rtb_Sum2_p);
-  b_R = AutopilotLaws_Y.out.data.Theta_deg - AutopilotLaws_P.Constant2_Value_f;
-  rtb_Gain4_m = AutopilotLaws_P.Gain4_Gain_o * b_R;
-  rtb_Gain5_n = AutopilotLaws_P.Gain5_Gain_c * AutopilotLaws_Y.out.data.bz_m_s2;
-  AutopilotLaws_WashoutFilter(AutopilotLaws_Y.out.data.bx_m_s2, AutopilotLaws_P.WashoutFilter_C1_m,
-    AutopilotLaws_Y.out.time.dt, &b_L, &AutopilotLaws_DWork.sf_WashoutFilter_g);
-  AutopilotLaws_WashoutFilter(AutopilotLaws_Y.out.data.H_ind_ft, AutopilotLaws_P.WashoutFilter_C1_ej,
-    AutopilotLaws_Y.out.time.dt, &b_R, &AutopilotLaws_DWork.sf_WashoutFilter_b);
-  if (AutopilotLaws_Y.out.data.H_radio_ft > AutopilotLaws_P.Saturation_UpperSat_e0a) {
-    distance_m = AutopilotLaws_P.Saturation_UpperSat_e0a;
-  } else if (AutopilotLaws_Y.out.data.H_radio_ft < AutopilotLaws_P.Saturation_LowerSat_m) {
-    distance_m = AutopilotLaws_P.Saturation_LowerSat_m;
+  AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain2_Gain_l * (AutopilotLaws_DWork.DelayInput1_DSTATE -
+    rtb_Saturation), rtb_Compare_jy, &rtb_Y_hc);
+  AutopilotLaws_Voter1(rtb_Saturation_c + rtb_Y_hc, AutopilotLaws_P.Gain1_Gain_d4 *
+                       ((AutopilotLaws_DWork.DelayInput1_DSTATE + AutopilotLaws_P.Bias_Bias) - rtb_Saturation),
+                       AutopilotLaws_P.Gain_Gain_eyl * ((AutopilotLaws_DWork.DelayInput1_DSTATE +
+    AutopilotLaws_P.Bias1_Bias) - rtb_Saturation), &rtb_Y_h);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_GainTheta - AutopilotLaws_P.Constant2_Value_f;
+  rtb_Sum2_p = AutopilotLaws_P.Gain4_Gain_o * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Gain5_n = AutopilotLaws_P.Gain5_Gain_c * AutopilotLaws_U.in.data.bz_m_s2;
+  AutopilotLaws_WashoutFilter(AutopilotLaws_U.in.data.bx_m_s2, AutopilotLaws_P.WashoutFilter_C1_m,
+    AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_WashoutFilter_g);
+  AutopilotLaws_WashoutFilter(AutopilotLaws_U.in.data.H_ind_ft, AutopilotLaws_P.WashoutFilter_C1_ej,
+    AutopilotLaws_U.in.time.dt, &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_WashoutFilter_b);
+  if (AutopilotLaws_U.in.data.H_radio_ft > AutopilotLaws_P.Saturation_UpperSat_e0a) {
+    rtb_Y_hc = AutopilotLaws_P.Saturation_UpperSat_e0a;
+  } else if (AutopilotLaws_U.in.data.H_radio_ft < AutopilotLaws_P.Saturation_LowerSat_m) {
+    rtb_Y_hc = AutopilotLaws_P.Saturation_LowerSat_m;
   } else {
-    distance_m = AutopilotLaws_Y.out.data.H_radio_ft;
+    rtb_Y_hc = AutopilotLaws_U.in.data.H_radio_ft;
   }
 
-  AutopilotLaws_LagFilter(distance_m, AutopilotLaws_P.LagFilter_C1_p, AutopilotLaws_Y.out.time.dt,
-    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_LagFilter_ov);
-  rtb_Y_k = (b_R + AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.DiscreteDerivativeVariableTs2_Gain;
-  b_R = (rtb_Y_k - AutopilotLaws_DWork.Delay_DSTATE_p) / AutopilotLaws_Y.out.time.dt;
-  AutopilotLaws_LagFilter(AutopilotLaws_P.Gain2_Gain_f * b_R, AutopilotLaws_P.LagFilter3_C1, AutopilotLaws_Y.out.time.dt,
-    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_LagFilter_f);
-  AutopilotLaws_WashoutFilter(AutopilotLaws_Y.out.data.H_dot_ft_min, AutopilotLaws_P.WashoutFilter1_C1_g,
-    AutopilotLaws_Y.out.time.dt, &b_R, &AutopilotLaws_DWork.sf_WashoutFilter_f);
-  b_R += AutopilotLaws_DWork.DelayInput1_DSTATE;
-  rtb_Compare_jy = (rtb_GainTheta1 == AutopilotLaws_P.CompareToConstant7_const);
+  AutopilotLaws_LagFilter(rtb_Y_hc, AutopilotLaws_P.LagFilter_C1_p, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
+    &AutopilotLaws_DWork.sf_LagFilter_ov);
+  rtb_Saturation_c = (AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_Saturation) *
+    AutopilotLaws_P.DiscreteDerivativeVariableTs2_Gain;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Saturation_c - AutopilotLaws_DWork.Delay_DSTATE_p;
+  AutopilotLaws_DWork.DelayInput1_DSTATE /= AutopilotLaws_U.in.time.dt;
+  AutopilotLaws_LagFilter(AutopilotLaws_P.Gain2_Gain_f * AutopilotLaws_DWork.DelayInput1_DSTATE,
+    AutopilotLaws_P.LagFilter3_C1, AutopilotLaws_U.in.time.dt, &rtb_Saturation, &AutopilotLaws_DWork.sf_LagFilter_f);
+  AutopilotLaws_WashoutFilter(AutopilotLaws_U.in.data.H_dot_ft_min, AutopilotLaws_P.WashoutFilter1_C1_g,
+    AutopilotLaws_U.in.time.dt, &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_WashoutFilter_f);
+  rtb_Saturation += AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Compare_jy = (rtb_error_d == AutopilotLaws_P.CompareToConstant7_const);
   if (!AutopilotLaws_DWork.wasActive_not_empty) {
     AutopilotLaws_DWork.wasActive = rtb_Compare_jy;
     AutopilotLaws_DWork.wasActive_not_empty = true;
   }
 
   if ((!AutopilotLaws_DWork.wasActive) && rtb_Compare_jy) {
-    distance_m = std::abs(b_R) / 60.0;
-    AutopilotLaws_DWork.Tau = AutopilotLaws_Y.out.data.H_radio_ft / (distance_m - 1.6666666666666667);
-    AutopilotLaws_DWork.H_bias = AutopilotLaws_DWork.Tau * distance_m - AutopilotLaws_Y.out.data.H_radio_ft;
+    rtb_Y_hc = std::abs(rtb_Saturation) / 60.0;
+    AutopilotLaws_DWork.Tau = AutopilotLaws_U.in.data.H_radio_ft / (rtb_Y_hc - 1.6666666666666667);
+    AutopilotLaws_DWork.H_bias = AutopilotLaws_DWork.Tau * rtb_Y_hc - AutopilotLaws_U.in.data.H_radio_ft;
   }
 
   if (rtb_Compare_jy) {
-    distance_m = -1.0 / AutopilotLaws_DWork.Tau * (AutopilotLaws_Y.out.data.H_radio_ft + AutopilotLaws_DWork.H_bias) *
-      60.0;
+    rtb_Y_hc = -1.0 / AutopilotLaws_DWork.Tau * (AutopilotLaws_U.in.data.H_radio_ft + AutopilotLaws_DWork.H_bias) * 60.0;
   } else {
-    distance_m = b_R;
+    rtb_Y_hc = rtb_Saturation;
   }
 
   AutopilotLaws_DWork.wasActive = rtb_Compare_jy;
-  rtb_Saturation_c = AutopilotLaws_P.kntoms_Gain_av * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat_ew) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_UpperSat_ew;
-  } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat_an) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_LowerSat_an;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_av * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_ew) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_ew;
+  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_an) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_an;
   }
 
-  rtb_Saturation_c = (distance_m - b_R) * AutopilotLaws_P.ftmintoms_Gain_j / rtb_Saturation_c;
-  if (rtb_Saturation_c > 1.0) {
-    rtb_Saturation_c = 1.0;
-  } else if (rtb_Saturation_c < -1.0) {
-    rtb_Saturation_c = -1.0;
+  rtb_Gain_ar0 = (rtb_Y_hc - rtb_Saturation) * AutopilotLaws_P.ftmintoms_Gain_j / AutopilotLaws_DWork.DelayInput1_DSTATE;
+  if (rtb_Gain_ar0 > 1.0) {
+    rtb_Gain_ar0 = 1.0;
+  } else if (rtb_Gain_ar0 < -1.0) {
+    rtb_Gain_ar0 = -1.0;
   }
 
-  rtb_Gain_ij = AutopilotLaws_P.Gain_Gain_by * std::asin(rtb_Saturation_c);
-  rtb_Sum_ae = AutopilotLaws_P.Constant1_Value_o0 - AutopilotLaws_Y.out.data.Theta_deg;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_iv * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_je) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_je;
-  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_hf) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_hf;
+  rtb_Gain_n1 = AutopilotLaws_P.Gain_Gain_by * std::asin(rtb_Gain_ar0);
+  rtb_Sum_ae = AutopilotLaws_P.Constant1_Value_o0 - rtb_GainTheta;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain_n * AutopilotLaws_U.in.data.H_dot_ft_min;
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_iv * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_je) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_je;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_hf) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_hf;
   }
 
-  b_R = std::atan(AutopilotLaws_P.fpmtoms_Gain_n * AutopilotLaws_Y.out.data.H_dot_ft_min /
-                  AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_nf;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_iv * AutopilotLaws_Y.out.data.Theta_deg;
-  rtb_Saturation_c = AutopilotLaws_P.kntoms_Gain_ka * AutopilotLaws_Y.out.data.V_gnd_kn;
-  if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat_dh) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_UpperSat_dh;
-  } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat_m2) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_LowerSat_m2;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Gain_ar0) *
+    AutopilotLaws_P.Gain_Gain_nf;
+  rtb_Saturation = AutopilotLaws_P.Gain1_Gain_ij * rtb_GainTheta1;
+  rtb_GainTheta1 = std::cos(rtb_Saturation);
+  rtb_Cos1_k = std::sin(rtb_Saturation);
+  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_ef * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
+  rtb_Add3_d1 = rtb_Y_hc - AutopilotLaws_P.Gain1_Gain_gk * AutopilotLaws_U.in.data.Psi_magnetic_deg;
+  rtb_Saturation = AutopilotLaws_P.ktstomps_Gain_jr * AutopilotLaws_U.in.data.V_gnd_kn;
+  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_ks * (AutopilotLaws_P.GStoGS_CAS_Gain_n2 * rtb_Saturation),
+    AutopilotLaws_P.WashoutFilter_C1_d, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
+    &AutopilotLaws_DWork.sf_WashoutFilter_l);
+  rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_ka * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_dh) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_dh;
+  } else if (rtb_Gain_ar0 < AutopilotLaws_P.Saturation_LowerSat_m2) {
+    rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_m2;
   }
 
-  rtb_Saturation_c = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_au *
-    AutopilotLaws_Y.out.data.H_dot_ft_min / rtb_Saturation_c) * AutopilotLaws_P.Gain_Gain_h3 *
-    AutopilotLaws_P.Gain1_Gain_it;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_ij * AutopilotLaws_Y.out.data.Phi_deg;
-  rtb_Cos_k = std::cos(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  rtb_Cos1_k = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_gk * AutopilotLaws_Y.out.data.Psi_magnetic_deg;
-  distance_m = AutopilotLaws_P.Gain1_Gain_ef * AutopilotLaws_Y.out.data.Psi_magnetic_track_deg;
-  rtb_Add3_fm = distance_m - AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.ktstomps_Gain_jr * AutopilotLaws_Y.out.data.V_gnd_kn;
-  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_ks * (AutopilotLaws_P.GStoGS_CAS_Gain_n2 *
-    AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.WashoutFilter_C1_d, AutopilotLaws_Y.out.time.dt,
-    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_WashoutFilter_l);
-  AutopilotLaws_LeadLagFilter(AutopilotLaws_DWork.DelayInput1_DSTATE - AutopilotLaws_P.g_Gain_l0 *
-    (AutopilotLaws_P.Gain1_Gain_et * (AutopilotLaws_P.Gain_Gain_an * (rtb_Saturation_c *
-    (AutopilotLaws_P.Constant_Value_f3 - rtb_Cos_k) + rtb_Cos1_k * std::sin(rtb_Add3_fm)))),
+  AutopilotLaws_LeadLagFilter(rtb_Saturation - AutopilotLaws_P.g_Gain_l0 * (AutopilotLaws_P.Gain1_Gain_et *
+    (AutopilotLaws_P.Gain_Gain_an * ((AutopilotLaws_P.Gain1_Gain_iv * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_it *
+    (AutopilotLaws_P.Gain_Gain_h3 * std::atan(AutopilotLaws_P.fpmtoms_Gain_au * AutopilotLaws_U.in.data.H_dot_ft_min /
+    rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_f3 - rtb_GainTheta1) + rtb_Cos1_k * std::sin(rtb_Add3_d1)))),
     AutopilotLaws_P.HighPassFilter_C1_i0, AutopilotLaws_P.HighPassFilter_C2_j, AutopilotLaws_P.HighPassFilter_C3_i,
-    AutopilotLaws_P.HighPassFilter_C4_nm, AutopilotLaws_Y.out.time.dt, &distance_m,
+    AutopilotLaws_P.HighPassFilter_C4_nm, AutopilotLaws_U.in.time.dt, &rtb_Y_hc,
     &AutopilotLaws_DWork.sf_LeadLagFilter_oi);
-  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_il * AutopilotLaws_Y.out.data.V_ias_kn,
+  AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_il * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_g, AutopilotLaws_P.LowPassFilter_C2_o, AutopilotLaws_P.LowPassFilter_C3_l,
-    AutopilotLaws_P.LowPassFilter_C4_p, AutopilotLaws_Y.out.time.dt, &AutopilotLaws_DWork.DelayInput1_DSTATE,
+    AutopilotLaws_P.LowPassFilter_C4_p, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
     &AutopilotLaws_DWork.sf_LeadLagFilter_j0);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (distance_m + AutopilotLaws_DWork.DelayInput1_DSTATE) *
-    AutopilotLaws_P.ug_Gain_c;
-  distance_m = AutopilotLaws_P.Gain1_Gain_ejc * b_R;
-  rtb_Saturation_c = AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m;
-  rtb_Cos_k = AutopilotLaws_P.Constant2_Value_kz - AutopilotLaws_Y.out.data.H_ind_ft;
-  distance_m = (AutopilotLaws_P.Gain1_Gain_h3 * AutopilotLaws_DWork.DelayInput1_DSTATE + distance_m) *
-    AutopilotLaws_P.Gain_Gain_ox;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_Y.out.data.V_ias_kn - AutopilotLaws_Y.out.input.V_c_kn;
-  AutopilotLaws_DWork.DelayInput1_DSTATE *= AutopilotLaws_P.Gain1_Gain_fo;
-  if ((rtb_Cos_k > AutopilotLaws_P.CompareToConstant_const_h) && (distance_m <
-       AutopilotLaws_P.CompareToConstant1_const_g) && (AutopilotLaws_DWork.DelayInput1_DSTATE <
-       AutopilotLaws_P.CompareToConstant2_const_m)) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_gj;
+  rtb_Saturation = (rtb_Y_hc + rtb_Saturation) * AutopilotLaws_P.ug_Gain_c;
+  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_ejc * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_GainTheta1 = rtb_Saturation + rtb_Y_hc;
+  rtb_Gain_ar0 = AutopilotLaws_P.Constant2_Value_kz - AutopilotLaws_U.in.data.H_ind_ft;
+  rtb_Y_hc = (AutopilotLaws_P.Gain1_Gain_h3 * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_ox;
+  rtb_Saturation = (AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.input.V_c_kn) * AutopilotLaws_P.Gain1_Gain_fo;
+  if ((rtb_Gain_ar0 > AutopilotLaws_P.CompareToConstant_const_h) && (rtb_Y_hc <
+       AutopilotLaws_P.CompareToConstant1_const_g) && (rtb_Saturation < AutopilotLaws_P.CompareToConstant2_const_m)) {
+    rtb_Saturation = AutopilotLaws_P.Constant_Value_gj;
   } else {
-    if (rtb_Cos_k > AutopilotLaws_P.Switch2_Threshold_b) {
+    if (rtb_Gain_ar0 > AutopilotLaws_P.Switch2_Threshold_b) {
       rtb_Cos1_k = AutopilotLaws_P.Constant1_Value_mq;
     } else {
-      rtb_Cos1_k = AutopilotLaws_P.Gain5_Gain_k * distance_m;
+      rtb_Cos1_k = AutopilotLaws_P.Gain5_Gain_k * rtb_Y_hc;
     }
 
-    if (AutopilotLaws_DWork.DelayInput1_DSTATE > rtb_Cos1_k) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Cos1_k;
+    if (rtb_Saturation > rtb_Cos1_k) {
+      rtb_Saturation = rtb_Cos1_k;
     } else {
-      if (rtb_Cos_k > AutopilotLaws_P.Switch1_Threshold_n) {
-        distance_m = std::fmax(AutopilotLaws_P.Constant2_Value_i, AutopilotLaws_P.Gain1_Gain_n * distance_m);
+      if (rtb_Gain_ar0 > AutopilotLaws_P.Switch1_Threshold_n) {
+        rtb_Y_hc = std::fmax(AutopilotLaws_P.Constant2_Value_i, AutopilotLaws_P.Gain1_Gain_n * rtb_Y_hc);
       } else {
-        distance_m *= AutopilotLaws_P.Gain6_Gain_o;
+        rtb_Y_hc *= AutopilotLaws_P.Gain6_Gain_o;
       }
 
-      if (AutopilotLaws_DWork.DelayInput1_DSTATE < distance_m) {
-        AutopilotLaws_DWork.DelayInput1_DSTATE = distance_m;
+      if (rtb_Saturation < rtb_Y_hc) {
+        rtb_Saturation = rtb_Y_hc;
       }
     }
   }
 
-  distance_m = (AutopilotLaws_P.Gain_Gain_p2 * rtb_Saturation_c - b_R) + AutopilotLaws_DWork.DelayInput1_DSTATE;
-  rtb_Saturation_c = AutopilotLaws_P.kntoms_Gain_iw * AutopilotLaws_Y.out.data.V_tas_kn;
-  if (rtb_Saturation_c > AutopilotLaws_P.Saturation_UpperSat_jt) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_UpperSat_jt;
-  } else if (rtb_Saturation_c < AutopilotLaws_P.Saturation_LowerSat_ih) {
-    rtb_Saturation_c = AutopilotLaws_P.Saturation_LowerSat_ih;
+  rtb_GainTheta1 = (AutopilotLaws_P.Gain_Gain_p2 * rtb_GainTheta1 - AutopilotLaws_DWork.DelayInput1_DSTATE) +
+    rtb_Saturation;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_iaf - AutopilotLaws_U.in.data.H_dot_ft_min;
+  rtb_Saturation = AutopilotLaws_P.ftmintoms_Gain_lv * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_iw * AutopilotLaws_U.in.data.V_tas_kn;
+  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_jt) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_jt;
+  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_ih) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_ih;
   }
 
-  rtb_Saturation_c = (AutopilotLaws_P.Constant_Value_iaf - AutopilotLaws_Y.out.data.H_dot_ft_min) *
-    AutopilotLaws_P.ftmintoms_Gain_lv / rtb_Saturation_c;
-  if (rtb_Saturation_c > 1.0) {
-    rtb_Saturation_c = 1.0;
-  } else if (rtb_Saturation_c < -1.0) {
-    rtb_Saturation_c = -1.0;
+  rtb_Gain_ar0 = rtb_Saturation / AutopilotLaws_DWork.DelayInput1_DSTATE;
+  if (rtb_Gain_ar0 > 1.0) {
+    rtb_Gain_ar0 = 1.0;
+  } else if (rtb_Gain_ar0 < -1.0) {
+    rtb_Gain_ar0 = -1.0;
   }
 
-  rtb_Saturation_c = AutopilotLaws_P.Gain_Gain_o1 * std::asin(rtb_Saturation_c);
-  AutopilotLaws_Voter1(rtb_Sum_ae, distance_m, rtb_Saturation_c, &b_R);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = L;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_P.Gain_Gain_pe * AutopilotLaws_DWork.DelayInput1_DSTATE +
-    rtb_Saturation) * AutopilotLaws_P.Gain1_Gain_f2;
-  switch (static_cast<int32_T>(rtb_GainTheta1)) {
+  rtb_Saturation = AutopilotLaws_P.Gain_Gain_o1 * std::asin(rtb_Gain_ar0);
+  AutopilotLaws_Voter1(rtb_Sum_ae, rtb_GainTheta1, rtb_Saturation, &rtb_Y_hc);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = a;
+  a = (b_L * AutopilotLaws_P.Gain_Gain_pe + AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain1_Gain_f2;
+  switch (static_cast<int32_T>(rtb_error_d)) {
    case 0:
-    a = AutopilotLaws_P.Constant_Value_d;
+    distance_m = AutopilotLaws_P.Constant_Value_d;
     break;
 
    case 1:
-    a = rtb_error_d;
+    distance_m = Phi2;
     break;
 
    case 2:
     break;
 
    case 3:
-    a = R;
+    distance_m = R;
     break;
 
    case 4:
-    a = rtb_Add3_l;
+    distance_m = rtb_Cos_f2;
     break;
 
    case 5:
-    a = rtb_Add3_n;
+    distance_m = rtb_Gain_dn;
     break;
 
    case 6:
-    a = AutopilotLaws_P.Gain1_Gain_d * rtb_Sum2_p;
+    distance_m = AutopilotLaws_P.Gain1_Gain_d * rtb_Y_h;
     break;
 
    case 7:
-    if (AutopilotLaws_Y.out.data.on_ground > AutopilotLaws_P.Switch1_Threshold_j) {
-      a = AutopilotLaws_P.Gain2_Gain_h * rtb_Gain4_m;
+    if (rtb_on_ground > AutopilotLaws_P.Switch1_Threshold_j) {
+      distance_m = AutopilotLaws_P.Gain2_Gain_h * rtb_Sum2_p;
     } else {
-      a = (AutopilotLaws_P.Gain1_Gain_ix * b_L + rtb_Gain5_n) + rtb_Gain_ij;
+      distance_m = (AutopilotLaws_P.Gain1_Gain_ix * rtb_Y_n0 + rtb_Gain5_n) + rtb_Gain_n1;
     }
     break;
 
    case 8:
-    a = b_R;
+    distance_m = rtb_Y_hc;
     break;
 
    default:
-    a = AutopilotLaws_DWork.DelayInput1_DSTATE;
+    distance_m = a;
     break;
   }
 
-  if (a > AutopilotLaws_P.Constant1_Value_i) {
-    b_R = AutopilotLaws_P.Constant1_Value_i;
+  if (distance_m > AutopilotLaws_P.Constant1_Value_i) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant1_Value_i;
   } else {
-    b_R = AutopilotLaws_P.Gain1_Gain_nu * AutopilotLaws_P.Constant1_Value_i;
-    if (a >= b_R) {
-      b_R = a;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_nu * AutopilotLaws_P.Constant1_Value_i;
+    if (distance_m >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
+      AutopilotLaws_DWork.DelayInput1_DSTATE = distance_m;
     }
   }
 
-  b_R -= rtb_GainTheta;
+  AutopilotLaws_RateLimiter(AutopilotLaws_DWork.DelayInput1_DSTATE - b_R, AutopilotLaws_P.RateLimiterVariableTs1_up,
+    AutopilotLaws_P.RateLimiterVariableTs1_lo, AutopilotLaws_U.in.time.dt,
+    AutopilotLaws_P.RateLimiterVariableTs1_InitialCondition, &rtb_Y_hc, &AutopilotLaws_DWork.sf_RateLimiter_a);
   AutopilotLaws_DWork.icLoad_f = ((AutopilotLaws_Y.out.output.ap_on == 0.0) || AutopilotLaws_DWork.icLoad_f);
   if (AutopilotLaws_DWork.icLoad_f) {
-    AutopilotLaws_DWork.Delay_DSTATE_h2 = AutopilotLaws_Y.out.data.Theta_deg;
+    AutopilotLaws_DWork.Delay_DSTATE_h2 = rtb_GainTheta;
   }
 
-  AutopilotLaws_Voter1(rtb_Sum_ae, AutopilotLaws_P.Gain_Gain_jx * distance_m, AutopilotLaws_P.VS_Gain_nx *
-                       rtb_Saturation_c, &rtb_GainTheta);
-  switch (static_cast<int32_T>(rtb_GainTheta1)) {
+  AutopilotLaws_Voter1(rtb_Sum_ae, AutopilotLaws_P.Gain_Gain_jx * rtb_GainTheta1, AutopilotLaws_P.VS_Gain_nx *
+                       rtb_Saturation, &AutopilotLaws_DWork.DelayInput1_DSTATE);
+  switch (static_cast<int32_T>(rtb_error_d)) {
    case 0:
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_d;
     break;
 
    case 1:
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.VS_Gain_n * rtb_error_d;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.VS_Gain_n * Phi2;
     break;
 
    case 2:
-    AutopilotLaws_DWork.DelayInput1_DSTATE = Phi2;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = L;
     break;
 
    case 3:
@@ -2077,50 +2051,53 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 4:
-    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Add3_d;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Cos1_pk;
     break;
 
    case 5:
-    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Gain_dn;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Add3_gy;
     break;
 
    case 6:
-    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Sum2_p;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_h;
     break;
 
    case 7:
-    if (AutopilotLaws_Y.out.data.on_ground > AutopilotLaws_P.Switch_Threshold) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Gain4_m;
+    if (rtb_on_ground > AutopilotLaws_P.Switch_Threshold) {
+      AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Sum2_p;
     } else {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_P.Gain3_Gain_l * b_L + rtb_Gain5_n) +
-        AutopilotLaws_P.VS_Gain_e * rtb_Gain_ij;
+      AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_P.Gain3_Gain_l * rtb_Y_n0 + rtb_Gain5_n) +
+        AutopilotLaws_P.VS_Gain_e * rtb_Gain_n1;
     }
     break;
 
    case 8:
-    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_GainTheta;
+    break;
+
+   default:
+    AutopilotLaws_DWork.DelayInput1_DSTATE = a;
     break;
   }
 
-  AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_Y.out.data.Theta_deg;
+  AutopilotLaws_DWork.DelayInput1_DSTATE += rtb_GainTheta;
   if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Constant1_Value_i) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant1_Value_i;
   } else {
-    rtb_GainTheta = AutopilotLaws_P.Gain1_Gain_m * AutopilotLaws_P.Constant1_Value_i;
-    if (AutopilotLaws_DWork.DelayInput1_DSTATE < rtb_GainTheta) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_GainTheta;
+    rtb_GainTheta1 = AutopilotLaws_P.Gain1_Gain_m * AutopilotLaws_P.Constant1_Value_i;
+    if (AutopilotLaws_DWork.DelayInput1_DSTATE < rtb_GainTheta1) {
+      AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_GainTheta1;
     }
   }
 
   AutopilotLaws_DWork.DelayInput1_DSTATE -= AutopilotLaws_DWork.Delay_DSTATE_h2;
   AutopilotLaws_DWork.DelayInput1_DSTATE = std::fmin(AutopilotLaws_DWork.DelayInput1_DSTATE,
-    AutopilotLaws_P.Constant2_Value_h1 * AutopilotLaws_Y.out.time.dt);
-  distance_m = AutopilotLaws_P.Gain1_Gain_i0l * AutopilotLaws_P.Constant2_Value_h1 * AutopilotLaws_Y.out.time.dt;
-  AutopilotLaws_DWork.Delay_DSTATE_h2 += std::fmax(AutopilotLaws_DWork.DelayInput1_DSTATE, distance_m);
+    AutopilotLaws_P.Constant2_Value_h1 * AutopilotLaws_U.in.time.dt);
+  AutopilotLaws_DWork.Delay_DSTATE_h2 += std::fmax(AutopilotLaws_DWork.DelayInput1_DSTATE,
+    AutopilotLaws_P.Gain1_Gain_i0l * AutopilotLaws_P.Constant2_Value_h1 * AutopilotLaws_U.in.time.dt);
   AutopilotLaws_LagFilter(AutopilotLaws_DWork.Delay_DSTATE_h2, AutopilotLaws_P.LagFilter_C1_i,
-    AutopilotLaws_Y.out.time.dt, &distance_m, &AutopilotLaws_DWork.sf_LagFilter_gn);
+    AutopilotLaws_U.in.time.dt, &b_R, &AutopilotLaws_DWork.sf_LagFilter_gn);
   AutopilotLaws_RateLimiter(AutopilotLaws_Y.out.output.ap_on, AutopilotLaws_P.RateLimiterVariableTs_up_i,
-    AutopilotLaws_P.RateLimiterVariableTs_lo_o, AutopilotLaws_Y.out.time.dt,
+    AutopilotLaws_P.RateLimiterVariableTs_lo_o, AutopilotLaws_U.in.time.dt,
     AutopilotLaws_P.RateLimiterVariableTs_InitialCondition_p, &AutopilotLaws_DWork.DelayInput1_DSTATE,
     &AutopilotLaws_DWork.sf_RateLimiter_eb);
   if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_ix) {
@@ -2129,11 +2106,11 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_eq;
   }
 
-  rtb_GainTheta = distance_m * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_GainTheta1 = b_R * AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_i4 - AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_DWork.DelayInput1_DSTATE *= AutopilotLaws_Y.out.data.Theta_deg;
-  AutopilotLaws_DWork.DelayInput1_DSTATE += rtb_GainTheta;
-  AutopilotLaws_Y.out.output.flight_director.Theta_c_deg = b_R;
+  AutopilotLaws_DWork.DelayInput1_DSTATE *= rtb_GainTheta;
+  AutopilotLaws_DWork.DelayInput1_DSTATE += rtb_GainTheta1;
+  AutopilotLaws_Y.out.output.flight_director.Theta_c_deg = rtb_Y_hc;
   AutopilotLaws_Y.out.output.autopilot.Theta_c_deg = AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_U.in.data.altimeter_setting_left_mbar;
   AutopilotLaws_DWork.DelayInput1_DSTATE_g = AutopilotLaws_U.in.data.altimeter_setting_right_mbar;
@@ -2147,8 +2124,8 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_DWork.Delay_DSTATE_e = rtb_dme;
   AutopilotLaws_DWork.icLoad = false;
   AutopilotLaws_DWork.Delay_DSTATE_hi = limit;
-  AutopilotLaws_DWork.Delay_DSTATE_n = rtb_Cos1_pk;
-  AutopilotLaws_DWork.Delay_DSTATE_p = rtb_Y_k;
+  AutopilotLaws_DWork.Delay_DSTATE_n = rtb_Add3_n2;
+  AutopilotLaws_DWork.Delay_DSTATE_p = rtb_Saturation_c;
   AutopilotLaws_DWork.icLoad_f = false;
 }
 

--- a/src/fbw/src/model/AutopilotLaws.cpp
+++ b/src/fbw/src/model/AutopilotLaws.cpp
@@ -372,9 +372,9 @@ void AutopilotLawsModelClass::step()
   real_T rtb_Saturation_c;
   real_T rtb_Sum2_p;
   real_T rtb_Sum_ae;
-  real_T rtb_Y_h;
-  real_T rtb_Y_hc;
-  real_T rtb_Y_n0;
+  real_T rtb_Y_d;
+  real_T rtb_Y_f;
+  real_T rtb_Y_g;
   real_T rtb_dme;
   real_T rtb_error_d;
   int32_T i;
@@ -403,9 +403,9 @@ void AutopilotLawsModelClass::step()
   result_tmp[7] = -a;
   result_tmp[2] = 0.0;
   distance_m = std::cos(rtb_dme);
-  rtb_Y_hc = 1.0 / distance_m;
-  result_tmp[5] = rtb_Y_hc * a;
-  result_tmp[8] = rtb_Y_hc * b_R;
+  rtb_Y_f = 1.0 / distance_m;
+  result_tmp[5] = rtb_Y_f * a;
+  result_tmp[8] = rtb_Y_f * b_R;
   rtb_error_d = AutopilotLaws_P.Gain_Gain_de * AutopilotLaws_U.in.data.p_rad_s * AutopilotLaws_P.Gainpk_Gain;
   rtb_Saturation = AutopilotLaws_P.Gain_Gain_d * AutopilotLaws_U.in.data.q_rad_s * AutopilotLaws_P.Gainqk_Gain;
   Phi2 = AutopilotLaws_P.Gain_Gain_m * AutopilotLaws_U.in.data.r_rad_s;
@@ -465,9 +465,9 @@ void AutopilotLawsModelClass::step()
     b_R = -b_L;
   }
 
-  rtb_Y_hc = std::cos(rtb_error_d);
+  rtb_Y_f = std::cos(rtb_error_d);
   rtb_error_d = std::sin(rtb_error_d);
-  L = mod_mvZvttxs(mod_mvZvttxs(mod_mvZvttxs(std::atan2(std::sin(R) * L, rtb_Y_hc * std::sin(Phi2) - rtb_error_d * L *
+  L = mod_mvZvttxs(mod_mvZvttxs(mod_mvZvttxs(std::atan2(std::sin(R) * L, rtb_Y_f * std::sin(Phi2) - rtb_error_d * L *
     std::cos(R)) * 57.295779513082323 + 360.0)) + 360.0) + 360.0;
   Phi2 = mod_mvZvttxs((mod_mvZvttxs(mod_mvZvttxs(mod_mvZvttxs(mod_mvZvttxs(AutopilotLaws_U.in.data.nav_loc_deg - b_R) +
     360.0)) + 360.0) - L) + 360.0);
@@ -510,13 +510,13 @@ void AutopilotLawsModelClass::step()
   distance_m = std::sin((AutopilotLaws_U.in.data.nav_gs_position.lon - AutopilotLaws_U.in.data.aircraft_position.lon) *
                         0.017453292519943295 / 2.0);
   L = std::cos(Phi2);
-  R = rtb_Y_hc;
-  a = rtb_Y_hc * L * distance_m * distance_m + a * a;
+  R = rtb_Y_f;
+  a = rtb_Y_f * L * distance_m * distance_m + a * a;
   distance_m = std::atan2(std::sqrt(a), std::sqrt(1.0 - a)) * 2.0 * 6.371E+6;
   a = AutopilotLaws_U.in.data.aircraft_position.alt - AutopilotLaws_U.in.data.nav_gs_position.alt;
   distance_m = std::sqrt(distance_m * distance_m + a * a);
   rtb_Saturation = 0.017453292519943295 * AutopilotLaws_U.in.data.nav_gs_position.lon - rtb_Saturation;
-  rtb_Saturation = std::atan2(std::sin(rtb_Saturation) * L, rtb_Y_hc * std::sin(Phi2) - rtb_error_d * L * std::cos
+  rtb_Saturation = std::atan2(std::sin(rtb_Saturation) * L, rtb_Y_f * std::sin(Phi2) - rtb_error_d * L * std::cos
     (rtb_Saturation)) * 57.295779513082323;
   if (rtb_Saturation + 360.0 == 0.0) {
     rtb_error_d = 0.0;
@@ -770,7 +770,7 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.limit = 15.0;
   }
 
-  AutopilotLaws_MATLABFunction(AutopilotLaws_P.tau_Value, AutopilotLaws_P.zeta_Value, &L, &rtb_Y_n0);
+  AutopilotLaws_MATLABFunction(AutopilotLaws_P.tau_Value, AutopilotLaws_P.zeta_Value, &L, &rtb_Y_g);
   if (rtb_dme > AutopilotLaws_P.Saturation_UpperSat_b) {
     Phi2 = AutopilotLaws_P.Saturation_UpperSat_b;
   } else if (rtb_dme < AutopilotLaws_P.Saturation_LowerSat_n) {
@@ -780,7 +780,7 @@ void AutopilotLawsModelClass::step()
   }
 
   Phi2 = std::sin(AutopilotLaws_P.Gain1_Gain_f * AutopilotLaws_U.in.data.nav_loc_error_deg) * Phi2 *
-    AutopilotLaws_P.Gain_Gain_h * rtb_Y_n0 / AutopilotLaws_U.in.data.V_gnd_kn;
+    AutopilotLaws_P.Gain_Gain_h * rtb_Y_g / AutopilotLaws_U.in.data.V_gnd_kn;
   AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_DWork.DelayInput1_DSTATE - (rt_modd(rt_modd
     (AutopilotLaws_U.in.data.nav_loc_error_deg + rtb_Saturation, AutopilotLaws_P.Constant3_Value_c) +
     AutopilotLaws_P.Constant3_Value_c, AutopilotLaws_P.Constant3_Value_c) + AutopilotLaws_P.Constant3_Value_p)) +
@@ -841,8 +841,8 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_P.Constant3_Value_d);
   AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_P.Constant3_Value_d;
   AutopilotLaws_storevalue(rtb_Compare_jy, rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE,
-    AutopilotLaws_P.Constant3_Value_d), &rtb_Y_n0, &AutopilotLaws_DWork.sf_storevalue);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_U.in.data.nav_loc_error_deg + rtb_Y_n0;
+    AutopilotLaws_P.Constant3_Value_d), &rtb_Y_g, &AutopilotLaws_DWork.sf_storevalue);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_U.in.data.nav_loc_error_deg + rtb_Y_g;
   AutopilotLaws_DWork.DelayInput1_DSTATE = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE,
     AutopilotLaws_P.Constant3_Value_o);
   AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_P.Constant3_Value_o;
@@ -954,7 +954,7 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_RateLimiter(AutopilotLaws_U.in.data.flight_guidance_phi_deg, AutopilotLaws_P.RateLimiterVariableTs_up,
     AutopilotLaws_P.RateLimiterVariableTs_lo, AutopilotLaws_U.in.time.dt,
     AutopilotLaws_P.RateLimiterVariableTs_InitialCondition, &L, &AutopilotLaws_DWork.sf_RateLimiter);
-  AutopilotLaws_LagFilter(L, AutopilotLaws_P.LagFilter_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_h,
+  AutopilotLaws_LagFilter(L, AutopilotLaws_P.LagFilter_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_d,
     &AutopilotLaws_DWork.sf_LagFilter);
   AutopilotLaws_LagFilter(AutopilotLaws_U.in.data.nav_loc_error_deg, AutopilotLaws_P.LagFilter2_C1,
     AutopilotLaws_U.in.time.dt, &L, &AutopilotLaws_DWork.sf_LagFilter_h);
@@ -962,7 +962,7 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_dme - AutopilotLaws_DWork.Delay_DSTATE_e;
   AutopilotLaws_DWork.DelayInput1_DSTATE /= AutopilotLaws_U.in.time.dt;
   AutopilotLaws_LagFilter(L + AutopilotLaws_P.Gain3_Gain_i * AutopilotLaws_DWork.DelayInput1_DSTATE,
-    AutopilotLaws_P.LagFilter_C1_n, AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_LagFilter_m);
+    AutopilotLaws_P.LagFilter_C1_n, AutopilotLaws_U.in.time.dt, &rtb_Y_g, &AutopilotLaws_DWork.sf_LagFilter_m);
   rtb_Delay_j = (AutopilotLaws_U.in.data.H_radio_ft <= AutopilotLaws_P.CompareToConstant_const_d);
   switch (static_cast<int32_T>(rtb_error_d)) {
    case 0:
@@ -990,7 +990,7 @@ void AutopilotLawsModelClass::step()
       rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat;
     }
 
-    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_h - (AutopilotLaws_P.Gain2_Gain *
+    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_d - (AutopilotLaws_P.Gain2_Gain *
       AutopilotLaws_U.in.data.flight_guidance_tae_deg + rtb_Gain_ar0) * b_R * AutopilotLaws_U.in.data.V_gnd_kn;
     break;
 
@@ -1005,7 +1005,7 @@ void AutopilotLawsModelClass::step()
       L = AutopilotLaws_P.Constant1_Value_fk;
     }
 
-    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_n0 * look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft,
+    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_g * look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft,
       AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_e, AutopilotLaws_P.ScheduledGain_Table_p, 4U) *
       look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn, AutopilotLaws_P.ScheduledGain2_BreakpointsForDimension1,
                     AutopilotLaws_P.ScheduledGain2_Table, 6U) + L;
@@ -1057,14 +1057,14 @@ void AutopilotLawsModelClass::step()
     (AutopilotLaws_P.RateLimiterVariableTs_up_n) * AutopilotLaws_U.in.time.dt), -std::abs
     (AutopilotLaws_P.RateLimiterVariableTs_lo_k) * AutopilotLaws_U.in.time.dt);
   if (AutopilotLaws_DWork.pY > AutopilotLaws_P.Saturation_UpperSat_k) {
-    rtb_Y_hc = AutopilotLaws_P.Saturation_UpperSat_k;
+    rtb_Y_f = AutopilotLaws_P.Saturation_UpperSat_k;
   } else if (AutopilotLaws_DWork.pY < AutopilotLaws_P.Saturation_LowerSat_f3) {
-    rtb_Y_hc = AutopilotLaws_P.Saturation_LowerSat_f3;
+    rtb_Y_f = AutopilotLaws_P.Saturation_LowerSat_f3;
   } else {
-    rtb_Y_hc = AutopilotLaws_DWork.pY;
+    rtb_Y_f = AutopilotLaws_DWork.pY;
   }
 
-  a = (AutopilotLaws_P.Gain_Gain_b * result[2] * rtb_Y_hc + (AutopilotLaws_P.Constant_Value_a - rtb_Y_hc) *
+  a = (AutopilotLaws_P.Gain_Gain_b * result[2] * rtb_Y_f + (AutopilotLaws_P.Constant_Value_a - rtb_Y_f) *
        (AutopilotLaws_P.Gain4_Gain * AutopilotLaws_U.in.data.beta_deg)) + AutopilotLaws_P.Gain5_Gain_o * a;
   if (rtb_Saturation_c > AutopilotLaws_P.Switch_Threshold_n) {
     switch (static_cast<int32_T>(rtb_error_d)) {
@@ -1106,41 +1106,41 @@ void AutopilotLawsModelClass::step()
     L = AutopilotLaws_P.Constant1_Value_fk;
   }
 
-  AutopilotLaws_LagFilter(L, AutopilotLaws_P.LagFilter1_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_n0,
+  AutopilotLaws_LagFilter(L, AutopilotLaws_P.LagFilter1_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_g,
     &AutopilotLaws_DWork.sf_LagFilter_c);
   switch (static_cast<int32_T>(rtb_error_d)) {
    case 0:
-    rtb_Y_hc = AutopilotLaws_P.beta_Value;
+    rtb_Y_f = AutopilotLaws_P.beta_Value;
     break;
 
    case 1:
-    rtb_Y_hc = AutopilotLaws_P.beta_Value_e;
+    rtb_Y_f = AutopilotLaws_P.beta_Value_e;
     break;
 
    case 2:
-    rtb_Y_hc = AutopilotLaws_P.beta_Value_b;
+    rtb_Y_f = AutopilotLaws_P.beta_Value_b;
     break;
 
    case 3:
-    rtb_Y_hc = AutopilotLaws_P.beta_Value_i;
+    rtb_Y_f = AutopilotLaws_P.beta_Value_i;
     break;
 
    case 4:
-    rtb_Y_hc = AutopilotLaws_P.beta_Value_c;
+    rtb_Y_f = AutopilotLaws_P.beta_Value_c;
     break;
 
    case 5:
-    if (rtb_Y_n0 > AutopilotLaws_P.Saturation_UpperSat_e) {
-      rtb_Y_hc = AutopilotLaws_P.Saturation_UpperSat_e;
-    } else if (rtb_Y_n0 < AutopilotLaws_P.Saturation_LowerSat_f) {
-      rtb_Y_hc = AutopilotLaws_P.Saturation_LowerSat_f;
+    if (rtb_Y_g > AutopilotLaws_P.Saturation_UpperSat_e) {
+      rtb_Y_f = AutopilotLaws_P.Saturation_UpperSat_e;
+    } else if (rtb_Y_g < AutopilotLaws_P.Saturation_LowerSat_f) {
+      rtb_Y_f = AutopilotLaws_P.Saturation_LowerSat_f;
     } else {
-      rtb_Y_hc = rtb_Y_n0;
+      rtb_Y_f = rtb_Y_g;
     }
     break;
 
    default:
-    rtb_Y_hc = AutopilotLaws_P.Gain7_Gain * a;
+    rtb_Y_f = AutopilotLaws_P.Gain7_Gain * a;
     break;
   }
 
@@ -1155,19 +1155,19 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_DWork.Delay_DSTATE_h += std::fmax(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Gain1_Gain_kf *
     AutopilotLaws_P.Constant2_Value_h * AutopilotLaws_U.in.time.dt);
   AutopilotLaws_LagFilter(AutopilotLaws_DWork.Delay_DSTATE_h, AutopilotLaws_P.LagFilter_C1_l, AutopilotLaws_U.in.time.dt,
-    &rtb_Y_h, &AutopilotLaws_DWork.sf_LagFilter_o);
+    &rtb_Y_d, &AutopilotLaws_DWork.sf_LagFilter_o);
   AutopilotLaws_RateLimiter(rtb_Saturation_c, AutopilotLaws_P.RateLimiterVariableTs_up_b,
     AutopilotLaws_P.RateLimiterVariableTs_lo_b, AutopilotLaws_U.in.time.dt,
-    AutopilotLaws_P.RateLimiterVariableTs_InitialCondition_il, &rtb_Y_n0, &AutopilotLaws_DWork.sf_RateLimiter_d);
-  if (rtb_Y_n0 > AutopilotLaws_P.Saturation_UpperSat_m) {
+    AutopilotLaws_P.RateLimiterVariableTs_InitialCondition_il, &rtb_Y_g, &AutopilotLaws_DWork.sf_RateLimiter_d);
+  if (rtb_Y_g > AutopilotLaws_P.Saturation_UpperSat_m) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_m;
-  } else if (rtb_Y_n0 < AutopilotLaws_P.Saturation_LowerSat_fw) {
+  } else if (rtb_Y_g < AutopilotLaws_P.Saturation_LowerSat_fw) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_fw;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_n0;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_g;
   }
 
-  rtb_error_d = rtb_Y_h * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_error_d = rtb_Y_d * AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_ii - AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE *= rtb_GainTheta1;
   AutopilotLaws_DWork.DelayInput1_DSTATE += rtb_error_d;
@@ -1181,8 +1181,8 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_Y.out.output.Nosewheel_c = rtb_Gain_ar0;
   }
 
-  AutopilotLaws_Y.out.output.flight_director.Beta_c_deg = rtb_Y_hc;
-  AutopilotLaws_Y.out.output.autopilot.Beta_c_deg = rtb_Y_hc;
+  AutopilotLaws_Y.out.output.flight_director.Beta_c_deg = rtb_Y_f;
+  AutopilotLaws_Y.out.output.autopilot.Beta_c_deg = rtb_Y_f;
   AutopilotLaws_Y.out.output.flight_director.Phi_c_deg = b_R;
   AutopilotLaws_Y.out.output.autopilot.Phi_c_deg = AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_WashoutFilter(rtb_GainTheta, AutopilotLaws_P.WashoutFilter_C1, AutopilotLaws_U.in.time.dt, &b_R,
@@ -1211,8 +1211,8 @@ void AutopilotLawsModelClass::step()
   }
 
   AutopilotLaws_LagFilter(AutopilotLaws_B.u - AutopilotLaws_U.in.data.H_ft, AutopilotLaws_P.LagFilter_C1_ai,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_LagFilter_g);
-  AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_P.Gain_Gain_ft * rtb_Y_n0;
+    AutopilotLaws_U.in.time.dt, &rtb_Y_g, &AutopilotLaws_DWork.sf_LagFilter_g);
+  AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_P.Gain_Gain_ft * rtb_Y_g;
   if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_n) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_n;
   } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_d4) {
@@ -1309,7 +1309,7 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_P.Gain_Gain_e3;
   rtb_Saturation = AutopilotLaws_P.Gain1_Gain_c * rtb_GainTheta1;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain * (AutopilotLaws_P.GStoGS_CAS_Gain * (AutopilotLaws_P.ktstomps_Gain *
-    AutopilotLaws_U.in.data.V_gnd_kn)), AutopilotLaws_P.WashoutFilter_C1_e, AutopilotLaws_U.in.time.dt, &rtb_Y_n0,
+    AutopilotLaws_U.in.data.V_gnd_kn)), AutopilotLaws_P.WashoutFilter_C1_e, AutopilotLaws_U.in.time.dt, &rtb_Y_g,
     &AutopilotLaws_DWork.sf_WashoutFilter);
   rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_b * AutopilotLaws_U.in.data.V_gnd_kn;
   if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_ei) {
@@ -1318,30 +1318,30 @@ void AutopilotLawsModelClass::step()
     rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_dz;
   }
 
-  AutopilotLaws_LeadLagFilter(rtb_Y_n0 - AutopilotLaws_P.g_Gain * (AutopilotLaws_P.Gain1_Gain_lp *
+  AutopilotLaws_LeadLagFilter(rtb_Y_g - AutopilotLaws_P.g_Gain * (AutopilotLaws_P.Gain1_Gain_lp *
     (AutopilotLaws_P.Gain_Gain_am * ((AutopilotLaws_P.Gain1_Gain_g * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_lx *
     (AutopilotLaws_P.Gain_Gain_c1 * std::atan(AutopilotLaws_P.fpmtoms_Gain_g * AutopilotLaws_U.in.data.H_dot_ft_min /
     rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_dy - std::cos(rtb_Saturation)) + std::sin(rtb_Saturation) * std::
     sin(AutopilotLaws_P.Gain1_Gain_pf * AutopilotLaws_U.in.data.Psi_magnetic_track_deg - AutopilotLaws_P.Gain1_Gain_e *
         AutopilotLaws_U.in.data.Psi_magnetic_deg)))), AutopilotLaws_P.HighPassFilter_C1,
     AutopilotLaws_P.HighPassFilter_C2, AutopilotLaws_P.HighPassFilter_C3, AutopilotLaws_P.HighPassFilter_C4,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_h, &AutopilotLaws_DWork.sf_LeadLagFilter);
+    AutopilotLaws_U.in.time.dt, &rtb_Y_d, &AutopilotLaws_DWork.sf_LeadLagFilter);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_b * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1, AutopilotLaws_P.LowPassFilter_C2, AutopilotLaws_P.LowPassFilter_C3,
-    AutopilotLaws_P.LowPassFilter_C4, AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_LeadLagFilter_o);
-  rtb_Saturation = (rtb_Y_h + rtb_Y_n0) * AutopilotLaws_P.ug_Gain;
-  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_bf * AutopilotLaws_DWork.DelayInput1_DSTATE;
-  distance_m = rtb_Saturation + rtb_Y_hc;
+    AutopilotLaws_P.LowPassFilter_C4, AutopilotLaws_U.in.time.dt, &rtb_Y_g, &AutopilotLaws_DWork.sf_LeadLagFilter_o);
+  rtb_Saturation = (rtb_Y_d + rtb_Y_g) * AutopilotLaws_P.ug_Gain;
+  rtb_Y_f = AutopilotLaws_P.Gain1_Gain_bf * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  distance_m = rtb_Saturation + rtb_Y_f;
   L = AutopilotLaws_P.Constant3_Value_nq - AutopilotLaws_P.Constant4_Value;
-  R = (AutopilotLaws_P.Gain1_Gain_ik * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_aj;
+  R = (AutopilotLaws_P.Gain1_Gain_ik * rtb_Saturation + rtb_Y_f) * AutopilotLaws_P.Gain_Gain_aj;
   if (L > AutopilotLaws_P.Switch_Threshold_l) {
     rtb_Saturation = AutopilotLaws_P.Constant1_Value_g;
   } else {
     rtb_Saturation = AutopilotLaws_P.Gain5_Gain * R;
   }
 
-  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &rtb_Y_n0);
-  b_L = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_n0) * AutopilotLaws_P.Gain1_Gain_oz;
+  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &rtb_Y_g);
+  b_L = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_g) * AutopilotLaws_P.Gain1_Gain_oz;
   if (b_L <= rtb_Saturation) {
     if (L > AutopilotLaws_P.Switch1_Threshold) {
       rtb_Saturation = AutopilotLaws_P.Constant_Value_g;
@@ -1368,7 +1368,7 @@ void AutopilotLawsModelClass::step()
   rtb_Saturation = AutopilotLaws_P.Gain1_Gain_j0 * rtb_GainTheta1;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_h * (AutopilotLaws_P.GStoGS_CAS_Gain_m *
     (AutopilotLaws_P.ktstomps_Gain_g * AutopilotLaws_U.in.data.V_gnd_kn)), AutopilotLaws_P.WashoutFilter_C1_e4,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_WashoutFilter_d);
+    AutopilotLaws_U.in.time.dt, &rtb_Y_g, &AutopilotLaws_DWork.sf_WashoutFilter_d);
   rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_l * AutopilotLaws_U.in.data.V_gnd_kn;
   if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_i) {
     rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_i;
@@ -1376,39 +1376,39 @@ void AutopilotLawsModelClass::step()
     rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_h;
   }
 
-  AutopilotLaws_LeadLagFilter(rtb_Y_n0 - AutopilotLaws_P.g_Gain_h * (AutopilotLaws_P.Gain1_Gain_dv *
+  AutopilotLaws_LeadLagFilter(rtb_Y_g - AutopilotLaws_P.g_Gain_h * (AutopilotLaws_P.Gain1_Gain_dv *
     (AutopilotLaws_P.Gain_Gain_id * ((AutopilotLaws_P.Gain1_Gain_kd * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_o4 *
     (AutopilotLaws_P.Gain_Gain_bs * std::atan(AutopilotLaws_P.fpmtoms_Gain_c * AutopilotLaws_U.in.data.H_dot_ft_min /
     rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_cg - std::cos(rtb_Saturation)) + std::sin(rtb_Saturation) * std::
     sin(AutopilotLaws_P.Gain1_Gain_bk * AutopilotLaws_U.in.data.Psi_magnetic_track_deg - AutopilotLaws_P.Gain1_Gain_lxx *
         AutopilotLaws_U.in.data.Psi_magnetic_deg)))), AutopilotLaws_P.HighPassFilter_C1_e,
     AutopilotLaws_P.HighPassFilter_C2_c, AutopilotLaws_P.HighPassFilter_C3_f, AutopilotLaws_P.HighPassFilter_C4_c,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_h, &AutopilotLaws_DWork.sf_LeadLagFilter_h);
+    AutopilotLaws_U.in.time.dt, &rtb_Y_d, &AutopilotLaws_DWork.sf_LeadLagFilter_h);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_i * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_n, AutopilotLaws_P.LowPassFilter_C2_a, AutopilotLaws_P.LowPassFilter_C3_o,
-    AutopilotLaws_P.LowPassFilter_C4_o, AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_LeadLagFilter_m);
-  rtb_Saturation = (rtb_Y_h + rtb_Y_n0) * AutopilotLaws_P.ug_Gain_a;
-  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_hm * AutopilotLaws_DWork.DelayInput1_DSTATE;
-  distance_m = rtb_Saturation + rtb_Y_hc;
+    AutopilotLaws_P.LowPassFilter_C4_o, AutopilotLaws_U.in.time.dt, &rtb_Y_g, &AutopilotLaws_DWork.sf_LeadLagFilter_m);
+  rtb_Saturation = (rtb_Y_d + rtb_Y_g) * AutopilotLaws_P.ug_Gain_a;
+  rtb_Y_f = AutopilotLaws_P.Gain1_Gain_hm * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  distance_m = rtb_Saturation + rtb_Y_f;
   L = AutopilotLaws_P.Constant1_Value_b4 - AutopilotLaws_P.Constant2_Value_c;
-  b_L = (AutopilotLaws_P.Gain1_Gain_mz * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_ie;
+  b_L = (AutopilotLaws_P.Gain1_Gain_mz * rtb_Saturation + rtb_Y_f) * AutopilotLaws_P.Gain_Gain_ie;
   if (L > AutopilotLaws_P.Switch_Threshold_b) {
     rtb_Saturation = AutopilotLaws_P.Constant1_Value_a;
   } else {
     rtb_Saturation = AutopilotLaws_P.Gain5_Gain_l * b_L;
   }
 
-  rtb_Y_n0 = AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.data.VMAX_kn;
-  rtb_Y_hc = rtb_Y_n0 * AutopilotLaws_P.Gain1_Gain_f1;
-  if (rtb_Y_hc <= rtb_Saturation) {
+  rtb_Y_g = AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.data.VMAX_kn;
+  rtb_Y_f = rtb_Y_g * AutopilotLaws_P.Gain1_Gain_f1;
+  if (rtb_Y_f <= rtb_Saturation) {
     if (L > AutopilotLaws_P.Switch1_Threshold_f) {
       rtb_Saturation = AutopilotLaws_P.Constant_Value_p;
     } else {
       rtb_Saturation = AutopilotLaws_P.Gain6_Gain_j * b_L;
     }
 
-    if (rtb_Y_hc >= rtb_Saturation) {
-      rtb_Saturation = rtb_Y_hc;
+    if (rtb_Y_f >= rtb_Saturation) {
+      rtb_Saturation = rtb_Y_f;
     }
   }
 
@@ -1429,8 +1429,8 @@ void AutopilotLawsModelClass::step()
   rtb_Saturation = AutopilotLaws_P.Gain1_Gain_fm * rtb_GainTheta1;
   rtb_Saturation_c = std::cos(rtb_Saturation);
   R = std::sin(rtb_Saturation);
-  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_hy * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
-  b_L = rtb_Y_hc - AutopilotLaws_P.Gain1_Gain_j2 * AutopilotLaws_U.in.data.Psi_magnetic_deg;
+  rtb_Y_f = AutopilotLaws_P.Gain1_Gain_hy * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
+  b_L = rtb_Y_f - AutopilotLaws_P.Gain1_Gain_j2 * AutopilotLaws_U.in.data.Psi_magnetic_deg;
   rtb_Saturation = AutopilotLaws_P.ktstomps_Gain_c * AutopilotLaws_U.in.data.V_gnd_kn;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_m * (AutopilotLaws_P.GStoGS_CAS_Gain_o * rtb_Saturation),
     AutopilotLaws_P.WashoutFilter_C1_l, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
@@ -1447,15 +1447,15 @@ void AutopilotLawsModelClass::step()
     (AutopilotLaws_P.Gain_Gain_ho * std::atan(AutopilotLaws_P.fpmtoms_Gain_e * AutopilotLaws_U.in.data.H_dot_ft_min /
     rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_j - rtb_Saturation_c) + R * std::sin(b_L)))),
     AutopilotLaws_P.HighPassFilter_C1_l, AutopilotLaws_P.HighPassFilter_C2_co, AutopilotLaws_P.HighPassFilter_C3_b,
-    AutopilotLaws_P.HighPassFilter_C4_j, AutopilotLaws_U.in.time.dt, &rtb_Y_hc, &AutopilotLaws_DWork.sf_LeadLagFilter_l);
+    AutopilotLaws_P.HighPassFilter_C4_j, AutopilotLaws_U.in.time.dt, &rtb_Y_f, &AutopilotLaws_DWork.sf_LeadLagFilter_l);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_n * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_f, AutopilotLaws_P.LowPassFilter_C2_p, AutopilotLaws_P.LowPassFilter_C3_a,
     AutopilotLaws_P.LowPassFilter_C4_g, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
     &AutopilotLaws_DWork.sf_LeadLagFilter_as);
-  rtb_Saturation = (rtb_Y_hc + rtb_Saturation) * AutopilotLaws_P.ug_Gain_l;
-  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_g1 * AutopilotLaws_DWork.DelayInput1_DSTATE;
-  rtb_Saturation_c = rtb_Saturation + rtb_Y_hc;
-  R = (AutopilotLaws_P.Gain1_Gain_ov * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_a2;
+  rtb_Saturation = (rtb_Y_f + rtb_Saturation) * AutopilotLaws_P.ug_Gain_l;
+  rtb_Y_f = AutopilotLaws_P.Gain1_Gain_g1 * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Saturation_c = rtb_Saturation + rtb_Y_f;
+  R = (AutopilotLaws_P.Gain1_Gain_ov * rtb_Saturation + rtb_Y_f) * AutopilotLaws_P.Gain_Gain_a2;
   AutopilotLaws_Voter1(AutopilotLaws_U.in.data.VLS_kn, AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VMAX_kn,
                        &rtb_Saturation);
   rtb_Saturation = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Saturation) * AutopilotLaws_P.Gain1_Gain_lxw;
@@ -1504,13 +1504,13 @@ void AutopilotLawsModelClass::step()
 
   rtb_Gain_dn = AutopilotLaws_P.Gain_Gain_ey * std::asin(rtb_Gain_ar0);
   if (AutopilotLaws_U.in.input.vertical_mode == 50.0) {
-    rtb_Y_hc = 0.3;
+    rtb_Y_f = 0.3;
   } else {
-    rtb_Y_hc = 0.1;
+    rtb_Y_f = 0.1;
   }
 
   rtb_Saturation_c = 9.81 / (AutopilotLaws_U.in.data.V_tas_kn * 0.51444444444444448);
-  limit = rtb_Saturation_c * rtb_Y_hc * 57.295779513082323;
+  limit = rtb_Saturation_c * rtb_Y_f * 57.295779513082323;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain_o * AutopilotLaws_U.in.data.H_dot_ft_min;
   rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_o * AutopilotLaws_U.in.data.V_gnd_kn;
   if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_f) {
@@ -1524,8 +1524,8 @@ void AutopilotLawsModelClass::step()
   rtb_Saturation = AutopilotLaws_P.Gain1_Gain_hi * rtb_GainTheta1;
   rtb_Cos_f2 = std::cos(rtb_Saturation);
   rtb_Cos1_pk = std::sin(rtb_Saturation);
-  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_hg * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
-  rtb_Add3_gy = rtb_Y_hc - AutopilotLaws_P.Gain1_Gain_da * AutopilotLaws_U.in.data.Psi_magnetic_deg;
+  rtb_Y_f = AutopilotLaws_P.Gain1_Gain_hg * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
+  rtb_Add3_gy = rtb_Y_f - AutopilotLaws_P.Gain1_Gain_da * AutopilotLaws_U.in.data.Psi_magnetic_deg;
   rtb_Saturation = AutopilotLaws_P.ktstomps_Gain_m * AutopilotLaws_U.in.data.V_gnd_kn;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_k * (AutopilotLaws_P.GStoGS_CAS_Gain_k * rtb_Saturation),
     AutopilotLaws_P.WashoutFilter_C1_o, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
@@ -1542,33 +1542,33 @@ void AutopilotLawsModelClass::step()
     (AutopilotLaws_P.Gain_Gain_in * std::atan(AutopilotLaws_P.fpmtoms_Gain_ey * AutopilotLaws_U.in.data.H_dot_ft_min /
     rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_od - rtb_Cos_f2) + rtb_Cos1_pk * std::sin(rtb_Add3_gy)))),
     AutopilotLaws_P.HighPassFilter_C1_g, AutopilotLaws_P.HighPassFilter_C2_l, AutopilotLaws_P.HighPassFilter_C3_j,
-    AutopilotLaws_P.HighPassFilter_C4_i, AutopilotLaws_U.in.time.dt, &rtb_Y_hc, &AutopilotLaws_DWork.sf_LeadLagFilter_b);
+    AutopilotLaws_P.HighPassFilter_C4_i, AutopilotLaws_U.in.time.dt, &rtb_Y_f, &AutopilotLaws_DWork.sf_LeadLagFilter_b);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_c2 * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_m, AutopilotLaws_P.LowPassFilter_C2_l, AutopilotLaws_P.LowPassFilter_C3_i,
     AutopilotLaws_P.LowPassFilter_C4_k, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
     &AutopilotLaws_DWork.sf_LeadLagFilter_kq);
-  rtb_Saturation = (rtb_Y_hc + rtb_Saturation) * AutopilotLaws_P.ug_Gain_aa;
-  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_gf * AutopilotLaws_DWork.DelayInput1_DSTATE;
-  rtb_Cos_f2 = rtb_Saturation + rtb_Y_hc;
+  rtb_Saturation = (rtb_Y_f + rtb_Saturation) * AutopilotLaws_P.ug_Gain_aa;
+  rtb_Y_f = AutopilotLaws_P.Gain1_Gain_gf * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Cos_f2 = rtb_Saturation + rtb_Y_f;
   rtb_Cos1_pk = AutopilotLaws_P.Constant3_Value_h1 - AutopilotLaws_P.Constant4_Value_f;
-  rtb_Gain_ar0 = (AutopilotLaws_P.Gain1_Gain_ovr * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_jy;
+  rtb_Gain_ar0 = (AutopilotLaws_P.Gain1_Gain_ovr * rtb_Saturation + rtb_Y_f) * AutopilotLaws_P.Gain_Gain_jy;
   if (rtb_Cos1_pk > AutopilotLaws_P.Switch_Threshold_o) {
     rtb_Saturation = AutopilotLaws_P.Constant1_Value_m5;
   } else {
     rtb_Saturation = AutopilotLaws_P.Gain5_Gain_h * rtb_Gain_ar0;
   }
 
-  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &rtb_Y_hc);
-  rtb_Y_hc = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_hc) * AutopilotLaws_P.Gain1_Gain_dvi;
-  if (rtb_Y_hc <= rtb_Saturation) {
+  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &rtb_Y_f);
+  rtb_Y_f = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_f) * AutopilotLaws_P.Gain1_Gain_dvi;
+  if (rtb_Y_f <= rtb_Saturation) {
     if (rtb_Cos1_pk > AutopilotLaws_P.Switch1_Threshold_c) {
       rtb_Saturation = AutopilotLaws_P.Constant_Value_b;
     } else {
       rtb_Saturation = AutopilotLaws_P.Gain6_Gain_a * rtb_Gain_ar0;
     }
 
-    if (rtb_Y_hc >= rtb_Saturation) {
-      rtb_Saturation = rtb_Y_hc;
+    if (rtb_Y_f >= rtb_Saturation) {
+      rtb_Saturation = rtb_Y_f;
     }
   }
 
@@ -1586,8 +1586,8 @@ void AutopilotLawsModelClass::step()
   rtb_Saturation = AutopilotLaws_P.Gain1_Gain_er * rtb_GainTheta1;
   rtb_Cos_f2 = std::cos(rtb_Saturation);
   rtb_Cos1_pk = std::sin(rtb_Saturation);
-  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_ero * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
-  rtb_Add3_n2 = rtb_Y_hc - AutopilotLaws_P.Gain1_Gain_fl * AutopilotLaws_U.in.data.Psi_magnetic_deg;
+  rtb_Y_f = AutopilotLaws_P.Gain1_Gain_ero * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
+  rtb_Add3_n2 = rtb_Y_f - AutopilotLaws_P.Gain1_Gain_fl * AutopilotLaws_U.in.data.Psi_magnetic_deg;
   rtb_Saturation = AutopilotLaws_P.ktstomps_Gain_a * AutopilotLaws_U.in.data.V_gnd_kn;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_i * (AutopilotLaws_P.GStoGS_CAS_Gain_n * rtb_Saturation),
     AutopilotLaws_P.WashoutFilter_C1_p, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
@@ -1604,28 +1604,28 @@ void AutopilotLawsModelClass::step()
     (AutopilotLaws_P.Gain_Gain_e5 * std::atan(AutopilotLaws_P.fpmtoms_Gain_j * AutopilotLaws_U.in.data.H_dot_ft_min /
     rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_ia - rtb_Cos_f2) + rtb_Cos1_pk * std::sin(rtb_Add3_n2)))),
     AutopilotLaws_P.HighPassFilter_C1_n, AutopilotLaws_P.HighPassFilter_C2_m, AutopilotLaws_P.HighPassFilter_C3_k,
-    AutopilotLaws_P.HighPassFilter_C4_h, AutopilotLaws_U.in.time.dt, &rtb_Y_hc, &AutopilotLaws_DWork.sf_LeadLagFilter_c);
+    AutopilotLaws_P.HighPassFilter_C4_h, AutopilotLaws_U.in.time.dt, &rtb_Y_f, &AutopilotLaws_DWork.sf_LeadLagFilter_c);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_o * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_l, AutopilotLaws_P.LowPassFilter_C2_c, AutopilotLaws_P.LowPassFilter_C3_g,
     AutopilotLaws_P.LowPassFilter_C4_d, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
     &AutopilotLaws_DWork.sf_LeadLagFilter_p);
-  rtb_Saturation = (rtb_Y_hc + rtb_Saturation) * AutopilotLaws_P.ug_Gain_f;
-  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_ot * AutopilotLaws_DWork.DelayInput1_DSTATE;
-  rtb_Cos_f2 = rtb_Saturation + rtb_Y_hc;
+  rtb_Saturation = (rtb_Y_f + rtb_Saturation) * AutopilotLaws_P.ug_Gain_f;
+  rtb_Y_f = AutopilotLaws_P.Gain1_Gain_ot * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Cos_f2 = rtb_Saturation + rtb_Y_f;
   rtb_Cos1_pk = AutopilotLaws_P.Constant1_Value_d - AutopilotLaws_P.Constant2_Value_k;
-  rtb_Y_hc = (AutopilotLaws_P.Gain1_Gain_ou * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_jg;
+  rtb_Y_f = (AutopilotLaws_P.Gain1_Gain_ou * rtb_Saturation + rtb_Y_f) * AutopilotLaws_P.Gain_Gain_jg;
   if (rtb_Cos1_pk > AutopilotLaws_P.Switch_Threshold_a) {
     rtb_Saturation = AutopilotLaws_P.Constant1_Value_mi;
   } else {
-    rtb_Saturation = AutopilotLaws_P.Gain5_Gain_g * rtb_Y_hc;
+    rtb_Saturation = AutopilotLaws_P.Gain5_Gain_g * rtb_Y_f;
   }
 
-  rtb_Gain_ar0 = rtb_Y_n0 * AutopilotLaws_P.Gain1_Gain_gy;
+  rtb_Gain_ar0 = rtb_Y_g * AutopilotLaws_P.Gain1_Gain_gy;
   if (rtb_Gain_ar0 <= rtb_Saturation) {
     if (rtb_Cos1_pk > AutopilotLaws_P.Switch1_Threshold_b) {
       rtb_Saturation = AutopilotLaws_P.Constant_Value_o;
     } else {
-      rtb_Saturation = AutopilotLaws_P.Gain6_Gain_c * rtb_Y_hc;
+      rtb_Saturation = AutopilotLaws_P.Gain6_Gain_c * rtb_Y_f;
     }
 
     if (rtb_Gain_ar0 >= rtb_Saturation) {
@@ -1661,10 +1661,10 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_P.Gain_Gain_hv;
   rtb_Saturation = AutopilotLaws_P.Gain1_Gain_gfa * rtb_GainTheta1;
   rtb_Saturation_c = std::cos(rtb_Saturation);
-  rtb_Y_hc = std::sin(rtb_Saturation);
+  rtb_Y_f = std::sin(rtb_Saturation);
   rtb_Saturation = AutopilotLaws_P.ktstomps_Gain_j * AutopilotLaws_U.in.data.V_gnd_kn;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_kb * (AutopilotLaws_P.GStoGS_CAS_Gain_o5 * rtb_Saturation),
-    AutopilotLaws_P.WashoutFilter_C1_j, AutopilotLaws_U.in.time.dt, &rtb_Y_h, &AutopilotLaws_DWork.sf_WashoutFilter_h);
+    AutopilotLaws_P.WashoutFilter_C1_j, AutopilotLaws_U.in.time.dt, &rtb_Y_d, &AutopilotLaws_DWork.sf_WashoutFilter_h);
   rtb_Gain_ar0 = AutopilotLaws_P.kntoms_Gain_k * AutopilotLaws_U.in.data.V_gnd_kn;
   if (rtb_Gain_ar0 > AutopilotLaws_P.Saturation_UpperSat_pj) {
     rtb_Gain_ar0 = AutopilotLaws_P.Saturation_UpperSat_pj;
@@ -1672,35 +1672,35 @@ void AutopilotLawsModelClass::step()
     rtb_Gain_ar0 = AutopilotLaws_P.Saturation_LowerSat_py;
   }
 
-  AutopilotLaws_LeadLagFilter(rtb_Y_h - AutopilotLaws_P.g_Gain_l * (AutopilotLaws_P.Gain1_Gain_n4 *
+  AutopilotLaws_LeadLagFilter(rtb_Y_d - AutopilotLaws_P.g_Gain_l * (AutopilotLaws_P.Gain1_Gain_n4 *
     (AutopilotLaws_P.Gain_Gain_bc * ((AutopilotLaws_P.Gain1_Gain_ej * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_jv *
     (AutopilotLaws_P.Gain_Gain_bf * std::atan(AutopilotLaws_P.fpmtoms_Gain_f * AutopilotLaws_U.in.data.H_dot_ft_min /
-    rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_l - rtb_Saturation_c) + rtb_Y_hc * std::sin
+    rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_l - rtb_Saturation_c) + rtb_Y_f * std::sin
     (AutopilotLaws_P.Gain1_Gain_j4 * AutopilotLaws_U.in.data.Psi_magnetic_track_deg - AutopilotLaws_P.Gain1_Gain_kw *
      AutopilotLaws_U.in.data.Psi_magnetic_deg)))), AutopilotLaws_P.HighPassFilter_C1_i,
     AutopilotLaws_P.HighPassFilter_C2_h, AutopilotLaws_P.HighPassFilter_C3_m, AutopilotLaws_P.HighPassFilter_C4_n,
     AutopilotLaws_U.in.time.dt, &rtb_Saturation, &AutopilotLaws_DWork.sf_LeadLagFilter_e);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_k * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_l4, AutopilotLaws_P.LowPassFilter_C2_po, AutopilotLaws_P.LowPassFilter_C3_f,
-    AutopilotLaws_P.LowPassFilter_C4_dt, AutopilotLaws_U.in.time.dt, &rtb_Y_h, &AutopilotLaws_DWork.sf_LeadLagFilter_k);
-  rtb_Saturation = (rtb_Saturation + rtb_Y_h) * AutopilotLaws_P.ug_Gain_n;
-  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_b1 * AutopilotLaws_DWork.DelayInput1_DSTATE;
-  rtb_Saturation_c = rtb_Saturation + rtb_Y_hc;
+    AutopilotLaws_P.LowPassFilter_C4_dt, AutopilotLaws_U.in.time.dt, &rtb_Y_d, &AutopilotLaws_DWork.sf_LeadLagFilter_k);
+  rtb_Saturation = (rtb_Saturation + rtb_Y_d) * AutopilotLaws_P.ug_Gain_n;
+  rtb_Y_f = AutopilotLaws_P.Gain1_Gain_b1 * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Saturation_c = rtb_Saturation + rtb_Y_f;
   rtb_Gain_ar0 = AutopilotLaws_P.Constant3_Value_nk - AutopilotLaws_P.Constant4_Value_o;
-  rtb_Y_hc = (AutopilotLaws_P.Gain1_Gain_on * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_hy;
+  rtb_Y_f = (AutopilotLaws_P.Gain1_Gain_on * rtb_Saturation + rtb_Y_f) * AutopilotLaws_P.Gain_Gain_hy;
   if (rtb_Gain_ar0 > AutopilotLaws_P.Switch_Threshold_d) {
     rtb_Saturation = AutopilotLaws_P.Constant1_Value_m;
   } else {
-    rtb_Saturation = AutopilotLaws_P.Gain5_Gain_b * rtb_Y_hc;
+    rtb_Saturation = AutopilotLaws_P.Gain5_Gain_b * rtb_Y_f;
   }
 
-  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &rtb_Y_h);
-  rtb_Gain_dn = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_h) * AutopilotLaws_P.Gain1_Gain_m1;
+  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &rtb_Y_d);
+  rtb_Gain_dn = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_d) * AutopilotLaws_P.Gain1_Gain_m1;
   if (rtb_Gain_dn <= rtb_Saturation) {
     if (rtb_Gain_ar0 > AutopilotLaws_P.Switch1_Threshold_d) {
       rtb_Saturation = AutopilotLaws_P.Constant_Value_p0;
     } else {
-      rtb_Saturation = AutopilotLaws_P.Gain6_Gain_n * rtb_Y_hc;
+      rtb_Saturation = AutopilotLaws_P.Gain6_Gain_n * rtb_Y_f;
     }
 
     if (rtb_Gain_dn >= rtb_Saturation) {
@@ -1728,43 +1728,43 @@ void AutopilotLawsModelClass::step()
   }
 
   rtb_Saturation = AutopilotLaws_P.Gain1_Gain_ky * rtb_GainTheta1;
-  rtb_Y_hc = std::cos(rtb_Saturation);
+  rtb_Y_f = std::cos(rtb_Saturation);
   rtb_Gain_ar0 = std::sin(rtb_Saturation);
   rtb_Saturation = AutopilotLaws_P.ktstomps_Gain_l * AutopilotLaws_U.in.data.V_gnd_kn;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_ip * (AutopilotLaws_P.GStoGS_CAS_Gain_e * rtb_Saturation),
-    AutopilotLaws_P.WashoutFilter_C1_c, AutopilotLaws_U.in.time.dt, &rtb_Y_h, &AutopilotLaws_DWork.sf_WashoutFilter_g5);
-  AutopilotLaws_LeadLagFilter(rtb_Y_h - AutopilotLaws_P.g_Gain_hq * (AutopilotLaws_P.Gain1_Gain_mx *
+    AutopilotLaws_P.WashoutFilter_C1_c, AutopilotLaws_U.in.time.dt, &rtb_Y_d, &AutopilotLaws_DWork.sf_WashoutFilter_g5);
+  AutopilotLaws_LeadLagFilter(rtb_Y_d - AutopilotLaws_P.g_Gain_hq * (AutopilotLaws_P.Gain1_Gain_mx *
     (AutopilotLaws_P.Gain_Gain_d3 * ((AutopilotLaws_P.Gain1_Gain_iw * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_lw *
     (AutopilotLaws_P.Gain_Gain_ej * std::atan(AutopilotLaws_P.fpmtoms_Gain_h * AutopilotLaws_U.in.data.H_dot_ft_min /
-    rtb_Saturation_c))) * (AutopilotLaws_P.Constant_Value_f - rtb_Y_hc) + rtb_Gain_ar0 * std::sin
+    rtb_Saturation_c))) * (AutopilotLaws_P.Constant_Value_f - rtb_Y_f) + rtb_Gain_ar0 * std::sin
     (AutopilotLaws_P.Gain1_Gain_ip * AutopilotLaws_U.in.data.Psi_magnetic_track_deg - AutopilotLaws_P.Gain1_Gain_nrn *
      AutopilotLaws_U.in.data.Psi_magnetic_deg)))), AutopilotLaws_P.HighPassFilter_C1_d,
     AutopilotLaws_P.HighPassFilter_C2_i, AutopilotLaws_P.HighPassFilter_C3_d, AutopilotLaws_P.HighPassFilter_C4_nr,
     AutopilotLaws_U.in.time.dt, &rtb_Saturation, &AutopilotLaws_DWork.sf_LeadLagFilter_j);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_mh * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_e, AutopilotLaws_P.LowPassFilter_C2_i, AutopilotLaws_P.LowPassFilter_C3_o5,
-    AutopilotLaws_P.LowPassFilter_C4_f, AutopilotLaws_U.in.time.dt, &rtb_Y_h, &AutopilotLaws_DWork.sf_LeadLagFilter_a);
-  rtb_Saturation = (rtb_Saturation + rtb_Y_h) * AutopilotLaws_P.ug_Gain_e;
-  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_be1 * AutopilotLaws_DWork.DelayInput1_DSTATE;
-  rtb_Saturation_c = rtb_Saturation + rtb_Y_hc;
+    AutopilotLaws_P.LowPassFilter_C4_f, AutopilotLaws_U.in.time.dt, &rtb_Y_d, &AutopilotLaws_DWork.sf_LeadLagFilter_a);
+  rtb_Saturation = (rtb_Saturation + rtb_Y_d) * AutopilotLaws_P.ug_Gain_e;
+  rtb_Y_f = AutopilotLaws_P.Gain1_Gain_be1 * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Saturation_c = rtb_Saturation + rtb_Y_f;
   rtb_Gain_ar0 = AutopilotLaws_P.Constant1_Value_o - AutopilotLaws_P.Constant2_Value_hd;
-  rtb_Gain_dn = (AutopilotLaws_P.Gain1_Gain_nj * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_aq;
+  rtb_Gain_dn = (AutopilotLaws_P.Gain1_Gain_nj * rtb_Saturation + rtb_Y_f) * AutopilotLaws_P.Gain_Gain_aq;
   if (rtb_Gain_ar0 > AutopilotLaws_P.Switch_Threshold_g) {
     rtb_Saturation = AutopilotLaws_P.Constant1_Value_f;
   } else {
     rtb_Saturation = AutopilotLaws_P.Gain5_Gain_a * rtb_Gain_dn;
   }
 
-  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_fle * rtb_Y_n0;
-  if (rtb_Y_hc <= rtb_Saturation) {
+  rtb_Y_f = AutopilotLaws_P.Gain1_Gain_fle * rtb_Y_g;
+  if (rtb_Y_f <= rtb_Saturation) {
     if (rtb_Gain_ar0 > AutopilotLaws_P.Switch1_Threshold_h) {
       rtb_Saturation = AutopilotLaws_P.Constant_Value_i;
     } else {
       rtb_Saturation = AutopilotLaws_P.Gain6_Gain_g * rtb_Gain_dn;
     }
 
-    if (rtb_Y_hc >= rtb_Saturation) {
-      rtb_Saturation = rtb_Y_hc;
+    if (rtb_Y_f >= rtb_Saturation) {
+      rtb_Saturation = rtb_Y_f;
     }
   }
 
@@ -1784,15 +1784,15 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain4_Gain_g * AutopilotLaws_DWork.DelayInput1_DSTATE,
     rtb_Compare_jy, &rtb_Saturation);
   AutopilotLaws_LagFilter(AutopilotLaws_U.in.data.nav_gs_error_deg, AutopilotLaws_P.LagFilter1_C1_p,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_h, &AutopilotLaws_DWork.sf_LagFilter_cu);
-  rtb_Add3_n2 = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain_o * rtb_Y_h;
+    AutopilotLaws_U.in.time.dt, &rtb_Y_d, &AutopilotLaws_DWork.sf_LagFilter_cu);
+  rtb_Add3_n2 = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain_o * rtb_Y_d;
   AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Add3_n2 - AutopilotLaws_DWork.Delay_DSTATE_n;
   AutopilotLaws_DWork.DelayInput1_DSTATE /= AutopilotLaws_U.in.time.dt;
-  AutopilotLaws_LagFilter(rtb_Y_h + AutopilotLaws_P.Gain3_Gain_n * AutopilotLaws_DWork.DelayInput1_DSTATE,
-    AutopilotLaws_P.LagFilter_C1_m, AutopilotLaws_U.in.time.dt, &rtb_Y_hc, &AutopilotLaws_DWork.sf_LagFilter_j);
+  AutopilotLaws_LagFilter(rtb_Y_d + AutopilotLaws_P.Gain3_Gain_n * AutopilotLaws_DWork.DelayInput1_DSTATE,
+    AutopilotLaws_P.LagFilter_C1_m, AutopilotLaws_U.in.time.dt, &rtb_Y_f, &AutopilotLaws_DWork.sf_LagFilter_j);
   AutopilotLaws_DWork.DelayInput1_DSTATE = look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft,
     AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_ec, AutopilotLaws_P.ScheduledGain_Table_l, 5U);
-  AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain3_Gain_c * (rtb_Saturation + rtb_Y_hc *
+  AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain3_Gain_c * (rtb_Saturation + rtb_Y_f *
     AutopilotLaws_DWork.DelayInput1_DSTATE), (AutopilotLaws_U.in.data.H_radio_ft >
     AutopilotLaws_P.CompareToConstant_const_k) && AutopilotLaws_U.in.data.nav_gs_valid, &rtb_Saturation_c);
   AutopilotLaws_storevalue(rtb_error_d == AutopilotLaws_P.CompareToConstant6_const, AutopilotLaws_Y.out.data.nav_gs_deg,
@@ -1803,37 +1803,37 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_ph;
   }
 
-  rtb_Y_hc = AutopilotLaws_P.kntoms_Gain_k4 * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Y_hc > AutopilotLaws_P.Saturation_UpperSat_eb) {
-    rtb_Y_hc = AutopilotLaws_P.Saturation_UpperSat_eb;
-  } else if (rtb_Y_hc < AutopilotLaws_P.Saturation_LowerSat_gk) {
-    rtb_Y_hc = AutopilotLaws_P.Saturation_LowerSat_gk;
+  rtb_Y_f = AutopilotLaws_P.kntoms_Gain_k4 * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Y_f > AutopilotLaws_P.Saturation_UpperSat_eb) {
+    rtb_Y_f = AutopilotLaws_P.Saturation_UpperSat_eb;
+  } else if (rtb_Y_f < AutopilotLaws_P.Saturation_LowerSat_gk) {
+    rtb_Y_f = AutopilotLaws_P.Saturation_LowerSat_gk;
   }
 
-  rtb_Saturation = std::atan(AutopilotLaws_P.fpmtoms_Gain_g4 * AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Y_hc) *
+  rtb_Saturation = std::atan(AutopilotLaws_P.fpmtoms_Gain_g4 * AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Y_f) *
     AutopilotLaws_P.Gain_Gain_ow;
   AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain2_Gain_l * (AutopilotLaws_DWork.DelayInput1_DSTATE -
-    rtb_Saturation), rtb_Compare_jy, &rtb_Y_hc);
-  AutopilotLaws_Voter1(rtb_Saturation_c + rtb_Y_hc, AutopilotLaws_P.Gain1_Gain_d4 *
+    rtb_Saturation), rtb_Compare_jy, &rtb_Y_f);
+  AutopilotLaws_Voter1(rtb_Saturation_c + rtb_Y_f, AutopilotLaws_P.Gain1_Gain_d4 *
                        ((AutopilotLaws_DWork.DelayInput1_DSTATE + AutopilotLaws_P.Bias_Bias) - rtb_Saturation),
                        AutopilotLaws_P.Gain_Gain_eyl * ((AutopilotLaws_DWork.DelayInput1_DSTATE +
-    AutopilotLaws_P.Bias1_Bias) - rtb_Saturation), &rtb_Y_h);
+    AutopilotLaws_P.Bias1_Bias) - rtb_Saturation), &rtb_Y_d);
   AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_GainTheta - AutopilotLaws_P.Constant2_Value_f;
   rtb_Sum2_p = AutopilotLaws_P.Gain4_Gain_o * AutopilotLaws_DWork.DelayInput1_DSTATE;
   rtb_Gain5_n = AutopilotLaws_P.Gain5_Gain_c * AutopilotLaws_U.in.data.bz_m_s2;
   AutopilotLaws_WashoutFilter(AutopilotLaws_U.in.data.bx_m_s2, AutopilotLaws_P.WashoutFilter_C1_m,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_WashoutFilter_g);
+    AutopilotLaws_U.in.time.dt, &rtb_Y_g, &AutopilotLaws_DWork.sf_WashoutFilter_g);
   AutopilotLaws_WashoutFilter(AutopilotLaws_U.in.data.H_ind_ft, AutopilotLaws_P.WashoutFilter_C1_ej,
     AutopilotLaws_U.in.time.dt, &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_WashoutFilter_b);
   if (AutopilotLaws_U.in.data.H_radio_ft > AutopilotLaws_P.Saturation_UpperSat_e0a) {
-    rtb_Y_hc = AutopilotLaws_P.Saturation_UpperSat_e0a;
+    rtb_Y_f = AutopilotLaws_P.Saturation_UpperSat_e0a;
   } else if (AutopilotLaws_U.in.data.H_radio_ft < AutopilotLaws_P.Saturation_LowerSat_m) {
-    rtb_Y_hc = AutopilotLaws_P.Saturation_LowerSat_m;
+    rtb_Y_f = AutopilotLaws_P.Saturation_LowerSat_m;
   } else {
-    rtb_Y_hc = AutopilotLaws_U.in.data.H_radio_ft;
+    rtb_Y_f = AutopilotLaws_U.in.data.H_radio_ft;
   }
 
-  AutopilotLaws_LagFilter(rtb_Y_hc, AutopilotLaws_P.LagFilter_C1_p, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
+  AutopilotLaws_LagFilter(rtb_Y_f, AutopilotLaws_P.LagFilter_C1_p, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
     &AutopilotLaws_DWork.sf_LagFilter_ov);
   rtb_Saturation_c = (AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_Saturation) *
     AutopilotLaws_P.DiscreteDerivativeVariableTs2_Gain;
@@ -1851,15 +1851,15 @@ void AutopilotLawsModelClass::step()
   }
 
   if ((!AutopilotLaws_DWork.wasActive) && rtb_Compare_jy) {
-    rtb_Y_hc = std::abs(rtb_Saturation) / 60.0;
-    AutopilotLaws_DWork.Tau = AutopilotLaws_U.in.data.H_radio_ft / (rtb_Y_hc - 1.6666666666666667);
-    AutopilotLaws_DWork.H_bias = AutopilotLaws_DWork.Tau * rtb_Y_hc - AutopilotLaws_U.in.data.H_radio_ft;
+    rtb_Y_f = std::abs(rtb_Saturation) / 60.0;
+    AutopilotLaws_DWork.Tau = AutopilotLaws_U.in.data.H_radio_ft / (rtb_Y_f - 1.6666666666666667);
+    AutopilotLaws_DWork.H_bias = AutopilotLaws_DWork.Tau * rtb_Y_f - AutopilotLaws_U.in.data.H_radio_ft;
   }
 
   if (rtb_Compare_jy) {
-    rtb_Y_hc = -1.0 / AutopilotLaws_DWork.Tau * (AutopilotLaws_U.in.data.H_radio_ft + AutopilotLaws_DWork.H_bias) * 60.0;
+    rtb_Y_f = -1.0 / AutopilotLaws_DWork.Tau * (AutopilotLaws_U.in.data.H_radio_ft + AutopilotLaws_DWork.H_bias) * 60.0;
   } else {
-    rtb_Y_hc = rtb_Saturation;
+    rtb_Y_f = rtb_Saturation;
   }
 
   AutopilotLaws_DWork.wasActive = rtb_Compare_jy;
@@ -1870,7 +1870,7 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_an;
   }
 
-  rtb_Gain_ar0 = (rtb_Y_hc - rtb_Saturation) * AutopilotLaws_P.ftmintoms_Gain_j / AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Gain_ar0 = (rtb_Y_f - rtb_Saturation) * AutopilotLaws_P.ftmintoms_Gain_j / AutopilotLaws_DWork.DelayInput1_DSTATE;
   if (rtb_Gain_ar0 > 1.0) {
     rtb_Gain_ar0 = 1.0;
   } else if (rtb_Gain_ar0 < -1.0) {
@@ -1892,8 +1892,8 @@ void AutopilotLawsModelClass::step()
   rtb_Saturation = AutopilotLaws_P.Gain1_Gain_ij * rtb_GainTheta1;
   rtb_GainTheta1 = std::cos(rtb_Saturation);
   rtb_Cos1_k = std::sin(rtb_Saturation);
-  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_ef * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
-  rtb_Add3_d1 = rtb_Y_hc - AutopilotLaws_P.Gain1_Gain_gk * AutopilotLaws_U.in.data.Psi_magnetic_deg;
+  rtb_Y_f = AutopilotLaws_P.Gain1_Gain_ef * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
+  rtb_Add3_d1 = rtb_Y_f - AutopilotLaws_P.Gain1_Gain_gk * AutopilotLaws_U.in.data.Psi_magnetic_deg;
   rtb_Saturation = AutopilotLaws_P.ktstomps_Gain_jr * AutopilotLaws_U.in.data.V_gnd_kn;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_ks * (AutopilotLaws_P.GStoGS_CAS_Gain_n2 * rtb_Saturation),
     AutopilotLaws_P.WashoutFilter_C1_d, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
@@ -1910,39 +1910,38 @@ void AutopilotLawsModelClass::step()
     (AutopilotLaws_P.Gain_Gain_h3 * std::atan(AutopilotLaws_P.fpmtoms_Gain_au * AutopilotLaws_U.in.data.H_dot_ft_min /
     rtb_Gain_ar0))) * (AutopilotLaws_P.Constant_Value_f3 - rtb_GainTheta1) + rtb_Cos1_k * std::sin(rtb_Add3_d1)))),
     AutopilotLaws_P.HighPassFilter_C1_i0, AutopilotLaws_P.HighPassFilter_C2_j, AutopilotLaws_P.HighPassFilter_C3_i,
-    AutopilotLaws_P.HighPassFilter_C4_nm, AutopilotLaws_U.in.time.dt, &rtb_Y_hc,
-    &AutopilotLaws_DWork.sf_LeadLagFilter_oi);
+    AutopilotLaws_P.HighPassFilter_C4_nm, AutopilotLaws_U.in.time.dt, &rtb_Y_f, &AutopilotLaws_DWork.sf_LeadLagFilter_oi);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_il * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_g, AutopilotLaws_P.LowPassFilter_C2_o, AutopilotLaws_P.LowPassFilter_C3_l,
     AutopilotLaws_P.LowPassFilter_C4_p, AutopilotLaws_U.in.time.dt, &rtb_Saturation,
     &AutopilotLaws_DWork.sf_LeadLagFilter_j0);
-  rtb_Saturation = (rtb_Y_hc + rtb_Saturation) * AutopilotLaws_P.ug_Gain_c;
-  rtb_Y_hc = AutopilotLaws_P.Gain1_Gain_ejc * AutopilotLaws_DWork.DelayInput1_DSTATE;
-  rtb_GainTheta1 = rtb_Saturation + rtb_Y_hc;
+  rtb_Saturation = (rtb_Y_f + rtb_Saturation) * AutopilotLaws_P.ug_Gain_c;
+  rtb_Y_f = AutopilotLaws_P.Gain1_Gain_ejc * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_GainTheta1 = rtb_Saturation + rtb_Y_f;
   rtb_Gain_ar0 = AutopilotLaws_P.Constant2_Value_kz - AutopilotLaws_U.in.data.H_ind_ft;
-  rtb_Y_hc = (AutopilotLaws_P.Gain1_Gain_h3 * rtb_Saturation + rtb_Y_hc) * AutopilotLaws_P.Gain_Gain_ox;
+  rtb_Y_f = (AutopilotLaws_P.Gain1_Gain_h3 * rtb_Saturation + rtb_Y_f) * AutopilotLaws_P.Gain_Gain_ox;
   rtb_Saturation = (AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.input.V_c_kn) * AutopilotLaws_P.Gain1_Gain_fo;
-  if ((rtb_Gain_ar0 > AutopilotLaws_P.CompareToConstant_const_h) && (rtb_Y_hc <
+  if ((rtb_Gain_ar0 > AutopilotLaws_P.CompareToConstant_const_h) && (rtb_Y_f <
        AutopilotLaws_P.CompareToConstant1_const_g) && (rtb_Saturation < AutopilotLaws_P.CompareToConstant2_const_m)) {
     rtb_Saturation = AutopilotLaws_P.Constant_Value_gj;
   } else {
     if (rtb_Gain_ar0 > AutopilotLaws_P.Switch2_Threshold_b) {
       rtb_Cos1_k = AutopilotLaws_P.Constant1_Value_mq;
     } else {
-      rtb_Cos1_k = AutopilotLaws_P.Gain5_Gain_k * rtb_Y_hc;
+      rtb_Cos1_k = AutopilotLaws_P.Gain5_Gain_k * rtb_Y_f;
     }
 
     if (rtb_Saturation > rtb_Cos1_k) {
       rtb_Saturation = rtb_Cos1_k;
     } else {
       if (rtb_Gain_ar0 > AutopilotLaws_P.Switch1_Threshold_n) {
-        rtb_Y_hc = std::fmax(AutopilotLaws_P.Constant2_Value_i, AutopilotLaws_P.Gain1_Gain_n * rtb_Y_hc);
+        rtb_Y_f = std::fmax(AutopilotLaws_P.Constant2_Value_i, AutopilotLaws_P.Gain1_Gain_n * rtb_Y_f);
       } else {
-        rtb_Y_hc *= AutopilotLaws_P.Gain6_Gain_o;
+        rtb_Y_f *= AutopilotLaws_P.Gain6_Gain_o;
       }
 
-      if (rtb_Saturation < rtb_Y_hc) {
-        rtb_Saturation = rtb_Y_hc;
+      if (rtb_Saturation < rtb_Y_f) {
+        rtb_Saturation = rtb_Y_f;
       }
     }
   }
@@ -1966,7 +1965,7 @@ void AutopilotLawsModelClass::step()
   }
 
   rtb_Saturation = AutopilotLaws_P.Gain_Gain_o1 * std::asin(rtb_Gain_ar0);
-  AutopilotLaws_Voter1(rtb_Sum_ae, rtb_GainTheta1, rtb_Saturation, &rtb_Y_hc);
+  AutopilotLaws_Voter1(rtb_Sum_ae, rtb_GainTheta1, rtb_Saturation, &rtb_Y_f);
   AutopilotLaws_DWork.DelayInput1_DSTATE = a;
   a = (b_L * AutopilotLaws_P.Gain_Gain_pe + AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain1_Gain_f2;
   switch (static_cast<int32_T>(rtb_error_d)) {
@@ -1994,19 +1993,19 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 6:
-    distance_m = AutopilotLaws_P.Gain1_Gain_d * rtb_Y_h;
+    distance_m = AutopilotLaws_P.Gain1_Gain_d * rtb_Y_d;
     break;
 
    case 7:
     if (rtb_on_ground > AutopilotLaws_P.Switch1_Threshold_j) {
       distance_m = AutopilotLaws_P.Gain2_Gain_h * rtb_Sum2_p;
     } else {
-      distance_m = (AutopilotLaws_P.Gain1_Gain_ix * rtb_Y_n0 + rtb_Gain5_n) + rtb_Gain_n1;
+      distance_m = (AutopilotLaws_P.Gain1_Gain_ix * rtb_Y_g + rtb_Gain5_n) + rtb_Gain_n1;
     }
     break;
 
    case 8:
-    distance_m = rtb_Y_hc;
+    distance_m = rtb_Y_f;
     break;
 
    default:
@@ -2025,7 +2024,10 @@ void AutopilotLawsModelClass::step()
 
   AutopilotLaws_RateLimiter(AutopilotLaws_DWork.DelayInput1_DSTATE - b_R, AutopilotLaws_P.RateLimiterVariableTs1_up,
     AutopilotLaws_P.RateLimiterVariableTs1_lo, AutopilotLaws_U.in.time.dt,
-    AutopilotLaws_P.RateLimiterVariableTs1_InitialCondition, &rtb_Y_hc, &AutopilotLaws_DWork.sf_RateLimiter_a);
+    AutopilotLaws_P.RateLimiterVariableTs1_InitialCondition, &AutopilotLaws_DWork.DelayInput1_DSTATE,
+    &AutopilotLaws_DWork.sf_RateLimiter_h);
+  AutopilotLaws_LagFilter(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.LagFilter_C1_g,
+    AutopilotLaws_U.in.time.dt, &rtb_Y_f, &AutopilotLaws_DWork.sf_LagFilter_p);
   AutopilotLaws_DWork.icLoad_f = ((AutopilotLaws_Y.out.output.ap_on == 0.0) || AutopilotLaws_DWork.icLoad_f);
   if (AutopilotLaws_DWork.icLoad_f) {
     AutopilotLaws_DWork.Delay_DSTATE_h2 = rtb_GainTheta;
@@ -2059,14 +2061,14 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 6:
-    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_h;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_d;
     break;
 
    case 7:
     if (rtb_on_ground > AutopilotLaws_P.Switch_Threshold) {
       AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Sum2_p;
     } else {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_P.Gain3_Gain_l * rtb_Y_n0 + rtb_Gain5_n) +
+      AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_P.Gain3_Gain_l * rtb_Y_g + rtb_Gain5_n) +
         AutopilotLaws_P.VS_Gain_e * rtb_Gain_n1;
     }
     break;
@@ -2110,7 +2112,7 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_i4 - AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE *= rtb_GainTheta;
   AutopilotLaws_DWork.DelayInput1_DSTATE += rtb_GainTheta1;
-  AutopilotLaws_Y.out.output.flight_director.Theta_c_deg = rtb_Y_hc;
+  AutopilotLaws_Y.out.output.flight_director.Theta_c_deg = rtb_Y_f;
   AutopilotLaws_Y.out.output.autopilot.Theta_c_deg = AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_U.in.data.altimeter_setting_left_mbar;
   AutopilotLaws_DWork.DelayInput1_DSTATE_g = AutopilotLaws_U.in.data.altimeter_setting_right_mbar;

--- a/src/fbw/src/model/AutopilotLaws.h
+++ b/src/fbw/src/model/AutopilotLaws.h
@@ -89,6 +89,7 @@ class AutopilotLawsModelClass
     rtDW_WashoutFilter_AutopilotLaws_T sf_WashoutFilter_fs;
     rtDW_LeadLagFilter_AutopilotLaws_T sf_LeadLagFilter_kq;
     rtDW_LeadLagFilter_AutopilotLaws_T sf_LeadLagFilter_b;
+    rtDW_RateLimiter_AutopilotLaws_T sf_RateLimiter_a;
     rtDW_RateLimiter_AutopilotLaws_T sf_RateLimiter_eb;
     rtDW_WashoutFilter_AutopilotLaws_T sf_WashoutFilter_fo;
     rtDW_LagFilter_AutopilotLaws_T sf_LagFilter_gn;
@@ -124,6 +125,7 @@ class AutopilotLawsModelClass
     rtDW_Chart_AutopilotLaws_T sf_Chart_ba;
     rtDW_RateLimiter_AutopilotLaws_T sf_RateLimiter_d;
     rtDW_LagFilter_AutopilotLaws_T sf_LagFilter_o;
+    rtDW_LagFilter_AutopilotLaws_T sf_LagFilter_mp;
     rtDW_storevalue_AutopilotLaws_T sf_storevalue;
     rtDW_Chart_AutopilotLaws_m_T sf_Chart_b;
     rtDW_Chart_AutopilotLaws_m_T sf_Chart_h;
@@ -154,10 +156,11 @@ class AutopilotLawsModelClass
     real_T LagFilter_C1;
     real_T LagFilter2_C1;
     real_T LagFilter_C1_n;
+    real_T LagFilter_C1_a;
     real_T LagFilter1_C1;
     real_T LagFilter_C1_l;
     real_T WashoutFilter_C1;
-    real_T LagFilter_C1_a;
+    real_T LagFilter_C1_ai;
     real_T WashoutFilter_C1_e;
     real_T HighPassFilter_C1;
     real_T LowPassFilter_C1;
@@ -258,6 +261,7 @@ class AutopilotLawsModelClass
     real_T DiscreteDerivativeVariableTs1_InitialCondition;
     real_T DiscreteDerivativeVariableTs_InitialCondition_c;
     real_T DiscreteDerivativeVariableTs2_InitialCondition;
+    real_T RateLimiterVariableTs1_InitialCondition;
     real_T RateLimiterVariableTs_InitialCondition_p;
     real_T DiscreteTimeIntegratorVariableTs_LowerLimit;
     real_T ScheduledGain_Table[3];
@@ -290,10 +294,12 @@ class AutopilotLawsModelClass
     real_T RateLimiterVariableTs_lo;
     real_T RateLimiterVariableTs_lo_k;
     real_T RateLimiterVariableTs_lo_b;
+    real_T RateLimiterVariableTs1_lo;
     real_T RateLimiterVariableTs_lo_o;
     real_T RateLimiterVariableTs_up;
     real_T RateLimiterVariableTs_up_n;
     real_T RateLimiterVariableTs_up_b;
+    real_T RateLimiterVariableTs1_up;
     real_T RateLimiterVariableTs_up_i;
     real_T DetectChange_vinit;
     real_T DetectChange1_vinit;

--- a/src/fbw/src/model/AutopilotLaws.h
+++ b/src/fbw/src/model/AutopilotLaws.h
@@ -89,10 +89,11 @@ class AutopilotLawsModelClass
     rtDW_WashoutFilter_AutopilotLaws_T sf_WashoutFilter_fs;
     rtDW_LeadLagFilter_AutopilotLaws_T sf_LeadLagFilter_kq;
     rtDW_LeadLagFilter_AutopilotLaws_T sf_LeadLagFilter_b;
-    rtDW_RateLimiter_AutopilotLaws_T sf_RateLimiter_a;
+    rtDW_RateLimiter_AutopilotLaws_T sf_RateLimiter_h;
     rtDW_RateLimiter_AutopilotLaws_T sf_RateLimiter_eb;
     rtDW_WashoutFilter_AutopilotLaws_T sf_WashoutFilter_fo;
     rtDW_LagFilter_AutopilotLaws_T sf_LagFilter_gn;
+    rtDW_LagFilter_AutopilotLaws_T sf_LagFilter_p;
     rtDW_WashoutFilter_AutopilotLaws_T sf_WashoutFilter_l;
     rtDW_LeadLagFilter_AutopilotLaws_T sf_LeadLagFilter_j0;
     rtDW_LeadLagFilter_AutopilotLaws_T sf_LeadLagFilter_oi;
@@ -194,6 +195,7 @@ class AutopilotLawsModelClass
     real_T WashoutFilter_C1_d;
     real_T HighPassFilter_C1_i0;
     real_T LowPassFilter_C1_g;
+    real_T LagFilter_C1_g;
     real_T LagFilter_C1_i;
     real_T HighPassFilter_C2;
     real_T LowPassFilter_C2;

--- a/src/fbw/src/model/AutopilotLaws_data.cpp
+++ b/src/fbw/src/model/AutopilotLaws_data.cpp
@@ -246,6 +246,8 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
 
   2.0,
 
+  2.0,
+
   0.0,
 
   0.0,
@@ -450,7 +452,7 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
 
   -10.0,
 
-  -5.0,
+  -15.0,
 
   -10.0,
 
@@ -460,7 +462,7 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
 
   1.0,
 
-  5.0,
+  15.0,
 
   1.0,
 

--- a/src/fbw/src/model/AutopilotLaws_data.cpp
+++ b/src/fbw/src/model/AutopilotLaws_data.cpp
@@ -170,6 +170,8 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
 
   2.0,
 
+  2.0,
+
   1.0,
 
   1.0,
@@ -378,6 +380,8 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
 
   0.0,
 
+  0.0,
+
   -3.0,
 
 
@@ -446,6 +450,8 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
 
   -10.0,
 
+  -5.0,
+
   -10.0,
 
   10.0,
@@ -453,6 +459,8 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
   0.2,
 
   1.0,
+
+  5.0,
 
   1.0,
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->


## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR moves the flight director smoothing from the FlyByWireInterface into the Matlab model.
Also, the smoothing behavior was slightly changed, which means that the lateral FD now uses a lag filter, while the vertical FD uses a rate limiter. This should make them behave closer to real life.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): 

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Fly the aircraft, and observe the behavior of the two FD bars. Compare them to some real-life or level-D sim footage, to determine if they are realistic. Also Test the FD with the TRK/FPA mode enabled.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
