### PR TITLE
fix(nd): Center 'TA ONLY' message

### DIFF
--- a/src/instruments/src/ND/elements/messages/TcasWxrMessages.tsx
+++ b/src/instruments/src/ND/elements/messages/TcasWxrMessages.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { Layer } from '@instruments/common/utils';
-import { Mode } from '@shared/NavigationDisplay';
 import { useSimVar } from '@instruments/common/simVars';
+import { Mode } from '@shared/NavigationDisplay';
 
 /*
 Messages in priority order, from 1-12 (full set with ATSAW and nice weather radar)
@@ -18,12 +18,6 @@ Messages in priority order, from 1-12 (full set with ATSAW and nice weather rada
 [                 |     ADS-B (amber)     ]
 */
 
-enum TcasPosition {
-    Standby = 0,
-    Ta = 1,
-    TaRa = 2,
-}
-
 interface TcasWxrMessage {
     text: string;
     color: 'White' | 'Amber';
@@ -34,49 +28,43 @@ export const TcasWxrMessages: FC<{ modeIndex: Mode }> = ({ modeIndex }) => {
 
     let leftMessage: TcasWxrMessage | undefined;
     let rightMessage: TcasWxrMessage | undefined;
+    let centerMessage: TcasWxrMessage | undefined;
 
-    // TODO use logic in TCAS when it's implemented
-    const [tcasPosition] = useSimVar('L:A32NX_SWITCH_TCAS_Position', 'enum', 500);
-    const [radioAlt] = useSimVar('PLANE ALT ABOVE GROUND MINUS CG', 'feet', 500);
-    if (tcasPosition === TcasPosition.Ta || (tcasPosition === TcasPosition.TaRa && radioAlt < 1000)) {
-        leftMessage = { text: 'TA ONLY', color: 'White' };
+    const [tcasOnly] = useSimVar('L:A32NX_TCAS_TA_ONLY', 'boolean', 200);
+    const [tcasFault] = useSimVar('L:A32NX_TCAS_FAULT', 'boolean', 200);
+
+    if (tcasFault) {
+        leftMessage = { text: 'TCAS', color: 'Amber' };
+    } else if (tcasOnly) {
+        centerMessage = { text: 'TA ONLY', color: 'White' };
     }
 
-    if (modeIndex !== Mode.ARC && modeIndex !== Mode.ROSE_NAV && modeIndex !== Mode.ROSE_VOR && modeIndex !== Mode.ROSE_ILS || (!leftMessage && !rightMessage)) {
+    if ((modeIndex !== Mode.ARC && modeIndex !== Mode.ROSE_NAV && modeIndex !== Mode.ROSE_VOR && modeIndex !== Mode.ROSE_ILS) || (!leftMessage && !rightMessage && !centerMessage)) {
         return null;
     }
 
-    const y = (modeIndex === Mode.ROSE_VOR || modeIndex === Mode.ROSE_ILS) ? 713 : 684;
+    const y = modeIndex === Mode.ROSE_VOR || modeIndex === Mode.ROSE_ILS ? 713 : 684;
 
     return (
         <Layer x={164} y={y}>
-            { /* we fill/mask the map under both message boxes, per IRL refs */ }
-            { (modeIndex === Mode.ARC || modeIndex === Mode.ROSE_NAV) && (
-                <rect x={0} y={0} width={440} height={59} className="BackgroundFill" stroke="none" />
-            )}
+            {/* we fill/mask the map under both message boxes, per IRL refs */}
+            {(modeIndex === Mode.ARC || modeIndex === Mode.ROSE_NAV) && <rect x={0} y={0} width={440} height={59} className="BackgroundFill" stroke="none" />}
 
             <rect x={0} y={0} width={440} height={30} className="White BackgroundFill" strokeWidth={1.75} />
 
-            { (leftMessage) && (
-                <text
-                    x={8}
-                    y={25}
-                    className={`${leftMessage.color}`}
-                    textAnchor="start"
-                    fontSize={25}
-                >
+            {leftMessage && (
+                <text x={8} y={25} className={`${leftMessage.color}`} textAnchor="start" fontSize={25}>
                     {leftMessage.text}
                 </text>
             )}
 
-            { (rightMessage) && (
-                <text
-                    x={425}
-                    y={25}
-                    className={`${rightMessage.color}`}
-                    textAnchor="end"
-                    fontSize={25}
-                >
+            {centerMessage && (
+                <text x={420 / 2} y={25} className={`${centerMessage.color} MiddleAlign`} textAnchor="middle" fontSize={25}>
+                    {centerMessage.text}
+                </text>
+            )}
+            {rightMessage && (
+                <text x={425} y={25} className={`${rightMessage.color}`} textAnchor="end" fontSize={25}>
                     {rightMessage.text}
                 </text>
             )}


### PR DESCRIPTION
## Summary of Changes
Changed 'TA ONLY' message on ND to show on center. I know this is positioned to left due to ATSAW but while this feature is not implemented I checked with a lot of FBW users and they said that liked 'TA ONLY' on center.

## Screenshots (if necessary)
![Microsoft Flight Simulator Screenshot 2022 02 06 - 09 24 55 62 Thumbnail](https://user-images.githubusercontent.com/30161990/152683564-7da76799-e30a-43d5-ad82-15824a0f5e9c.png)

## References
I have talked with some brazilian A320Neo Pilots and they told me that 'TA ONLY' message shows on center. We also can see this on this [real  A320 NEO video](https://youtu.be/cv41hm4JEB8?t=158).

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username: **afbb#0987**

## Testing instructions
Just open aircraft and chose one situation when 'TA ONLY' message is displayed, liked before takeoff.

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
