### PR TITLE
fix: ALT CST and DES logic

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -146,6 +146,7 @@
 1. [ELEC] Fix emergency elec on init in flight wrongly triggering the RAT - @Crocket63
 1. [ATHR] Fix ATHR Speed Undershoot - @IbrahimK42 (IbrahimK42)
 1. [FLIGHTMODEL] Improved pitch stability in turbulence - @aguther (Andreas Guther)
+1. [AP] Fix DES not being armed in ALT CST and altitude constraint changing to FCU altitude - @aguther (Andreas Guther)
 
 ## 0.7.0
 

--- a/src/fbw/src/model/AutopilotStateMachine.cpp
+++ b/src/fbw/src/model/AutopilotStateMachine.cpp
@@ -2596,6 +2596,7 @@ void AutopilotStateMachineModelClass::step()
   boolean_T engageCondition;
   boolean_T guard1{ false };
 
+  boolean_T inFlightDisarmCondition;
   boolean_T isGoAroundModeActive;
   boolean_T rtb_AND;
   boolean_T rtb_AND_j;
@@ -2608,7 +2609,6 @@ void AutopilotStateMachineModelClass::step()
   boolean_T rtb_cGA;
   boolean_T rtb_cLAND;
   boolean_T sCLB_tmp;
-  boolean_T sCLB_tmp_0;
   boolean_T speedTargetChanged;
   boolean_T state_e_tmp;
   boolean_T state_e_tmp_0;
@@ -3554,24 +3554,24 @@ void AutopilotStateMachineModelClass::step()
   if ((AutopilotStateMachine_U.in.data.flight_phase == 2.0) || (AutopilotStateMachine_U.in.data.flight_phase == 3.0) ||
       (AutopilotStateMachine_U.in.data.flight_phase == 6.0)) {
     if (AutopilotStateMachine_U.in.input.H_fcu_ft < AutopilotStateMachine_U.in.data.H_ind_ft) {
-      state_i_tmp = true;
+      inFlightDisarmCondition = true;
     } else if (L < 50.0) {
-      state_i_tmp = true;
+      inFlightDisarmCondition = true;
     } else if ((AutopilotStateMachine_U.in.input.H_fcu_ft == AutopilotStateMachine_U.in.input.H_constraint_ft) && (std::
                 abs(AutopilotStateMachine_U.in.data.H_ind_ft - AutopilotStateMachine_U.in.input.H_fcu_ft) < 50.0)) {
-      state_i_tmp = true;
+      inFlightDisarmCondition = true;
     } else if ((AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode != vertical_mode_ALT_CST) &&
                (AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode != vertical_mode_ALT_CST_CPT) &&
                (AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode != vertical_mode_SRS) &&
                (AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode != vertical_mode_SRS_GA)) {
-      state_i_tmp = true;
+      inFlightDisarmCondition = true;
     } else {
-      state_i_tmp = ((AutopilotStateMachine_U.in.data.flight_phase == 4.0) ||
-                     (AutopilotStateMachine_U.in.data.flight_phase == 5.0));
+      inFlightDisarmCondition = ((AutopilotStateMachine_U.in.data.flight_phase == 4.0) ||
+        (AutopilotStateMachine_U.in.data.flight_phase == 5.0));
     }
   } else {
-    state_i_tmp = ((AutopilotStateMachine_U.in.data.flight_phase == 4.0) ||
-                   (AutopilotStateMachine_U.in.data.flight_phase == 5.0));
+    inFlightDisarmCondition = ((AutopilotStateMachine_U.in.data.flight_phase == 4.0) ||
+      (AutopilotStateMachine_U.in.data.flight_phase == 5.0));
   }
 
   sCLB_tmp = ((((AutopilotStateMachine_U.in.data.flight_phase == 0.0) || (AutopilotStateMachine_U.in.data.flight_phase ==
@@ -3589,10 +3589,30 @@ void AutopilotStateMachineModelClass::step()
                 (AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode == vertical_mode_SRS) ||
                 (AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode == vertical_mode_SRS_GA))));
   AutopilotStateMachine_DWork.sCLB = (sCLB_tmp || AutopilotStateMachine_DWork.sCLB);
-  sCLB_tmp_0 = ((!AutopilotStateMachine_DWork.DelayInput1_DSTATE_ib) &&
-                (!AutopilotStateMachine_DWork.DelayInput1_DSTATE_bd) &&
-                (!AutopilotStateMachine_DWork.DelayInput1_DSTATE_ah));
-  AutopilotStateMachine_DWork.sCLB = (sCLB_tmp_0 && (!state_i_tmp) && (sCLB_tmp && AutopilotStateMachine_DWork.sCLB));
+  state_i_tmp = ((!AutopilotStateMachine_DWork.DelayInput1_DSTATE_ib) &&
+                 (!AutopilotStateMachine_DWork.DelayInput1_DSTATE_bd) &&
+                 (!AutopilotStateMachine_DWork.DelayInput1_DSTATE_ah));
+  AutopilotStateMachine_DWork.sCLB = (state_i_tmp && (!inFlightDisarmCondition) && (sCLB_tmp &&
+    AutopilotStateMachine_DWork.sCLB));
+  if (rtb_on_ground == 0) {
+    if (AutopilotStateMachine_U.in.input.H_fcu_ft > AutopilotStateMachine_U.in.data.H_ind_ft) {
+      inFlightDisarmCondition = true;
+    } else if (L < 50.0) {
+      inFlightDisarmCondition = true;
+    } else if ((AutopilotStateMachine_U.in.input.H_fcu_ft == AutopilotStateMachine_U.in.input.H_constraint_ft) && (std::
+                abs(AutopilotStateMachine_U.in.data.H_ind_ft - AutopilotStateMachine_U.in.input.H_fcu_ft) < 50.0)) {
+      inFlightDisarmCondition = true;
+    } else {
+      inFlightDisarmCondition = (((AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode != vertical_mode_ALT_CST) &&
+        (AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode != vertical_mode_ALT_CST_CPT)) ||
+        ((AutopilotStateMachine_DWork.Delay_DSTATE.output.mode != lateral_mode_NAV) &&
+         (AutopilotStateMachine_DWork.Delay_DSTATE.output.mode != lateral_mode_LOC_CPT) &&
+         (AutopilotStateMachine_DWork.Delay_DSTATE.output.mode != lateral_mode_LOC_TRACK)));
+    }
+  } else {
+    inFlightDisarmCondition = false;
+  }
+
   AutopilotStateMachine_DWork.sDES = (((rtb_on_ground == 0) && (result_tmp < -50.0) &&
     ((AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode == vertical_mode_ALT_CST) ||
      (AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode == vertical_mode_ALT_CST_CPT)) &&
@@ -3600,14 +3620,7 @@ void AutopilotStateMachineModelClass::step()
      (AutopilotStateMachine_DWork.Delay_DSTATE.output.mode == lateral_mode_LOC_CPT) ||
      (AutopilotStateMachine_DWork.Delay_DSTATE.output.mode == lateral_mode_LOC_TRACK))) ||
     AutopilotStateMachine_DWork.sDES);
-  AutopilotStateMachine_DWork.sDES = (sCLB_tmp_0 && ((rtb_on_ground != 0) || ((AutopilotStateMachine_U.in.input.H_fcu_ft
-    <= AutopilotStateMachine_U.in.data.H_ind_ft) && ((L >= 50.0) && ((AutopilotStateMachine_U.in.input.H_fcu_ft !=
-    AutopilotStateMachine_U.in.input.H_constraint_ft) && ((!(AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode !=
-    vertical_mode_ALT_CST)) || (!(AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode != vertical_mode_ALT_CST_CPT))) &&
-    ((!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode != lateral_mode_NAV)) ||
-     (!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode != lateral_mode_LOC_CPT)) ||
-     (!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode != lateral_mode_LOC_TRACK))))))) &&
-    AutopilotStateMachine_DWork.sDES);
+  AutopilotStateMachine_DWork.sDES = (state_i_tmp && (!inFlightDisarmCondition) && AutopilotStateMachine_DWork.sDES);
   AutopilotStateMachine_DWork.sFINAL_DES = (((AutopilotStateMachine_U.in.data.H_radio_ft >= 400.0) && engageCondition &&
     (AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode != vertical_mode_FINAL_DES) &&
     (AutopilotStateMachine_DWork.Delay1_DSTATE.output.mode != vertical_mode_SRS) &&


### PR DESCRIPTION
## Summary of Changes
This PR fixes an issue when flying in ALT CST and the altitude constraint jumping to the FCU altitude. Now the DES mode is correctly engaged, and the aircraft descends to the FCU altitude. When nothing further changes, it will capture the altitude with ALT* and will end in ALT.

The broken behavior before was that DES only disarmed and the plane incorrectly remained in ALT CST. This error only happened when FCU altitude and new altitude constraints were equal. This applied only to DES and not to CLB.

## Testing instructions
- test the above-described scenario:
  - set 6000 ft on the FCU altitude and climb/descend to it
  - engage NAV
  - set an altitude constraint with +5000 ft
  - set FCU altitude to 4000 ft
  - push ALT knob to engage DES
  - plane should capture the constraint of 5000 ft (and end in ALT CST)
  - for next waypoint set altitude constraint to +4000 ft
  - wait for waypoint to cycle
  - plane should engage DES when altitude constraint changes
  - plane should capture 4000 ft in ALT* and end in ALT

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
