### PR TITLE
feat(lnav): DME arc support

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "webpack-dev-server": "^3.11.1"
   },
   "dependencies": {
+    "msfs-geo": "^0.1.0-alpha3",
     "@flybywiresim/api-client": "^0.13.0",
     "@flybywiresim/react-components": "^0.3.1",
     "@flybywiresim/tailwind-config": "^0.5.0",

--- a/src/fmgc/src/flightplanning/LegsProcedure.ts
+++ b/src/fmgc/src/flightplanning/LegsProcedure.ts
@@ -124,6 +124,9 @@ export class LegsProcedure {
           } else {
               try {
                   switch (currentLeg.type) {
+                  case LegType.AF:
+                      mappedLeg = this.mapArcToFix(currentLeg, this._previousFix);
+                      break;
                   case LegType.CD:
                       mappedLeg = this.mapHeadingUntilDistanceFromOrigin(currentLeg, this._previousFix);
                       break;
@@ -415,6 +418,20 @@ export class LegsProcedure {
 
       const coordinates = Avionics.Utils.bearingDistanceToCoordinates(leg.theta, leg.rho / 1852, origin.lat, origin.lon);
       return this.buildWaypoint(`${originIdent}${Math.trunc(leg.rho / 1852)}`, coordinates);
+  }
+
+  public mapArcToFix(leg: RawProcedureLeg, prevLeg: WayPoint): WayPoint {
+      const toFix = this._facilities.get(leg.fixIcao);
+      const navaid = this._facilities.get(leg.originIcao);
+
+      const waypoint = RawDataMapper.toWaypoint(toFix, this._instrument);
+
+      waypoint.additionalData.navaid = { lat: navaid.lat, long: navaid.lon };
+      waypoint.additionalData.rho = leg.rho / 1852;
+      waypoint.additionalData.theta = leg.theta;
+      waypoint.additionalData.vectorsCourse = leg.course;
+
+      return waypoint;
   }
 
   public mapRadiusToFix(leg: RawProcedureLeg): WayPoint {

--- a/src/fmgc/src/guidance/ControlLaws.ts
+++ b/src/fmgc/src/guidance/ControlLaws.ts
@@ -1,3 +1,8 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
 /**
  * This enum represents a Control Law selected by the guidance system.
  */
@@ -22,11 +27,17 @@ export enum ControlLaw {
 export type HeadingGuidance = {
     law: ControlLaw.HEADING,
     heading: Degrees;
+
+    /** Only for RAD */
+    phiCommand?: Degrees;
 }
 
 export type TrackGuidance = {
     law: ControlLaw.TRACK,
     course: Degrees;
+
+    /** Only for RAD */
+    phiCommand?: Degrees;
 }
 
 export type LateralPathGuidance = {

--- a/src/fmgc/src/guidance/Geometry.ts
+++ b/src/fmgc/src/guidance/Geometry.ts
@@ -1,3 +1,8 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
 import { Transition } from '@fmgc/guidance/lnav/Transition';
 import { FixedRadiusTransition } from '@fmgc/guidance/lnav/transitions/FixedRadiusTransition';
 import { TFLeg } from '@fmgc/guidance/lnav/legs/TF';
@@ -244,7 +249,7 @@ export class Geometry {
                 + `PHI ${(guidanceParams as LateralPathGuidance).phiCommand?.toFixed(5) ?? '(NO DATA)'}\n`
                 + '---\n'
                 + `CURR GUIDABLE ${activeGuidable?.repr ?? '---'}\n`
-                + `CURR GUIDABLE DTG ${dtg.toFixed(3)}\n`
+                + `CURR GUIDABLE DTG ${dtg?.toFixed(3) ?? '---'}\n`
                 + ((activeGuidable instanceof DirectToFixTransition) ? `DFX STATE ${DirectToFixTransitionGuidanceState[(activeGuidable as DirectToFixTransition).state]}\n` : '')
                 + '---\n'
                 + `RAD GUIDABLE ${nextGuidable?.repr ?? '---'}\n`

--- a/src/fmgc/src/guidance/GuidanceManager.ts
+++ b/src/fmgc/src/guidance/GuidanceManager.ts
@@ -1,3 +1,8 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
 import { HALeg, HFLeg, HMLeg } from '@fmgc/guidance/lnav/legs/HX';
 import { RFLeg } from '@fmgc/guidance/lnav/legs/RF';
 import { TFLeg } from '@fmgc/guidance/lnav/legs/TF';
@@ -15,6 +20,7 @@ import { CFLeg } from '@fmgc/guidance/lnav/legs/CF';
 import { CRLeg } from '@fmgc/guidance/lnav/legs/CR';
 import { CILeg } from '@fmgc/guidance/lnav/legs/CI';
 import { XFLeg } from '@fmgc/guidance/lnav/legs/XF';
+import { AFLeg } from '@fmgc/guidance/lnav/legs/AF';
 import { FlightPlanManager, FlightPlans } from '../flightplanning/FlightPlanManager';
 import { Geometry } from './Geometry';
 
@@ -68,6 +74,10 @@ export class GuidanceManager {
         }
 
         if (to.additionalData) {
+            if (to.additionalData.legType === LegType.AF) {
+                return new AFLeg(to, to.additionalData.navaid, to.additionalData.rho, to.additionalData.theta, to.additionalData.vectorsCourse, segment);
+            }
+
             if (to.additionalData.legType === LegType.CF) {
                 return new CFLeg(to, to.additionalData.course, segment);
             }

--- a/src/fmgc/src/guidance/lnav/LnavDriver.ts
+++ b/src/fmgc/src/guidance/lnav/LnavDriver.ts
@@ -1,3 +1,8 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
 import { ControlLaw, LateralMode, VerticalMode } from '@shared/autopilot';
 import { MathUtils } from '@shared/MathUtils';
 import { Geometry } from '@fmgc/guidance/Geometry';
@@ -223,7 +228,7 @@ export class LnavDriver implements GuidanceComponent {
 
                     break;
                 case ControlLaw.HEADING:
-                    const { heading } = params;
+                    const { heading, phiCommand: forcedPhiHeading } = params;
 
                     if (!this.lastAvail) {
                         SimVar.SetSimVarValue('L:A32NX_FG_AVAIL', 'Bool', true);
@@ -264,7 +269,12 @@ export class LnavDriver implements GuidanceComponent {
                             this.lastTAE = deltaHeading;
                         }
 
-                        if (this.lastPhi !== 0) {
+                        if (forcedPhiHeading !== undefined) {
+                            if (forcedPhiHeading !== this.lastPhi) {
+                                SimVar.SetSimVarValue('L:A32NX_FG_PHI_COMMAND', 'degree', forcedPhiHeading);
+                                this.lastPhi = forcedPhiHeading;
+                            }
+                        } else if (this.lastPhi !== 0) {
                             SimVar.SetSimVarValue('L:A32NX_FG_PHI_COMMAND', 'degree', 0);
                             this.lastPhi = 0;
                         }
@@ -272,7 +282,7 @@ export class LnavDriver implements GuidanceComponent {
 
                     break;
                 case ControlLaw.TRACK:
-                    const { course } = params;
+                    const { course, phiCommand: forcedPhiCourse } = params;
 
                     if (!this.lastAvail) {
                         SimVar.SetSimVarValue('L:A32NX_FG_AVAIL', 'Bool', true);
@@ -309,7 +319,12 @@ export class LnavDriver implements GuidanceComponent {
                             this.lastTAE = deltaCourse;
                         }
 
-                        if (this.lastPhi !== 0) {
+                        if (forcedPhiCourse !== undefined) {
+                            if (forcedPhiCourse !== this.lastPhi) {
+                                SimVar.SetSimVarValue('L:A32NX_FG_PHI_COMMAND', 'degree', forcedPhiCourse);
+                                this.lastPhi = forcedPhiCourse;
+                            }
+                        } else if (this.lastPhi !== 0) {
                             SimVar.SetSimVarValue('L:A32NX_FG_PHI_COMMAND', 'degree', 0);
                             this.lastPhi = 0;
                         }

--- a/src/fmgc/src/guidance/lnav/TransitionPicker.ts
+++ b/src/fmgc/src/guidance/lnav/TransitionPicker.ts
@@ -1,3 +1,8 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
 import { Leg } from '@fmgc/guidance/lnav/legs/Leg';
 import { CALeg } from '@fmgc/guidance/lnav/legs/CA';
 import { DFLeg } from '@fmgc/guidance/lnav/legs/DF';
@@ -14,9 +19,14 @@ import { HoldEntryTransition } from '@fmgc/guidance/lnav/transitions/HoldEntryTr
 import { CFLeg } from '@fmgc/guidance/lnav/legs/CF';
 import { CRLeg } from '@fmgc/guidance/lnav/legs/CR';
 import { CILeg } from '@fmgc/guidance/lnav/legs/CI';
+import { AFLeg } from '@fmgc/guidance/lnav/legs/AF';
+import { DmeArcTransition } from '@fmgc/guidance/lnav/transitions/DmeArcTransition';
 
 export class TransitionPicker {
     static forLegs(from: Leg, to: Leg): Transition | null {
+        if (from instanceof AFLeg) {
+            return TransitionPicker.fromAF(from, to);
+        }
         if (from instanceof CALeg) {
             return TransitionPicker.fromCA(from, to);
         }
@@ -82,7 +92,41 @@ export class TransitionPicker {
         return null;
     }
 
+    private static fromAF(from: AFLeg, to: Leg): Transition | null {
+        if (to instanceof CALeg) {
+            return new CourseCaptureTransition(from, to);
+        }
+        if (to instanceof CFLeg) {
+            // FIXME fixed radius / revert to path capture
+            return new DmeArcTransition(from, to);
+        }
+        if (to instanceof CILeg) {
+            return new CourseCaptureTransition(from, to);
+        }
+        if (to instanceof CRLeg) {
+            return new CourseCaptureTransition(from, to);
+        }
+        if (to instanceof HALeg || to instanceof HFLeg || to instanceof HMLeg) {
+            return new HoldEntryTransition(from, to);
+        }
+        if (to instanceof TFLeg) {
+            return new DmeArcTransition(from, to);
+        }
+        if (to instanceof VMLeg) {
+            return new CourseCaptureTransition(from, to);
+        }
+
+        if (DEBUG) {
+            console.error(`Illegal sequence AFLEg -> ${to.constructor.name}`);
+        }
+
+        return null;
+    }
+
     private static fromCF(from: CFLeg, to: Leg): Transition | null {
+        if (to instanceof AFLeg) {
+            return new DmeArcTransition(from, to);
+        }
         if (to instanceof CALeg) {
             return new CourseCaptureTransition(from, to);
         }
@@ -117,6 +161,9 @@ export class TransitionPicker {
     }
 
     private static fromCI(from: CILeg, to: Leg): Transition | null {
+        if (to instanceof AFLeg) {
+            return new DmeArcTransition(from, to);
+        }
         if (to instanceof CFLeg) {
             return new FixedRadiusTransition(from, to);
         }
@@ -129,6 +176,9 @@ export class TransitionPicker {
     }
 
     private static fromDF(from: DFLeg, to: Leg): Transition | null {
+        if (to instanceof AFLeg) {
+            return new DmeArcTransition(from, to);
+        }
         if (to instanceof CALeg) {
             return new CourseCaptureTransition(from, to);
         }
@@ -162,6 +212,9 @@ export class TransitionPicker {
     }
 
     private static fromHX(from: HALeg | HFLeg |HMLeg, to: Leg): Transition | null {
+        if (to instanceof AFLeg) {
+            return new PathCaptureTransition(from, to);
+        }
         if (to instanceof CALeg) {
             return new CourseCaptureTransition(from, to);
         }
@@ -210,6 +263,9 @@ export class TransitionPicker {
     }
 
     private static fromTF(from: TFLeg, to: Leg): Transition | null {
+        if (to instanceof AFLeg) {
+            return new DmeArcTransition(from, to);
+        }
         if (to instanceof CALeg) {
             return new CourseCaptureTransition(from, to);
         }

--- a/src/fmgc/src/guidance/lnav/TransitionPicker.ts
+++ b/src/fmgc/src/guidance/lnav/TransitionPicker.ts
@@ -98,7 +98,7 @@ export class TransitionPicker {
         }
         if (to instanceof CFLeg) {
             // FIXME fixed radius / revert to path capture
-            return new DmeArcTransition(from, to);
+            return new PathCaptureTransition(from, to);
         }
         if (to instanceof CILeg) {
             return new CourseCaptureTransition(from, to);

--- a/src/fmgc/src/guidance/lnav/legs/AF.ts
+++ b/src/fmgc/src/guidance/lnav/legs/AF.ts
@@ -1,0 +1,175 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
+import { XFLeg } from '@fmgc/guidance/lnav/legs/XF';
+import { SegmentType } from '@fmgc/flightplanning/FlightPlanSegment';
+import { arcDistanceToGo, arcGuidance } from '@fmgc/guidance/lnav/CommonGeometry';
+import { Coordinates } from '@fmgc/flightplanning/data/geo';
+import { GuidanceParameters } from '@fmgc/guidance/ControlLaws';
+import { Guidable } from '@fmgc/guidance/Guidable';
+import { DmeArcTransition } from '@fmgc/guidance/lnav/transitions/DmeArcTransition';
+import { MathUtils } from '@shared/MathUtils';
+import { Geo } from '@fmgc/utils/Geo';
+import { TurnDirection } from '@fmgc/types/fstypes/FSEnums';
+import {
+    AltitudeConstraint,
+    getAltitudeConstraintFromWaypoint,
+    getSpeedConstraintFromWaypoint,
+    SpeedConstraint,
+} from '@fmgc/guidance/lnav/legs/index';
+import { LnavConfig } from '@fmgc/guidance/LnavConfig';
+import { PathVector, PathVectorType } from '../PathVector';
+
+export class AFLeg extends XFLeg {
+    predictedPath: PathVector[] = [];
+
+    constructor(
+        fix: WayPoint,
+        private navaid: Coordinates,
+        private rho: NauticalMiles,
+        private theta: NauticalMiles,
+        private boundaryRadial: NauticalMiles,
+        segment: SegmentType,
+    ) {
+        super(fix);
+
+        this.segment = segment;
+
+        this.centre = navaid;
+        this.radius = this.rho;
+        this.terminationRadial = this.theta;
+        this.bearing = Avionics.Utils.clampAngle(Geo.getGreatCircleBearing(this.centre, this.fix.infos.coordinates) + 90 * this.turnDirectionSign);
+        this.startPoint = Geo.computeDestinationPoint(this.centre, this.radius, this.boundaryRadial);
+        this.endPoint = Geo.computeDestinationPoint(this.centre, this.radius, this.terminationRadial);
+
+        this.inboundCourse = this.boundaryRadial + 90 * this.turnDirectionSign;
+        this.outboundCourse = this.terminationRadial + 90 * this.turnDirectionSign;
+    }
+
+    get altitudeConstraint(): AltitudeConstraint | undefined {
+        return getAltitudeConstraintFromWaypoint(this.fix);
+    }
+
+    get speedConstraint(): SpeedConstraint | undefined {
+        return getSpeedConstraintFromWaypoint(this.fix);
+    }
+
+    private previousGuidable: Guidable | undefined
+
+    private nextGuidable: Guidable | undefined
+
+    readonly centre: Coordinates | undefined
+
+    private readonly terminationRadial: DegreesTrue | undefined;
+
+    private readonly bearing: DegreesTrue | undefined
+
+    private readonly startPoint: Coordinates | undefined
+
+    private readonly endPoint: Coordinates | undefined
+
+    readonly radius: NauticalMiles | undefined
+
+    private sweepAngle: Degrees | undefined
+
+    private clockwise: boolean | undefined
+
+    inboundCourse: DegreesTrue | undefined
+
+    outboundCourse: DegreesTrue | undefined
+
+    getPathStartPoint(): Coordinates | undefined {
+        return this.previousGuidable instanceof DmeArcTransition ? this.previousGuidable.getPathEndPoint() : this.startPoint;
+    }
+
+    getPathEndPoint(): Coordinates | undefined {
+        if (this.nextGuidable instanceof DmeArcTransition && this.nextGuidable.isComputed) {
+            return this.nextGuidable.getPathStartPoint();
+        }
+
+        return this.endPoint;
+    }
+
+    recomputeWithParameters(_isActive: boolean, _tas: Knots, _gs: Knots, _ppos: Coordinates, _trueTrack: DegreesTrue, previousGuidable: Guidable, nextGuidable: Guidable) {
+        this.previousGuidable = previousGuidable;
+        this.nextGuidable = nextGuidable;
+
+        this.sweepAngle = MathUtils.diffAngle(Geo.getGreatCircleBearing(this.centre, this.getPathStartPoint()), Geo.getGreatCircleBearing(this.centre, this.getPathEndPoint()));
+        this.clockwise = this.sweepAngle > 0;
+
+        this.predictedPath.length = 0;
+        this.predictedPath.push({
+            type: PathVectorType.Arc,
+            startPoint: this.getPathStartPoint(),
+            centrePoint: this.centre,
+            endPoint: this.getPathEndPoint(),
+            sweepAngle: this.sweepAngle,
+        });
+
+        if (LnavConfig.DEBUG_PREDICTED_PATH) {
+            this.predictedPath.push(
+                {
+                    type: PathVectorType.DebugPoint,
+                    startPoint: this.getPathStartPoint(),
+                    annotation: 'AF ITP',
+                },
+                {
+                    type: PathVectorType.DebugPoint,
+                    startPoint: this.getPathEndPoint(),
+                    annotation: 'AF FTP',
+                },
+            );
+        }
+    }
+
+    public get turnDirectionSign(): 1 | -1 {
+        if (this.fix.turnDirection !== TurnDirection.Right && this.fix.turnDirection !== TurnDirection.Left) {
+            throw new Error('AFLeg found without specific turnDirection');
+        }
+
+        return this.fix.turnDirection === TurnDirection.Left ? -1 : 1;
+    }
+
+    get startsInCircularArc(): boolean {
+        return true;
+    }
+
+    get endsInCircularArc(): boolean {
+        return true;
+    }
+
+    getNominalRollAngle(gs: MetresPerSecond): Degrees | undefined {
+        const gsMs = gs * (463 / 900);
+        return (this.clockwise ? 1 : -1) * Math.atan((gsMs ** 2) / (this.radius * 1852 * 9.81)) * (180 / Math.PI);
+    }
+
+    getGuidanceParameters(ppos: Coordinates, trueTrack: Degrees): GuidanceParameters | undefined {
+        return arcGuidance(ppos, trueTrack, this.getPathStartPoint(), this.centre, this.sweepAngle);
+    }
+
+    getDistanceToGo(ppos: Coordinates): NauticalMiles | undefined {
+        return arcDistanceToGo(ppos, this.getPathStartPoint(), this.centre, this.sweepAngle);
+    }
+
+    isAbeam(ppos: Coordinates): boolean {
+        const bearingPpos = Avionics.Utils.computeGreatCircleHeading(
+            this.centre,
+            ppos,
+        );
+
+        const bearingFrom = Avionics.Utils.computeGreatCircleHeading(
+            this.centre,
+            this.getPathStartPoint(),
+        );
+
+        const trackAngleError = this.clockwise ? Avionics.Utils.diffAngle(bearingFrom, bearingPpos) : Avionics.Utils.diffAngle(bearingPpos, bearingFrom);
+
+        return trackAngleError >= 0;
+    }
+
+    get repr(): string {
+        return `AF(${this.radius.toFixed(1)}NM) TO ${this.fix.ident}`;
+    }
+}

--- a/src/fmgc/src/guidance/lnav/legs/CI.ts
+++ b/src/fmgc/src/guidance/lnav/legs/CI.ts
@@ -1,3 +1,8 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
 import { AltitudeConstraint, SpeedConstraint } from '@fmgc/guidance/lnav/legs/index';
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
 import { Guidable } from '@fmgc/guidance/Guidable';
@@ -8,9 +13,9 @@ import { Geo } from '@fmgc/utils/Geo';
 import { LnavConfig } from '@fmgc/guidance/LnavConfig';
 import { Leg } from '@fmgc/guidance/lnav/legs/Leg';
 import { IFLeg } from '@fmgc/guidance/lnav/legs/IF';
-import { XFLeg } from '@fmgc/guidance/lnav/legs/XF';
 import { TurnDirection } from '@fmgc/types/fstypes/FSEnums';
 import { FixedRadiusTransition } from '@fmgc/guidance/lnav/transitions/FixedRadiusTransition';
+import { DmeArcTransition } from '@fmgc/guidance/lnav/transitions/DmeArcTransition';
 import { PathVector, PathVectorType } from '../PathVector';
 
 export class CILeg extends Leg {
@@ -58,6 +63,10 @@ export class CILeg extends Leg {
 
     getPathEndPoint(): Coordinates | undefined {
         if (this.outboundGuidable instanceof FixedRadiusTransition && !this.outboundGuidable.isReverted && this.outboundGuidable.isComputed) {
+            return this.outboundGuidable.getPathStartPoint();
+        }
+
+        if (this.outboundGuidable instanceof DmeArcTransition && this.outboundGuidable.isComputed) {
             return this.outboundGuidable.getPathStartPoint();
         }
 

--- a/src/fmgc/src/guidance/lnav/legs/DF.ts
+++ b/src/fmgc/src/guidance/lnav/legs/DF.ts
@@ -1,3 +1,8 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
 import { AltitudeConstraint, SpeedConstraint } from '@fmgc/guidance/lnav/legs/index';
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
 import { Guidable } from '@fmgc/guidance/Guidable';
@@ -26,14 +31,6 @@ export class DFLeg extends XFLeg {
 
     getPathStartPoint(): Coordinates | undefined {
         return this.inboundGuidable?.getPathEndPoint() ?? this.estimateStartPoint();
-    }
-
-    getPathEndPoint(): Coordinates | undefined {
-        if (this.outboundGuidable instanceof FixedRadiusTransition && !this.outboundGuidable.isReverted && this.outboundGuidable.isComputed) {
-            return this.outboundGuidable.getTurningPoints()[0];
-        }
-
-        return this.fix.infos.coordinates;
     }
 
     get predictedPath(): PathVector[] {

--- a/src/fmgc/src/guidance/lnav/legs/XF.ts
+++ b/src/fmgc/src/guidance/lnav/legs/XF.ts
@@ -1,8 +1,14 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
 import { Leg } from '@fmgc/guidance/lnav/legs/Leg';
 import { TurnDirection } from '@fmgc/types/fstypes/FSEnums';
 import { FixedRadiusTransition } from '@fmgc/guidance/lnav/transitions/FixedRadiusTransition';
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
 import { Guidable } from '@fmgc/guidance/Guidable';
+import { DmeArcTransition } from '@fmgc/guidance/lnav/transitions/DmeArcTransition';
 
 export abstract class XFLeg extends Leg {
     protected constructor(
@@ -19,6 +25,10 @@ export abstract class XFLeg extends Leg {
 
     getPathEndPoint(): Coordinates | undefined {
         if (this.outboundGuidable instanceof FixedRadiusTransition && !this.outboundGuidable.isReverted && this.outboundGuidable.isComputed) {
+            return this.outboundGuidable.getPathStartPoint();
+        }
+
+        if (this.outboundGuidable instanceof DmeArcTransition && this.outboundGuidable.isComputed) {
             return this.outboundGuidable.getPathStartPoint();
         }
 

--- a/src/fmgc/src/guidance/lnav/transitions/CourseCaptureTransition.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/CourseCaptureTransition.ts
@@ -1,3 +1,8 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
 import { MathUtils } from '@shared/MathUtils';
 import { CALeg } from '@fmgc/guidance/lnav/legs/CA';
 import { DFLeg } from '@fmgc/guidance/lnav/legs/DF';
@@ -14,12 +19,13 @@ import { PathVector, PathVectorType } from '@fmgc/guidance/lnav/PathVector';
 import { Guidable } from '@fmgc/guidance/Guidable';
 import { TurnDirection } from '@fmgc/types/fstypes/FSEnums';
 import { LnavConfig } from '@fmgc/guidance/LnavConfig';
+import { AFLeg } from '@fmgc/guidance/lnav/legs/AF';
 import { arcDistanceToGo, maxBank } from '../CommonGeometry';
 import { CFLeg } from '../legs/CF';
 import { CRLeg } from '../legs/CR';
 import { CILeg } from '../legs/CI';
 
-type PrevLeg = /* AFLeg | */ CALeg | /* CDLeg | */ CFLeg | CRLeg | DFLeg | /* | FALeg | FMLeg | */ HALeg | HFLeg | HMLeg | RFLeg | TFLeg | /* VALeg | VDLeg | */ VMLeg;
+type PrevLeg = AFLeg | CALeg | /* CDLeg | */ CFLeg | CRLeg | DFLeg | /* | FALeg | FMLeg | */ HALeg | HFLeg | HMLeg | RFLeg | TFLeg | /* VALeg | VDLeg | */ VMLeg;
 type NextLeg = CALeg | /* CDLeg | */ CILeg | CRLeg | /* VALeg | VDLeg | VILeg | */ VMLeg;
 
 const tan = (input: Degrees) => Math.tan(input * (Math.PI / 180));

--- a/src/fmgc/src/guidance/lnav/transitions/DmeArcTransition.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/DmeArcTransition.ts
@@ -1,0 +1,230 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
+import { Transition } from '@fmgc/guidance/lnav/Transition';
+import { AFLeg } from '@fmgc/guidance/lnav/legs/AF';
+import { TFLeg } from '@fmgc/guidance/lnav/legs/TF';
+import { DFLeg } from '@fmgc/guidance/lnav/legs/DF';
+import { CILeg } from '@fmgc/guidance/lnav/legs/CI';
+import { CFLeg } from '@fmgc/guidance/lnav/legs/CF';
+import { arcDistanceToGo, arcGuidance, maxBank } from '@fmgc/guidance/lnav/CommonGeometry';
+import { Coordinates } from '@fmgc/flightplanning/data/geo';
+import { MathUtils } from '@shared/MathUtils';
+import { Geo } from '@fmgc/utils/Geo';
+import { Guidable } from '@fmgc/guidance/Guidable';
+import { closestSmallCircleIntersection } from 'msfs-geo';
+import { PathVector, pathVectorLength, PathVectorType } from '@fmgc/guidance/lnav/PathVector';
+import { GuidanceParameters } from '@fmgc/guidance/ControlLaws';
+import { CALeg } from '@fmgc/guidance/lnav/legs/CA';
+import { LnavConfig } from '@fmgc/guidance/LnavConfig';
+
+export type DmeArcTransitionPreviousLeg = AFLeg /* | CDLeg */ | CFLeg | CILeg | DFLeg | TFLeg; /* | VILeg | VDLeg */
+export type DmeArcTransitionNextLeg = AFLeg | CALeg | CFLeg /* | FALeg | FMLeg */ | TFLeg;
+
+const tan = (input: Degrees) => Math.tan(input * (Math.PI / 180));
+
+export class DmeArcTransition extends Transition {
+    predictedPath: PathVector[] = [];
+
+    constructor(
+        previousLeg: DmeArcTransitionPreviousLeg,
+        nextLeg: DmeArcTransitionNextLeg,
+    ) {
+        super();
+        this.previousLeg = previousLeg;
+        this.nextLeg = nextLeg;
+    }
+
+    getPathStartPoint(): Coordinates | undefined {
+        return this.itp;
+    }
+
+    getPathEndPoint(): Coordinates | undefined {
+        return this.ftp;
+    }
+
+    private radius: NauticalMiles | undefined
+
+    private itp: Coordinates | undefined
+
+    private centre: Coordinates | undefined
+
+    private ftp: Coordinates | undefined
+
+    private sweepAngle: Degrees | undefined
+
+    private clockwise: boolean | undefined
+
+    recomputeWithParameters(_isActive: boolean, tas: Knots, gs: MetresPerSecond, _ppos: Coordinates, _trueTrack: DegreesTrue, _previousGuidable: Guidable, _nextGuidable: Guidable) {
+        this.radius = (gs ** 2 / (9.81 * tan(maxBank(tas, true))) / 6080.2);
+
+        if (this.previousLeg instanceof AFLeg) {
+            const turnDirection = Math.sign(MathUtils.diffAngle(this.previousLeg.outboundCourse, this.nextLeg.inboundCourse));
+            const nextLegReference = this.nextLeg.getPathStartPoint(); // FIXME FX legs
+            const reference = Geo.computeDestinationPoint(nextLegReference, this.radius, this.nextLeg.inboundCourse + 90 * turnDirection);
+            const dme = this.previousLeg.centre;
+
+            const turnCentre = closestSmallCircleIntersection(
+                dme,
+                this.previousLeg.radius + this.radius * turnDirection * -this.previousLeg.turnDirectionSign,
+                reference,
+                this.nextLeg.inboundCourse - 180,
+            );
+
+            if (!turnCentre) {
+                throw new Error('AFLeg did not intersect with previous leg offset reference');
+            }
+
+            this.centre = turnCentre;
+
+            this.itp = Geo.computeDestinationPoint(
+                turnCentre,
+                this.radius,
+                turnDirection * -this.previousLeg.turnDirectionSign === 1 ? Geo.getGreatCircleBearing(turnCentre, dme) : Geo.getGreatCircleBearing(dme, turnCentre),
+            );
+            this.ftp = Geo.computeDestinationPoint(
+                turnCentre,
+                this.radius,
+                this.nextLeg.inboundCourse - 90 * turnDirection,
+            );
+
+            this.sweepAngle = MathUtils.diffAngle(Geo.getGreatCircleBearing(turnCentre, this.itp), Geo.getGreatCircleBearing(turnCentre, this.ftp));
+            this.clockwise = this.sweepAngle > 0;
+
+            this.predictedPath.length = 0;
+            this.predictedPath.push({
+                type: PathVectorType.Arc,
+                startPoint: this.itp,
+                centrePoint: turnCentre,
+                endPoint: this.ftp,
+                sweepAngle: this.sweepAngle,
+            });
+
+            this.isComputed = true;
+
+            if (LnavConfig.DEBUG_PREDICTED_PATH) {
+                this.addDebugPoints();
+            }
+        } else if (this.nextLeg instanceof AFLeg) {
+            const turnDirection = Math.sign(MathUtils.diffAngle(this.previousLeg.outboundCourse, this.nextLeg.inboundCourse));
+            const reference = Geo.computeDestinationPoint(this.previousLeg.getPathEndPoint(), this.radius, this.previousLeg.outboundCourse + 90 * turnDirection);
+            const dme = this.nextLeg.centre;
+
+            const turnCentre = closestSmallCircleIntersection(
+                dme,
+                this.nextLeg.radius + this.radius * turnDirection * -this.nextLeg.turnDirectionSign,
+                reference,
+                this.previousLeg.outboundCourse,
+            );
+
+            if (!turnCentre) {
+                throw new Error('AFLeg did not intersect with previous leg offset reference');
+            }
+
+            this.centre = turnCentre;
+
+            this.itp = Geo.computeDestinationPoint(
+                turnCentre,
+                this.radius,
+                this.previousLeg.outboundCourse - 90 * turnDirection,
+            );
+            this.ftp = Geo.computeDestinationPoint(
+                turnCentre,
+                this.radius,
+                turnDirection * -this.nextLeg.turnDirectionSign === 1 ? Geo.getGreatCircleBearing(turnCentre, dme) : Geo.getGreatCircleBearing(dme, turnCentre),
+            );
+
+            this.sweepAngle = MathUtils.diffAngle(Geo.getGreatCircleBearing(turnCentre, this.itp), Geo.getGreatCircleBearing(turnCentre, this.ftp));
+            this.clockwise = this.sweepAngle > 0;
+
+            this.predictedPath.length = 0;
+            this.predictedPath.push({
+                type: PathVectorType.Arc,
+                startPoint: this.itp,
+                centrePoint: turnCentre,
+                endPoint: this.ftp,
+                sweepAngle: this.sweepAngle,
+            });
+
+            this.isComputed = true;
+
+            if (LnavConfig.DEBUG_PREDICTED_PATH) {
+                this.addDebugPoints();
+            }
+        }
+    }
+
+    private addDebugPoints() {
+        if (this.itp && this.centre && this.ftp) {
+            this.predictedPath.push(
+                {
+                    type: PathVectorType.DebugPoint,
+                    startPoint: this.itp,
+                    annotation: 'DME TRANS ITP',
+                },
+                {
+                    type: PathVectorType.DebugPoint,
+                    startPoint: this.centre,
+                    annotation: 'DME TRANS C',
+                },
+                {
+                    type: PathVectorType.DebugPoint,
+                    startPoint: this.ftp,
+                    annotation: 'DME TRANS FTP',
+                },
+            );
+        }
+    }
+
+    getTurningPoints(): [Coordinates, Coordinates] {
+        return [this.itp, this.ftp];
+    }
+
+    get distance(): NauticalMiles {
+        return pathVectorLength(this.predictedPath[0]); // FIXME HAX
+    }
+
+    get startsInCircularArc(): boolean {
+        return true;
+    }
+
+    get endsInCircularArc(): boolean {
+        return true;
+    }
+
+    getNominalRollAngle(gs: MetresPerSecond): Degrees | undefined {
+        const gsMs = gs * (463 / 900);
+        return (this.clockwise ? 1 : -1) * Math.atan((gsMs ** 2) / (this.radius * 1852 * 9.81)) * (180 / Math.PI);
+    }
+
+    getGuidanceParameters(ppos: Coordinates, trueTrack: Degrees): GuidanceParameters | undefined {
+        return arcGuidance(ppos, trueTrack, this.getPathStartPoint(), this.centre, this.sweepAngle);
+    }
+
+    getDistanceToGo(ppos: Coordinates): NauticalMiles | undefined {
+        return arcDistanceToGo(ppos, this.getPathStartPoint(), this.centre, this.sweepAngle);
+    }
+
+    isAbeam(ppos: Coordinates): boolean {
+        const turningPoints = this.getTurningPoints();
+        if (!turningPoints) {
+            return false;
+        }
+
+        const [inbound, outbound] = turningPoints;
+
+        const inBearingAc = Avionics.Utils.computeGreatCircleHeading(inbound, ppos);
+        const inHeadingAc = Math.abs(MathUtils.diffAngle(this.previousLeg.outboundCourse, inBearingAc));
+
+        const outBearingAc = Avionics.Utils.computeGreatCircleHeading(outbound, ppos);
+        const outHeadingAc = Math.abs(MathUtils.diffAngle(this.nextLeg.inboundCourse, outBearingAc));
+
+        return inHeadingAc <= 90 && outHeadingAc >= 90;
+    }
+
+    get repr(): string {
+        return `DME(${this.previousLeg.repr}, ${this.nextLeg.repr})`;
+    }
+}

--- a/src/fmgc/src/guidance/lnav/transitions/HoldEntryTransition.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/HoldEntryTransition.ts
@@ -1,5 +1,7 @@
-//  Copyright (c) 2021 FlyByWire Simulations
-//  SPDX-License-Identifier: GPL-3.0
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
 
 import { Transition } from '@fmgc/guidance/lnav/Transition';
 import { DFLeg } from '@fmgc/guidance/lnav/legs/DF';
@@ -14,6 +16,7 @@ import { Geometry } from '@fmgc/guidance/Geometry';
 import { Guidable } from '@fmgc/guidance/Guidable';
 import { CFLeg } from '@fmgc/guidance/lnav/legs/CF';
 import { LnavConfig } from '@fmgc/guidance/LnavConfig';
+import { AFLeg } from '@fmgc/guidance/lnav/legs/AF';
 import { PathVector, PathVectorType } from '../PathVector';
 import { arcDistanceToGo, arcGuidance, courseToFixDistanceToGo, courseToFixGuidance, maxBank } from '../CommonGeometry';
 
@@ -60,7 +63,7 @@ export class HoldEntryTransition extends Transition {
     private frozen = false;
 
     constructor(
-        public previousLeg: /* AFLeg | */ CFLeg | DFLeg | RFLeg | TFLeg,
+        public previousLeg: AFLeg | CFLeg | DFLeg | RFLeg | TFLeg,
         public nextLeg: HALeg | HFLeg | HMLeg,
         _predictWithCurrentSpeed: boolean = true, // TODO we don't need this?
     ) {

--- a/src/fmgc/src/guidance/lnav/transitions/PathCaptureTransition.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/PathCaptureTransition.ts
@@ -1,3 +1,8 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
 import { MathUtils } from '@shared/MathUtils';
 import { CALeg } from '@fmgc/guidance/lnav/legs/CA';
 import { CILeg } from '@fmgc/guidance/lnav/legs/CI';
@@ -16,13 +21,14 @@ import { LnavConfig } from '@fmgc/guidance/LnavConfig';
 import { TurnDirection } from '@fmgc/types/fstypes/FSEnums';
 import { arcLength, maxBank } from '@fmgc/guidance/lnav/CommonGeometry';
 import { ControlLaw } from '@shared/autopilot';
+import { AFLeg } from '@fmgc/guidance/lnav/legs/AF';
 import { Leg } from '../legs/Leg';
 import { CFLeg } from '../legs/CF';
 import { CRLeg } from '../legs/CR';
 
 export type PrevLeg = CALeg | /* CDLeg | */ CRLeg | /* FALeg | */ HALeg | HFLeg | HMLeg;
 export type ReversionLeg = CFLeg | CILeg | DFLeg | TFLeg;
-export type NextLeg = /* AFLeg | */ CFLeg | /* FALeg | */ TFLeg;
+export type NextLeg = AFLeg | CFLeg | /* FALeg | */ TFLeg;
 
 const cos = (input: Degrees) => Math.cos(input * (Math.PI / 180));
 const tan = (input: Degrees) => Math.tan(input * MathUtils.DEGREES_TO_RADIANS);

--- a/src/fmgc/src/guidance/lnav/transitions/PathCaptureTransition.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/PathCaptureTransition.ts
@@ -26,7 +26,7 @@ import { Leg } from '../legs/Leg';
 import { CFLeg } from '../legs/CF';
 import { CRLeg } from '../legs/CR';
 
-export type PrevLeg = CALeg | /* CDLeg | */ CRLeg | /* FALeg | */ HALeg | HFLeg | HMLeg;
+export type PrevLeg = AFLeg | CALeg | /* CDLeg | */ CRLeg | /* FALeg | */ HALeg | HFLeg | HMLeg;
 export type ReversionLeg = CFLeg | CILeg | DFLeg | TFLeg;
 export type NextLeg = AFLeg | CFLeg | /* FALeg | */ TFLeg;
 

--- a/src/fmgc/src/utils/Geo.ts
+++ b/src/fmgc/src/utils/Geo.ts
@@ -79,6 +79,11 @@ export class Geo {
 
             return d1 > d2 ? intersections[1] : intersections[0];
         }
+
+        if (leg.getPathEndPoint() === undefined || leg.outboundCourse === undefined) {
+            throw new Error('[FMS/LNAV] Cannot compute leg intercept if leg end point or outbound course are undefined');
+        }
+
         const intersections1 = A32NX_Util.bothGreatCircleIntersections(
             from,
             Avionics.Utils.clampAngle(bearing),


### PR DESCRIPTION
## Summary of Changes

* Add `AFLeg`, `DmeArcTransition` guidables
* Pass through AF legs from WTFPM
* Generate `AFLeg`, `DmeArcTransition` in geometry
* Support intercepting AF legs in `CILeg`
* Fix RAD for TRACK and HEADING submodes of HPATH law

## Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/4503241/150626905-123ec889-e1a1-44aa-9ce3-3b9b6a20ef07.png)

![image](https://user-images.githubusercontent.com/4503241/150626915-bf31cc9c-4913-4dd1-826f-c12319ccae83.png)

## References
Lots.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): someperson#4953

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
