### PR TITLE
fix(sentry): improvements to sentry.io client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /flybywire-aircraft-a320-neo/build_info.json
 /flybywire-aircraft-a320-neo/html_ui/JS/atsu/
 /flybywire-aircraft-a320-neo/html_ui/JS/fmgc/
+/flybywire-aircraft-a320-neo/html_ui/JS/sentry-client/
 /flybywire-aircraft-a320-neo/html_ui/JS/tcas/
 /flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/A32NX
 /flybywire-aircraft-a320-neo/html_ui/JS/generated/**

--- a/src/instruments/src/Common/index.tsx
+++ b/src/instruments/src/Common/index.tsx
@@ -15,9 +15,9 @@ export const render = (Slot: React.ReactElement, enableSentryTracing = false, se
         buildInfoFilePrefix: 'a32nx',
         enableTracing: enableSentryTracing,
         root: sentryRootClient,
-    }).then(() => {
-        ReactDOM.render(<SimVarProvider>{Slot}</SimVarProvider>, Defaults.getRenderTarget());
     });
+
+    ReactDOM.render(<SimVarProvider>{Slot}</SimVarProvider>, Defaults.getRenderTarget());
 };
 
 /**

--- a/src/sentry-client/src/FbwAircraftSentryClient.ts
+++ b/src/sentry-client/src/FbwAircraftSentryClient.ts
@@ -130,8 +130,8 @@ export class FbwAircraftSentryClient {
         return new Promise<boolean>((resolve) => {
             popup.showPopUp(
                 'A32NX - ERROR REPORTING',
-                'Are you willing to help us by enabling anonymous error reporting? This is 100% optional and we will never collect your personal data, '
-                + 'but it will help us diagnose issues quickly.',
+                'Are you willing to help FlyByWire Simulations by enabling anonymous reporting of error that may occur in the future? '
+                + 'This is 100% optional and we will never collect your personal data, but it will help us diagnose issues quickly.',
                 'normal',
                 () => resolve(true),
                 () => resolve(false),

--- a/src/sentry-client/src/FbwAircraftSentryClient.ts
+++ b/src/sentry-client/src/FbwAircraftSentryClient.ts
@@ -59,7 +59,20 @@ export class FbwAircraftSentryClient {
         if (config.root) {
             console.log('[SentryClient] Starting as root client');
 
-            return this.runRootClientFlow(config);
+            const instrument = document.querySelector('vcockpit-panel > *');
+
+            if (instrument) {
+                return new Promise<boolean>((resolve) => {
+                    instrument.addEventListener('FlightStart', () => {
+                        // Give ourselves a buffer
+                        setTimeout(() => {
+                            resolve(this.runRootClientFlow(config));
+                        }, 1_000);
+                    });
+                });
+            }
+
+            return Promise.reject(new Error('[SentryClient] Could not find an instrument element to hook onto'));
         }
 
         NXDataStore.getAndSubscribe(SENTRY_CONSENT_KEY, (key, value) => {

--- a/src/sentry-client/src/FbwAircraftSentryClient.ts
+++ b/src/sentry-client/src/FbwAircraftSentryClient.ts
@@ -56,25 +56,23 @@ export class FbwAircraftSentryClient {
             return Promise.resolve(false);
         }
 
+        this.runClientSubscription(config);
+
         if (config.root) {
             console.log('[SentryClient] Starting as root client');
 
-            const instrument = document.querySelector('vcockpit-panel > *');
-
-            if (instrument) {
-                return new Promise<boolean>((resolve) => {
-                    instrument.addEventListener('FlightStart', () => {
-                        // Give ourselves a buffer
-                        setTimeout(() => {
-                            resolve(this.runRootClientFlow(config));
-                        }, 1_000);
-                    });
-                });
-            }
-
-            return Promise.reject(new Error('[SentryClient] Could not find an instrument element to hook onto'));
+            return this.runRootClientFlow(config);
         }
 
+        return Promise.resolve(false);
+    }
+
+    /**
+     * Runs the client subscription (subscribes to the NXDataStore property and controls the client accordingly)
+     *
+     * @param config a {@link FbwAircraftSentryClientConfiguration} object
+     */
+    private async runClientSubscription(config: FbwAircraftSentryClientConfiguration) {
         NXDataStore.getAndSubscribe(SENTRY_CONSENT_KEY, (key, value) => {
             if (value === SentryConsentState.Given) {
                 console.log('[SentryClient] Synchronised consent state is Given. Initializing sentry');
@@ -84,8 +82,6 @@ export class FbwAircraftSentryClient {
                 FbwAircraftSentryClient.closeSentry();
             }
         });
-
-        return Promise.resolve(false);
     }
 
     /**
@@ -106,21 +102,36 @@ export class FbwAircraftSentryClient {
         case SentryConsentState.Unknown:
             console.log('[SentryClient] Consent state is Unknown. Asking for consent');
 
-            return FbwAircraftSentryClient.requestConsent().then((didConsent) => {
-                if (didConsent) {
-                    NXDataStore.set(SENTRY_CONSENT_KEY, SentryConsentState.Given);
+            // It seems that for some people, spawning the popup / writing to NXDataStore can cause a CTD if the flight is not fully loaded.
+            // So instead, we wait for a bit after the FlightStart event to show it and gather consent.
+            return new Promise((resolve, reject) => {
+                const instrument = document.querySelector('vcockpit-panel > *');
 
-                    console.log('[SentryClient] User requested consent state Given. Initializing sentry');
+                if (instrument) {
+                    instrument.addEventListener('FlightStart', () => {
+                        // ...and give ourselves some breathing room
+                        setTimeout(() => {
+                            resolve(FbwAircraftSentryClient.requestConsent().then((didConsent) => {
+                                if (didConsent) {
+                                    NXDataStore.set(SENTRY_CONSENT_KEY, SentryConsentState.Given);
 
-                    return FbwAircraftSentryClient.attemptInitializeSentry(config);
+                                    console.log('[SentryClient] User requested consent state Given. Initializing sentry');
+
+                                    return FbwAircraftSentryClient.attemptInitializeSentry(config);
+                                }
+
+                                NXDataStore.set(SENTRY_CONSENT_KEY, SentryConsentState.Refused);
+
+                                console.log('[SentryClient] User requested consent state Refused. Doing nothing');
+
+                                return false;
+                            }).catch(() => false));
+                        }, 1_000);
+                    });
+                } else {
+                    reject(new Error('[SentryClient] Could not find an instrument element to hook onto'));
                 }
-
-                NXDataStore.set(SENTRY_CONSENT_KEY, SentryConsentState.Refused);
-
-                console.log('[SentryClient] User requested consent state Refused. Doing nothing');
-
-                return false;
-            }).catch(() => false);
+            });
         case SentryConsentState.Refused:
             console.log('[SentryClient] Consent state is Refused. Doing nothing');
             break;
@@ -143,7 +154,7 @@ export class FbwAircraftSentryClient {
         return new Promise<boolean>((resolve) => {
             popup.showPopUp(
                 'A32NX - ERROR REPORTING',
-                'Are you willing to help FlyByWire Simulations by enabling anonymous reporting of error that may occur in the future? '
+                'Are you willing to help FlyByWire Simulations by enabling anonymous reporting of errors that may occur in the future? '
                 + 'This is 100% optional and we will never collect your personal data, but it will help us diagnose issues quickly.',
                 'normal',
                 () => resolve(true),

--- a/src/tcas/src/components/TcasComputer.ts
+++ b/src/tcas/src/components/TcasComputer.ts
@@ -158,7 +158,7 @@ export class TcasComputer implements TcasComponent {
 
     private debug: boolean;
 
-    private sendListener = RegisterViewListener('JS_LISTENER_SIMVARS');
+    private sendListener = RegisterViewListener('JS_LISTENER_SIMVARS', null, true);
 
     private updateThrottler: UpdateThrottler; // Utility to restrict updates
 


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

* Runs root client flow (consent gather) 1 second after `FlightStart` event instead of immediately
* Tweak message to make it more clear this is from the A32NX and not MSFS
* Add generated `sentry-client` to `.gitignore`
* Fix a stray non-singleton `JS_LISTENER_SIMVARS`

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![image](https://user-images.githubusercontent.com/4503241/154183946-055ef766-30c4-40e8-86db-427bc170615d.png)

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

* Make sure toggling of error reporting in the EFB ATSU/AOC settings works

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
