### PR TITLE
feat: Advanced weather widget for flypadosv3 

### DIFF
--- a/src/instruments/src/Common/metarTypes.ts
+++ b/src/instruments/src/Common/metarTypes.ts
@@ -1,14 +1,25 @@
 /* eslint-disable camelcase */
 // Disable eslint camelcase as these are types for external library
+
+export enum ColorCode {
+    None,
+    Highlight,
+    Caution,
+    Warning,
+    TrendMarker,
+    Info
+}
+
 export type MetarParserType = {
     raw_text: string,
-    raw_parts: [string],
+    raw_parts: string[],
+    color_codes: ColorCode[], // contains codes for coloring parts - order must be identical to raw_parts
     icao: string,
     observed: Date,
     wind: Wind,
     visibility: Visibility,
-    conditions: [ConditionCode],
-    clouds: [Cloud],
+    conditions: ConditionCode[],
+    clouds: Cloud[],
     ceiling: Ceiling,
     temperature: Temperature,
     dewpoint: Dewpoint,
@@ -19,6 +30,8 @@ export type MetarParserType = {
 
 export type Wind = {
     degrees: number,
+    degrees_from: number,
+    degrees_to: number,
     speed_kts: number,
     speed_mps: number,
     gust_kts: number,

--- a/src/instruments/src/EFB/Dashboard/Dashboard.tsx
+++ b/src/instruments/src/EFB/Dashboard/Dashboard.tsx
@@ -1,15 +1,40 @@
 import React from 'react';
 import { FlightWidget } from './Widgets/FlightWidget';
 import { RemindersWidget } from './Widgets/RemindersWidget';
+import { WeatherWidget } from './Widgets/WeatherWidget';
+import { useAppSelector } from '../Store/store';
 
-export const Dashboard = () => (
-    <div className="w-full">
-        <h1 className="font-bold">Dashboard</h1>
+export const Dashboard = () => {
+    const { departingAirport, arrivingAirport } = useAppSelector((state) => state.simbrief.data);
+    const { userDepartureIcao, userDestinationIcao } = useAppSelector((state) => state.dashboard);
 
-        <div className="flex mt-4 space-x-6 w-full h-efb">
-            <FlightWidget />
+    return (
+        <div className="w-full">
+            <h1 className="font-bold">Dashboard</h1>
 
-            <RemindersWidget />
+            <div className="flex mt-4 w-full h-efb">
+                <FlightWidget />
+
+                <div className="flex flex-col w-3/5">
+
+                    <div className="p-6 mb-3 h-2/5 rounded-lg border-2 border-theme-accent shadow-md">
+                        <div className="flex items-center h-full">
+                            <div className="w-1/2">
+                                <WeatherWidget name="origin" simbriefIcao={departingAirport} userIcao={userDepartureIcao} />
+                            </div>
+                            <div className="h-60 rounded-full border border-gray-500" />
+                            <div className="w-1/2">
+                                <WeatherWidget name="destination" simbriefIcao={arrivingAirport} userIcao={userDestinationIcao} />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="overflow-hidden p-6 h-3/5 rounded-lg border-2 border-theme-accent">
+                        <RemindersWidget />
+                    </div>
+
+                </div>
+            </div>
         </div>
-    </div>
-);
+    );
+};

--- a/src/instruments/src/EFB/Dashboard/Widgets/ColorMetar.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/ColorMetar.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { ColorCode, MetarParserType } from '@instruments/common/metarTypes';
+
+/**
+ * Returns HTML with coloring for METAR parts marked with coloring hints.
+ * ColorCode: src/instruments/src/Common/metarTypes.ts
+ */
+export const ColoredMetar = ({ metar }: { metar: MetarParserType }) => {
+    const partsList = metar.raw_parts.map((metarPart, index) => {
+        switch (metar.color_codes[index]) {
+        case ColorCode.Highlight:
+            return (
+                <span className="text-teal-regular">
+                    {metarPart}
+                    {' '}
+                </span>
+            );
+        case ColorCode.Info:
+            return (
+                <span className="text-gray-500">
+                    {metarPart}
+                    {' '}
+                </span>
+            );
+        case ColorCode.Caution:
+            return (
+                <span className="text-yellow-500">
+                    {metarPart}
+                    {' '}
+                </span>
+            );
+        case ColorCode.Warning:
+            return (
+                <span className="text-red-600">
+                    {metarPart}
+                    {' '}
+                </span>
+            );
+        case ColorCode.TrendMarker:
+            return (
+                <>
+                    <span className="font-bold text-gray-500 underline">
+                        {metarPart}
+                    </span>
+                    {' '}
+                </>
+            );
+        default:
+            return (
+                <span>
+                    {metarPart}
+                    {' '}
+                </span>
+            );
+        }
+    });
+
+    return (
+        <span>{ partsList }</span>
+    );
+};

--- a/src/instruments/src/EFB/Store/features/dashboard.ts
+++ b/src/instruments/src/EFB/Store/features/dashboard.ts
@@ -1,0 +1,30 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { TypedAction } from '../store';
+
+/**
+ * DashboardState holds any preservable states on the Dashboard Widgets and its
+ * children widgets (mainly WeatherWidget).
+ * This makes sure that switching EFB pages retains user selections or input.
+ */
+interface DashboardState {
+    userDepartureIcao: string;
+    userDestinationIcao: string;
+}
+
+const initialState: DashboardState = { userDepartureIcao: '', userDestinationIcao: '' };
+
+export const dashboardSlice = createSlice({
+    name: 'dashboard',
+    initialState,
+    reducers: {
+        setUserDepartureIcao: (state, action: TypedAction<string>) => {
+            state.userDepartureIcao = action.payload;
+        },
+        setUserDestinationIcao: (state, action: TypedAction<string>) => {
+            state.userDestinationIcao = action.payload;
+        },
+    },
+});
+
+export const { setUserDepartureIcao, setUserDestinationIcao } = dashboardSlice.actions;
+export default dashboardSlice.reducer;

--- a/src/instruments/src/EFB/Store/store.ts
+++ b/src/instruments/src/EFB/Store/store.ts
@@ -9,7 +9,9 @@ import simbriefReducer from './features/simbrief';
 import performanceReducer from './features/performance';
 import flightProgressReducer from './features/flightProgress';
 import navigationTabReducer from './features/navigationPage';
+import dashboardReducer from './features/dashboard';
 
+export type TypedAction<T> = { type: string, payload: T };
 export type RootState = ReturnType<typeof combinedReducer>;
 export type AppDispatch = typeof store.dispatch;
 
@@ -22,6 +24,7 @@ const combinedReducer = combineReducers({
     performance: performanceReducer,
     flightProgress: flightProgressReducer,
     navigationTab: navigationTabReducer,
+    dashboard: dashboardReducer,
 });
 
 const rootReducer: Reducer = (state: RootState, action: AnyAction) => {

--- a/src/instruments/src/EFB/Utils/parseMetar.spec.ts
+++ b/src/instruments/src/EFB/Utils/parseMetar.spec.ts
@@ -1,0 +1,262 @@
+// Copyright (c) 2022 FlyByWire Simulations
+// SPDX-License-Identifier: GPL-3.0
+
+import { ColorCode } from '../../Common/metarTypes';
+import { parseMetar } from './parseMetar';
+
+describe('Test that parseMetar', () => {
+    it('throws an error when provided with an empty value', () => {
+        // empty metar string
+        expect(() => {
+            parseMetar('');
+        }).toThrow(new Error('Not enough METAR information found'));
+    });
+
+    it('throws an error when provided with an incomplete value', () => {
+        // empty metar string
+        expect(() => {
+            parseMetar('EDDM 291250Z');
+        }).toThrow(new Error('Not enough METAR information found'));
+    });
+});
+
+describe('Test real life METARs:', () => {
+    test('EDDM 291350Z 26017KT 9999 DZ BKN027 09/00 Q1025 NOSIG', () => {
+        const metarObject = parseMetar('EDDM 281350Z 26017KT 9999 DZ BKN027 09/00 Q1025 NOSIG');
+        expect(metarObject.icao).toBe('EDDM');
+        expect(metarObject.observed.getUTCDate()).toBe(28);
+        expect(metarObject.observed.getUTCHours()).toBe(13);
+        expect(metarObject.observed.getUTCMinutes()).toBe(50);
+        expect(metarObject.wind.speed_kts).toBe(17);
+        expect(metarObject.wind.gust_kts).toBe(17);
+        expect(metarObject.wind.degrees).toBe(260);
+        expect(metarObject.wind.degrees_from).toBe(260);
+        expect(metarObject.wind.degrees_to).toBe(260);
+        expect(metarObject.visibility.meters_float).toBe(9999);
+        expect(metarObject.visibility.meters).toBe('10000');
+        expect(metarObject.visibility.miles_float).toBe(6.213090551181102);
+        expect(metarObject.visibility.miles).toBe('6');
+        expect(metarObject.conditions).toHaveLength(1);
+        expect(metarObject.conditions[0].code).toBe('DZ');
+        expect(metarObject.clouds).toHaveLength(1);
+        expect(metarObject.clouds[0].code).toBe('BKN');
+        expect(metarObject.clouds[0].base_feet_agl).toBe(2700);
+        expect(metarObject.temperature.celsius).toBe(9);
+        expect(metarObject.dewpoint.celsius).toBe(0);
+        expect(metarObject.barometer.mb).toBe(1025);
+        expect(metarObject.barometer.hg).toBe(30.2682377);
+        expect(metarObject.barometer.kpa).toBe(102.5);
+        expect(metarObject.color_codes).toEqual(
+            [ColorCode.Highlight, // EDDM
+                ColorCode.None, // 291350Z
+                ColorCode.None, // 26017KT
+                ColorCode.None, // 9999
+                ColorCode.None, // DZ
+                ColorCode.None, // BKN027
+                ColorCode.None, // 09/00
+                ColorCode.None, // Q1025
+                ColorCode.None], // NOSIG
+        );
+    });
+
+    test('KJFK 291451Z 34027G34KT 300V020 1/4SM R04R/1600V2800FT +SN BLSN FZFG VV007 M09/M11 A2967 RMK AO2 PK WND 34035/1420 SLP046 SNINCR 1/8 P0000 60002 T10941111 51001', () => {
+        // eslint-disable-next-line max-len
+        const metarObject = parseMetar('KJFK 281451Z 34027G34KT 300V020 1/4SM R04R/1600V2800FT +SN BLSN FZFG VV007 M09/M11 A2967 RMK AO2 PK WND 34035/1420 SLP046 SNINCR 1/8 P0000 60002 T10941111 51001');
+        expect(metarObject.icao).toBe('KJFK');
+        expect(metarObject.observed.getUTCDate()).toBe(28);
+        expect(metarObject.observed.getUTCHours()).toBe(14);
+        expect(metarObject.observed.getUTCMinutes()).toBe(51);
+        expect(metarObject.wind.speed_kts).toBe(27);
+        expect(metarObject.wind.gust_kts).toBe(34);
+        expect(metarObject.wind.degrees).toBe(340);
+        expect(metarObject.wind.degrees_from).toBe(300);
+        expect(metarObject.wind.degrees_to).toBe(20);
+        expect(metarObject.visibility.miles).toBe('0.5');
+        expect(metarObject.visibility.miles_float).toBe(0.25);
+        expect(metarObject.visibility.meters).toBe('500');
+        expect(metarObject.visibility.meters_float).toBe(402.336);
+        expect(metarObject.conditions).toHaveLength(3);
+        expect(metarObject.conditions[0].code).toBe('+SN');
+        // @ts-ignore
+        expect(metarObject.conditions[1].code).toBe('BLSN');
+        // @ts-ignore
+        expect(metarObject.conditions[2].code).toBe('FZFG');
+        expect(metarObject.clouds).toHaveLength(1);
+        expect(metarObject.clouds[0].code).toBe('VV');
+        expect(metarObject.clouds[0].base_feet_agl).toBe(700);
+        expect(metarObject.temperature.celsius).toBe(-9);
+        expect(metarObject.dewpoint.celsius).toBe(-11);
+        expect(metarObject.barometer.mb).toBe(1004.741349708642);
+        expect(metarObject.barometer.hg).toBe(29.67);
+        expect(metarObject.barometer.kpa).toBe(100.4741349708642);
+        expect(metarObject.color_codes).toHaveLength(metarObject.raw_parts.length);
+        expect(metarObject.color_codes).toEqual(
+            [
+                ColorCode.Highlight, // KJFK
+                ColorCode.None, // 291451Z
+                ColorCode.Warning, // 34027G34KT
+                ColorCode.None, // 300V020
+                ColorCode.Warning, // 1/4SM
+                ColorCode.None, // R04R/1600V2800FT
+                ColorCode.Warning, // +SN
+                ColorCode.Caution, // BLSN
+                ColorCode.Warning, // FZFG
+                ColorCode.Caution, // VV007
+                ColorCode.Caution, // M09/M11
+                ColorCode.None, // A2967
+                ColorCode.Info, // RMK
+                ColorCode.Info, // AO2
+                ColorCode.Info, // PK
+                ColorCode.Info, // WND
+                ColorCode.Info, // 34035/1420
+                ColorCode.Info, // SLP046
+                ColorCode.Info, // SNINCR
+                ColorCode.Info, // 1/8
+                ColorCode.Info, // P0000
+                ColorCode.Info, // 60002
+                ColorCode.Info, // T10941111
+                ColorCode.Info], // 51001
+        );
+    });
+
+    test('EKCH 301350Z AUTO 32020G36KT 290V350 9999 NCD 07/M03 Q1011 TEMPO 31025G40KT 2500', () => {
+        // eslint-disable-next-line max-len
+        const metarObject = parseMetar('EKCH 251350Z AUTO 32020G36KT 290V350 9999 NCD 07/M03 Q1011 TEMPO 31025G40KT 2500');
+        expect(metarObject.icao).toBe('EKCH');
+        expect(metarObject.observed.getUTCDate()).toBe(25);
+        expect(metarObject.observed.getUTCHours()).toBe(13);
+        expect(metarObject.observed.getUTCMinutes()).toBe(50);
+        expect(metarObject.wind.speed_kts).toBe(20);
+        expect(metarObject.wind.gust_kts).toBe(36);
+        expect(metarObject.wind.degrees).toBe(320);
+        expect(metarObject.wind.degrees_from).toBe(290);
+        expect(metarObject.wind.degrees_to).toBe(350);
+        expect(metarObject.visibility.meters_float).toBe(9999);
+        expect(metarObject.visibility.meters).toBe('10000');
+        expect(metarObject.visibility.miles_float).toBe(6.213090551181102);
+        expect(metarObject.visibility.miles).toBe('6');
+        expect(metarObject.conditions).toHaveLength(0);
+        expect(metarObject.clouds).toHaveLength(0);
+        expect(metarObject.temperature.celsius).toBe(7);
+        expect(metarObject.dewpoint.celsius).toBe(-3);
+        expect(metarObject.barometer.mb).toBe(1011);
+        expect(metarObject.barometer.hg).toBe(29.854817868);
+        expect(metarObject.barometer.kpa).toBe(101.1);
+        expect(metarObject.color_codes).toHaveLength(metarObject.raw_parts.length);
+        expect(metarObject.color_codes).toEqual(
+            [
+                ColorCode.Highlight, // EKCH
+                ColorCode.None, // 301350Z
+                ColorCode.None, // AUTO
+                ColorCode.Warning, // 32020G36KT
+                ColorCode.None, // 290V350
+                ColorCode.None, // 9999
+                ColorCode.None, // NCD
+                ColorCode.Caution, // 07/M03
+                ColorCode.None, // Q1011
+                ColorCode.TrendMarker, // TEMPO
+                ColorCode.Warning, // 31025G40KT
+                ColorCode.Caution, // 2500
+            ],
+        );
+    });
+
+    test('K1U7 301420Z AUTO 00000KT 1/4SM FZFG OVC002 M23/M24 A3024 TEMPO 18040KT 1/4SM FZFG OVC004 M23/M24 A3024', () => {
+        // eslint-disable-next-line max-len
+        const metarObject = parseMetar('K1U7 011420Z AUTO 00000KT 1/4SM FZFG OVC002 M23/M24 A3024 TEMPO 18040KT 1/4SM FZFG OVC004 M23/M24 A3024');
+        expect(metarObject.icao).toBe('K1U7');
+        expect(metarObject.observed.getUTCDate()).toBe(1);
+        expect(metarObject.observed.getUTCHours()).toBe(14);
+        expect(metarObject.observed.getUTCMinutes()).toBe(20);
+        expect(metarObject.wind.speed_kts).toBe(0);
+        expect(metarObject.wind.gust_kts).toBe(0);
+        expect(metarObject.wind.degrees).toBe(0);
+        expect(metarObject.wind.degrees_from).toBe(0);
+        expect(metarObject.wind.degrees_to).toBe(0);
+        expect(metarObject.visibility.miles).toBe('0.5');
+        expect(metarObject.visibility.miles_float).toBe(0.25);
+        expect(metarObject.visibility.meters).toBe('500');
+        expect(metarObject.visibility.meters_float).toBe(402.336);
+        expect(metarObject.conditions).toHaveLength(1);
+        expect(metarObject.conditions[0].code).toBe('FZFG');
+        expect(metarObject.clouds).toHaveLength(1);
+        expect(metarObject.clouds[0].code).toBe('OVC');
+        expect(metarObject.clouds[0].base_feet_agl).toBe(200);
+        expect(metarObject.ceiling.code).toBe('OVC');
+        expect(metarObject.ceiling.feet_agl).toBe(200);
+        expect(metarObject.temperature.celsius).toBe(-23);
+        expect(metarObject.dewpoint.celsius).toBe(-24);
+        expect(metarObject.barometer.mb).toBe(1024.0437618870687);
+        expect(metarObject.barometer.hg).toBe(30.24);
+        expect(metarObject.barometer.kpa).toBe(102.40437618870688);
+        expect(metarObject.color_codes).toHaveLength(metarObject.raw_parts.length);
+        expect(metarObject.color_codes).toEqual(
+            [
+                ColorCode.Highlight, // K1U7
+                ColorCode.None, // 301420Z
+                ColorCode.None, // AUTO
+                ColorCode.None, // 00000KT
+                ColorCode.Warning, // 1/4SM
+                ColorCode.Warning, // FZFG
+                ColorCode.Warning, // OVC002
+                ColorCode.Warning, // M23/M24
+                ColorCode.None, // A3024
+                ColorCode.TrendMarker, // TREND
+                ColorCode.Warning, // 18040KT
+                ColorCode.Warning, // 1/4SM
+                ColorCode.Warning, // FZFG
+                ColorCode.Caution, // OVC004
+                ColorCode.Warning, // M23/M24
+                ColorCode.None, // A3024
+            ],
+        );
+    });
+});
+
+test('KSFO 301456Z 17004KT 10SM FEW008 SCT011 SCT200 07/06 A3021 RMK AO2 SLP230 T00720056 50002', () => {
+    const metarObject = parseMetar('KSFO 021456Z 17004KT 10SM FEW008 SCT011 SCT200 07/06 A3021 RMK AO2 SLP230 T00720056 50002');
+    expect(metarObject.icao).toBe('KSFO');
+    expect(metarObject.observed.getUTCDate()).toBe(2);
+    expect(metarObject.observed.getUTCHours()).toBe(14);
+    expect(metarObject.observed.getUTCMinutes()).toBe(56);
+    expect(metarObject.wind.speed_kts).toBe(4);
+    expect(metarObject.wind.gust_kts).toBe(4);
+    expect(metarObject.wind.degrees).toBe(170);
+    expect(metarObject.wind.degrees_from).toBe(170);
+    expect(metarObject.wind.degrees_to).toBe(170);
+    expect(metarObject.visibility.meters_float).toBe(16093.44);
+    expect(metarObject.visibility.meters).toBe('16000');
+    expect(metarObject.visibility.miles_float).toBe(10.0);
+    expect(metarObject.visibility.miles).toBe('10');
+    expect(metarObject.conditions).toHaveLength(0);
+    expect(metarObject.clouds).toHaveLength(3);
+    expect(metarObject.clouds[0].code).toBe('FEW');
+    expect(metarObject.clouds[0].base_feet_agl).toBe(800);
+    // @ts-ignore
+    expect(metarObject.clouds[1].code).toBe('SCT');
+    // @ts-ignore
+    expect(metarObject.clouds[2].code).toBe('SCT');
+    expect(metarObject.ceiling.code).toBe('SCT');
+    expect(metarObject.ceiling.feet_agl).toBe(20000);
+    expect(metarObject.temperature.celsius).toBe(7);
+    expect(metarObject.dewpoint.celsius).toBe(6);
+    expect(metarObject.barometer.mb).toBe(1023.0278454566253);
+    expect(metarObject.barometer.hg).toBe(30.21);
+    expect(metarObject.color_codes).toEqual(
+        [
+            ColorCode.Highlight, // KSFO
+            ColorCode.None, // 301456Z
+            ColorCode.None, // 17004KT
+            ColorCode.None, // 10SM
+            ColorCode.None, // FEW008
+            ColorCode.None, // SCT011
+            ColorCode.None, // SCT200
+            ColorCode.Caution, // 07/06
+            ColorCode.None, // A3021
+            ColorCode.Info, // RMK
+            ColorCode.Info, // AO2
+            ColorCode.Info, // SLP230
+            ColorCode.Info, // T00720056
+            ColorCode.Info], // 50002
+    );
+});

--- a/src/instruments/src/EFB/Utils/parseMetar.tsx
+++ b/src/instruments/src/EFB/Utils/parseMetar.tsx
@@ -1,0 +1,440 @@
+// Copyright (c) 2022 FlyByWire Simulations
+// SPDX-License-Identifier: GPL-3.0
+
+import { ColorCode, MetarParserType, Visibility, Wind } from '../../Common/metarTypes';
+
+/**
+ * Convert METAR string into structured object.
+ * Extension to the original library:  hints and functions for
+ * creating a colored METAR string.
+ *
+ * This is based on the work of Frank Boës and his aewx-metar-parser library.
+ * @see       https://github.com/fboes/metar-parser.git
+ *
+ * @see       https://api.checkwx.com/#31-single
+ * @see       https://www.skybrary.aero/index.php/Meteorological_Terminal_Air_Report_(METAR)
+ * @param     {String}  metarString - A string containing the raw metar information
+ * @returns   MetarParserType with structured information from src/instruments/src/Common/metarTypes.ts
+ * @author    Original library: Frank Boës, Extensions: FlyByWire Simulations
+ * @copyright Original library: Copyright (c) 2019 Frank Boës, Extensions: (c) 2022 FlyByWire Simulations
+ * @license   Original library: MIT License, Extensions: https://github.com/flybywiresim/a32nx/blob/master/LICENSE
+ */
+export function parseMetar(metarString: string): MetarParserType {
+    const metarArray = metarString
+        .trim()
+        .replace(/^METAR\S*?\s/, '')
+        // convert visibility range like `1 1/2 SM`
+        .replace(/(\s)(\d)\s(\d)\/(\d)(SM)/, (all, a, b, c, d, e) => `${a + (Number(b) * Number(d) + Number(c))}/${d}${e}`)
+        .split(' ');
+
+    if (metarArray.length < 3) {
+        throw new Error('Not enough METAR information found');
+    }
+
+    const metarObject: MetarParserType = {
+        raw_text: metarString,
+        raw_parts: metarArray,
+        color_codes: Array(metarArray.length).fill(ColorCode.None),
+        icao: '',
+        observed: new Date(0),
+        wind: {
+            degrees: 0,
+            degrees_from: 0,
+            degrees_to: 0,
+            speed_kts: 0,
+            speed_mps: 0,
+            gust_kts: 0,
+            gust_mps: 0,
+        },
+        visibility: {
+            miles: '',
+            miles_float: 0.0,
+            meters: '',
+            meters_float: 0.0,
+        },
+        conditions: [],
+        clouds: [],
+        ceiling: {
+            code: '',
+            feet_agl: 0,
+            meters_agl: 0,
+        },
+        temperature: {
+            celsius: 0,
+            fahrenheit: 0,
+        },
+        dewpoint: {
+            celsius: 0,
+            fahrenheit: 0,
+        },
+        humidity_percent: 0,
+        barometer: {
+            hg: 0,
+            kpa: 0,
+            mb: 0,
+        },
+        flight_category: '',
+    };
+
+    const calcHumidity = (temp, dew) => Math.exp((17.625 * dew) / (243.04 + dew))
+        / Math.exp((17.625 * temp) / (243.04 + temp));
+
+    const round = (value, toNext = 500) => Math.round(value / toNext) * toNext;
+
+    // mode describes which metar part are we expecting next
+    enum Mode {
+        ICAO,
+        DATE,
+        WIND,
+        VISIBILITY,
+        COND,
+        CLOUD,
+        TEMP,
+        PRESS,
+        TREND,
+        RMK,
+        MISC,
+    }
+    let mode = Mode.ICAO;
+
+    // as trend can be a complete new metar section we have this mode to not
+    // store into the main object but still use coloring.
+    let trendMode = false;
+    metarArray.forEach((metarPart, index) => {
+        let match;
+        if (mode < Mode.VISIBILITY && metarPart.match(/^(\d+)(?:\/(\d+))?(SM)?$/)) {
+            mode = Mode.VISIBILITY; // no wind reported
+        }
+        if (mode < Mode.CLOUD && metarPart.match(/^(FEW|SCT|BKN|OVC|VV)(\d+)?/)) {
+            mode = Mode.CLOUD; // no visibility / conditions reported
+        }
+        if (mode < Mode.TEMP && metarPart.match(/^M?\d+\/M?\d+$/)) {
+            mode = Mode.TEMP; // end of clouds
+        }
+        if (mode < Mode.RMK && metarPart.match(/^RMK$/)) {
+            mode = Mode.RMK; // end of clouds
+        }
+        switch (mode) {
+        case Mode.ICAO:
+            // ICAO Code
+            metarObject.icao = metarPart;
+            metarObject.color_codes[index] = ColorCode.Highlight;
+            mode = Mode.DATE;
+            break;
+        case Mode.DATE:
+            // Observed Date
+            match = metarPart.match(/^(\d\d)(\d\d)(\d\d)Z$/);
+            if (match) {
+                metarObject.observed = new Date();
+                metarObject.observed.setUTCDate(Number(match[1]));
+                metarObject.observed.setUTCHours(Number(match[2]));
+                metarObject.observed.setUTCMinutes(Number(match[3]));
+                mode = Mode.WIND;
+            }
+            break;
+        case Mode.WIND:
+            // Wind
+            match = metarPart.match(/^(\d\d\d|VRB)P?(\d+)(?:G(\d+))?(KT|MPS|KPH)/);
+            if (match) {
+                match[2] = Number(match[2]);
+                match[3] = match[3] ? Number(match[3]) : match[2];
+                if (match[4] === 'KPH') {
+                    match[2] = convert.kphToMps(match[2]);
+                    match[3] = convert.kphToMps(match[3]);
+                    match[4] = 'MPS';
+                }
+
+                const tmpWind: Wind = {
+                    degrees: (match[1] === 'VRB') ? 180 : Number(match[1]),
+                    degrees_from: (match[1] === 'VRB') ? 0 : Number(match[1]),
+                    degrees_to: (match[1] === 'VRB') ? 359 : Number(match[1]),
+                    speed_kts: (match[4] === 'MPS') ? convert.mpsToKts(match[2]) : match[2],
+                    speed_mps: (match[4] === 'MPS') ? match[2] : convert.ktsToMps(match[2]),
+                    gust_kts: (match[4] === 'MPS') ? convert.mpsToKts(match[3]) : match[3],
+                    gust_mps: (match[4] === 'MPS') ? match[3] : convert.ktsToMps(match[3]),
+                };
+
+                // coloring
+                if (tmpWind.gust_kts > 30) {
+                    metarObject.color_codes[index] = ColorCode.Warning;
+                } else if (metarObject.wind.gust_kts > 20) {
+                    metarObject.color_codes[index] = ColorCode.Caution;
+                }
+
+                // only write to the object for the main section
+                if (!trendMode) {
+                    metarObject.wind = tmpWind;
+                }
+                mode = Mode.VISIBILITY;
+            }
+            break;
+        case Mode.VISIBILITY:
+            // Visibility
+            match = metarPart.match(/^(\d+)(?:\/(\d+))?(SM)?$/);
+            if (match) {
+                const speed: number = (match[2])
+                    ? Number(match[1]) / Number(match[2])
+                    : Number(match[1]);
+
+                const tmpVisibility: Visibility = {
+                    miles: (match[3] && match[3] === 'SM') ? speed.toString() : convert.metersToMiles(speed).toString(),
+                    miles_float: (match[3] && match[3] === 'SM') ? speed : convert.metersToMiles(speed),
+                    meters: (match[3] && match[3] === 'SM') ? convert.milesToMeters(speed).toString() : speed.toString(),
+                    meters_float: (match[3] && match[3] === 'SM') ? convert.milesToMeters(speed) : speed,
+                };
+
+                // coloring
+                if (tmpVisibility.meters_float < 1000.0) {
+                    metarObject.color_codes[index] = ColorCode.Warning;
+                } else if (tmpVisibility.meters_float < 5000.0) {
+                    metarObject.color_codes[index] = ColorCode.Caution;
+                }
+
+                // only write to the object for the main section
+                if (!trendMode) {
+                    metarObject.visibility = tmpVisibility;
+                }
+
+                mode = Mode.COND;
+            } else if (metarPart === 'CAVOK'
+                || metarPart === 'CLR'
+                || metarPart === 'NCD') {
+                // only write to the object for the main section
+                if (!trendMode) {
+                    metarObject.visibility = {
+                        miles: '10',
+                        miles_float: 10,
+                        meters: convert.milesToMeters(10).toString(),
+                        meters_float: convert.milesToMeters(10),
+                    };
+                }
+                mode = Mode.CLOUD; // no visibility & conditions reported
+            } else if (metarObject.wind) {
+                // Variable wind direction
+                match = metarPart.match(/^(\d+)V(\d+)$/);
+                // only write to the object for the main section
+                if (match && !trendMode) {
+                    metarObject.wind.degrees_from = Number(match[1]);
+                    metarObject.wind.degrees_to = Number(match[2]);
+                }
+            }
+            break;
+        case Mode.COND:
+            // Conditions
+            // https://weather.cod.edu/notes/metar.html#wx
+            // https://en.wikipedia.org/wiki/METAR#METAR_weather_codes
+            // Caution: the syntax of metar and especially this part is not very well defined.
+            // Neither order nor actual grammar seems to be standardized in detail.
+            match = metarPart.match(/^(\+|-|VC|RE)?(MI|PR|BC|DR|BL|SH|TS|FZ|WS)?(DZ|RA|SN|SG|IC|PL|GR|GS|UP)?(BR|FG|FU|VA|DU|SA|HZ|PY)?(PO|SQ|FC|SS|DS)?$/);
+            if (match) {
+                // only write to the object for the main section
+                if (!trendMode) metarObject.conditions.push({ code: match[0] });
+
+                // coloring
+                const intensity = match[1]; // or proximity
+                const descriptor = match[2];
+                const precipitation = match[3];
+                const obscuration = match[4];
+                const other = match[5];
+
+                const condCaution: string[] = ['RA', 'SN', 'FG', 'VA'];
+                const condWarning: string[] = ['FZ', 'TS', 'SQ', 'DS', 'SS'];
+
+                // cautions
+                if ((intensity === 'VC' && descriptor === 'SH')
+                    || condCaution.includes(precipitation)
+                    || condCaution.includes(obscuration)
+                ) {
+                    metarObject.color_codes[index] = ColorCode.Caution;
+                }
+                // warnings
+                if (intensity === '+'
+                    || condWarning.includes(descriptor)
+                    || condWarning.includes(precipitation)
+                    || condWarning.includes(obscuration)
+                    || condWarning.includes(other)
+                ) {
+                    metarObject.color_codes[index] = ColorCode.Warning;
+                }
+            }
+            break;
+        case Mode.CLOUD:
+            // Clouds
+            match = metarPart.match(/^(FEW|SCT|BKN|OVC|VV)(\d+)(CB|TCU)?/);
+            if (match) {
+                match[2] = Number(match[2]) * 100;
+                const cloud = {
+                    code: match[1],
+                    base_feet_agl: match[2],
+                    base_meters_agl: convert.feetToMeters(match[2]),
+                };
+
+                // only write to the object for the main section
+                if (!trendMode) metarObject.clouds.push(cloud);
+
+                // coloring
+                if (match[2] <= 300) {
+                    metarObject.color_codes[index] = ColorCode.Warning;
+                } else if (match[3] || match[2] < 800) { // CB or TCU suffix
+                    metarObject.color_codes[index] = ColorCode.Caution;
+                }
+            }
+            break;
+        case Mode.TEMP:
+            // Temperature
+            match = metarPart.match(/^(M?\d+)\/(M?\d+)$/);
+            if (match) {
+                match[1] = Number(match[1].replace('M', '-'));
+                match[2] = Number(match[2].replace('M', '-'));
+                const tmpTemperature = {
+                    celsius: match[1],
+                    fahrenheit: convert.celsiusToFahrenheit(match[1]),
+                };
+                const tmpDewpoint = {
+                    celsius: match[2],
+                    fahrenheit: convert.celsiusToFahrenheit(match[2]),
+                };
+                const tmpHumidityPercent = calcHumidity(match[1], match[2]) * 100;
+
+                // only write to the object for the main section
+                if (!trendMode) {
+                    metarObject.temperature = tmpTemperature;
+                    metarObject.dewpoint = tmpDewpoint;
+                    metarObject.humidity_percent = tmpHumidityPercent;
+                }
+
+                if (tmpTemperature.celsius < -20) {
+                    metarObject.color_codes[index] = ColorCode.Warning;
+                } else if (tmpTemperature.celsius < 8) {
+                    metarObject.color_codes[index] = ColorCode.Caution;
+                }
+                mode = Mode.PRESS;
+            }
+            break;
+        case Mode.PRESS:
+            // Pressure
+            match = metarPart.match(/^([QA])(\d+)/);
+            if (match && !trendMode) {
+                match[2] = Number(match[2]);
+                match[2] /= (match[1] === 'Q') ? 10 : 100;
+                metarObject.barometer = {
+                    hg: (match[1] === 'Q') ? convert.kpaToInhg(match[2]) : match[2],
+                    kpa: (match[1] === 'Q') ? match[2] : convert.inhgToKpa(match[2]),
+                    mb: (match[1] === 'Q') ? match[2] * 10 : convert.inhgToKpa(match[2] * 10),
+                };
+                mode = Mode.TREND;
+            }
+            break;
+        case Mode.TREND:
+            // TREND
+            match = metarPart.match(/^(RMK|NOISG|BECMG|TEMPO)(.*)/);
+            if (match) {
+                switch (match[1]) {
+                case 'TEMPO':
+                    metarObject.color_codes[index] = ColorCode.TrendMarker;
+                    trendMode = true;
+                    mode = Mode.WIND;
+                    break;
+                case 'BECMG':
+                    metarObject.color_codes[index] = ColorCode.TrendMarker;
+                    trendMode = true;
+                    break;
+                case 'RMK':
+                    metarObject.color_codes[index] = ColorCode.Info;
+                    mode = Mode.RMK;
+                    break;
+                default:
+                    break;
+                }
+            }
+            break;
+        default:
+            // Rest
+            match = metarPart.match(/^(.*)$/);
+            if (match) {
+                metarObject.color_codes[index] = ColorCode.Info;
+            }
+            break;
+        }
+    });
+
+    if (!metarObject.visibility) {
+        metarObject.visibility = {
+            miles: '10',
+            miles_float: 10,
+            meters: convert.milesToMeters(10).toString(),
+            meters_float: convert.milesToMeters(10),
+        };
+    }
+
+    // Finishing touches
+
+    metarObject.visibility.miles = String(round(metarObject.visibility.miles, 0.5));
+    metarObject.visibility.meters = String(round(metarObject.visibility.meters));
+
+    if (metarObject.clouds.length) {
+        const highestCloud = metarObject.clouds[metarObject.clouds.length - 1];
+        metarObject.ceiling = {
+            code: highestCloud.code,
+            feet_agl: highestCloud.base_feet_agl,
+            meters_agl: highestCloud.base_meters_agl,
+        };
+    }
+
+    metarObject.flight_category = '';
+    if (metarObject.visibility.miles_float > 5
+        && (!metarObject.ceiling || metarObject.ceiling.feet_agl > 3000)
+    ) {
+        metarObject.flight_category = 'VFR';
+    } else if (metarObject.visibility.miles_float >= 3
+        && (!metarObject.ceiling || metarObject.ceiling.feet_agl >= 1000)
+    ) {
+        metarObject.flight_category = 'MVFR';
+    } else if (metarObject.visibility.miles_float >= 1
+        && (!metarObject.ceiling || metarObject.ceiling.feet_agl >= 500)
+    ) {
+        metarObject.flight_category = 'IFR';
+    } else {
+        metarObject.flight_category = 'LIFR';
+    }
+
+    return metarObject;
+}
+
+const convert = {
+    celsiusToFahrenheit(celsius) {
+        return celsius * 1.8 + 32;
+    },
+
+    feetToMeters(feet) {
+        return feet * 0.3048;
+    },
+
+    milesToMeters(miles) {
+        return miles * 1609.344;
+    },
+
+    metersToMiles(meters) {
+        return meters / 1609.344;
+    },
+
+    inhgToKpa(inHg) {
+        return inHg / 0.29529988;
+    },
+
+    kpaToInhg(kpa) {
+        return kpa * 0.29529988;
+    },
+
+    kphToMps(kph) {
+        return kph / 3600 * 1000;
+    },
+
+    mpsToKts(mps) {
+        return mps * 1.9438445;
+    },
+
+    ktsToMps(kts) {
+        return kts / 1.9438445;
+    },
+};


### PR DESCRIPTION
## Summary of Changes

- Added colored METAR 
  - created separate parseMetar function and removed "aewx-metar-parser library"
  - added unit tests for parseMetar
- Keeping state when changing EFB pages 
  - added Redux state for Dashboard
- Added a fix so barotype works for user ICAOs as well 
  -  AUTO: choose baro type based on ICAO or respect the setting in the EFB. 
 
## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/16833201/151662388-9955a5c2-3fdb-4296-839a-1c28d8500e16.png)
![image](https://user-images.githubusercontent.com/16833201/151662468-90d19af2-61f9-4fe7-b171-0b29bc4b3cd5.png)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
TBD

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
