### PR TITLE
test: ignore long-running tests

### DIFF
--- a/src/systems/a320_systems/src/hydraulic/mod.rs
+++ b/src/systems/a320_systems/src/hydraulic/mod.rs
@@ -5323,6 +5323,7 @@ mod tests {
         }
 
         #[test]
+        #[ignore]
         // Checks numerical stability of reservoir level: level should remain after multiple pressure cycles
         fn yellow_circuit_reservoir_coherency() {
             let mut test_bed = test_bed_with()
@@ -5401,6 +5402,7 @@ mod tests {
         }
 
         #[test]
+        #[ignore]
         // Checks numerical stability of reservoir level: level should remain after multiple pressure cycles
         fn green_circuit_reservoir_coherency() {
             let mut test_bed = test_bed_with()
@@ -5455,6 +5457,7 @@ mod tests {
         }
 
         #[test]
+        #[ignore]
         // Checks numerical stability of reservoir level: level should remain after multiple pressure cycles
         fn blue_circuit_reservoir_coherency() {
             let mut test_bed = test_bed_with()

--- a/src/systems/a320_systems/src/pneumatic.rs
+++ b/src/systems/a320_systems/src/pneumatic.rs
@@ -1889,6 +1889,7 @@ mod tests {
 
     // Just a way for me to plot some graphs
     #[test]
+    #[ignore]
     fn full_graphing_test() {
         let alt = Length::new::<foot>(0.);
 
@@ -2050,6 +2051,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn hydraulic_reservoir_pressurization_graphs() {
         let alt = Length::new::<foot>(0.);
 
@@ -2095,6 +2097,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn pack_pressurization_graphs() {
         let alt = Length::new::<foot>(0.);
 


### PR DESCRIPTION
## Summary of Changes
Ignore a few tests that take ~25s to run on my machine. The pneumatic tests are primarily intended to draw graphs and will be moved to a separate application by @BlueberryKing at a later time. The hydraulic tests try to ensure we're not leaking hydraulic fluid due to floating point precision issues. They simulate a lot of time to do so.

All these tests can still be used by executing: `cargo test -- --ignored`.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

## Testing instructions
Testing is not unnecessary.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
