### PR TITLE
fix: ND track line when LOC is armed

### DIFF
--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -1565,6 +1565,7 @@ In the variables below, {number} should be replaced with one item in the set: { 
       ROLL_OUT | 34
       SRS | 40
       SRS_GA | 41
+      TCAS | 50
 
 - A32NX_FMA_VERTICAL_ARMED
     - Bitmask
@@ -1577,6 +1578,7 @@ In the variables below, {number} should be replaced with one item in the set: { 
       DES | 3
       GS | 4
       FINAL | 5
+      TCAS | 6
 
 - A32NX_FMA_EXPEDITE_MODE
     - Boolean

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
@@ -542,7 +542,6 @@ class A320_Neo_FCU_Heading extends A320_Neo_FCU_Component {
 
     onRotate() {
         const lateralMode = SimVar.GetSimVarValue("L:A32NX_FMA_LATERAL_MODE", "Number");
-        const lateralArmed = SimVar.GetSimVarValue("L:A32NX_FMA_LATERAL_ARMED", "Number");
         const isTRKMode = SimVar.GetSimVarValue("L:A32NX_TRK_FPA_MODE_ACTIVE", "Bool");
         const radioHeight = SimVar.GetSimVarValue("RADIO HEIGHT", "feet");
 

--- a/src/fmgc/src/efis/EfisVectors.ts
+++ b/src/fmgc/src/efis/EfisVectors.ts
@@ -7,7 +7,7 @@ import { GuidanceController } from '@fmgc/guidance/GuidanceController';
 import { EfisSide, EfisVectorsGroup } from '@shared/NavigationDisplay';
 import { PathVector, pathVectorLength, pathVectorValid } from '@fmgc/guidance/lnav/PathVector';
 import { LnavConfig } from '@fmgc/guidance/LnavConfig';
-import { LateralMode } from '@shared/autopilot';
+import { ArmedLateralMode, isArmed, LateralMode } from '@shared/autopilot';
 import { TaskCategory } from '@fmgc/guidance/TaskQueue';
 import stringify from 'safe-stable-stringify';
 
@@ -68,7 +68,7 @@ export class EfisVectors {
 
         const engagedLateralMode = SimVar.GetSimVarValue('L:A32NX_FMA_LATERAL_MODE', 'Number') as LateralMode;
         const armedLateralMode = SimVar.GetSimVarValue('L:A32NX_FMA_LATERAL_ARMED', 'Enum');
-        const navArmed = (armedLateralMode & 1) === 1;
+        const navArmed = isArmed(armedLateralMode, ArmedLateralMode.NAV);
 
         const transmitActive = engagedLateralMode === LateralMode.NAV || engagedLateralMode === LateralMode.LOC_CPT || engagedLateralMode === LateralMode.LOC_TRACK || navArmed;
         const clearActive = !transmitActive && this.currentActiveVectors.length > 0;

--- a/src/instruments/src/ND/pages/ArcMode.tsx
+++ b/src/instruments/src/ND/pages/ArcMode.tsx
@@ -4,7 +4,7 @@ import { getSmallestAngle } from '@instruments/common/utils';
 import { MathUtils } from '@shared/MathUtils';
 import { useFlightPlanManager } from '@instruments/common/flightplan';
 import { RangeSetting, Mode, EfisSide, NdSymbol } from '@shared/NavigationDisplay';
-import { LateralMode } from '@shared/autopilot';
+import { ArmedLateralMode, isArmed, LateralMode } from '@shared/autopilot';
 import { FlightPlan } from '../elements/FlightPlan';
 import { MapParameters } from '../utils/MapParameters';
 import { RadioNeedle } from '../elements/RadioNeedles';
@@ -34,7 +34,7 @@ export const ArcMode: React.FC<ArcModeProps> = ({ symbols, adirsAlign, rangeSett
     const [lsCourse] = useSimVar('L:A32NX_FM_LS_COURSE', 'number');
     const [lsDisplayed] = useSimVar(`L:BTN_LS_${side === 'L' ? 1 : 2}_FILTER_ACTIVE`, 'bool'); // TODO rename simvar
     const [fmaLatMode] = useSimVar('L:A32NX_FMA_LATERAL_MODE', 'enum', 200);
-    const [fmaLatArmed] = useSimVar('L:A32NX_FMA_LATERAL_ARMED', 'enum', 200);
+    const [armedLateralBitmask] = useSimVar('L:A32NX_FMA_LATERAL_ARMED', 'enum', 200);
     const [groundSpeed] = useSimVar('GPS GROUND SPEED', 'Meters per second', 200);
 
     const heading = Number(MathUtils.fastToFixed(magHeading, 2));
@@ -78,9 +78,10 @@ export const ArcMode: React.FC<ArcModeProps> = ({ symbols, adirsAlign, rangeSett
                             debug={false}
                         />
 
-                        { (((fmaLatMode === LateralMode.NONE
+                        { ((fmaLatMode === LateralMode.NONE
                             || fmaLatMode === LateralMode.HDG
-                            || fmaLatMode === LateralMode.TRACK) && !fmaLatArmed)) && (
+                            || fmaLatMode === LateralMode.TRACK)
+                            && !isArmed(armedLateralBitmask, ArmedLateralMode.NAV)) && (
                             <TrackLine x={384} y={620} heading={heading} track={track} />
                         )}
                     </g>

--- a/src/instruments/src/ND/pages/RoseMode.tsx
+++ b/src/instruments/src/ND/pages/RoseMode.tsx
@@ -5,7 +5,7 @@ import { useFlightPlanManager } from '@instruments/common/flightplan';
 import { MathUtils } from '@shared/MathUtils';
 import { TuningMode } from '@fmgc/radionav';
 import { Mode, EfisSide, NdSymbol } from '@shared/NavigationDisplay';
-import { LateralMode } from '@shared/autopilot';
+import { ArmedLateralMode, isArmed, LateralMode } from '@shared/autopilot';
 import { ToWaypointIndicator } from '../elements/ToWaypointIndicator';
 import { FlightPlan, FlightPlanType } from '../elements/FlightPlan';
 import { MapParameters } from '../utils/MapParameters';
@@ -37,7 +37,7 @@ export const RoseMode: FC<RoseModeProps> = ({ symbols, adirsAlign, rangeSetting,
     const [lsDisplayed] = useSimVar(`L:BTN_LS_${side === 'L' ? 1 : 2}_FILTER_ACTIVE`, 'bool'); // TODO rename simvar
     const [showTmpFplan] = useSimVar('L:MAP_SHOW_TEMPORARY_FLIGHT_PLAN', 'bool');
     const [fmaLatMode] = useSimVar('L:A32NX_FMA_LATERAL_MODE', 'enum', 200);
-    const [fmaLatArmed] = useSimVar('L:A32NX_FMA_LATERAL_ARMED', 'enum', 200);
+    const [armedLateralBitmask] = useSimVar('L:A32NX_FMA_LATERAL_ARMED', 'enum', 200);
     const [groundSpeed] = useSimVar('GPS GROUND SPEED', 'Meters per second', 200);
 
     const heading = Math.round(Number(MathUtils.fastToFixed(magHeading, 1)) * 1000) / 1000;
@@ -82,9 +82,9 @@ export const RoseMode: FC<RoseModeProps> = ({ symbols, adirsAlign, rangeSetting,
                                 debug={false}
                             />
 
-                            { (((fmaLatMode === LateralMode.NONE
-                                || fmaLatMode === LateralMode.HDG
-                                || fmaLatMode === LateralMode.TRACK) && !fmaLatArmed) || !flightPlanManager.getCurrentFlightPlan().length) && (
+                            { (((fmaLatMode === LateralMode.NONE || fmaLatMode === LateralMode.HDG || fmaLatMode === LateralMode.TRACK)
+                                && !isArmed(armedLateralBitmask, ArmedLateralMode.NAV))
+                                || !flightPlanManager.getCurrentFlightPlan().length) && (
                                 <TrackLine x={384} y={384} heading={heading} track={track} />
                             )}
                         </g>

--- a/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
+++ b/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
@@ -1,4 +1,5 @@
 import { Arinc429Word } from '@shared/arinc429';
+import { LateralMode, VerticalMode } from '@shared/autopilot.js';
 import React from 'react';
 import { getSimVar } from '../util.js';
 
@@ -81,7 +82,7 @@ export const AttitudeIndicatorFixedCenter = ({ pitch, roll, isOnGround, FDActive
 const FDYawBar = ({ FDActive }) => {
     const lateralMode = getSimVar('L:A32NX_FMA_LATERAL_MODE', 'number');
 
-    if (!FDActive || !(lateralMode === 40 || lateralMode === 33 || lateralMode === 34)) {
+    if (!FDActive || !(lateralMode === LateralMode.RWY || lateralMode === LateralMode.FLARE || lateralMode === LateralMode.ROLL_OUT)) {
         return null;
     }
 
@@ -101,8 +102,8 @@ const FlightDirector = ({ FDActive }) => {
     const lateralAPMode = getSimVar('L:A32NX_FMA_LATERAL_MODE', 'number');
     const verticalAPMode = getSimVar('L:A32NX_FMA_VERTICAL_MODE', 'enum');
 
-    const showLateralFD = lateralAPMode !== 0 && lateralAPMode !== 34 && lateralAPMode !== 40;
-    const showVerticalFD = verticalAPMode !== 0 && verticalAPMode !== 34;
+    const showLateralFD = lateralAPMode !== LateralMode.NONE && lateralAPMode !== LateralMode.ROLL_OUT && lateralAPMode !== LateralMode.RWY;
+    const showVerticalFD = verticalAPMode !== VerticalMode.NONE && verticalAPMode !== VerticalMode.ROLL_OUT;
 
     let FDRollOffset = 0;
     let FDPitchOffset = 0;

--- a/src/instruments/src/PFD/AttitudeIndicatorHorizon.tsx
+++ b/src/instruments/src/PFD/AttitudeIndicatorHorizon.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Arinc429Word } from '@shared/arinc429';
 import { useUpdate } from '@instruments/common/hooks';
 import { getSmallestAngle } from '@instruments/common/utils';
+import { LateralMode, VerticalMode } from '@shared/autopilot';
 import {
     calculateHorizonOffsetFromPitch,
     calculateVerticalOffsetFromRoll,
@@ -204,8 +205,8 @@ const FlightPathDirector = ({ FDActive }) => {
 
     const lateralAPMode = getSimVar('L:A32NX_FMA_LATERAL_MODE', 'number');
     const verticalAPMode = getSimVar('L:A32NX_FMA_VERTICAL_MODE', 'enum');
-    const showLateralFD = lateralAPMode !== 0 && lateralAPMode !== 34 && lateralAPMode !== 40;
-    const showVerticalFD = verticalAPMode !== 0 && verticalAPMode !== 34;
+    const showLateralFD = lateralAPMode !== LateralMode.NONE && lateralAPMode !== LateralMode.ROLL_OUT && lateralAPMode !== LateralMode.RWY;
+    const showVerticalFD = verticalAPMode !== VerticalMode.NONE && verticalAPMode !== VerticalMode.ROLL_OUT;
 
     if (!showVerticalFD && !showLateralFD) {
         return null;

--- a/src/instruments/src/PFD/FMA.tsx
+++ b/src/instruments/src/PFD/FMA.tsx
@@ -1,10 +1,12 @@
+import { ArmedLateralMode, ArmedVerticalMode, isArmed, LateralMode, VerticalMode } from '@shared/autopilot.js';
 import React, { Component } from 'react';
 import { createDeltaTimeCalculator, getSimVar, renderTarget } from '../util.js';
 
 export const FMA = ({ isAttExcessive }) => {
     const activeLateralMode = getSimVar('L:A32NX_FMA_LATERAL_MODE', 'number');
     const activeVerticalMode = getSimVar('L:A32NX_FMA_VERTICAL_MODE', 'enum');
-    const sharedModeActive = activeLateralMode === 32 || activeLateralMode === 33 || activeLateralMode === 34 || (activeLateralMode === 20 && activeVerticalMode === 24);
+    const sharedModeActive = activeLateralMode === LateralMode.LAND || activeLateralMode === LateralMode.FLARE || activeLateralMode === LateralMode.ROLL_OUT
+        || (activeLateralMode === LateralMode.NAV && activeVerticalMode === VerticalMode.FINAL);
     const engineMessage = getSimVar('L:A32NX_AUTOTHRUST_MODE_MESSAGE', 'enum');
     const BC3Message = getBC3Message(isAttExcessive)[0] !== null;
     const AB3Message = (getSimVar('L:A32NX_MachPreselVal', 'mach') !== -1
@@ -252,68 +254,65 @@ const B1Cell = () => {
     let inProtection = false;
 
     switch (activeVerticalMode) {
-    case 31:
+    case VerticalMode.GS_TRACK:
         text = 'G/S';
         break;
     // case 2:
     //     text = 'F-G/S';
     //     break;
-    case 30:
+    case VerticalMode.GS_CPT:
         text = 'G/S*';
         break;
     // case 4:
     //     text = 'F-G/S*';
     //     break;
-    case 40:
-    case 41:
+    case VerticalMode.SRS:
+    case VerticalMode.SRS_GA:
         text = 'SRS';
         break;
-    case 50:
+    case VerticalMode.TCAS:
         text = 'TCAS';
         break;
     // case 9:
     //     text = 'FINAL';
     //     break;
-    case 23:
+    case VerticalMode.DES:
         text = 'DES';
         break;
-    case 13:
+    case VerticalMode.OP_DES:
         if (getSimVar('L:A32NX_FMA_EXPEDITE_MODE', 'bool')) {
             text = 'EXP DES';
         } else {
             text = 'OP DES';
         }
         break;
-    case 22:
+    case VerticalMode.CLB:
         text = 'CLB';
         break;
-    case 12:
+    case VerticalMode.OP_CLB:
         if (getSimVar('L:A32NX_FMA_EXPEDITE_MODE', 'bool')) {
             text = 'EXP CLB';
         } else {
             text = 'OP CLB';
         }
         break;
-    case 10:
+    case VerticalMode.ALT:
         if (getSimVar('L:A32NX_FMA_CRUISE_ALT_MODE', 'Bool')) {
             text = 'ALT CRZ';
         } else {
             text = 'ALT';
         }
         break;
-    case 11:
+    case VerticalMode.ALT_CPT:
         text = 'ALT*';
         break;
-    case 21:
-        text = 'ALT CST*';
-        break;
-    case 20:
+    case VerticalMode.ALT_CST:
         text = 'ALT CST';
         break;
-    // case 18:
-    //     text = 'ALT CRZ';
-    //     break;
-    case 15: {
+    case VerticalMode.ALT_CST_CPT:
+        text = 'ALT CST*';
+        break;
+    case VerticalMode.FPA: {
         const FPA = getSimVar('L:A32NX_AUTOPILOT_FPA_SELECTED', 'Degree');
         inProtection = getSimVar('L:A32NX_FMA_SPEED_PROTECTION_MODE', 'bool');
         const FPAText = `${(FPA >= 0 ? '+' : '')}${(Math.round(FPA * 10) / 10).toFixed(1)}°`;
@@ -326,7 +325,7 @@ const B1Cell = () => {
         );
         break;
     }
-    case 14: {
+    case VerticalMode.VS: {
         const VS = getSimVar('L:A32NX_AUTOPILOT_VS_SELECTED', 'feet per minute');
         inProtection = getSimVar('L:A32NX_FMA_SPEED_PROTECTION_MODE', 'bool');
         const VSText = `${(VS >= 0 ? '+' : '')}${Math.round(VS).toString()}`.padStart(5, ' ');
@@ -343,13 +342,13 @@ const B1Cell = () => {
         return null;
     }
 
-    const inSpeedProtection = inProtection && (activeVerticalMode === 14 || activeVerticalMode === 15);
+    const inSpeedProtection = inProtection && (activeVerticalMode === VerticalMode.VS || activeVerticalMode === VerticalMode.FPA);
     const inModeReversion = getSimVar('L:A32NX_FMA_MODE_REVERSION', 'bool');
 
     const tcasModeDisarmedMessage = getSimVar('L:A32NX_AUTOPILOT_TCAS_MESSAGE_DISARM', 'bool');
 
     const boxClassName = (inSpeedProtection || inModeReversion) ? 'NormalStroke None' : 'NormalStroke White';
-    const boxPathString = activeVerticalMode === 50 && tcasModeDisarmedMessage ? 'm34.656 1.8143h29.918v13.506h-29.918z' : 'm34.656 1.8143h29.918v6.0476h-29.918z';
+    const boxPathString = activeVerticalMode === VerticalMode.TCAS && tcasModeDisarmedMessage ? 'm34.656 1.8143h29.918v13.506h-29.918z' : 'm34.656 1.8143h29.918v6.0476h-29.918z';
 
     return (
         <g>
@@ -366,12 +365,12 @@ const B1Cell = () => {
 const B2Cell = () => {
     const armedVerticalBitmask = getSimVar('L:A32NX_FMA_VERTICAL_ARMED', 'number');
 
-    const altArmed = (armedVerticalBitmask >> 0) & 1;
-    const altCstArmed = (armedVerticalBitmask >> 1) & 1;
-    const clbArmed = (armedVerticalBitmask >> 2) & 1;
-    const desArmed = (armedVerticalBitmask >> 3) & 1;
-    const gsArmed = (armedVerticalBitmask >> 4) & 1;
-    const finalArmed = (armedVerticalBitmask >> 5) & 1;
+    const altArmed = isArmed(armedVerticalBitmask, ArmedVerticalMode.ALT);
+    const altCstArmed = isArmed(armedVerticalBitmask, ArmedVerticalMode.ALT_CST);
+    const clbArmed = isArmed(armedVerticalBitmask, ArmedVerticalMode.CLB);
+    const desArmed = isArmed(armedVerticalBitmask, ArmedVerticalMode.DES);
+    const gsArmed = isArmed(armedVerticalBitmask, ArmedVerticalMode.GS);
+    const finalArmed = isArmed(armedVerticalBitmask, ArmedVerticalMode.FINAL);
 
     let text1: string | null;
     let color1 = 'Cyan';
@@ -414,37 +413,37 @@ const C1Cell = () => {
     const activeLateralMode = getSimVar('L:A32NX_FMA_LATERAL_MODE', 'number');
 
     const armedVerticalBitmask = getSimVar('L:A32NX_FMA_VERTICAL_ARMED', 'number');
-    const finalArmed = (armedVerticalBitmask >> 5) & 1;
+    const finalArmed = isArmed(armedVerticalBitmask, ArmedVerticalMode.FINAL);
 
     const activeVerticalMode = getSimVar('L:A32NX_FMA_VERTICAL_MODE', 'enum');
 
     let text: string;
     let id = 0;
-    if (activeLateralMode === 50) {
+    if (activeLateralMode === LateralMode.GA_TRACK) {
         text = 'GA TRK';
         id = 1;
-    } else if (activeLateralMode === 30) {
+    } else if (activeLateralMode === LateralMode.LOC_CPT) {
         text = 'LOC *';
         id = 3;
-    } else if (activeLateralMode === 10) {
+    } else if (activeLateralMode === LateralMode.HDG) {
         text = 'HDG';
         id = 5;
-    } else if (activeLateralMode === 40) {
+    } else if (activeLateralMode === LateralMode.RWY) {
         text = 'RWY';
         id = 6;
-    } else if (activeLateralMode === 41) {
+    } else if (activeLateralMode === LateralMode.RWY_TRACK) {
         text = 'RWY TRK';
         id = 7;
-    } else if (activeLateralMode === 11) {
+    } else if (activeLateralMode === LateralMode.TRACK) {
         text = 'TRACK';
         id = 8;
-    } else if (activeLateralMode === 31) {
+    } else if (activeLateralMode === LateralMode.LOC_TRACK) {
         text = 'LOC';
         id = 10;
-    } else if (activeLateralMode === 20 && !finalArmed && activeVerticalMode !== 24) {
+    } else if (activeLateralMode === LateralMode.NAV && !finalArmed && activeVerticalMode !== VerticalMode.FINAL) {
         text = 'NAV';
         id = 13;
-    } else if (activeLateralMode === 20 && finalArmed && activeVerticalMode !== 24) {
+    } else if (activeLateralMode === LateralMode.NAV && finalArmed && activeVerticalMode !== VerticalMode.FINAL) {
         text = 'APP NAV';
         id = 12;
     } else {
@@ -466,10 +465,6 @@ const C1Cell = () => {
     //     text = 'F-LOC';
     //     id = 11;
     //     break;
-    // case 12:
-    //     text = 'APP NAV';
-    //     id = 12;
-    //     break;
 
     return (
         <g>
@@ -484,11 +479,11 @@ const C1Cell = () => {
 const C2Cell = () => {
     const armedLateralBitmask = getSimVar('L:A32NX_FMA_LATERAL_ARMED', 'number');
 
-    const navArmed = (armedLateralBitmask >> 0) & 1;
-    const locArmed = (armedLateralBitmask >> 1) & 1;
+    const navArmed = isArmed(armedLateralBitmask, ArmedLateralMode.NAV);
+    const locArmed = isArmed(armedLateralBitmask, ArmedLateralMode.LOC);
 
     const armedVerticalBitmask = getSimVar('L:A32NX_FMA_VERTICAL_ARMED', 'number');
-    const finalArmed = (armedVerticalBitmask >> 5) & 1;
+    const finalArmed = isArmed(armedVerticalBitmask, ArmedVerticalMode.FINAL);
 
     const activeVerticalMode = getSimVar('L:A32NX_FMA_VERTICAL_MODE', 'enum');
 
@@ -501,7 +496,7 @@ const C2Cell = () => {
         // case 3:
         //     text = 'F-LOC';
         //     break;
-    } else if (navArmed && (finalArmed || activeVerticalMode === 24)) {
+    } else if (navArmed && (finalArmed || activeVerticalMode === VerticalMode.FINAL)) {
         text = 'APP NAV';
     } else if (navArmed) {
         text = 'NAV';
@@ -520,16 +515,16 @@ const BC1Cell = () => {
 
     let text: string;
     let id = 0;
-    if (activeVerticalMode === 34) {
+    if (activeVerticalMode === VerticalMode.ROLL_OUT) {
         text = 'ROLL OUT';
         id = 1;
-    } else if (activeVerticalMode === 33) {
+    } else if (activeVerticalMode === VerticalMode.FLARE) {
         text = 'FLARE';
         id = 2;
-    } else if (activeVerticalMode === 32) {
+    } else if (activeVerticalMode === VerticalMode.LAND) {
         text = 'LAND';
         id = 3;
-    } else if (activeVerticalMode === 24 && activeLateralMode === 20) {
+    } else if (activeVerticalMode === VerticalMode.FINAL && activeLateralMode === LateralMode.NAV) {
         text = 'FINAL APP';
         id = 4;
     } else {
@@ -548,7 +543,7 @@ const BC1Cell = () => {
 
 const getBC3Message = (isAttExcessive: boolean) => {
     const armedVerticalBitmask = getSimVar('L:A32NX_FMA_VERTICAL_ARMED', 'number');
-    const TCASArmed = (armedVerticalBitmask >> 6) & 1;
+    const TCASArmed = isArmed(armedVerticalBitmask, ArmedVerticalMode.TCAS);
 
     const trkFpaDeselectedTCAS = getSimVar('L:A32NX_AUTOPILOT_TCAS_MESSAGE_TRK_FPA_DESELECTION', 'bool');
     const tcasRaInhibited = getSimVar('L:A32NX_AUTOPILOT_TCAS_MESSAGE_RA_INHIBITED', 'bool');

--- a/src/instruments/src/PFD/index.tsx
+++ b/src/instruments/src/PFD/index.tsx
@@ -3,6 +3,7 @@ import { A320Failure, FailuresConsumer } from '@flybywiresim/failures';
 import { useArinc429Var } from '@instruments/common/arinc429';
 import { useInteractionEvent, useUpdate } from '@instruments/common/hooks';
 import { getSupplier, isCaptainSide } from '@instruments/common/utils';
+import { ArmedLateralMode, ArmedVerticalMode, isArmed, VerticalMode } from '@shared/autopilot';
 import { Horizon } from './AttitudeIndicatorHorizon';
 import { AttitudeIndicatorFixedUpper, AttitudeIndicatorFixedCenter } from './AttitudeIndicatorFixed';
 import { LandingSystem } from './LandingSystemIndicator';
@@ -121,10 +122,11 @@ export const PFD: React.FC = () => {
     const armedLateralBitmask = getSimVar('L:A32NX_FMA_LATERAL_ARMED', 'number');
     const fmgcFlightPhase = getSimVar('L:A32NX_FMGC_FLIGHT_PHASE', 'enum');
     const cstnAlt = getSimVar('L:A32NX_FG_ALTITUDE_CONSTRAINT', 'feet');
-    const altArmed = (armedVerticalBitmask >> 1) & 1;
-    const clbArmed = (armedVerticalBitmask >> 2) & 1;
-    const navArmed = (armedLateralBitmask >> 0) & 1;
-    const isManaged = !!(altArmed || activeVerticalMode === 21 || activeVerticalMode === 20 || (!!cstnAlt && fmgcFlightPhase < 2 && clbArmed && navArmed));
+    const altCstArmed = isArmed(armedVerticalBitmask, ArmedVerticalMode.ALT_CST);
+    const clbArmed = isArmed(armedVerticalBitmask, ArmedVerticalMode.CLB);
+    const navArmed = isArmed(armedLateralBitmask, ArmedLateralMode.NAV);
+    const isManaged = !!(altCstArmed || activeVerticalMode === VerticalMode.ALT_CST_CPT || activeVerticalMode === VerticalMode.ALT_CST
+         || (!!cstnAlt && fmgcFlightPhase < 2 && clbArmed && navArmed));
     const targetAlt = isManaged ? cstnAlt : Simplane.getAutoPilotDisplayedAltitudeLockValue();
 
     let targetSpeed: number | null;

--- a/src/shared/src/autopilot.ts
+++ b/src/shared/src/autopilot.ts
@@ -15,6 +15,11 @@ enum LateralMode {
     GA_TRACK = 50,
 }
 
+enum ArmedLateralMode {
+    NAV = 0,
+    LOC = 1,
+}
+
 enum VerticalMode {
     NONE = 0,
     ALT = 10,
@@ -27,6 +32,7 @@ enum VerticalMode {
     ALT_CST_CPT = 21,
     CLB = 22,
     DES = 23,
+    FINAL = 24,
     GS_CPT = 30,
     GS_TRACK = 31,
     LAND = 32,
@@ -34,10 +40,28 @@ enum VerticalMode {
     ROLL_OUT = 34,
     SRS = 40,
     SRS_GA = 41,
+    TCAS = 50,
+}
+
+enum ArmedVerticalMode {
+    ALT = 0,
+    ALT_CST = 1,
+    CLB = 2,
+    DES = 3,
+    GS = 4,
+    FINAL = 5,
+    TCAS = 6,
+}
+
+function isArmed(bitmask, armedBit: ArmedVerticalMode | ArmedLateralMode): boolean {
+    return ((bitmask >> armedBit) & 1) === 1;
 }
 
 export {
     ControlLaw,
     LateralMode,
+    ArmedLateralMode,
     VerticalMode,
+    ArmedVerticalMode,
+    isArmed,
 };


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
The track line is now also displayed when NAV is armed per reference below.
Also the usage of magic numbers in the code has been refactored and a helper function added to simplify detection of armed modes.

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/1447245/152377693-49490283-9b58-4ab8-8190-03eda7ad8505.png)


## References
On HDG switching from NAV blue to LOC blue:

https://youtu.be/bjGT9aJU6jo?t=625


## Additional context
N/A


## Testing instructions
Refactoring testing:
 * regular flight
 * check FMA
 * check that colour of the constrained altitude in managed CLB/DCT is correct
 * check FD/FPV indicator (bird)

Bugfix testing:
 * check track line on ND in e.g. HDG mode disappears when NAV is armed
 * check that it stays visible in LOC blue until LOC*
 * check for ROSE(NAV) and ARC mode

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
