### PR TITLE
feat: improved G/S and FLARE law

### DIFF
--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -111,6 +111,7 @@ class FlyByWireInterface {
   InterpolatingLookupTable throttleLookupTable;
 
   bool developmentLocalVariablesEnabled = false;
+  bool useCalculatedLocalizerAndGlideSlope = false;
   std::unique_ptr<LocalVariable> idDevelopmentAutoland_condition_Flare;
   std::unique_ptr<LocalVariable> idDevelopmentAutoland_H_dot_radio_fpm;
   std::unique_ptr<LocalVariable> idDevelopmentAutoland_H_dot_c_fpm;

--- a/src/fbw/src/model/AutopilotLaws.cpp
+++ b/src/fbw/src/model/AutopilotLaws.cpp
@@ -442,12 +442,12 @@ void AutopilotLawsModelClass::step()
   real_T rtb_Gain_a2;
   real_T rtb_Gain_ds;
   real_T rtb_Gain_nrh;
+  real_T rtb_Product_dh;
   real_T rtb_Saturation;
   real_T rtb_Sum3_m3;
   real_T rtb_Sum_ia;
   real_T rtb_Sum_if;
   real_T rtb_Vz;
-  real_T rtb_Y_d;
   real_T rtb_Y_g;
   real_T rtb_Y_j;
   real_T rtb_Y_pt;
@@ -1987,7 +1987,7 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_U.in.time.dt), AutopilotLaws_P.LagFilter_C1_m, AutopilotLaws_U.in.time.dt, &Phi2,
     &AutopilotLaws_DWork.sf_LagFilter_j);
   L = look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft, AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_ec,
-                    AutopilotLaws_P.ScheduledGain_Table_l, 5U);
+                    AutopilotLaws_P.ScheduledGain_Table_l, 6U);
   AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain3_Gain_c * (AutopilotLaws_DWork.DelayInput1_DSTATE + Phi2 * L),
     (AutopilotLaws_U.in.data.H_radio_ft > AutopilotLaws_P.CompareToConstant_const_k) &&
     AutopilotLaws_U.in.data.nav_gs_valid, &rtb_Divide);
@@ -2013,7 +2013,9 @@ void AutopilotLawsModelClass::step()
     rtb_Delay_j, &Phi2);
   AutopilotLaws_Voter1(rtb_Divide + Phi2, AutopilotLaws_P.Gain1_Gain_d4 * ((L + AutopilotLaws_P.Bias_Bias) -
     AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.Gain_Gain_eyl * ((L + AutopilotLaws_P.Bias1_Bias) -
-    AutopilotLaws_DWork.DelayInput1_DSTATE), &rtb_Y_d);
+    AutopilotLaws_DWork.DelayInput1_DSTATE), &rtb_Y_pt);
+  rtb_Product_dh = rtb_Y_pt * look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn,
+    AutopilotLaws_P.ScheduledGain1_BreakpointsForDimension1, AutopilotLaws_P.ScheduledGain1_Table, 6U);
   rtb_Gain4_m = (rtb_GainTheta - AutopilotLaws_P.Constant2_Value_f) * AutopilotLaws_P.Gain4_Gain_oy;
   rtb_Y_j = AutopilotLaws_P.Gain5_Gain_c * AutopilotLaws_U.in.data.bz_m_s2;
   AutopilotLaws_WashoutFilter(AutopilotLaws_U.in.data.bx_m_s2, AutopilotLaws_P.WashoutFilter_C1_m,
@@ -2250,7 +2252,7 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 6:
-    b_L = AutopilotLaws_P.Gain1_Gain_d * rtb_Y_d;
+    b_L = AutopilotLaws_P.Gain1_Gain_d * rtb_Product_dh;
     break;
 
    case 7:
@@ -2300,7 +2302,7 @@ void AutopilotLawsModelClass::step()
   }
 
   AutopilotLaws_VSLimiter(AutopilotLaws_P.Gain_Gain_k2 * rtb_lo_k, &AutopilotLaws_Y.out, &a);
-  AutopilotLaws_VSLimiter(rtb_Y_d, &AutopilotLaws_Y.out, &b_L);
+  AutopilotLaws_VSLimiter(rtb_Product_dh, &AutopilotLaws_Y.out, &b_L);
   distance_m = AutopilotLaws_P.Gain3_Gain_l * rtb_Y_pt;
   rtb_lo_k = AutopilotLaws_P.VS_Gain_e * rtb_Gain_a2;
   AutopilotLaws_WashoutFilter(rtb_Saturation, AutopilotLaws_P.WashoutFilter1_C1_h, AutopilotLaws_U.in.time.dt, &b_R,
@@ -2407,7 +2409,7 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_Y.out.output.flight_director.Theta_c_deg = Phi2;
   AutopilotLaws_Y.out.output.autopilot.Theta_c_deg = (AutopilotLaws_P.Constant_Value_i4 - L) * rtb_GainTheta + b_R * L;
   AutopilotLaws_Y.out.output.flare_law.condition_Flare = ((AutopilotLaws_U.in.data.H_radio_ft < 60.0) &&
-    ((AutopilotLaws_U.in.data.H_radio_ft * 15.0 <= std::abs(rtb_Add3_a)) || (AutopilotLaws_U.in.data.H_radio_ft <= 45.0)));
+    ((AutopilotLaws_U.in.data.H_radio_ft * 15.0 <= std::abs(rtb_Add3_a)) || (AutopilotLaws_U.in.data.H_radio_ft <= 40.0)));
   AutopilotLaws_Y.out.output.flare_law.H_dot_radio_fpm = rtb_Add3_a;
   AutopilotLaws_Y.out.output.flare_law.H_dot_c_fpm = rtb_Vz;
   AutopilotLaws_Y.out.output.flare_law.delta_Theta_H_dot_deg = rtb_lo_k;

--- a/src/fbw/src/model/AutopilotLaws.h
+++ b/src/fbw/src/model/AutopilotLaws.h
@@ -175,7 +175,8 @@ class AutopilotLawsModelClass
     real_T ScheduledGain_BreakpointsForDimension1_o[7];
     real_T ScheduledGain2_BreakpointsForDimension1[7];
     real_T ScheduledGain_BreakpointsForDimension1_e[5];
-    real_T ScheduledGain_BreakpointsForDimension1_ec[6];
+    real_T ScheduledGain_BreakpointsForDimension1_ec[7];
+    real_T ScheduledGain1_BreakpointsForDimension1[7];
     real_T LagFilter_C1;
     real_T LagFilter2_C1;
     real_T LagFilter_C1_n;
@@ -301,7 +302,8 @@ class AutopilotLawsModelClass
     real_T ScheduledGain_Table_e[7];
     real_T ScheduledGain2_Table[7];
     real_T ScheduledGain_Table_p[5];
-    real_T ScheduledGain_Table_l[6];
+    real_T ScheduledGain_Table_l[7];
+    real_T ScheduledGain1_Table[7];
     real_T DiscreteTimeIntegratorVariableTs_UpperLimit;
     real_T Subsystem_Value;
     real_T Subsystem_Value_n;

--- a/src/fbw/src/model/AutopilotLaws_data.cpp
+++ b/src/fbw/src/model/AutopilotLaws_data.cpp
@@ -170,7 +170,10 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
   { 0.0, 50.0, 100.0, 1000.0, 2500.0 },
 
 
-  { 0.0, 50.0, 100.0, 200.0, 1000.0, 2500.0 },
+  { 0.0, 50.0, 100.0, 200.0, 400.0, 1000.0, 2500.0 },
+
+
+  { 0.0, 100.0, 150.0, 200.0, 250.0, 300.0, 400.0 },
 
   4.0,
 
@@ -428,7 +431,10 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
   { 3.7, 3.7, 4.3, 7.8, 15.0 },
 
 
-  { 0.0, -0.02, -0.25, -0.5, -1.6, -3.0 },
+  { 0.0, 0.0, -0.15, -0.4, -0.775, -1.6, -3.0 },
+
+
+  { 2.0, 2.0, 1.5, 1.0, 1.0, 1.0, 1.0 },
 
   3.0,
 
@@ -1432,7 +1438,7 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
 
   -2.0,
 
-  -0.7,
+  -0.9,
 
   -0.3,
 


### PR DESCRIPTION
## Summary of Changes
This PR improves the following:
- decreased minimum flare height to 40 ft
- tuned gains of G/S law
- added option to use calculated ILS deviations

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Testing instructions
- perform multiple Autoland in various conditions

### Autoland Limits

#### Automatic landing without automatic rollout
Headwind: 30 kt
Tailwind: 10 kt
Crosswind: 20 kt

#### Maximum wind conditions for automatic rollout
Headwind: 30 kt
Tailwind: 10 kt
Crosswind: 15 kt

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
