### PR TITLE
feat: improve mid-air state initialization for landing challenges and missions

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_Core.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_Core.js
@@ -4,6 +4,11 @@ class A32NX_Core {
     constructor() {
         this.modules = [
             {
+                name: 'StateInitializer',
+                module: new A32NX_StateInitializer(),
+                updateInterval: 250,
+            },
+            {
                 name: 'ADIRS',
                 module: new A32NX_ADIRS(),
                 updateInterval: 100,

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_StateInitializer.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_StateInitializer.js
@@ -1,0 +1,64 @@
+class A32NX_StateInitializer {
+    constructor() {
+        this.autobrakeLevel = null;
+        this.selectedSpeed = null;
+        this.selectedAlt = null;
+    }
+
+    init() {
+        this.autobrakeLevel = SimVar.GetSimVarValue("L:A32NX_STATE_INIT_AUTOBRK_LVL", "Number");
+        this.selectedSpeed = SimVar.GetSimVarValue("L:A32NX_STATE_INIT_SELECTED_SPEED", "Number");
+        this.selectedAlt = Math.max(2000, SimVar.GetSimVarValue("L:A32NX_STATE_INIT_SELECTED_ALT", "Number"));
+    }
+
+    update() {
+        const active = SimVar.GetSimVarValue("L:A32NX_STATE_INIT_ACTIVE", "Bool");
+        if (active === 1) {
+            SimVar.SetSimVarValue("K:FREEZE_LATITUDE_LONGITUDE_SET", "number", 1);
+            SimVar.SetSimVarValue("K:FREEZE_ALTITUDE_SET", "number", 1);
+            SimVar.SetSimVarValue("K:FREEZE_ATTITUDE_SET", "number", 1);
+
+            const athr = SimVar.GetSimVarValue("L:A32NX_AUTOTHRUST_STATUS", "Number");
+
+            if (athr === 0) {
+                if (this.autobrakeLevel === 1) {
+                    SimVar.SetSimVarValue("L:A32NX_OVHD_AUTOBRK_LOW_ON_IS_PRESSED", "Number", 1).then(() => {
+                        SimVar.SetSimVarValue("L:A32NX_OVHD_AUTOBRK_LOW_ON_IS_PRESSED", "Number", 0);
+                    });
+                } else if (this.autobrakeLevel === 2) {
+                    SimVar.SetSimVarValue("L:A32NX_OVHD_AUTOBRK_MED_ON_IS_PRESSED", "Number", 1).then(() => {
+                        SimVar.SetSimVarValue("L:A32NX_OVHD_AUTOBRK_MED_ON_IS_PRESSED", "Number", 0);
+                    });
+                } else if (this.autobrakeLevel === 3) {
+                    SimVar.SetSimVarValue("L:A32NX_OVHD_AUTOBRK_MAX_ON_IS_PRESSED", "Number", 1).then(() => {
+                        SimVar.SetSimVarValue("L:A32NX_OVHD_AUTOBRK_MAX_ON_IS_PRESSED", "Number", 0);
+                    });
+                }
+
+                SimVar.SetSimVarValue("K:3:AP_ALT_VAR_SET_ENGLISH", "number", this.selectedAlt);
+                SimVar.SetSimVarValue("L:A32NX_AUTOTHRUST_TLA:1", "Number", 45);
+                SimVar.SetSimVarValue("L:A32NX_AUTOTHRUST_TLA:2", "Number", 45);
+            } else if (athr === 1) {
+                this.setClimbThrust().then(() => {
+                    SimVar.SetSimVarValue("L:A320_Neo_FCU_SPEED_SET_DATA", "Number", this.selectedSpeed).then(() => {
+                        SimVar.SetSimVarValue("H:A320_Neo_FCU_SPEED_SET", "Number", 1).then(() => {
+                            SimVar.SetSimVarValue("H:A320_Neo_FCU_SPEED_PULL", "Number", 1).then(() => {
+                                console.log("A32NX_StateInitializer: Finished setting all speed variables.");
+                            });
+                        });
+                    });
+                });
+            } else if (athr === 2 && SimVar.GetSimVarValue("L:A32NX_AUTOPILOT_SPEED_SELECTED", "Number") === this.selectedSpeed && SimVar.GetSimVarValue("L:A32NX_AUTOTHRUST_MODE", "Number") === 7) {
+                SimVar.SetSimVarValue("L:A32NX_STATE_INIT_ACTIVE", "Bool", 0);
+                SimVar.SetSimVarValue("K:FREEZE_LATITUDE_LONGITUDE_TOGGLE", "number", 1);
+                SimVar.SetSimVarValue("K:FREEZE_ALTITUDE_TOGGLE", "number", 1);
+                SimVar.SetSimVarValue("K:FREEZE_ATTITUDE_TOGGLE", "number", 1);
+            }
+        }
+    }
+
+    async setClimbThrust() {
+        await SimVar.SetSimVarValue("L:A32NX_AUTOTHRUST_TLA:1", "Number", 25);
+        await SimVar.SetSimVarValue("L:A32NX_AUTOTHRUST_TLA:2", "Number", 25);
+    }
+}

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU.html
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU.html
@@ -136,6 +136,7 @@
 
 <script type="text/html" import-script="/Pages/A32NX_Core/math.js"></script>
 
+<script type="text/html" import-script="/Pages/A32NX_Core/A32NX_StateInitializer.js"></script>
 <script type="text/html" import-script="/Pages/A32NX_Core/A32NX_Speeds.js"></script>
 <script type="text/html" import-script="/Pages/A32NX_Core/A32NX_SoundManager.js"></script>
 <script type="text/html" import-script="/Pages/A32NX_Core/A32NX_BaroSelector.js"></script>

--- a/src/systems/a320_systems_wasm/src/lib.rs
+++ b/src/systems/a320_systems_wasm/src/lib.rs
@@ -272,12 +272,16 @@ impl MsfsAspectCtor for Flaps {
                 right_slat: 0.,
             },
 
-            flaps_handle_position: 0,
-            left_flaps_position: 0.,
-            right_flaps_position: 0.,
+            flaps_handle_position: NamedVariable::from("A32NX_FLAPS_HANDLE_INDEX").get_value(),
+            left_flaps_position: NamedVariable::from("A32NX_LEFT_FLAPS_POSITION_PERCENT")
+                .get_value(),
+            right_flaps_position: NamedVariable::from("A32NX_RIGHT_FLAPS_POSITION_PERCENT")
+                .get_value(),
 
-            left_slats_position: 0.,
-            right_slats_position: 0.,
+            left_slats_position: NamedVariable::from("A32NX_LEFT_SLATS_POSITION_PERCENT")
+                .get_value(),
+            right_slats_position: NamedVariable::from("A32NX_RIGHT_SLATS_POSITION_PERCENT")
+                .get_value(),
         })
     }
 }


### PR DESCRIPTION
Adds support for proper flap, autothrust and autobrake initialization when spawning mid-air for landing challenges

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
