### PR TITLE
feat(adirs): Improve ADIRS SSM and behaviours

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -190,6 +190,8 @@
 1. [AP] Corrected guidance for OP DES, CLB and DES for small flight level changes - @aguther (Andreas Guther)
 1. [AP] Improved roll law transition from flight to ground mode during Autoland - @aguther (Andreas Guther)
 1. [AP] Improved V/PATH law - lukecologne (luke)
+1. [ADIRS] Improve ADR SSM behaviour, add missing data to the IR - @luke (lukecologne#1156)
+1. [PFD] Improve SPD and MACH flag behaviour, add FPV flag - @luke (lukecologne#1156)
 
 ## 0.7.0
 

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -1486,17 +1486,18 @@ In the variables below, {number} should be replaced with one item in the set: { 
 - A32NX_ADIRS_ADR_{number}_STATIC_AIR_TEMPERATURE
     - Arinc429Word<Celsius>
     - The static air temperature (SAT).
-      {number}: 1 or 3
 
 - A32NX_ADIRS_ADR_{number}_TOTAL_AIR_TEMPERATURE
     - Arinc429Word<Celsius>
     - The total air temperature (TAT).
-      {number}: 1 or 3
 
 - A32NX_ADIRS_ADR_{number}_INTERNATIONAL_STANDARD_ATMOSPHERE_DELTA
     - Arinc429Word<Celsius>
     - The delta (deviation) from international standard atmosphere temperature.
-      {number}: 1 or 3
+
+- A32NX_ADIRS_ADR_{number}_ANGLE_OF_ATTACK
+    - Arinc429Word<Degrees>
+    - The angle of attack (α) of the aircraft
 
 - A32NX_ADIRS_IR_{number}_PITCH
     - Arinc429Word<Degrees>
@@ -1537,6 +1538,50 @@ In the variables below, {number} should be replaced with one item in the set: { 
 - A32NX_ADIRS_IR_{number}_LONGITUDE
     - Arinc429Word<Degrees>
     - The longitude of the aircraft.
+
+- A32NX_ADIRS_IR_{number}_DRIFT_ANGLE
+    - Arinc429Word<Degrees>
+    - The drift angle of the aircraft (drift angle = heading - track)
+
+- A32NX_ADIRS_IR_{number}_FLIGHT_PATH_ANGLE
+    - Arinc429Word<Degrees>
+    - The kinematic flight path angle (γ) (arctan(VS / GS))
+
+- A32NX_ADIRS_IR_{number}_BODY_PITCH_RATE
+    - Arinc429Word<Degrees per second>
+    - The body pitch rate (q) of the aircraft
+
+- A32NX_ADIRS_IR_{number}_BODY_ROLL_RATE
+    - Arinc429Word<Degrees per second>
+    - The body roll rate (p) of the aircraft
+
+- A32NX_ADIRS_IR_{number}_BODY_YAW_RATE
+    - Arinc429Word<Degrees per second>
+    - The body yaw rate (r) of the aircraft
+
+- A32NX_ADIRS_IR_{number}_BODY_LONGITUDINAL_ACC
+    - Arinc429Word<g-Number>
+    - The longitudinal (forward/backward) acceleration of the aircraft
+
+- A32NX_ADIRS_IR_{number}_BODY_LATERAL_ACC
+    - Arinc429Word<g-Number>
+    - The lateral (left/right) acceleration of the aircraft
+
+- A32NX_ADIRS_IR_{number}_BODY_NORMAL_ACC
+    - Arinc429Word<g-Number>
+    - The normal acceleration (load factor) of the aircraft
+
+- A32NX_ADIRS_IR_{number}_HEADING_RATE
+    - Arinc429Word<Degrees per second>
+    - The heading rate (ψ^dot) of the aircraft
+
+- A32NX_ADIRS_IR_{number}_PITCH_ATT_RATE
+    - Arinc429Word<Degrees per second>
+    - The pitch rate (θ^dot) of the aircraft
+
+- A32NX_ADIRS_IR_{number}_ROLL_ATT_RATE
+    - Arinc429Word<Degrees per second>
+    - The roll rate (φ^dot) of the aircraft
 
 - A32NX_ADIRS_USES_GPS_AS_PRIMARY
     - Bool

--- a/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
+++ b/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
@@ -1,5 +1,4 @@
 import { Arinc429Word } from '@shared/arinc429';
-import { getSmallestAngle } from '@instruments/common/utils.js';
 import { LateralMode, VerticalMode } from '@shared/autopilot.js';
 import React from 'react';
 import { calculateHorizonOffsetFromPitch } from './PFDUtils';

--- a/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
+++ b/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
@@ -47,16 +47,14 @@ export const AttitudeIndicatorFixedUpper = ({ pitch, roll }: AttitudeIndicatorFi
 interface AttitudeIndicatorFixedCenterProps {
     pitch: Arinc429Word;
     roll: Arinc429Word;
-    vs: Arinc429Word;
-    gs: Arinc429Word;
-    heading: Arinc429Word;
-    track: Arinc429Word
+    fpa: Arinc429Word;
+    da: Arinc429Word
     isOnGround: boolean;
     FDActive: boolean;
     isAttExcessive: boolean;
 }
 
-export const AttitudeIndicatorFixedCenter = ({ pitch, roll, vs, gs, heading, track, isOnGround, FDActive, isAttExcessive }: AttitudeIndicatorFixedCenterProps) => {
+export const AttitudeIndicatorFixedCenter = ({ pitch, roll, fpa, da, isOnGround, FDActive, isAttExcessive }: AttitudeIndicatorFixedCenterProps) => {
     if (!pitch.isNormalOperation() || !roll.isNormalOperation()) {
         return (
             <text id="AttFailText" className="Blink9Seconds FontLargest Red EndAlign" x="75.893127" y="83.136955">ATT</text>
@@ -83,15 +81,13 @@ export const AttitudeIndicatorFixedCenter = ({ pitch, roll, vs, gs, heading, tra
                 <path d="m88.55 86.114h2.5184v-4.0317h12.592v-2.5198h-15.11z" />
                 <path d="m34.153 79.563h15.11v6.5516h-2.5184v-4.0317h-12.592z" />
             </g>
-            <FlightPathVector pitch={pitch} roll={roll} vs={vs} gs={gs} heading={heading} track={track} />
+            <FlightPathVector pitch={pitch} roll={roll} fpa={fpa} da={da} />
             {!isAttExcessive && (
                 <FlightPathDirector
                     pitch={pitch}
                     roll={roll}
-                    vs={vs}
-                    gs={gs}
-                    heading={heading}
-                    track={track}
+                    fpa={fpa}
+                    da={da}
                     FDActive={FDActive}
                 />
             ) }
@@ -159,61 +155,58 @@ const FlightDirector = ({ FDActive }) => {
 interface FPVProps {
     pitch: Arinc429Word;
     roll: Arinc429Word;
-    vs: Arinc429Word;
-    gs: Arinc429Word;
-    heading: Arinc429Word;
-    track: Arinc429Word
+    fpa: Arinc429Word;
+    da: Arinc429Word;
 }
-const FlightPathVector = ({ pitch, roll, vs, gs, heading, track }: FPVProps) => {
-    if (!getSimVar('L:A32NX_TRK_FPA_MODE_ACTIVE', 'bool')) {
-        return null;
-    }
+const FlightPathVector = ({ pitch, roll, fpa, da }: FPVProps) => {
+    const fpaModeActive = getSimVar('L:A32NX_TRK_FPA_MODE_ACTIVE', 'bool');
+    const daAndFpaValid = fpa.isNormalOperation() && da.isNormalOperation();
 
-    // TODO FPA and DA should come directly from the IR, and not be calculated here.
-    const FPA = Math.atan(vs.value / gs.value * 0.009875) * 180 / Math.PI;
-    const DA = getSmallestAngle(track.value, heading.value);
-
-    const daLimConv = Math.max(Math.min(DA, 21), -21) * DistanceSpacing / ValueSpacing;
-    const pitchSubFpaConv = (calculateHorizonOffsetFromPitch(-pitch.value) - calculateHorizonOffsetFromPitch(FPA));
+    const daLimConv = Math.max(Math.min(da.value, 21), -21) * DistanceSpacing / ValueSpacing;
+    const pitchSubFpaConv = (calculateHorizonOffsetFromPitch(-pitch.value) - calculateHorizonOffsetFromPitch(fpa.value));
     const rollCos = Math.cos(roll.value * Math.PI / 180);
     const rollSin = Math.sin(roll.value * Math.PI / 180);
 
     const xOffset = daLimConv * rollCos - pitchSubFpaConv * rollSin;
     const yOffset = pitchSubFpaConv * rollCos + daLimConv * rollSin;
 
-    return (
-        <g transform={`translate(${xOffset} ${yOffset})`}>
-            <svg x="53.4" y="65.3" width="31px" height="31px" version="1.1" viewBox="0 0 31 31" xmlns="http://www.w3.org/2000/svg">
-                <g>
-                    <path
-                        className="NormalOutline"
-                        // eslint-disable-next-line max-len
-                        d="m17.766 15.501c8.59e-4 -1.2531-1.0142-2.2694-2.2665-2.2694-1.2524 0-2.2674 1.0163-2.2665 2.2694-8.57e-4 1.2531 1.0142 2.2694 2.2665 2.2694 1.2524 0 2.2674-1.0163 2.2665-2.2694z"
-                    />
-                    <path className="ThickOutline" d="m17.766 15.501h5.0367m-9.5698 0h-5.0367m7.3033-2.2678v-2.5199" />
-                    <path
-                        className="NormalStroke Green"
-                        // eslint-disable-next-line max-len
-                        d="m17.766 15.501c8.59e-4 -1.2531-1.0142-2.2694-2.2665-2.2694-1.2524 0-2.2674 1.0163-2.2665 2.2694-8.57e-4 1.2531 1.0142 2.2694 2.2665 2.2694 1.2524 0 2.2674-1.0163 2.2665-2.2694z"
-                    />
-                    <path className="ThickStroke Green" d="m17.766 15.501h5.0367m-9.5698 0h-5.0367m7.3033-2.2678v-2.5199" />
-                </g>
-            </svg>
-        </g>
-    );
+    if (daAndFpaValid && fpaModeActive) {
+        return (
+            <g transform={`translate(${xOffset} ${yOffset})`}>
+                <svg x="53.4" y="65.3" width="31px" height="31px" version="1.1" viewBox="0 0 31 31" xmlns="http://www.w3.org/2000/svg">
+                    <g>
+                        <path
+                            className="NormalOutline"
+                            // eslint-disable-next-line max-len
+                            d="m17.766 15.501c8.59e-4 -1.2531-1.0142-2.2694-2.2665-2.2694-1.2524 0-2.2674 1.0163-2.2665 2.2694-8.57e-4 1.2531 1.0142 2.2694 2.2665 2.2694 1.2524 0 2.2674-1.0163 2.2665-2.2694z"
+                        />
+                        <path className="ThickOutline" d="m17.766 15.501h5.0367m-9.5698 0h-5.0367m7.3033-2.2678v-2.5199" />
+                        <path
+                            className="NormalStroke Green"
+                            // eslint-disable-next-line max-len
+                            d="m17.766 15.501c8.59e-4 -1.2531-1.0142-2.2694-2.2665-2.2694-1.2524 0-2.2674 1.0163-2.2665 2.2694-8.57e-4 1.2531 1.0142 2.2694 2.2665 2.2694 1.2524 0 2.2674-1.0163 2.2665-2.2694z"
+                        />
+                        <path className="ThickStroke Green" d="m17.766 15.501h5.0367m-9.5698 0h-5.0367m7.3033-2.2678v-2.5199" />
+                    </g>
+                </svg>
+            </g>
+        );
+    } if (fpaModeActive && pitch.isNormalOperation() && roll.isNormalOperation()) {
+        return <text id="FPVFlag" x="62.987099" y="89.42025" className="Blink9Seconds FontLargest Red EndAlign">FPV</text>;
+    }
+    return null;
 };
 
 interface FPDProps {
     pitch: Arinc429Word;
     roll: Arinc429Word;
-    vs: Arinc429Word;
-    gs: Arinc429Word;
-    heading: Arinc429Word;
-    track: Arinc429Word;
+    fpa: Arinc429Word;
+    da: Arinc429Word;
     FDActive: boolean;
 }
-const FlightPathDirector = ({ pitch, roll, vs, gs, heading, track, FDActive }: FPDProps) => {
-    if (!FDActive || !getSimVar('L:A32NX_TRK_FPA_MODE_ACTIVE', 'bool')) {
+const FlightPathDirector = ({ pitch, roll, fpa, da, FDActive }: FPDProps) => {
+    const daAndFpaValid = fpa.isNormalOperation() && da.isNormalOperation();
+    if (!FDActive || !getSimVar('L:A32NX_TRK_FPA_MODE_ACTIVE', 'bool') || !daAndFpaValid) {
         return null;
     }
 
@@ -231,12 +224,8 @@ const FlightPathDirector = ({ pitch, roll, vs, gs, heading, track, FDActive }: F
     const FDPitchOrder = getSimVar('L:A32NX_FLIGHT_DIRECTOR_PITCH', 'number');
     const FDPitchOrderLim = Math.max(Math.min(FDPitchOrder, 22.5), -22.5) * 1.9;
 
-    // TODO FPA and DA should come directly from the IR, and not be calculated here.
-    const FPA = Math.atan(vs.value / gs.value * 0.009875) * 180 / Math.PI;
-    const DA = getSmallestAngle(track.value, heading.value);
-
-    const daLimConv = Math.max(Math.min(DA, 21), -21) * DistanceSpacing / ValueSpacing;
-    const pitchSubFpaConv = (calculateHorizonOffsetFromPitch(-pitch.value) - calculateHorizonOffsetFromPitch(FPA));
+    const daLimConv = Math.max(Math.min(da.value, 21), -21) * DistanceSpacing / ValueSpacing;
+    const pitchSubFpaConv = (calculateHorizonOffsetFromPitch(-pitch.value) - calculateHorizonOffsetFromPitch(fpa.value));
     const rollCos = Math.cos(roll.value * Math.PI / 180);
     const rollSin = Math.sin(roll.value * Math.PI / 180);
 

--- a/src/instruments/src/PFD/SpeedIndicator.tsx
+++ b/src/instruments/src/PFD/SpeedIndicator.tsx
@@ -173,8 +173,8 @@ export const AirspeedIndicator = ({ airspeed, airspeedAcc, FWCFlightPhase, altit
             {showBars
                 && (
                     <>
-                        <VLsBar airspeed={airspeed} VLs={VLs} VAlphaProt={ValphaProtection} />
-                        <VAlphaLimBar airspeed={airspeed} VAlphalim={ValphaMax} />
+                        <VLsBar airspeed={airspeedValue} VLs={VLs} VAlphaProt={ValphaProtection} />
+                        <VAlphaLimBar airspeed={airspeedValue} VAlphalim={ValphaMax} />
                     </>
                 )}
         </g>

--- a/src/instruments/src/PFD/SpeedIndicator.tsx
+++ b/src/instruments/src/PFD/SpeedIndicator.tsx
@@ -285,7 +285,7 @@ export const MachNumber = ({ mach, onGround }: MachNumberProps) => {
         }
     }, [showMach, machPermille]);
 
-    if (mach.isFailureWarning() && !onGround) {
+    if (!mach.isNormalOperation() && !onGround) {
         return (
             <text id="MachFailText" className="Blink9Seconds FontLargest StartAlign Red" x="5.4257932" y="136.88908">MACH</text>
         );

--- a/src/instruments/src/PFD/SpeedIndicator.tsx
+++ b/src/instruments/src/PFD/SpeedIndicator.tsx
@@ -76,17 +76,27 @@ const VProtBug = (offset: number) => (
 );
 
 interface AirspeedIndicatorProps {
-    airspeed: number;
+    airspeed: Arinc429Word;
     airspeedAcc: number;
     FWCFlightPhase: number;
     altitude: Arinc429Word;
     VLs: number;
     VMax: number;
     showBars: boolean;
+    onGround: boolean;
 }
 
-export const AirspeedIndicator = ({ airspeed, airspeedAcc, FWCFlightPhase, altitude, VLs, VMax, showBars }: AirspeedIndicatorProps) => {
-    if (Number.isNaN(airspeed)) {
+export const AirspeedIndicator = ({ airspeed, airspeedAcc, FWCFlightPhase, altitude, VLs, VMax, showBars, onGround }: AirspeedIndicatorProps) => {
+    let airspeedValue: number;
+    if (airspeed.isFailureWarning() || (airspeed.isNoComputedData() && !onGround)) {
+        airspeedValue = NaN;
+    } else if (airspeed.isNoComputedData()) {
+        airspeedValue = 30;
+    } else {
+        airspeedValue = airspeed.value;
+    }
+
+    if (Number.isNaN(airspeedValue)) {
         return (
             <>
                 <path id="SpeedTapeBackground" className="TapeBackground" d="m1.9058 123.56v-85.473h17.125v85.473z" />
@@ -102,16 +112,16 @@ export const AirspeedIndicator = ({ airspeed, airspeedAcc, FWCFlightPhase, altit
     const bugs: [(offset: number) => JSX.Element, number][] = [];
 
     if (showBars) {
-        bugs.push(...BarberpoleIndicator(airspeed, ValphaProtection, false, DisplayRange, VAlphaProtBar, 2.923));
+        bugs.push(...BarberpoleIndicator(airspeedValue, ValphaProtection, false, DisplayRange, VAlphaProtBar, 2.923));
     }
-    bugs.push(...BarberpoleIndicator(airspeed, VMax, true, DisplayRange, VMaxBar, 5.040));
+    bugs.push(...BarberpoleIndicator(airspeedValue, VMax, true, DisplayRange, VMaxBar, 5.040));
 
     const showVProt = VMax > 240;
     if (showVProt) {
         bugs.push([VProtBug, VMax + 6]);
     }
 
-    const clampedSpeed = Math.max(Math.min(airspeed, 660), 30);
+    const clampedSpeed = Math.max(Math.min(airspeedValue, 660), 30);
 
     const flapsHandleIndex = getSimVar('L:A32NX_FLAPS_HANDLE_INDEX', 'Number');
 
@@ -146,7 +156,7 @@ export const AirspeedIndicator = ({ airspeed, airspeedAcc, FWCFlightPhase, altit
     return (
         <g id="SpeedTapeElementsGroup">
             <path id="SpeedTapeBackground" className="TapeBackground" d="m1.9058 123.56v-85.473h17.125v85.473z" />
-            <SpeedTapeOutline airspeed={airspeed} />
+            <SpeedTapeOutline airspeed={airspeed.value} />
             <VerticalTape
                 tapeValue={clampedSpeed}
                 bugs={bugs}
@@ -197,8 +207,17 @@ const VLsBar = ({ VAlphaProt, VLs, airspeed }) => {
     );
 };
 
-export const AirspeedIndicatorOfftape = ({ airspeed, targetSpeed, speedIsManaged }) => {
-    if (Number.isNaN(airspeed)) {
+export const AirspeedIndicatorOfftape = ({ airspeed, targetSpeed, speedIsManaged, onGround }) => {
+    let airspeedValue: number;
+    if (airspeed.isFailureWarning() || (airspeed.isNoComputedData() && !onGround)) {
+        airspeedValue = NaN;
+    } else if (airspeed.isNoComputedData()) {
+        airspeedValue = 30;
+    } else {
+        airspeedValue = airspeed.value;
+    }
+
+    if (Number.isNaN(airspeedValue)) {
         return (
             <>
                 <path id="SpeedTapeOutlineUpper" className="NormalStroke Red" d="m1.9058 38.086h21.859" />
@@ -207,7 +226,7 @@ export const AirspeedIndicatorOfftape = ({ airspeed, targetSpeed, speedIsManaged
         );
     }
 
-    const clampedSpeed = Math.max(Math.min(airspeed, 660), 30);
+    const clampedSpeed = Math.max(Math.min(airspeedValue, 660), 30);
     const clampedTargetSpeed = Math.max(Math.min(targetSpeed, 660), 30);
     const showLower = clampedSpeed > 72;
     return (
@@ -250,9 +269,10 @@ const SpeedTapeOutline = ({ airspeed, isRed = false }) => {
 
 interface MachNumberProps {
     mach: Arinc429Word,
+    onGround: boolean,
 }
 
-export const MachNumber = ({ mach }: MachNumberProps) => {
+export const MachNumber = ({ mach, onGround }: MachNumberProps) => {
     const machPermille = Math.round(mach.valueOr(0) * 1000);
     const [showMach, setShowMach] = useState(machPermille > 500);
 
@@ -265,7 +285,7 @@ export const MachNumber = ({ mach }: MachNumberProps) => {
         }
     }, [showMach, machPermille]);
 
-    if (!mach.isNormalOperation()) {
+    if (mach.isFailureWarning() && !onGround) {
         return (
             <text id="MachFailText" className="Blink9Seconds FontLargest StartAlign Red" x="5.4257932" y="136.88908">MACH</text>
         );

--- a/src/instruments/src/PFD/index.tsx
+++ b/src/instruments/src/PFD/index.tsx
@@ -123,7 +123,8 @@ export const PFD: React.FC = () => {
 
     const heading = useArinc429Var(`L:A32NX_ADIRS_IR_${inertialReferenceSource}_HEADING`);
     const groundTrack = useArinc429Var(`L:A32NX_ADIRS_IR_${inertialReferenceSource}_TRACK`);
-    const groundSpeed = useArinc429Var(`L:A32NX_ADIRS_IR_${inertialReferenceSource}_GROUND_SPEED`);
+    const fpa = useArinc429Var(`L:A32NX_ADIRS_IR_${inertialReferenceSource}_FLIGHT_PATH_ANGLE`);
+    const da = useArinc429Var(`L:A32NX_ADIRS_IR_${inertialReferenceSource}_DRIFT_ANGLE`);
 
     const decisionHeight = getSimVar('L:AIRLINER_DECISION_HEIGHT', 'feet');
 
@@ -207,10 +208,8 @@ export const PFD: React.FC = () => {
                 <AttitudeIndicatorFixedCenter
                     pitch={pitch}
                     roll={roll}
-                    vs={inertialVerticalSpeed}
-                    gs={groundSpeed}
-                    heading={heading}
-                    track={groundTrack}
+                    fpa={fpa}
+                    da={da}
                     isOnGround={isOnGround}
                     FDActive={FDActive}
                     isAttExcessive={isAttExcessive}

--- a/src/systems/a320_systems_wasm/src/lib.rs
+++ b/src/systems/a320_systems_wasm/src/lib.rs
@@ -134,6 +134,9 @@ async fn systems(mut gauge: msfs::Gauge) -> Result<(), Box<dyn Error>> {
     .provides_aircraft_variable("VELOCITY BODY Z", "feet per second", 0)?
     .provides_aircraft_variable("VELOCITY WORLD Y", "feet per minute", 0)?
     .provides_aircraft_variable("INCIDENCE ALPHA", "degree", 0)?
+    .provides_aircraft_variable("ROTATION VELOCITY BODY X", "degree per second", 0)?
+    .provides_aircraft_variable("ROTATION VELOCITY BODY Y", "degree per second", 0)?
+    .provides_aircraft_variable("ROTATION VELOCITY BODY Z", "degree per second", 0)?
     .with_aspect(|builder| {
         builder.copy(
             Variable::aircraft("APU GENERATOR SWITCH", "Bool", 0),

--- a/src/systems/a320_systems_wasm/src/lib.rs
+++ b/src/systems/a320_systems_wasm/src/lib.rs
@@ -133,6 +133,7 @@ async fn systems(mut gauge: msfs::Gauge) -> Result<(), Box<dyn Error>> {
     .provides_aircraft_variable("VELOCITY BODY Y", "feet per second", 0)?
     .provides_aircraft_variable("VELOCITY BODY Z", "feet per second", 0)?
     .provides_aircraft_variable("VELOCITY WORLD Y", "feet per minute", 0)?
+    .provides_aircraft_variable("INCIDENCE ALPHA", "degree", 0)?
     .with_aspect(|builder| {
         builder.copy(
             Variable::aircraft("APU GENERATOR SWITCH", "Bool", 0),

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -1964,6 +1964,7 @@ mod tests {
 
         #[rstest]
         #[case(1)]
+        #[case(2)]
         #[case(3)]
         fn static_air_temperature_is_supplied_by_adr(#[case] adiru_number: usize) {
             let sat = ThermodynamicTemperature::new::<degree_celsius>(15.);
@@ -1981,21 +1982,8 @@ mod tests {
         }
 
         #[rstest]
-        #[case(2)]
-        fn static_air_temperature_is_not_supplied_by_adr(#[case] adiru_number: usize) {
-            let sat = ThermodynamicTemperature::new::<degree_celsius>(15.);
-            let mut test_bed = all_adirus_aligned_test_bed();
-            test_bed.set_ambient_temperature(sat);
-            test_bed.run();
-
-            assert_eq!(
-                test_bed.static_air_temperature(adiru_number).value(),
-                ThermodynamicTemperature::new::<degree_celsius>(0.)
-            );
-        }
-
-        #[rstest]
         #[case(1)]
+        #[case(2)]
         #[case(3)]
         fn total_air_temperature_is_supplied_by_adr(#[case] adiru_number: usize) {
             let tat = ThermodynamicTemperature::new::<degree_celsius>(15.);
@@ -2012,20 +2000,8 @@ mod tests {
         }
 
         #[rstest]
-        #[case(2)]
-        fn total_air_temperature_is_not_supplied_by_adr(#[case] adiru_number: usize) {
-            let tat = ThermodynamicTemperature::new::<degree_celsius>(15.);
-            let mut test_bed = all_adirus_aligned_test_bed_with().total_air_temperature_of(tat);
-            test_bed.run();
-
-            assert_eq!(
-                test_bed.total_air_temperature(adiru_number).value(),
-                ThermodynamicTemperature::new::<degree_celsius>(0.)
-            );
-        }
-
-        #[rstest]
         #[case(1)]
+        #[case(2)]
         #[case(3)]
         fn international_standard_atmosphere_delta_is_supplied_by_adr(#[case] adiru_number: usize) {
             let sea_level_temperature = 15.;
@@ -2043,28 +2019,6 @@ mod tests {
                     .normal_value()
                     .unwrap(),
                 ThermodynamicTemperature::new::<degree_celsius>(deviation)
-            );
-        }
-
-        #[rstest]
-        #[case(2)]
-        fn international_standard_atmosphere_delta_is_not_supplied_by_adr(
-            #[case] adiru_number: usize,
-        ) {
-            let sea_level_temperature = 15.;
-            let deviation = 5.;
-            let mut test_bed = all_adirus_aligned_test_bed_with();
-            test_bed.set_indicated_altitude(Length::new::<foot>(0.));
-            test_bed.set_ambient_temperature(ThermodynamicTemperature::new::<degree_celsius>(
-                sea_level_temperature + deviation,
-            ));
-            test_bed.run();
-
-            assert_eq!(
-                test_bed
-                    .international_standard_atmosphere_delta(adiru_number)
-                    .value(),
-                ThermodynamicTemperature::new::<degree_celsius>(0.)
             );
         }
     }

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -2399,7 +2399,6 @@ mod tests {
             let track = Angle::new::<degree>(180.);
             let mut test_bed = all_adirus_aligned_test_bed_with()
                 .track_of(track)
-                .and()
                 .heading_of(heading)
                 .and()
                 .ground_speed_of(Velocity::new::<knot>(

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -1334,6 +1334,21 @@ mod tests {
             self
         }
 
+        fn body_roll_rate_of(mut self, rate: AngularVelocity) -> Self {
+            self.write_by_name(AdirsSimulatorData::BODY_ROTATION_RATE_Z, rate);
+            self
+        }
+
+        fn body_pitch_rate_of(mut self, rate: AngularVelocity) -> Self {
+            self.write_by_name(AdirsSimulatorData::BODY_ROTATION_RATE_X, rate);
+            self
+        }
+
+        fn body_yaw_rate_of(mut self, rate: AngularVelocity) -> Self {
+            self.write_by_name(AdirsSimulatorData::BODY_ROTATION_RATE_Y, rate);
+            self
+        }
+
         fn heading_of(mut self, angle: Angle) -> Self {
             self.write_by_name(AdirsSimulatorData::HEADING, angle);
             self
@@ -1557,6 +1572,86 @@ mod tests {
             ))
         }
 
+        fn flight_path_angle(&mut self, adiru_number: usize) -> Arinc429Word<Angle> {
+            self.read_arinc429_by_name(&output_data_id(
+                OutputDataType::Ir,
+                adiru_number,
+                InertialReference::FLIGHT_PATH_ANGLE,
+            ))
+        }
+
+        fn body_pitch_rate(&mut self, adiru_number: usize) -> Arinc429Word<AngularVelocity> {
+            self.read_arinc429_by_name(&output_data_id(
+                OutputDataType::Ir,
+                adiru_number,
+                InertialReference::BODY_PITCH_RATE,
+            ))
+        }
+
+        fn body_roll_rate(&mut self, adiru_number: usize) -> Arinc429Word<AngularVelocity> {
+            self.read_arinc429_by_name(&output_data_id(
+                OutputDataType::Ir,
+                adiru_number,
+                InertialReference::BODY_ROLL_RATE,
+            ))
+        }
+
+        fn body_yaw_rate(&mut self, adiru_number: usize) -> Arinc429Word<AngularVelocity> {
+            self.read_arinc429_by_name(&output_data_id(
+                OutputDataType::Ir,
+                adiru_number,
+                InertialReference::BODY_YAW_RATE,
+            ))
+        }
+
+        fn body_long_acc(&mut self, adiru_number: usize) -> Arinc429Word<Ratio> {
+            self.read_arinc429_by_name(&output_data_id(
+                OutputDataType::Ir,
+                adiru_number,
+                InertialReference::BODY_LONGITUDINAL_ACC,
+            ))
+        }
+
+        fn body_lat_acc(&mut self, adiru_number: usize) -> Arinc429Word<Ratio> {
+            self.read_arinc429_by_name(&output_data_id(
+                OutputDataType::Ir,
+                adiru_number,
+                InertialReference::BODY_LATERAL_ACC,
+            ))
+        }
+
+        fn body_normal_acc(&mut self, adiru_number: usize) -> Arinc429Word<Ratio> {
+            self.read_arinc429_by_name(&output_data_id(
+                OutputDataType::Ir,
+                adiru_number,
+                InertialReference::BODY_NORMAL_ACC,
+            ))
+        }
+
+        fn pitch_att_rate(&mut self, adiru_number: usize) -> Arinc429Word<Angle> {
+            self.read_arinc429_by_name(&output_data_id(
+                OutputDataType::Ir,
+                adiru_number,
+                InertialReference::PITCH_ATT_RATE,
+            ))
+        }
+
+        fn roll_att_rate(&mut self, adiru_number: usize) -> Arinc429Word<Angle> {
+            self.read_arinc429_by_name(&output_data_id(
+                OutputDataType::Ir,
+                adiru_number,
+                InertialReference::ROLL_ATT_RATE,
+            ))
+        }
+
+        fn heading_rate(&mut self, adiru_number: usize) -> Arinc429Word<Angle> {
+            self.read_arinc429_by_name(&output_data_id(
+                OutputDataType::Ir,
+                adiru_number,
+                InertialReference::HEADING_RATE,
+            ))
+        }
+
         fn ground_speed(&mut self, adiru_number: usize) -> Arinc429Word<Velocity> {
             self.read_arinc429_by_name(&output_data_id(
                 OutputDataType::Ir,
@@ -1661,6 +1756,14 @@ mod tests {
         fn assert_ir_non_attitude_data_available(&mut self, available: bool, adiru_number: usize) {
             assert_eq!(self.track(adiru_number).is_normal_operation(), available);
             assert_eq!(
+                self.drift_angle(adiru_number).is_normal_operation(),
+                available
+            );
+            assert_eq!(
+                self.flight_path_angle(adiru_number).is_normal_operation(),
+                available
+            );
+            assert_eq!(
                 self.inertial_vertical_speed(adiru_number)
                     .is_normal_operation(),
                 available
@@ -1687,6 +1790,42 @@ mod tests {
         fn assert_ir_attitude_data_available(&mut self, available: bool, adiru_number: usize) {
             assert_eq!(self.pitch(adiru_number).is_normal_operation(), available);
             assert_eq!(self.roll(adiru_number).is_normal_operation(), available);
+            assert_eq!(
+                self.body_pitch_rate(adiru_number).is_normal_operation(),
+                available
+            );
+            assert_eq!(
+                self.body_roll_rate(adiru_number).is_normal_operation(),
+                available
+            );
+            assert_eq!(
+                self.body_yaw_rate(adiru_number).is_normal_operation(),
+                available
+            );
+            assert_eq!(
+                self.body_long_acc(adiru_number).is_normal_operation(),
+                available
+            );
+            assert_eq!(
+                self.body_lat_acc(adiru_number).is_normal_operation(),
+                available
+            );
+            assert_eq!(
+                self.body_normal_acc(adiru_number).is_normal_operation(),
+                available
+            );
+            assert_eq!(
+                self.pitch_att_rate(adiru_number).is_normal_operation(),
+                available
+            );
+            assert_eq!(
+                self.roll_att_rate(adiru_number).is_normal_operation(),
+                available
+            );
+            assert_eq!(
+                self.heading_rate(adiru_number).is_normal_operation(),
+                available
+            );
         }
 
         fn assert_all_ir_data_available(&mut self, available: bool, adiru_number: usize) {
@@ -2315,6 +2454,7 @@ mod tests {
 
     mod ir {
         use super::*;
+        use uom::si::angular_velocity::revolution_per_minute;
 
         #[rstest]
         #[case(1)]
@@ -2451,6 +2591,119 @@ mod tests {
         #[case(1)]
         #[case(2)]
         #[case(3)]
+        fn body_roll_rate_is_supplied_by_ir(#[case] adiru_number: usize) {
+            let rate = AngularVelocity::new::<revolution_per_minute>(5.);
+            let mut test_bed = all_adirus_aligned_test_bed_with().body_roll_rate_of(rate);
+            test_bed.run();
+
+            assert_about_eq!(
+                test_bed
+                    .body_roll_rate(adiru_number)
+                    .normal_value()
+                    .unwrap()
+                    .get::<degree_per_second>(),
+                rate.get::<revolution_per_minute>()
+            );
+        }
+
+        #[rstest]
+        #[case(1)]
+        #[case(2)]
+        #[case(3)]
+        fn body_pitch_rate_is_supplied_by_ir(#[case] adiru_number: usize) {
+            let rate = AngularVelocity::new::<revolution_per_minute>(5.);
+            let mut test_bed = all_adirus_aligned_test_bed_with().body_pitch_rate_of(rate);
+            test_bed.run();
+
+            assert_about_eq!(
+                test_bed
+                    .body_pitch_rate(adiru_number)
+                    .normal_value()
+                    .unwrap()
+                    .get::<degree_per_second>(),
+                rate.get::<revolution_per_minute>()
+            );
+        }
+
+        #[rstest]
+        #[case(1)]
+        #[case(2)]
+        #[case(3)]
+        fn body_yaw_rate_is_supplied_by_ir(#[case] adiru_number: usize) {
+            let rate = AngularVelocity::new::<revolution_per_minute>(5.);
+            let mut test_bed = all_adirus_aligned_test_bed_with().body_yaw_rate_of(rate);
+            test_bed.run();
+
+            assert_about_eq!(
+                test_bed
+                    .body_yaw_rate(adiru_number)
+                    .normal_value()
+                    .unwrap()
+                    .get::<degree_per_second>(),
+                rate.get::<revolution_per_minute>()
+            );
+        }
+
+        #[rstest]
+        #[case(1)]
+        #[case(2)]
+        #[case(3)]
+        fn body_long_acc_is_supplied_by_ir(#[case] adiru_number: usize) {
+            let acc = Acceleration::new::<meter_per_second_squared>(1.);
+            let g = Acceleration::new::<meter_per_second_squared>(9.81);
+            let mut test_bed = all_adirus_aligned_test_bed();
+            test_bed.set_long_acc(acc);
+            test_bed.run();
+
+            assert_about_eq!(
+                V::from(test_bed.body_long_acc(adiru_number).normal_value().unwrap()),
+                V::from(acc / g)
+            );
+        }
+
+        #[rstest]
+        #[case(1)]
+        #[case(2)]
+        #[case(3)]
+        fn body_lat_acc_is_supplied_by_ir(#[case] adiru_number: usize) {
+            let acc = Acceleration::new::<meter_per_second_squared>(1.);
+            let g = Acceleration::new::<meter_per_second_squared>(9.81);
+            let mut test_bed = all_adirus_aligned_test_bed();
+            test_bed.set_lat_acc(acc);
+            test_bed.run();
+
+            assert_about_eq!(
+                V::from(test_bed.body_lat_acc(adiru_number).normal_value().unwrap()),
+                V::from(acc / g)
+            );
+        }
+
+        #[rstest]
+        #[case(1)]
+        #[case(2)]
+        #[case(3)]
+        fn body_norm_acc_is_supplied_by_ir(#[case] adiru_number: usize) {
+            let acc = Acceleration::new::<meter_per_second_squared>(1.);
+            let g = Acceleration::new::<meter_per_second_squared>(9.81);
+            let mut test_bed = all_adirus_aligned_test_bed();
+            test_bed.set_norm_acc(acc);
+            test_bed.run();
+
+            assert_about_eq!(
+                V::from(
+                    test_bed
+                        .body_normal_acc(adiru_number)
+                        .normal_value()
+                        .unwrap()
+                ),
+                V::from(acc / g)
+            );
+        }
+
+        #[rstest]
+        #[case(1)]
+        #[case(2)]
+        #[case(3)]
         fn heading_is_supplied_by_ir(#[case] adiru_number: usize) {
             let angle = Angle::new::<degree>(160.);
             let mut test_bed = all_adirus_aligned_test_bed_with().heading_of(angle);
@@ -2537,6 +2790,57 @@ mod tests {
                 .track_of(track)
                 .and()
                 .heading_of(heading)
+                .and()
+                .ground_speed_of(Velocity::new::<knot>(
+                    InertialReference::MINIMUM_GROUND_SPEED_FOR_TRACK_KNOTS - 0.01,
+                ));
+            test_bed.run();
+
+            assert_eq!(
+                test_bed.drift_angle(adiru_number).normal_value().unwrap(),
+                Angle::new::<degree>(0.)
+            );
+        }
+
+        #[rstest]
+        #[case(1)]
+        #[case(2)]
+        #[case(3)]
+        fn flight_path_angle_is_supplied_when_ground_speed_greater_than_or_equal_to_50_knots(
+            #[case] adiru_number: usize,
+        ) {
+            let vs = Velocity::new::<foot_per_minute>(500.);
+            let mut test_bed = all_adirus_aligned_test_bed_with()
+                .vertical_speed_of(vs)
+                .and()
+                .ground_speed_of(Velocity::new::<knot>(
+                    InertialReference::MINIMUM_GROUND_SPEED_FOR_TRACK_KNOTS,
+                ));
+            test_bed.run();
+
+            assert_about_eq!(
+                test_bed
+                    .flight_path_angle(adiru_number)
+                    .normal_value()
+                    .unwrap()
+                    .get::<degree>(),
+                vs.atan2(Velocity::new::<knot>(
+                    InertialReference::MINIMUM_GROUND_SPEED_FOR_TRACK_KNOTS,
+                ))
+                .get::<degree>()
+            );
+        }
+
+        #[rstest]
+        #[case(1)]
+        #[case(2)]
+        #[case(3)]
+        fn flight_path_angle_is_zero_when_ground_speed_less_than_50_knots(
+            #[case] adiru_number: usize,
+        ) {
+            let vs = Velocity::new::<foot_per_minute>(500.);
+            let mut test_bed = all_adirus_aligned_test_bed_with()
+                .vertical_speed_of(vs)
                 .and()
                 .ground_speed_of(Velocity::new::<knot>(
                     InertialReference::MINIMUM_GROUND_SPEED_FOR_TRACK_KNOTS - 0.01,

--- a/src/systems/systems/src/simulation/test.rs
+++ b/src/systems/systems/src/simulation/test.rs
@@ -78,6 +78,18 @@ pub trait TestBed {
         self.test_bed_mut().indicated_airspeed()
     }
 
+    fn set_long_acc(&mut self, acc: Acceleration) {
+        self.test_bed_mut().set_long_acceleration(acc);
+    }
+
+    fn set_lat_acc(&mut self, acc: Acceleration) {
+        self.test_bed_mut().set_lat_acceleration(acc);
+    }
+
+    fn set_norm_acc(&mut self, acc: Acceleration) {
+        self.test_bed_mut().set_normal_acceleration(acc);
+    }
+
     fn set_indicated_altitude(&mut self, indicated_altitude: Length) {
         self.test_bed_mut()
             .set_indicated_altitude(indicated_altitude);
@@ -359,6 +371,20 @@ impl<T: Aircraft> SimulationTestBed<T> {
     pub fn set_long_acceleration(&mut self, accel: Acceleration) {
         self.write_by_name(
             UpdateContext::ACCEL_BODY_Z_KEY,
+            accel.get::<foot_per_second_squared>(),
+        );
+    }
+
+    pub fn set_lat_acceleration(&mut self, accel: Acceleration) {
+        self.write_by_name(
+            UpdateContext::ACCEL_BODY_X_KEY,
+            accel.get::<foot_per_second_squared>(),
+        );
+    }
+
+    pub fn set_normal_acceleration(&mut self, accel: Acceleration) {
+        self.write_by_name(
+            UpdateContext::ACCEL_BODY_Y_KEY,
             accel.get::<foot_per_second_squared>(),
         );
     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR:
* Outputs SSM=FW for all ADR labels when the ADR is off or not aligned
* Improves the ADR behaviour for low speeds. The following values are now coded as NCD with value=0 when below a threshold:
   * CAS, when below 30kts
   * TAS, when below 60kts
   * Mach, when below 0.1
* All 3 ADRs now output temperature values, instead of only 1 and 3.
* Added new data outputs to the ADR:
   * Angle of Attack (coded NCD below 60kts CAS, but the actual value is still output)
* Added new data outputs to the IR:
   * Drift Angle (DA), which is 0 below 50kts GS
   * Kinematic Flight Path Angle (gamma_k), which is 0 below 50kts GS
   * The Body axis rotation rates: p, q, r
      * Derived from these the Pitch/Roll/Heading rates: Theta_dot, Phi_dot, Psi_dot
   * The Body accelerations: a_x, a_y, a_z

The FPA and DA are now used for the FPV on the PFD. In case of FPA or DA set as FW/NCD, the FPV flag is now shown (when the attitude is still valid and TRK/FPA mode is active, for example when the IR is in ATT mode).
Also, if the CAS goes below 30kts in flight, the SPD flag is shown now, since CAS is then coded NCD.
Finally, if mach is not valid, the MACH flag is not shown on ground, only in flight. This means that if MACH goes below 0.1 in the air, the MACH flight will also be shown, since it is coded NCD in that case.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
https://streamable.com/hudxhn

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
For low airspeeds and extreme attitudes, I found these videos, in which you can clearly see the SPD and MACH flag, and also the FPV snapping away below 50kts:
https://www.youtube.com/watch?v=Eap-3siSgLc
https://www.youtube.com/watch?v=rKEKwYTvuZU
https://www.youtube.com/watch?v=AYm1aLu49Pk

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
* Make sure that the bird and the FPV flag on the PFD in TRK/FPA mode beave as described above and are plausible
* Make sure that the CAS/TAS/mach values (and invalidity flags) on the ND/PFD behave as described above and are plausible
* Unfortunately, the other parameters added (AoA, the rotation rates and accelerations) cannot be easily checked without decoding the Arinc429 values and looking at the numeric value, so they probably cannot be tested properly.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
