### PR TITLE
fix(gear): add missing aircraft variables

### DIFF
--- a/src/systems/a320_systems_wasm/src/lib.rs
+++ b/src/systems/a320_systems_wasm/src/lib.rs
@@ -124,6 +124,8 @@ async fn systems(mut gauge: msfs::Gauge) -> Result<(), Box<dyn Error>> {
             .provides_aircraft_variable("GEAR ANIMATION POSITION", "Percent", 1)?
             .provides_aircraft_variable("GEAR ANIMATION POSITION", "Percent", 2)?
             .provides_aircraft_variable("GEAR CENTER POSITION", "Percent", 0)?
+            .provides_aircraft_variable("GEAR LEFT POSITION", "Percent", 0)?
+            .provides_aircraft_variable("GEAR RIGHT POSITION", "Percent", 0)?
             .provides_aircraft_variable("GEAR HANDLE POSITION", "Bool", 0)?
             .provides_aircraft_variable_with_additional_names(
                 "GENERAL ENG MASTER ALTERNATOR",


### PR DESCRIPTION
## Summary of Changes
Two aircraft variables were missing, causing unexpected behaviour within the aircraft system simulation.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
