### PR TITLE
fix: no ground spoiler compensation in C* law

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -126,6 +126,7 @@
 1. [AP] Do not disengage SRS on RTO, engage it only in FLX detent when FLX is configured - @aguther (Andreas Guther)
 1. [ATHR] Improved thrust limits, FLX limits now CLB when entered into FMGC - @aguther (Andreas Guther)
 1. [AP] Improved LOC ALGIN and ROLL OUT during Autoland - @aguther (Andreas Guther)
+1. [FBW] Fix: do not compensate ground spoilers in C* law - @aguther (Andreas Guther)
 
 ## 0.7.0
 

--- a/src/fbw/src/model/FlyByWire.cpp
+++ b/src/fbw/src/model/FlyByWire.cpp
@@ -1133,7 +1133,8 @@ void FlyByWireModelClass::step()
   rtb_Limiterxi = ((((rtb_Sum1_a - FlyByWire_DWork.Delay_DSTATE_ca) / FlyByWire_U.in.time.dt * FlyByWire_P.Gain3_Gain_l
                      + rtb_Limiterxi * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.PLUT_bp01Data,
     FlyByWire_P.PLUT_tableData, 1U)) + (rtb_Divide1 - FlyByWire_DWork.Delay_DSTATE_jv) / FlyByWire_U.in.time.dt) +
-                   FlyByWire_P.Gain_Gain_o * rtb_LimiteriH) + FlyByWire_P.Gain1_Gain_l * rtb_Y_p;
+                   FlyByWire_P.Gain_Gain_o * rtb_LimiteriH) + rtb_Y_p * look1_binlxpw(FlyByWire_U.in.data.H_radio_ft,
+    FlyByWire_P.ScheduledGain_BreakpointsForDimension1, FlyByWire_P.ScheduledGain_Table, 3U);
   if (L_xi > FlyByWire_P.Saturation3_UpperSat_c) {
     L_xi = FlyByWire_P.Saturation3_UpperSat_c;
   } else if (L_xi < FlyByWire_P.Saturation3_LowerSat_h) {
@@ -1149,7 +1150,7 @@ void FlyByWireModelClass::step()
   rtb_Limiterxi = (FlyByWire_P.Constant_Value_p - rtb_Limiterxi1) * rtb_Limiterxi + L_xi * rtb_Limiterxi1;
   FlyByWire_Y.out.pitch.law_normal.nz_c_g = rtb_Switch_c;
   rtb_alpha_err_gain = rtb_Limiterxi * look1_binlxpw(FlyByWire_U.in.time.dt,
-    FlyByWire_P.ScheduledGain_BreakpointsForDimension1, FlyByWire_P.ScheduledGain_Table, 4U);
+    FlyByWire_P.ScheduledGain_BreakpointsForDimension1_c, FlyByWire_P.ScheduledGain_Table_p, 4U);
   FlyByWire_Y.out.pitch.law_normal.Cstar_g = rtb_uDLookupTable_g;
   rtb_Switch_c = FlyByWire_P.DiscreteTimeIntegratorVariableTs_Gain_k * rtb_alpha_err_gain * FlyByWire_U.in.time.dt;
   FlyByWire_DWork.icLoad_e = ((rtb_Y_f == 0.0) || (rtb_alpha_floor_inhib != 0) || FlyByWire_DWork.icLoad_e);
@@ -1409,7 +1410,7 @@ void FlyByWireModelClass::step()
   }
 
   L_xi = (rtb_Gain - std::sin(FlyByWire_P.Gain1_Gain_f * rtb_uDLookupTable_g) * FlyByWire_P.Constant2_Value_p * std::cos
-          (FlyByWire_P.Gain1_Gain_lc * rtb_GainTheta) / (FlyByWire_P.Gain6_Gain_k * L_xi) * FlyByWire_P.Gain_Gain_i3) *
+          (FlyByWire_P.Gain1_Gain_l * rtb_GainTheta) / (FlyByWire_P.Gain6_Gain_k * L_xi) * FlyByWire_P.Gain_Gain_i3) *
     look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.ScheduledGain_BreakpointsForDimension1_a,
                   FlyByWire_P.ScheduledGain_Table_e, 6U);
   rtb_Limiterxi = rtb_Gain * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn,
@@ -1463,8 +1464,8 @@ void FlyByWireModelClass::step()
   FlyByWire_LagFilter((rtb_Switch_c - L_xi) * look1_binlxpw(FlyByWire_U.in.data.V_ias_kn,
     FlyByWire_P.ScheduledGain1_BreakpointsForDimension1_a, FlyByWire_P.ScheduledGain1_Table_o, 4U) - Vtas,
                       FlyByWire_P.LagFilter_C1_e, FlyByWire_U.in.time.dt, &rtb_Y_p, &FlyByWire_DWork.sf_LagFilter_e);
-  L_xi = rtb_Switch_c * look1_binlxpw(FlyByWire_U.in.data.V_ias_kn, FlyByWire_P.ScheduledGain_BreakpointsForDimension1_c,
-    FlyByWire_P.ScheduledGain_Table_d, 8U) + rtb_Y_p;
+  L_xi = rtb_Switch_c * look1_binlxpw(FlyByWire_U.in.data.V_ias_kn,
+    FlyByWire_P.ScheduledGain_BreakpointsForDimension1_cf, FlyByWire_P.ScheduledGain_Table_d, 8U) + rtb_Y_p;
   if (L_xi > FlyByWire_P.Saturation_UpperSat_p4) {
     L_xi = FlyByWire_P.Saturation_UpperSat_p4;
   } else if (L_xi < FlyByWire_P.Saturation_LowerSat_he) {

--- a/src/fbw/src/model/FlyByWire.h
+++ b/src/fbw/src/model/FlyByWire.h
@@ -151,12 +151,13 @@ class FlyByWireModelClass
 
   struct Parameters_FlyByWire_T {
     fbw_output fbw_output_MATLABStruct;
-    real_T ScheduledGain_BreakpointsForDimension1[5];
+    real_T ScheduledGain_BreakpointsForDimension1[4];
+    real_T ScheduledGain_BreakpointsForDimension1_c[5];
     real_T ScheduledGain_BreakpointsForDimension1_j[5];
     real_T ScheduledGain_BreakpointsForDimension1_a[7];
     real_T ScheduledGain1_BreakpointsForDimension1[7];
     real_T ScheduledGain_BreakpointsForDimension1_jh[4];
-    real_T ScheduledGain_BreakpointsForDimension1_c[9];
+    real_T ScheduledGain_BreakpointsForDimension1_cf[9];
     real_T ScheduledGain1_BreakpointsForDimension1_a[5];
     real_T LagFilter_C1;
     real_T LagFilter_C1_a;
@@ -231,7 +232,8 @@ class FlyByWireModelClass
     real_T DiscreteTimeIntegratorVariableTs_LowerLimit_b;
     real_T DiscreteTimeIntegratorVariableTs_LowerLimit_c;
     real_T DiscreteTimeIntegratorVariableTs1_LowerLimit;
-    real_T ScheduledGain_Table[5];
+    real_T ScheduledGain_Table[4];
+    real_T ScheduledGain_Table_p[5];
     real_T ScheduledGain_Table_i[5];
     real_T ScheduledGain_Table_e[7];
     real_T ScheduledGain1_Table[7];
@@ -473,7 +475,6 @@ class FlyByWireModelClass
     real_T Gain_Gain_o;
     real_T SaturationSpoilers_UpperSat;
     real_T SaturationSpoilers_LowerSat;
-    real_T Gain1_Gain_l;
     real_T Saturation_UpperSat_j;
     real_T Saturation_LowerSat_c;
     real_T Switch_Threshold_d;
@@ -511,7 +512,7 @@ class FlyByWireModelClass
     real_T Gain_Gain_p;
     real_T Constant2_Value_p;
     real_T Gain1_Gain_f;
-    real_T Gain1_Gain_lc;
+    real_T Gain1_Gain_l;
     real_T Saturation_UpperSat_ek;
     real_T Saturation_LowerSat_j;
     real_T Gain6_Gain_k;

--- a/src/fbw/src/model/FlyByWire_data.cpp
+++ b/src/fbw/src/model/FlyByWire_data.cpp
@@ -194,6 +194,9 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P{
   },
 
 
+  { 0.0, 50.0, 100.0, 200.0 },
+
+
   { 0.0, 0.06, 0.1, 0.2, 1.0 },
 
 
@@ -359,6 +362,9 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P{
   -67.0,
 
   -20.0,
+
+
+  { 0.0, 0.0, -30.0, -30.0 },
 
 
   { 1.0, 1.0, 0.5, 0.3, 0.3 },
@@ -894,8 +900,6 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P{
   1.0,
 
   -1.0,
-
-  -30.0,
 
   30.0,
 


### PR DESCRIPTION
## Summary of Changes
Recently, a compensation for spoilers has been added to the C* law. This should not happen for ground spoilers to avoid a pitch up moment on landing. This PR removes this compensation.

## Testing instructions
- Do several landings with ground spoilers armed

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
