### PR TITLE
fix(efb): fix faa taf option to match fbw api

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -115,6 +115,7 @@
 1. [BLEED] Fix potential NaN calculations for fast flows - @Crocket63
 1. [Hyd] Reservoirs connected to pneumatics and first failures - @Crocket63
 1. [ATSU] Don't include airport as a waypoint in route uplink - @tracernz (Mike)
+1. [EFB] Fix FAA TAF option - @tracernz (Mike)
 
 ## 0.7.0
 

--- a/src/instruments/src/EFB/Settings/Settings.tsx
+++ b/src/instruments/src/EFB/Settings/Settings.tsx
@@ -549,7 +549,7 @@ const ATSUAOCPage = () => {
     ];
 
     const metarSourceButtons: ButtonType[] = [
-        { name: 'MeteoBlue', setting: 'MSFS' },
+        { name: 'Microsoft', setting: 'MSFS' },
         { name: 'PilotEdge', setting: 'PILOTEDGE' },
         { name: 'IVAO', setting: 'IVAO' },
         { name: 'VATSIM', setting: 'VATSIM' },

--- a/src/instruments/src/EFB/Settings/Settings.tsx
+++ b/src/instruments/src/EFB/Settings/Settings.tsx
@@ -556,7 +556,7 @@ const ATSUAOCPage = () => {
     ];
 
     const tafSourceButtons: ButtonType[] = [
-        { name: 'IVAO', setting: 'IVAO' },
+        { name: 'FAA', setting: 'FAA' },
         { name: 'NOAA', setting: 'NOAA' },
     ];
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #6396.

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The EFB TAF options do not match what is available from our API. I have always thought that TAFs just weren't available for the airports I fly in/out of... until I had a play with the API's swagger web UI, and it worked. So then I look at the TAF options available in the EFB and they do not match the API! This is fixed.

While at it I also fixed #6396.

EFB:
https://github.com/flybywiresim/a32nx/blob/f808039638890cba8a27195b9617929971bd9c7e/src/instruments/src/EFB/Settings/Settings.tsx#L558-L561

Note the NOAA setting, and some others, are mapped to different names in the ATSU before they hit the API because it's boring without a few layers of indirection:
 https://github.com/flybywiresim/a32nx/blob/f808039638890cba8a27195b9617929971bd9c7e/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_ATSU.js#L2-L9

API:
https://github.com/flybywiresim/api/blob/b670bb1ef989106a95ceeafa7973796e8c19f3cf/src/taf/taf.service.ts#L25-L31
```ts
      switch (source?.toLowerCase()) {
      case 'aviationweather':
      default:
          return this.handleAviationWeather(icaoCode).toPromise();
      case 'faa':
          return this.handleFaa(icaoCode);
      }
```

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before:
![image](https://user-images.githubusercontent.com/9995998/149534611-25f4b07c-c44e-4d5d-b64f-98c3bd340d28.png)
After:
![image](https://user-images.githubusercontent.com/9995998/149533632-81316e5c-a3fd-452e-a157-8e310b2d68ed.png)
vs. ifis.airways.co.nz
```
TAF NZQN 141110Z 1412/1506
VRB02KT 20KM SKC
BECMG 1420/1422 25010KT
BECMG 1503/1505 18015KT
2000FT WIND 15010KT
BECMG 1418/1420 VRB05KT =
```
![image](https://user-images.githubusercontent.com/9995998/149533780-b4387516-a537-4625-89ea-ab7ed502d752.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Check that you can get TAFs. The FAA source seems to have a very wide range available... IVAO not so much.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
