### PR TITLE
fix(fpm): properly map FC legs

### DIFF
--- a/src/fmgc/src/flightplanning/LegsProcedure.ts
+++ b/src/fmgc/src/flightplanning/LegsProcedure.ts
@@ -250,13 +250,13 @@ export class LegsProcedure {
    * @returns The mapped leg.
    */
   public mapBearingAndDistanceFromOrigin(leg: RawProcedureLeg): WayPoint {
-      const origin = this._facilities.get(leg.originIcao);
+      const origin = this._facilities.get(leg.type === LegType.FD ? leg.originIcao : leg.fixIcao);
       const originIdent = origin.icao.substring(7, 12).trim();
 
       const _course = leg.course + GeoMath.getMagvar(origin.lat, origin.lon);
       const coordinates = Avionics.Utils.bearingDistanceToCoordinates(leg.course, leg.distance / 1852, origin.lat, origin.lon);
 
-      return this.buildWaypoint(`${originIdent}${Math.trunc(leg.distance / 1852)}`, coordinates);
+      return this.buildWaypoint(`${originIdent.substring(0, 3)}/${Math.trunc(leg.distance / 1852).toString().padStart(2, '0')}`, coordinates);
   }
 
   /**

--- a/src/fmgc/src/flightplanning/LegsProcedure.ts
+++ b/src/fmgc/src/flightplanning/LegsProcedure.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import { AltitudeDescriptor, FixTypeFlags } from '../types/fstypes/FSEnums';
+import { AltitudeDescriptor, FixTypeFlags, LegType } from '../types/fstypes/FSEnums';
 import { FixNamingScheme } from './FixNamingScheme';
 import { GeoMath } from './GeoMath';
 import { RawDataMapper } from './RawDataMapper';


### PR DESCRIPTION
## Summary of Changes

* Temporary fix of FC leg mapping to TF leg until LNAV supports FC legs

## Screenshots (if necessary)

NONE!

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): someperson#4953

## Testing instructions

* Test arrival at EGGD ILS27 via BRI (first one)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
