### PR TITLE
feat(ecam): packs off abnormally warning

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -137,6 +137,8 @@
 1. [ATHR] Fix ATHR Alt Soft Mode - @IbrahimK42 (IbrahimK42)
 1. [HYD] Simplified max step loop updater - @Crocket63
 
+1. [ECAM] Add pack abnormally off warnings - @tracernz (Mike)
+
 ## 0.7.0
 
 1. [HYD] First building block, more to come. Hydraulics do not impact the sim YET. - @crocket6 (crocket)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -137,7 +137,6 @@
 1. [ATHR] Fix ATHR Alt Soft Mode - @IbrahimK42 (IbrahimK42)
 1. [HYD] Simplified max step loop updater - @Crocket63
 1. [MISC] Fix for bleed/hyd system failure in some conditions - @Crocket63
-
 1. [ECAM] Add pack abnormally off warnings - @tracernz (Mike)
 
 ## 0.7.0

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -105,6 +105,10 @@ var A320_Neo_UpperECAM;
             this.iceNotDetTimer1 = new NXLogic_ConfirmNode(60);
             this.iceNotDetTimer2 = new NXLogic_ConfirmNode(130);
             this.predWsMemo = new NXLogic_MemoryNode(true);
+            this.packOffNotFailed1 = new NXLogic_ConfirmNode(60);
+            this.packOffNotFailed2 = new NXLogic_ConfirmNode(60);
+            this.packOffBleedAvailable1 = new NXLogic_ConfirmNode(5, false);
+            this.packOffBleedAvailable2 = new NXLogic_ConfirmNode(5, false);
         }
         get templateID() {
             return "UpperECAMTemplate";
@@ -814,6 +818,29 @@ var A320_Neo_UpperECAM;
                                     },
                                 ]
                             },
+                        ]
+                    },
+                    {
+                        name: "AIR",
+                        messages: [
+                            {
+                                message: "PACK 1 OFF",
+                                level: 2,
+                                flightPhasesInhib: [1, 2, 3, 4, 5, 7, 8, 9, 10],
+                                inopSystems: ["PACK_1"],
+                                isActive: () => this.packOffNotFailed1.read(), // TODO should also be not outflow valve fault
+                                actions: [],
+                                page: "BLEED",
+                            },
+                            {
+                                message: "PACK 2 OFF",
+                                level: 2,
+                                flightPhasesInhib: [1, 2, 3, 4, 5, 7, 8, 9, 10],
+                                inopSystems: ["PACK_2"],
+                                isActive: () => this.packOffNotFailed2.read(), // TODO should also be not outflow valve fault
+                                actions: [],
+                                page: "BLEED",
+                            }
                         ]
                     },
                     {
@@ -1705,6 +1732,7 @@ var A320_Neo_UpperECAM;
 
             this.updateInhibitMessages(_deltaTime);
             this.updateIcing(_deltaTime);
+            this.updatePacks(_deltaTime);
 
             const memosInhibited = this.leftEcamMessagePanel.hasWarnings || this.leftEcamMessagePanel.hasCautions;
             const showTOMemo = SimVar.GetSimVarValue("L:A32NX_FWC_TOMEMO", "Bool") && !memosInhibited;
@@ -1902,6 +1930,23 @@ var A320_Neo_UpperECAM;
             const notDet1 = this.iceNotDetTimer1.write(isAnyAntiIceOn, _deltaTime);
             this.iceNotDetTimer2.write(!isActivelyIcing && notDet1, _deltaTime);
 
+        }
+
+        updatePacks(deltaTime) {
+            // this is a bit of a hack, but near enough until the new FWC, and underlying system implementations
+            const crossfeed = SimVar.GetSimVarValue("L:A32NX_PNEU_XBLEED_VALVE_OPEN", "bool");
+            const eng1Bleed = SimVar.GetSimVarValue("L:A32NX_OVHD_PNEU_ENG_1_BLEED_PB_IS_AUTO", "bool") && !SimVar.GetSimVarValue("A32NX_OVHD_PNEU_ENG_1_BLEED_PB_HAS_FAULT", "bool");
+            const eng2Bleed = SimVar.GetSimVarValue("L:A32NX_OVHD_PNEU_ENG_2_BLEED_PB_IS_AUTO", "bool") && !SimVar.GetSimVarValue("A32NX_OVHD_PNEU_ENG_2_BLEED_PB_HAS_FAULT", "bool");
+            this.packOffBleedAvailable1.write(eng1Bleed || crossfeed, deltaTime);
+            this.packOffBleedAvailable2.write(eng2Bleed || crossfeed, deltaTime);
+
+            const pack1Fault = SimVar.GetSimVarValue("L:A32NX_AIRCOND_PACK1_FAULT", "bool");
+            const pack2Fault = SimVar.GetSimVarValue("L:A32NX_AIRCOND_PACK2_FAULT", "bool");
+            const pack1Off = !SimVar.GetSimVarValue("L:A32NX_AIRCOND_PACK1_TOGGLE", "bool");
+            const pack2Off = !SimVar.GetSimVarValue("L:A32NX_AIRCOND_PACK2_TOGGLE", "bool");
+
+            this.packOffNotFailed1.write(pack1Off && !pack1Fault && this.packOffBleedAvailable1.read() && this.fwcFlightPhase === 6, deltaTime);
+            this.packOffNotFailed2.write(pack2Off && !pack2Fault && this.packOffBleedAvailable2.read() && this.fwcFlightPhase === 6, deltaTime);
         }
 
         getInfoPanelManager() {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -1935,8 +1935,8 @@ var A320_Neo_UpperECAM;
         updatePacks(deltaTime) {
             // this is a bit of a hack, but near enough until the new FWC, and underlying system implementations
             const crossfeed = SimVar.GetSimVarValue("L:A32NX_PNEU_XBLEED_VALVE_OPEN", "bool");
-            const eng1Bleed = SimVar.GetSimVarValue("L:A32NX_OVHD_PNEU_ENG_1_BLEED_PB_IS_AUTO", "bool") && !SimVar.GetSimVarValue("A32NX_OVHD_PNEU_ENG_1_BLEED_PB_HAS_FAULT", "bool");
-            const eng2Bleed = SimVar.GetSimVarValue("L:A32NX_OVHD_PNEU_ENG_2_BLEED_PB_IS_AUTO", "bool") && !SimVar.GetSimVarValue("A32NX_OVHD_PNEU_ENG_2_BLEED_PB_HAS_FAULT", "bool");
+            const eng1Bleed = SimVar.GetSimVarValue("A:BLEED AIR ENGINE:1", "bool") && !SimVar.GetSimVarValue("L:A32NX_OVHD_PNEU_ENG_1_BLEED_PB_HAS_FAULT", "bool");
+            const eng2Bleed = SimVar.GetSimVarValue("A:BLEED AIR ENGINE:2", "bool") && !SimVar.GetSimVarValue("L:A32NX_OVHD_PNEU_ENG_2_BLEED_PB_HAS_FAULT", "bool");
             this.packOffBleedAvailable1.write(eng1Bleed || crossfeed, deltaTime);
             this.packOffBleedAvailable2.write(eng2Bleed || crossfeed, deltaTime);
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
When maximum takeoff performance is required, it is possible to do a packs off takeoff. It is normal to takeoff with the packs turned off, and turn them on upon reaching the thrust reduction altitude. If you forget to do so the cabin will not remain pressurised when climbing to higher flight levels. My general feeling from the community is that this does happen quite frequently since we actually simulate the pressurisation system now. This PR adds the ECAM warning that exists to prevent such an occurence.

The exact logic requires some additional system implementation that is out of scope for this PR, so a few of the conditions have been approximated for now. The whole thing will later be replaced with the new FWS, but I felt this was still worth a small amount of effort in the short term. 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/9995998/152636950-5df492b8-8466-4c98-a7f2-d35796294dba.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Do a packs off takeoff and 60 seconds after passing 1500 feet you should get an upper ECAM warning as shown in the screenshot above... the lower ECAM will automatically switch to the BLEED page. The status page will show PACKS 1 + 2 as INOP. Turn one of the packs on and ensure the warning for that pack goes away, repeat for the other.

Do a packs off takeoff with both engine bleeds off. The particular warnings shown above should not occur.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
