### PR TITLE
fix: Fixed input for ICAO on EFB dashboard to avoid key press leaks to sim

### DIFF
--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -4,6 +4,7 @@ import { Metar } from '@flybywiresim/api-client';
 import { IconWind, IconGauge, IconDroplet, IconTemperature, IconPoint, IconCloud } from '@tabler/icons';
 import { MetarParserType, Wind } from '../../../Common/metarTypes';
 import { usePersistentProperty } from '../../../Common/persistence';
+import SimpleInput from '../../Components/Form/SimpleInput/SimpleInput';
 
 const MetarParserTypeWindState: Wind = {
     degrees: 0,
@@ -80,10 +81,10 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
 
     const source = metarSource;
 
-    const handleIcao = (event: { target: { value: React.SetStateAction<string>; }; }) => {
-        if (event.target.value.length === 4) {
-            getMetar(event.target.value, source);
-        } else if (event.target.value.length === 0) {
+    const handleIcao = (icao: string) => {
+        if (icao.length === 4) {
+            getMetar(icao, source);
+        } else if (icao.length === 0) {
             getMetar(props.icao, source);
         }
     };
@@ -119,11 +120,11 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
                                 <div className="ml-8">
                                     <IconCloud size={35} stroke={1.5} strokeLinejoin="miter" />
                                 </div>
-                                <input
+                                <SimpleInput
+                                    noLabel
                                     className="text-left ml-4 border-none focus:outline-none text-2xl bg-transparent font-medium uppercase"
-                                    type="text"
                                     placeholder={props.icao}
-                                    onChange={handleIcao}
+                                    onChange={(event) => handleIcao(event)}
                                     maxLength={4}
                                 />
                             </div>

--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -122,7 +122,7 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
                                 </div>
                                 <SimpleInput
                                     noLabel
-                                    className="text-left ml-4 border-none focus:outline-none text-2xl bg-transparent font-medium uppercase"
+                                    className="text-center w-24 ml-4 text-2xl font-medium uppercase"
                                     placeholder={props.icao}
                                     onChange={(event) => handleIcao(event)}
                                     maxLength={4}

--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -124,7 +124,7 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
                                     noLabel
                                     className="text-center w-24 ml-4 text-2xl font-medium uppercase"
                                     placeholder={props.icao}
-                                    onChange={(event) => handleIcao(event)}
+                                    onChange={(value) => handleIcao(value)}
                                     maxLength={4}
                                 />
                             </div>


### PR DESCRIPTION
Fixes #6524

## Summary of Changes
Changed input component on EFB dashboard weather widget for ICAO input. 

- Used SimpleInput instead to prevent leaking key presses to the sim. 
- Added input box around ICAO in EFB dashboard weather widget to signifying that an input can be made


## Screenshots (if necessary)
See issue https://github.com/flybywiresim/a32nx/issues/6524

![image](https://user-images.githubusercontent.com/16833201/149152586-a4d10438-44de-4276-9669-da89623f7862.png)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Start flight anywhere
Turn on EFB and enter an ICAO (or any value) into the airport ICAO fields ("----").
Make sure that no input is leaked to the sim. 
Examples: 
"L" in the sim should trigger lights on/off - should not trigger it while in ICAO input field
"O" in the sim should trigger Strobes on/off - should not trigger it while in ICAO input field

Test flight plan import and any other related option to see if you can break it. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
