### PR TITLE
fix(mcdu): Display scratchpad colors on remote MCDU

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -112,6 +112,7 @@
 1. [MISC] Fixed flap configuration in final.flt and runway.flt files -  @donstim (donbikes#4084)
 1. [EFB] Added Reset to Defaults button to EFB throttle calibration page - @frankkopp (Cdr_Maverick#6475)
 1. [BLEED] Fix potential NaN calculations for fast flows - @Crocket63
+1. [MCDU] Fixed scratchpad colors showing incorrectly on remote MCDU - @Stemis
 
 ## 0.7.0
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -1542,7 +1542,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
                     this._labels[5],
                     this._lines[5],
                 ],
-                scratchpad: this.scratchpad._displayUnit._scratchpadElement.textContent,
+                scratchpad: `{${this.scratchpad._displayUnit._scratchpadElement.className}}${this.scratchpad._displayUnit._scratchpadElement.textContent}{end}`,
                 title: this._title,
                 titleLeft: `{small}${this._titleLeft}{end}`,
                 page: this._pageCount > 0 ? `{small}${this._pageCurrent}/${this._pageCount}{end}` : '',


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #6481 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The scratchpad color was not passed on to the remote MCDU over the websocket connection.
This is now added.
The message over the websocket is now `{amber}ENTER DEST DATA{end}` instead of just `ENTER DEST DATA` 
This should fix the color issue on the remote MCDU 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
**Before screenshots**
Check: #6481 
**After screenshots**
Remote MCDU
![Screenshot 2022-01-07 203450](https://user-images.githubusercontent.com/4124979/148598440-4aaa9d56-669a-4c1c-b52f-c96d6a7f6b3a.png)
**In-game MCDU**
![Screenshot 2022-01-07 203433](https://user-images.githubusercontent.com/4124979/148598477-283d7cce-2b3d-4510-a2e2-69af3ae38873.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Delota#1404

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Start a flight with the remote MCDU
2. Climb to your CRZ alt
3. Wait for the `ENTER DEST DATA` message to pop up
4. Compare the color of the MCDU message with the color of the remote MCDU message.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
