### PR TITLE
fix(hyd): Increased default reservoir air pressure values

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -113,9 +113,9 @@
 1. [EFB] Added Reset to Defaults button to EFB throttle calibration page - @frankkopp (Cdr_Maverick#6475)
 1. [HYD] Added more accurate simulation model of PTU - @Gurgel100 (Pascal)
 1. [BLEED] Fix potential NaN calculations for fast flows - @Crocket63
-1. [Hyd] Reservoirs connected to pneumatics and first failures - @Crocket63
+1. [HYD] Reservoirs connected to pneumatics and first failures - @Crocket63
 1. [ATSU] Don't include airport as a waypoint in route uplink - @tracernz (Mike)
-1. [Hyd] Increased reservoirs air pressure to avoid low air fault on pumps - @Crocket63
+1. [HYD] Increased reservoirs air pressure to avoid low air fault on pumps - @Crocket63
 
 ## 0.7.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -115,6 +115,7 @@
 1. [BLEED] Fix potential NaN calculations for fast flows - @Crocket63
 1. [Hyd] Reservoirs connected to pneumatics and first failures - @Crocket63
 1. [ATSU] Don't include airport as a waypoint in route uplink - @tracernz (Mike)
+1. [Hyd] Increased reservoirs air pressure to avoid low air fault on pumps - @Crocket63
 
 ## 0.7.0
 

--- a/src/systems/a320_systems/src/pneumatic.rs
+++ b/src/systems/a320_systems/src/pneumatic.rs
@@ -157,7 +157,7 @@ impl A320Pneumatic {
                 HydraulicColor::Green,
                 VariableVolumeContainer::new(
                     Volume::new::<gallon>(2.5),
-                    Pressure::new::<psi>(43.5),
+                    Pressure::new::<psi>(50.),
                     ThermodynamicTemperature::new::<degree_celsius>(15.),
                 ),
                 Pressure::new::<psi>(70.),
@@ -167,7 +167,7 @@ impl A320Pneumatic {
                 HydraulicColor::Blue,
                 VariableVolumeContainer::new(
                     Volume::new::<gallon>(1.1),
-                    Pressure::new::<psi>(42.1),
+                    Pressure::new::<psi>(50.),
                     ThermodynamicTemperature::new::<degree_celsius>(15.),
                 ),
                 Pressure::new::<psi>(70.),
@@ -177,7 +177,7 @@ impl A320Pneumatic {
                 HydraulicColor::Yellow,
                 VariableVolumeContainer::new(
                     Volume::new::<gallon>(1.7),
-                    Pressure::new::<psi>(45.4),
+                    Pressure::new::<psi>(50.),
                     ThermodynamicTemperature::new::<degree_celsius>(15.),
                 ),
                 Pressure::new::<psi>(70.),


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Starting state of air pressure in hydraulic reservoir was a bit low as in a long cold start case, it could cause blue pump fault depending on local atmospheric pressure.

We called the maintenance crew and now they have pressurised all 3 reservoirs to 50 psi.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

No fault appears on pumps be it on cold start or runway start.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
