### PR TITLE
fix: Split SimOptions Settings page into SimOptions and Realism page

### DIFF
--- a/src/instruments/src/EFB/Settings/Pages/RealismPage.tsx
+++ b/src/instruments/src/EFB/Settings/Pages/RealismPage.tsx
@@ -1,4 +1,4 @@
-import React, { } from 'react';
+import React from 'react';
 import { usePersistentProperty } from '@instruments/common/persistence';
 import { useSimVar } from '@instruments/common/simVars';
 

--- a/src/instruments/src/EFB/Settings/Pages/RealismPage.tsx
+++ b/src/instruments/src/EFB/Settings/Pages/RealismPage.tsx
@@ -1,0 +1,128 @@
+import React, { } from 'react';
+import { usePersistentProperty } from '@instruments/common/persistence';
+import { useSimVar } from '@instruments/common/simVars';
+
+import { Toggle } from '../../UtilComponents/Form/Toggle';
+import { ButtonType, SettingItem, SettingsPage } from '../Settings';
+
+import { SelectGroup, SelectItem } from '../../UtilComponents/Form/Select';
+import { SimpleInput } from '../../UtilComponents/Form/SimpleInput/SimpleInput';
+
+type SimVarButton = {
+    simVarValue: number,
+}
+
+export const RealismPage = () => {
+    const [adirsAlignTime, setAdirsAlignTime] = usePersistentProperty('CONFIG_ALIGN_TIME', 'REAL');
+    const [, setAdirsAlignTimeSimVar] = useSimVar('L:A32NX_CONFIG_ADIRS_IR_ALIGN_TIME', 'Enum', Number.MAX_SAFE_INTEGER);
+    const [dmcSelfTestTime, setDmcSelfTestTime] = usePersistentProperty('CONFIG_SELF_TEST_TIME', '12');
+    const [mcduInput, setMcduInput] = usePersistentProperty('MCDU_KB_INPUT', 'DISABLED');
+    const [mcduTimeout, setMcduTimeout] = usePersistentProperty('CONFIG_MCDU_KB_TIMEOUT', '60');
+    const [boardingRate, setBoardingRate] = usePersistentProperty('CONFIG_BOARDING_RATE', 'REAL');
+    const [realisticTiller, setRealisticTiller] = usePersistentProperty('REALISTIC_TILLER_ENABLED', '0');
+
+    const adirsAlignTimeButtons: (ButtonType & SimVarButton)[] = [
+        { name: 'Instant', setting: 'INSTANT', simVarValue: 1 },
+        { name: 'Fast', setting: 'FAST', simVarValue: 2 },
+        { name: 'Real', setting: 'REAL', simVarValue: 0 },
+    ];
+
+    const dmcSelfTestTimeButtons: ButtonType[] = [
+        { name: 'Instant', setting: '0' },
+        { name: 'Fast', setting: '5' },
+        { name: 'Real', setting: '12' },
+    ];
+
+    const boardingRateButtons: ButtonType[] = [
+        { name: 'Instant', setting: 'INSTANT' },
+        { name: 'Fast', setting: 'FAST' },
+        { name: 'Real', setting: 'REAL' },
+    ];
+
+    const steeringSeparationButtons: (ButtonType & SimVarButton)[] = [
+        { name: 'Disabled', setting: '0', simVarValue: 0 },
+        { name: 'Enabled', setting: '1', simVarValue: 1 },
+    ];
+
+    return (
+        <div>
+            <SettingsPage name="Sim Options">
+                <SettingItem name="ADIRS Align Time">
+                    <SelectGroup>
+                        {adirsAlignTimeButtons.map((button) => (
+                            <SelectItem
+                                onSelect={() => {
+                                    setAdirsAlignTime(button.setting);
+                                    setAdirsAlignTimeSimVar(button.simVarValue);
+                                }}
+                                selected={adirsAlignTime === button.setting}
+                            >
+                                {button.name}
+                            </SelectItem>
+                        ))}
+                    </SelectGroup>
+                </SettingItem>
+
+                <SettingItem name="DMC Self Test Time">
+                    <SelectGroup>
+                        {dmcSelfTestTimeButtons.map((button) => (
+                            <SelectItem
+                                onSelect={() => setDmcSelfTestTime(button.setting)}
+                                selected={dmcSelfTestTime === button.setting}
+                            >
+                                {button.name}
+                            </SelectItem>
+                        ))}
+                    </SelectGroup>
+                </SettingItem>
+
+                <SettingItem name="Boarding Time">
+                    <SelectGroup>
+                        {boardingRateButtons.map((button) => (
+                            <SelectItem
+                                onSelect={() => setBoardingRate(button.setting)}
+                                selected={boardingRate === button.setting}
+                            >
+                                {button.name}
+                            </SelectItem>
+                        ))}
+                    </SelectGroup>
+                </SettingItem>
+
+                <SettingItem name="MCDU Keyboard Input" unrealistic>
+                    <Toggle value={mcduInput === 'ENABLED'} onToggle={(value) => setMcduInput(value ? 'ENABLED' : 'DISABLED')} />
+                </SettingItem>
+
+                <SettingItem name="MCDU Focus Timeout (seconds)">
+                    <SimpleInput
+                        className="text-center w-30"
+                        value={mcduTimeout}
+                        noLabel
+                        min={5}
+                        max={120}
+                        disabled={(mcduInput !== 'ENABLED')}
+                        onChange={(event) => {
+                            if (!Number.isNaN(event) && parseInt(event) >= 5 && parseInt(event) <= 120) {
+                                setMcduTimeout(event.trim());
+                            }
+                        }}
+                    />
+                </SettingItem>
+
+                <SettingItem name="Separate Tiller from Rudder Inputs">
+                    <SelectGroup>
+                        {steeringSeparationButtons.map((button) => (
+                            <SelectItem
+                                onSelect={() => setRealisticTiller(button.setting)}
+                                selected={realisticTiller === button.setting}
+                            >
+                                {button.name}
+                            </SelectItem>
+                        ))}
+                    </SelectGroup>
+                </SettingItem>
+
+            </SettingsPage>
+        </div>
+    );
+};

--- a/src/instruments/src/EFB/Settings/Pages/RealismPage.tsx
+++ b/src/instruments/src/EFB/Settings/Pages/RealismPage.tsx
@@ -45,84 +45,82 @@ export const RealismPage = () => {
     ];
 
     return (
-        <>
-            <SettingsPage name="Realism">
-                <SettingItem name="ADIRS Align Time">
-                    <SelectGroup>
-                        {adirsAlignTimeButtons.map((button) => (
-                            <SelectItem
-                                onSelect={() => {
-                                    setAdirsAlignTime(button.setting);
-                                    setAdirsAlignTimeSimVar(button.simVarValue);
-                                }}
-                                selected={adirsAlignTime === button.setting}
-                            >
-                                {button.name}
-                            </SelectItem>
-                        ))}
-                    </SelectGroup>
-                </SettingItem>
+        <SettingsPage name="Realism">
+            <SettingItem name="ADIRS Align Time">
+                <SelectGroup>
+                    {adirsAlignTimeButtons.map((button) => (
+                        <SelectItem
+                            onSelect={() => {
+                                setAdirsAlignTime(button.setting);
+                                setAdirsAlignTimeSimVar(button.simVarValue);
+                            }}
+                            selected={adirsAlignTime === button.setting}
+                        >
+                            {button.name}
+                        </SelectItem>
+                    ))}
+                </SelectGroup>
+            </SettingItem>
 
-                <SettingItem name="DMC Self Test Time">
-                    <SelectGroup>
-                        {dmcSelfTestTimeButtons.map((button) => (
-                            <SelectItem
-                                onSelect={() => setDmcSelfTestTime(button.setting)}
-                                selected={dmcSelfTestTime === button.setting}
-                            >
-                                {button.name}
-                            </SelectItem>
-                        ))}
-                    </SelectGroup>
-                </SettingItem>
+            <SettingItem name="DMC Self Test Time">
+                <SelectGroup>
+                    {dmcSelfTestTimeButtons.map((button) => (
+                        <SelectItem
+                            onSelect={() => setDmcSelfTestTime(button.setting)}
+                            selected={dmcSelfTestTime === button.setting}
+                        >
+                            {button.name}
+                        </SelectItem>
+                    ))}
+                </SelectGroup>
+            </SettingItem>
 
-                <SettingItem name="Boarding Time">
-                    <SelectGroup>
-                        {boardingRateButtons.map((button) => (
-                            <SelectItem
-                                onSelect={() => setBoardingRate(button.setting)}
-                                selected={boardingRate === button.setting}
-                            >
-                                {button.name}
-                            </SelectItem>
-                        ))}
-                    </SelectGroup>
-                </SettingItem>
+            <SettingItem name="Boarding Time">
+                <SelectGroup>
+                    {boardingRateButtons.map((button) => (
+                        <SelectItem
+                            onSelect={() => setBoardingRate(button.setting)}
+                            selected={boardingRate === button.setting}
+                        >
+                            {button.name}
+                        </SelectItem>
+                    ))}
+                </SelectGroup>
+            </SettingItem>
 
-                <SettingItem name="MCDU Keyboard Input" unrealistic>
-                    <Toggle value={mcduInput === 'ENABLED'} onToggle={(value) => setMcduInput(value ? 'ENABLED' : 'DISABLED')} />
-                </SettingItem>
+            <SettingItem name="MCDU Keyboard Input" unrealistic>
+                <Toggle value={mcduInput === 'ENABLED'} onToggle={(value) => setMcduInput(value ? 'ENABLED' : 'DISABLED')} />
+            </SettingItem>
 
-                <SettingItem name="MCDU Focus Timeout (seconds)">
-                    <SimpleInput
-                        className="text-center w-30"
-                        value={mcduTimeout}
-                        noLabel
-                        min={5}
-                        max={120}
-                        disabled={(mcduInput !== 'ENABLED')}
-                        onChange={(event) => {
-                            if (!Number.isNaN(event) && parseInt(event) >= 5 && parseInt(event) <= 120) {
-                                setMcduTimeout(event.trim());
-                            }
-                        }}
-                    />
-                </SettingItem>
+            <SettingItem name="MCDU Focus Timeout (seconds)">
+                <SimpleInput
+                    className="text-center w-30"
+                    value={mcduTimeout}
+                    noLabel
+                    min={5}
+                    max={120}
+                    disabled={(mcduInput !== 'ENABLED')}
+                    onChange={(event) => {
+                        if (!Number.isNaN(event) && parseInt(event) >= 5 && parseInt(event) <= 120) {
+                            setMcduTimeout(event.trim());
+                        }
+                    }}
+                />
+            </SettingItem>
 
-                <SettingItem name="Separate Tiller from Rudder Inputs">
-                    <SelectGroup>
-                        {steeringSeparationButtons.map((button) => (
-                            <SelectItem
-                                onSelect={() => setRealisticTiller(button.setting)}
-                                selected={realisticTiller === button.setting}
-                            >
-                                {button.name}
-                            </SelectItem>
-                        ))}
-                    </SelectGroup>
-                </SettingItem>
+            <SettingItem name="Separate Tiller from Rudder Inputs">
+                <SelectGroup>
+                    {steeringSeparationButtons.map((button) => (
+                        <SelectItem
+                            onSelect={() => setRealisticTiller(button.setting)}
+                            selected={realisticTiller === button.setting}
+                        >
+                            {button.name}
+                        </SelectItem>
+                    ))}
+                </SelectGroup>
+            </SettingItem>
 
-            </SettingsPage>
-        </>
+        </SettingsPage>
     );
 };

--- a/src/instruments/src/EFB/Settings/Pages/RealismPage.tsx
+++ b/src/instruments/src/EFB/Settings/Pages/RealismPage.tsx
@@ -45,7 +45,7 @@ export const RealismPage = () => {
     ];
 
     return (
-        <div>
+        <>
             <SettingsPage name="Realism">
                 <SettingItem name="ADIRS Align Time">
                     <SelectGroup>
@@ -123,6 +123,6 @@ export const RealismPage = () => {
                 </SettingItem>
 
             </SettingsPage>
-        </div>
+        </>
     );
 };

--- a/src/instruments/src/EFB/Settings/Pages/RealismPage.tsx
+++ b/src/instruments/src/EFB/Settings/Pages/RealismPage.tsx
@@ -46,7 +46,7 @@ export const RealismPage = () => {
 
     return (
         <div>
-            <SettingsPage name="Sim Options">
+            <SettingsPage name="Realism">
                 <SettingItem name="ADIRS Align Time">
                     <SelectGroup>
                         {adirsAlignTimeButtons.map((button) => (

--- a/src/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
+++ b/src/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { usePersistentProperty } from '@instruments/common/persistence';
-import { useSimVar } from '@instruments/common/simVars';
 
 import { Toggle } from '../../UtilComponents/Form/Toggle';
 import { ButtonType, SettingItem, SettingsPage } from '../Settings';
@@ -11,36 +10,13 @@ import { SimpleInput } from '../../UtilComponents/Form/SimpleInput/SimpleInput';
 
 import { ThrottleConfig } from '../ThrottleConfig/ThrottleConfig';
 
-type SimVarButton = {
-    simVarValue: number,
-}
-
 export const SimOptionsPage = () => {
     const [showThrottleSettings, setShowThrottleSettings] = useState(false);
 
-    const [adirsAlignTime, setAdirsAlignTime] = usePersistentProperty('CONFIG_ALIGN_TIME', 'REAL');
-    const [, setAdirsAlignTimeSimVar] = useSimVar('L:A32NX_CONFIG_ADIRS_IR_ALIGN_TIME', 'Enum', Number.MAX_SAFE_INTEGER);
-    const [dmcSelfTestTime, setDmcSelfTestTime] = usePersistentProperty('CONFIG_SELF_TEST_TIME', '12');
     const [defaultBaro, setDefaultBaro] = usePersistentProperty('CONFIG_INIT_BARO_UNIT', 'AUTO');
-    const [mcduInput, setMcduInput] = usePersistentProperty('MCDU_KB_INPUT', 'DISABLED');
-    const [mcduTimeout, setMcduTimeout] = usePersistentProperty('CONFIG_MCDU_KB_TIMEOUT', '60');
     const [dynamicRegistration, setDynamicRegistration] = usePersistentProperty('DYNAMIC_REGISTRATION_DECAL', 'DISABLED');
     const [fpSync, setFpSync] = usePersistentProperty('FP_SYNC', 'LOAD');
-    const [boardingRate, setBoardingRate] = usePersistentProperty('CONFIG_BOARDING_RATE', 'REAL');
-    const [realisticTiller, setRealisticTiller] = usePersistentProperty('REALISTIC_TILLER_ENABLED', '0');
     const [mcduServerPort, setMcduServerPort] = usePersistentProperty('CONFIG_EXTERNAL_MCDU_PORT', '8080');
-
-    const adirsAlignTimeButtons: (ButtonType & SimVarButton)[] = [
-        { name: 'Instant', setting: 'INSTANT', simVarValue: 1 },
-        { name: 'Fast', setting: 'FAST', simVarValue: 2 },
-        { name: 'Real', setting: 'REAL', simVarValue: 0 },
-    ];
-
-    const dmcSelfTestTimeButtons: ButtonType[] = [
-        { name: 'Instant', setting: '0' },
-        { name: 'Fast', setting: '5' },
-        { name: 'Real', setting: '12' },
-    ];
 
     const defaultBaroButtons: ButtonType[] = [
         { name: 'Auto', setting: 'AUTO' },
@@ -54,50 +30,11 @@ export const SimOptionsPage = () => {
         { name: 'Save', setting: 'SAVE' },
     ];
 
-    const boardingRateButtons: ButtonType[] = [
-        { name: 'Instant', setting: 'INSTANT' },
-        { name: 'Fast', setting: 'FAST' },
-        { name: 'Real', setting: 'REAL' },
-    ];
-
-    const steeringSeparationButtons: (ButtonType & SimVarButton)[] = [
-        { name: 'Disabled', setting: '0', simVarValue: 0 },
-        { name: 'Enabled', setting: '1', simVarValue: 1 },
-    ];
-
     return (
         <div>
             {!showThrottleSettings
             && (
                 <SettingsPage name="Sim Options">
-                    <SettingItem name="ADIRS Align Time">
-                        <SelectGroup>
-                            {adirsAlignTimeButtons.map((button) => (
-                                <SelectItem
-                                    onSelect={() => {
-                                        setAdirsAlignTime(button.setting);
-                                        setAdirsAlignTimeSimVar(button.simVarValue);
-                                    }}
-                                    selected={adirsAlignTime === button.setting}
-                                >
-                                    {button.name}
-                                </SelectItem>
-                            ))}
-                        </SelectGroup>
-                    </SettingItem>
-
-                    <SettingItem name="DMC Self Test Time">
-                        <SelectGroup>
-                            {dmcSelfTestTimeButtons.map((button) => (
-                                <SelectItem
-                                    onSelect={() => setDmcSelfTestTime(button.setting)}
-                                    selected={dmcSelfTestTime === button.setting}
-                                >
-                                    {button.name}
-                                </SelectItem>
-                            ))}
-                        </SelectGroup>
-                    </SettingItem>
 
                     <SettingItem name="Default Barometer Unit">
                         <SelectGroup>
@@ -110,30 +47,6 @@ export const SimOptionsPage = () => {
                                 </SelectItem>
                             ))}
                         </SelectGroup>
-                    </SettingItem>
-
-                    <SettingItem name="MCDU Keyboard Input" unrealistic>
-                        <Toggle value={mcduInput === 'ENABLED'} onToggle={(value) => setMcduInput(value ? 'ENABLED' : 'DISABLED')} />
-                    </SettingItem>
-
-                    <SettingItem name="MCDU Focus Timeout (seconds)">
-                        <SimpleInput
-                            className="text-center w-30"
-                            value={mcduTimeout}
-                            noLabel
-                            min={5}
-                            max={120}
-                            disabled={(mcduInput !== 'ENABLED')}
-                            onChange={(event) => {
-                                if (!Number.isNaN(event) && parseInt(event) >= 5 && parseInt(event) <= 120) {
-                                    setMcduTimeout(event.trim());
-                                }
-                            }}
-                        />
-                    </SettingItem>
-
-                    <SettingItem name="Dynamic Registration Decal">
-                        <Toggle value={dynamicRegistration === 'ENABLED'} onToggle={(value) => setDynamicRegistration(value ? 'ENABLED' : 'DISABLED')} />
                     </SettingItem>
 
                     <SettingItem name="Sync MSFS Flight Plan">
@@ -149,31 +62,6 @@ export const SimOptionsPage = () => {
                         </SelectGroup>
                     </SettingItem>
 
-                    <SettingItem name="Boarding Time">
-                        <SelectGroup>
-                            {boardingRateButtons.map((button) => (
-                                <SelectItem
-                                    onSelect={() => setBoardingRate(button.setting)}
-                                    selected={boardingRate === button.setting}
-                                >
-                                    {button.name}
-                                </SelectItem>
-                            ))}
-                        </SelectGroup>
-                    </SettingItem>
-
-                    <SettingItem name="Separate Tiller from Rudder Inputs">
-                        <SelectGroup>
-                            {steeringSeparationButtons.map((button) => (
-                                <SelectItem
-                                    onSelect={() => setRealisticTiller(button.setting)}
-                                    selected={realisticTiller === button.setting}
-                                >
-                                    {button.name}
-                                </SelectItem>
-                            ))}
-                        </SelectGroup>
-                    </SettingItem>
                     <SettingItem name="External MCDU Server Port">
                         <SimpleInput
                             className="text-center w-30"
@@ -185,9 +73,14 @@ export const SimOptionsPage = () => {
                         />
                     </SettingItem>
 
+                    <SettingItem name="Dynamic Registration Decal">
+                        <Toggle value={dynamicRegistration === 'ENABLED'} onToggle={(value) => setDynamicRegistration(value ? 'ENABLED' : 'DISABLED')} />
+                    </SettingItem>
+
                     <SettingItem name="Throttle Detents">
                         <Button className="bg-theme-highlight" text="Calibrate" onClick={() => setShowThrottleSettings(true)} />
                     </SettingItem>
+
                 </SettingsPage>
             )}
             <ThrottleConfig isShown={showThrottleSettings} onClose={() => setShowThrottleSettings(false)} />

--- a/src/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
+++ b/src/instruments/src/EFB/Settings/Pages/SimOptionsPage.tsx
@@ -31,7 +31,7 @@ export const SimOptionsPage = () => {
     ];
 
     return (
-        <div>
+        <>
             {!showThrottleSettings
             && (
                 <SettingsPage name="Sim Options">
@@ -84,6 +84,6 @@ export const SimOptionsPage = () => {
                 </SettingsPage>
             )}
             <ThrottleConfig isShown={showThrottleSettings} onClose={() => setShowThrottleSettings(false)} />
-        </div>
+        </>
     );
 };

--- a/src/instruments/src/EFB/Settings/Settings.tsx
+++ b/src/instruments/src/EFB/Settings/Settings.tsx
@@ -9,6 +9,7 @@ import { ScrollableContainer } from '../UtilComponents/ScrollableContainer';
 import { pathify, TabRoutes } from '../Utils/routing';
 import { AircraftOptionsPinProgramsPage } from './Pages/AircraftOptionsPinProgramsPage';
 import { SimOptionsPage } from './Pages/SimOptionsPage';
+import { RealismPage } from './Pages/RealismPage';
 import { AtsuAocPage } from './Pages/AtsuAocPage';
 import { AudioPage } from './Pages/AudioPage';
 import { FlyPadPage } from './Pages/FlyPadPage';
@@ -33,7 +34,7 @@ export const SelectionTabs = ({ tabs }: SelectionTabsProps) => (
             tabs.map((tab) => (
                 <Link
                     to={`settings/${pathify(tab.name)}`}
-                    className="flex justify-between items-center p-6 rounded-md border-2 border-transparent transition duration-100 bg-theme-secondary hover:border-theme-highlight"
+                    className="flex justify-between items-center p-6 bg-theme-secondary rounded-md border-2 border-transparent hover:border-theme-highlight transition duration-100"
                 >
                     <p className="text-2xl">{tab.name}</p>
                     <ChevronRight size={30} />
@@ -47,6 +48,7 @@ export const Settings = () => {
     const tabs: PageLink[] = [
         { name: 'Aircraft Options / Pin Programs', component: <AircraftOptionsPinProgramsPage /> },
         { name: 'Sim Options', component: <SimOptionsPage /> },
+        { name: 'Realism', component: <RealismPage /> },
         { name: 'ATSU / AOC', component: <AtsuAocPage /> },
         { name: 'Audio', component: <AudioPage /> },
         { name: 'flyPad', component: <FlyPadPage /> },
@@ -73,7 +75,7 @@ type SettingsPageProps = {
 export const SettingsPage: FC<SettingsPageProps> = ({ name, children }) => (
     <div>
         <Link to="/settings" className="inline-block mb-4">
-            <div className="flex flex-row items-center space-x-3 transition duration-100 hover:text-theme-highlight">
+            <div className="flex flex-row items-center space-x-3 hover:text-theme-highlight transition duration-100">
                 <ArrowLeft size={30} />
                 <h1 className="font-bold text-current">
                     Settings
@@ -82,7 +84,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ name, children }) => (
                 </h1>
             </div>
         </Link>
-        <div className="py-2 px-6 w-full rounded-lg border-2 h-efb border-theme-accent">
+        <div className="py-2 px-6 w-full h-efb rounded-lg border-2 border-theme-accent">
             <ScrollableContainer height={53}>
                 <div className="h-full divide-y-2 divide-theme-accent">
                     {children}


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
Split SimOptions Settings page into SimOptions and Realism page

## References
As in current Development

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
-

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
