### PR TITLE
fix(atsu): don't include airport as waypoint in route uplink

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -113,6 +113,7 @@
 1. [EFB] Added Reset to Defaults button to EFB throttle calibration page - @frankkopp (Cdr_Maverick#6475)
 1. [BLEED] Fix potential NaN calculations for fast flows - @Crocket63
 1. [Hyd] Reservoirs connected to pneumatics and first failures - @Crocket63
+1. [ATSU] Don't include airport as a waypoint in route uplink - @tracernz (Mike)
 
 ## 0.7.0
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_ATSU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_ATSU.js
@@ -345,6 +345,9 @@ const uplinkRoute = async (mcdu) => {
             continue;
         } else {
             if (fix.via_airway === 'DCT') {
+                if (fix.type === 'apt' && nextFix === undefined) {
+                    break;
+                }
                 console.log("Inserting waypoint: " + fix.ident);
                 await addWaypointAsync(fix, mcdu, fix.ident);
                 continue;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes an issue reported a few times on Discord, but no bug recorded that I could find.
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Simbrief includes the destination airport as the last waypoint in the flight plan. We have logic that filters out waypoints that are part of a SID or STAR, which normally excludes it, but if your flight plan doesn't have a STAR the airport ends up being inserted, and then when you select an approach in-sim it goes after the airport waypoint. Now we filter an airport waypoint that is the last in the flightplan.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Route: YSSY/34L WOL2 WOL H20 NWA DCT URBOB DCT MER DCT YMER/03
Before:
![image](https://user-images.githubusercontent.com/9995998/149097294-64555ec5-522c-4c4c-97d0-eee0281d9214.png)
After:
![image](https://user-images.githubusercontent.com/9995998/149097362-0eb7ed7e-2889-4aef-96b7-69b651f2a0c1.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Import SimBrief routes with no STAR, check that the destination airport doesn't get added as part of the route (it will still get added as the destination). Check routes with SID/STAR as well to be sure all is well.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
