### PR TITLE
fix(athr): alt soft mode

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -134,6 +134,7 @@
 1. [MISC] Animation speed/behaviors for button, switches and knobs - @bouveng (Johan Bouveng)
 1. [AP] Added Autoland capability for special terrain profiles, i.e. KSEA 16R - @aguther (Andreas Guther)
 1. [ATHR] Adjustment of ATHR SPD/MACH gains - @IbrahimK42 (IbrahimK42)
+1. [ATHR] Fix ATHR Alt Soft Mode - @IbrahimK42 (IbrahimK42)
 ## 0.7.0
 
 1. [HYD] First building block, more to come. Hydraulics do not impact the sim YET. - @crocket6 (crocket)

--- a/src/fbw/src/model/Autothrust.cpp
+++ b/src/fbw/src/model/Autothrust.cpp
@@ -708,11 +708,11 @@ void AutothrustModelClass::step()
    case 1:
     if (Autothrust_U.in.input.is_approach_mode_active) {
       rtb_Saturation = ((Autothrust_P.Gain_Gain_i * rtb_Sum5 + rtb_y_hw) + (Autothrust_P.Gain3_Gain_g * rtb_Saturation +
-        rtb_Gain2)) * look1_binlxpw(static_cast<real_T>(Autothrust_U.in.input.is_alt_soft_mode_active),
-        Autothrust_P.ScheduledGain3_BreakpointsForDimension1, Autothrust_P.ScheduledGain3_Table, 1U) * look1_binlxpw(std::
-        fmin(rtb_BusAssignment_n.data.commanded_engine_N1_1_percent,
-             rtb_BusAssignment_n.data.commanded_engine_N1_1_percent),
-        Autothrust_P.ScheduledGain2_BreakpointsForDimension1, Autothrust_P.ScheduledGain2_Table, 3U);
+        rtb_Gain2)) * look1_binlxpw(std::fmin(rtb_BusAssignment_n.data.commanded_engine_N1_1_percent,
+        rtb_BusAssignment_n.data.commanded_engine_N1_1_percent), Autothrust_P.ScheduledGain2_BreakpointsForDimension1,
+        Autothrust_P.ScheduledGain2_Table, 3U) * look1_binlxpw(static_cast<real_T>
+        (Autothrust_U.in.input.is_alt_soft_mode_active), Autothrust_P.ScheduledGain4_BreakpointsForDimension1,
+        Autothrust_P.ScheduledGain4_Table, 1U);
       if (rtb_Saturation > Autothrust_P.Saturation1_UpperSat) {
         rtb_Saturation = Autothrust_P.Saturation1_UpperSat;
       } else if (rtb_Saturation < Autothrust_P.Saturation1_LowerSat) {
@@ -720,11 +720,11 @@ void AutothrustModelClass::step()
       }
     } else {
       rtb_Saturation = ((Autothrust_P.Gain_Gain_i * rtb_Sum5 + rtb_y_hw) + (Autothrust_P.Gain3_Gain_g * rtb_Saturation +
-        rtb_Gain2)) * look1_binlxpw(static_cast<real_T>(Autothrust_U.in.input.is_alt_soft_mode_active),
-        Autothrust_P.ScheduledGain3_BreakpointsForDimension1, Autothrust_P.ScheduledGain3_Table, 1U) * look1_binlxpw(std::
-        fmin(rtb_BusAssignment_n.data.commanded_engine_N1_1_percent,
-             rtb_BusAssignment_n.data.commanded_engine_N1_1_percent),
-        Autothrust_P.ScheduledGain2_BreakpointsForDimension1, Autothrust_P.ScheduledGain2_Table, 3U);
+        rtb_Gain2)) * look1_binlxpw(std::fmin(rtb_BusAssignment_n.data.commanded_engine_N1_1_percent,
+        rtb_BusAssignment_n.data.commanded_engine_N1_1_percent), Autothrust_P.ScheduledGain2_BreakpointsForDimension1,
+        Autothrust_P.ScheduledGain2_Table, 3U) * look1_binlxpw(static_cast<real_T>
+        (Autothrust_U.in.input.is_alt_soft_mode_active), Autothrust_P.ScheduledGain4_BreakpointsForDimension1,
+        Autothrust_P.ScheduledGain4_Table, 1U);
       if (rtb_Saturation > Autothrust_P.Saturation_UpperSat) {
         rtb_Saturation = Autothrust_P.Saturation_UpperSat;
       } else if (rtb_Saturation < Autothrust_P.Saturation_LowerSat) {

--- a/src/fbw/src/model/Autothrust.h
+++ b/src/fbw/src/model/Autothrust.h
@@ -102,8 +102,8 @@ class AutothrustModelClass
   struct Parameters_Autothrust_T {
     athr_out athr_out_MATLABStruct;
     real_T ScheduledGain1_BreakpointsForDimension1[5];
-    real_T ScheduledGain3_BreakpointsForDimension1[2];
     real_T ScheduledGain2_BreakpointsForDimension1[4];
+    real_T ScheduledGain4_BreakpointsForDimension1[2];
     real_T WashoutFilter_C1;
     real_T HighPassFilter_C1;
     real_T LowPassFilter_C1;
@@ -138,8 +138,8 @@ class AutothrustModelClass
     real_T DiscreteTimeIntegratorVariableTs_LowerLimit_e;
     real_T DiscreteTimeIntegratorVariableTs1_LowerLimit_h;
     real_T ScheduledGain1_Table[5];
-    real_T ScheduledGain3_Table[2];
     real_T ScheduledGain2_Table[4];
+    real_T ScheduledGain4_Table[2];
     real_T DiscreteTimeIntegratorVariableTs_UpperLimit;
     real_T DiscreteTimeIntegratorVariableTs_UpperLimit_l;
     real_T DiscreteTimeIntegratorVariableTs1_UpperLimit;

--- a/src/fbw/src/model/Autothrust_data.cpp
+++ b/src/fbw/src/model/Autothrust_data.cpp
@@ -115,10 +115,10 @@ AutothrustModelClass::Parameters_Autothrust_T AutothrustModelClass::Autothrust_P
   { -100.0, -20.0, 0.0, 10.0, 100.0 },
 
 
-  { 0.0, 1.0 },
-
-
   { 0.0, 20.0, 45.0, 100.0 },
+
+
+  { 0.0, 1.0 },
 
   2.0,
 
@@ -190,10 +190,10 @@ AutothrustModelClass::Parameters_Autothrust_T AutothrustModelClass::Autothrust_P
   { 1.8, 1.8, 1.0, 1.2, 1.2 },
 
 
-  { 1.0, 3.0 },
-
-
   { 5.0, 5.0, 1.0, 1.0 },
+
+
+  { 1.0, 0.01 },
 
   2.0,
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
This PR fixes the ATHR alt soft mode gain. It reacted to agile in alt soft mode.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
do some tests in ALT CRZ and other mode and observe if the reaction in ALT CRZ is not so agil.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
