### PR TITLE
fix(elec): remove in-flight engine generator spool up time

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -137,6 +137,7 @@
 1. [ATHR] Fix ATHR Alt Soft Mode - @IbrahimK42 (IbrahimK42)
 1. [HYD] Simplified max step loop updater - @Crocket63
 1. [MISC] Fix for bleed/hyd system failure in some conditions - @Crocket63
+1. [ELEC] Fix emergency elec on init in flight wrongly triggering the RAT - @Crocket63
 
 ## 0.7.0
 

--- a/src/systems/systems/src/electrical/engine_generator.rs
+++ b/src/systems/systems/src/electrical/engine_generator.rs
@@ -165,7 +165,8 @@ impl IntegratedDriveGenerator {
             activated: true,
             number,
 
-            time_above_threshold_in_milliseconds: 0,
+            time_above_threshold_in_milliseconds:
+                INTEGRATED_DRIVE_GENERATOR_STABILIZATION_TIME_IN_MILLISECONDS,
         }
     }
 

--- a/src/systems/systems/src/electrical/engine_generator.rs
+++ b/src/systems/systems/src/electrical/engine_generator.rs
@@ -802,18 +802,10 @@ mod tests {
             assert!(test_bed.contains_variable_with_name("ELEC_ENG_GEN_1_IDG_IS_CONNECTED"));
         }
 
-
         #[test]
         fn starts_unstable_with_engines_off() {
             let mut test_bed = SimulationTestBed::from(ElementCtorFn(idg))
-            .with_update_after_power_distribution(|idg, context| {
-                idg.update(
-                    context,
-                    &TestEngine::new(Ratio::new::<percent>(0.)),
-                    &TestOverhead::new(false, false),
-                    &TestFireOverhead::new(false),
-                )
-            });
+                .with_update_after_power_distribution(engine_not_running);
             test_bed.run_without_delta();
 
             assert!(!test_bed.query_element(|e| e.provides_stable_power_output()));
@@ -822,14 +814,7 @@ mod tests {
         #[test]
         fn starts_stable_with_engines_on() {
             let mut test_bed = SimulationTestBed::from(ElementCtorFn(idg))
-            .with_update_after_power_distribution(|idg, context| {
-                idg.update(
-                    context,
-                    &TestEngine::new(Ratio::new::<percent>(80.)),
-                    &TestOverhead::new(true, false),
-                    &TestFireOverhead::new(false),
-                )
-            });
+                .with_update_after_power_distribution(engine_running_above_threshold(false));
             test_bed.run_without_delta();
 
             assert!(test_bed.query_element(|e| e.provides_stable_power_output()));
@@ -837,27 +822,13 @@ mod tests {
 
         #[test]
         fn becomes_stable_once_engine_above_threshold_for_500_milliseconds() {
-                        // First enforcing engine in off state
-                        let mut test_bed = SimulationTestBed::from(ElementCtorFn(idg))
-                        .with_update_after_power_distribution(|idg, context| {
-                            idg.update(
-                                context,
-                                &TestEngine::new(Ratio::new::<percent>(0.)),
-                                &TestOverhead::new(false, false),
-                                &TestFireOverhead::new(false),
-                            )
-                        });
-                    test_bed.run_without_delta();
+            // First enforcing engine in off state
+            let mut test_bed = SimulationTestBed::from(ElementCtorFn(idg))
+                .with_update_after_power_distribution(engine_not_running);
+            test_bed.run_without_delta();
 
             let mut test_bed = SimulationTestBed::from(ElementCtorFn(idg))
-                .with_update_after_power_distribution(|idg, context| {
-                    idg.update(
-                        context,
-                        &TestEngine::new(Ratio::new::<percent>(80.)),
-                        &TestOverhead::new(true, false),
-                        &TestFireOverhead::new(false),
-                    )
-                });
+                .with_update_after_power_distribution(engine_running_above_threshold(false));
 
             test_bed.run_with_delta(Duration::from_millis(500));
 
@@ -868,25 +839,10 @@ mod tests {
         fn does_not_become_stable_before_engine_above_threshold_for_500_milliseconds() {
             // First enforcing engine in off state
             let mut test_bed = SimulationTestBed::from(ElementCtorFn(idg))
-                .with_update_after_power_distribution(|idg, context| {
-                    idg.update(
-                        context,
-                        &TestEngine::new(Ratio::new::<percent>(0.)),
-                        &TestOverhead::new(false, false),
-                        &TestFireOverhead::new(false),
-                    )
-                });
+                .with_update_after_power_distribution(engine_not_running);
             test_bed.run_without_delta();
 
-            test_bed.set_update_after_power_distribution(|idg, context| {
-                idg.update(
-                    context,
-                    &TestEngine::new(Ratio::new::<percent>(80.)),
-                    &TestOverhead::new(true, false),
-                    &TestFireOverhead::new(false),
-                )
-            });
-
+            test_bed.set_update_after_power_distribution(engine_running_above_threshold(false));
             test_bed.run_with_delta(Duration::from_millis(499));
 
             assert!(!test_bed.query_element(|e| e.provides_stable_power_output()));
@@ -895,26 +851,10 @@ mod tests {
         #[test]
         fn cannot_reconnect_once_disconnected() {
             let mut test_bed = SimulationTestBed::from(ElementCtorFn(idg))
-                .with_update_after_power_distribution(|idg, context| {
-                    idg.update(
-                        context,
-                        &TestEngine::new(Ratio::new::<percent>(80.)),
-                        &TestOverhead::new(true, true),
-                        &TestFireOverhead::new(false),
-                    )
-                });
-
+                .with_update_after_power_distribution(engine_running_above_threshold(true));
             test_bed.run_with_delta(Duration::from_millis(500));
 
-            test_bed.set_update_after_power_distribution(|idg, context| {
-                idg.update(
-                    context,
-                    &TestEngine::new(Ratio::new::<percent>(80.)),
-                    &TestOverhead::new(true, false),
-                    &TestFireOverhead::new(false),
-                )
-            });
-
+            test_bed.set_update_after_power_distribution(engine_running_above_threshold(false));
             test_bed.run_with_delta(Duration::from_millis(500));
 
             assert!(!test_bed.query_element(|e| e.provides_stable_power_output()));
@@ -923,14 +863,7 @@ mod tests {
         #[test]
         fn running_engine_warms_up_idg() {
             let mut test_bed = SimulationTestBed::from(ElementCtorFn(idg))
-                .with_update_after_power_distribution(|idg, context| {
-                    idg.update(
-                        context,
-                        &TestEngine::new(Ratio::new::<percent>(80.)),
-                        &TestOverhead::new(true, false),
-                        &TestFireOverhead::new(false),
-                    )
-                });
+                .with_update_after_power_distribution(engine_running_above_threshold(false));
 
             let starting_temperature = test_bed.query_element(|e| e.oil_outlet_temperature);
 
@@ -942,14 +875,7 @@ mod tests {
         #[test]
         fn running_engine_does_not_warm_up_idg_when_disconnected() {
             let mut test_bed = SimulationTestBed::from(ElementCtorFn(idg))
-                .with_update_after_power_distribution(|idg, context| {
-                    idg.update(
-                        context,
-                        &TestEngine::new(Ratio::new::<percent>(80.)),
-                        &TestOverhead::new(true, true),
-                        &TestFireOverhead::new(false),
-                    )
-                });
+                .with_update_after_power_distribution(engine_running_above_threshold(true));
 
             let starting_temperature = test_bed.query_element(|e| e.oil_outlet_temperature);
 
@@ -964,31 +890,37 @@ mod tests {
         #[test]
         fn shutdown_engine_cools_down_idg() {
             let mut test_bed = SimulationTestBed::from(ElementCtorFn(idg))
-                .with_update_after_power_distribution(|idg, context| {
-                    idg.update(
-                        context,
-                        &TestEngine::new(Ratio::new::<percent>(80.)),
-                        &TestOverhead::new(true, false),
-                        &TestFireOverhead::new(false),
-                    )
-                });
-
+                .with_update_after_power_distribution(engine_running_above_threshold(false));
             test_bed.run_with_delta(Duration::from_secs(10));
 
             let starting_temperature = test_bed.query_element(|e| e.oil_outlet_temperature);
 
-            test_bed.set_update_after_power_distribution(|idg, context| {
-                idg.update(
-                    context,
-                    &TestEngine::new(Ratio::new::<percent>(0.)),
-                    &TestOverhead::new(true, false),
-                    &TestFireOverhead::new(false),
-                )
-            });
-
+            test_bed.set_update_after_power_distribution(engine_not_running);
             test_bed.run_with_delta(Duration::from_secs(10));
 
             assert!(test_bed.query_element(|e| e.oil_outlet_temperature) < starting_temperature);
+        }
+
+        fn engine_not_running(idg: &mut IntegratedDriveGenerator, context: &UpdateContext) {
+            idg.update(
+                context,
+                &TestEngine::new(Ratio::new::<percent>(0.)),
+                &TestOverhead::new(false, false),
+                &TestFireOverhead::new(false),
+            )
+        }
+
+        fn engine_running_above_threshold(
+            idg_push_button_is_released: bool,
+        ) -> impl Fn(&mut IntegratedDriveGenerator, &UpdateContext) {
+            move |idg: &mut IntegratedDriveGenerator, context: &UpdateContext| {
+                idg.update(
+                    context,
+                    &TestEngine::new(Ratio::new::<percent>(80.)),
+                    &TestOverhead::new(true, idg_push_button_is_released),
+                    &TestFireOverhead::new(false),
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Avoids triggering emergency elec on first ticks after initialisation. Initializing plane in flight is causing a short emergency elec condition which triggers the RAT. This is a fix for this case.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Init the plane in flight from game map. Check that RAT is not out on Hyd Ecam (Should not see a solid green arrow for RAT)

After init in cold and dark, wfter engines are started, engine generators should provide electric current as expected.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
