### PR TITLE
feat(navigation): add radio altimeter systems

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -173,6 +173,7 @@
 1. [MCDU] Added button press sound to remote mcdu  - @frankkopp (Cdr_Maverick#6475)
 1. [MCDU] Improved Remote MCDU with CLR hold and light-dark mode - @frankkopp (Frank Kopp)
 1. [MCDU] Improved mcdu server command line handling  - @frankkopp (Cdr_Maverick#6475)
+1. [RA] Add dual Radio Altimeter simulation - @beheh (Benedict Etzel)
 
 ## 0.7.0
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The following aircraft configuration is currently simulated or targeted:
  APU         APS3200
  FMS         Honeywell Release H3
  FWC Std.    H2F9C
+ RA          Honeywell ALA-52B
  TAWS        Honeywell EGPWS
  ACAS        Honeywell TPA-100B
  ATC         Honeywell TRA-100B

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -15,6 +15,7 @@
 1. [Pneumatic](#pneumatic)
 1. [Landing Gear (ATA 32)](#landing-gear-ata-32)
 1. [ATC (ATA 34)](#atc-ata-34)
+1. [Radio Altimeter (ATA 34)](#ra-ata-34)
 
 ## Uncategorized
 
@@ -2518,3 +2519,12 @@ In the variables below, {number} should be replaced with one item in the set: { 
     - {number}
         - 0
         - 1
+
+## Radio Altimeter (ATA 34)
+
+- A32NX_RA_{number}_RADIO_ALTITUDE
+    - `Arinc429Word<Feet>`
+    - The height over ground as measured by the corresponding radio altimeter towards the aft of the aircraft
+    - {number}
+      - 0
+      - 1

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_FWC.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_FWC.js
@@ -47,7 +47,7 @@ class A32NX_FWC {
 
         // ESDL 1. 0.190
         this.memoLdgMemo_conf01 = new NXLogic_ConfirmNode(1, true); // CONF 01
-        this.memoLdgMemo_memory1 = new NXLogic_MemoryNode(false);
+        this.memoLdgMemo_inhibit = new NXLogic_MemoryNode(false);
         this.memoLdgMemo_conf02 = new NXLogic_ConfirmNode(10, true); // CONF 01
         this.memoLdgMemo_below2000ft = new NXLogic_MemoryNode(true);
 
@@ -115,7 +115,9 @@ class A32NX_FWC {
     }
 
     _updateFlightPhase(_deltaTime) {
-        const radioHeight = SimVar.GetSimVarValue("RADIO HEIGHT", "Feet");
+        const radioHeight1 = Arinc429Word.fromSimVarValue("L:A32NX_RA_1_RADIO_ALTITUDE");
+        const radioHeight2 = Arinc429Word.fromSimVarValue("L:A32NX_RA_2_RADIO_ALTITUDE");
+        const radioHeight = radioHeight1.isFailureWarning() || radioHeight1.isNoComputedData() ? radioHeight2 : radioHeight1;
         const eng1N1 = SimVar.GetSimVarValue("ENG N1 RPM:1", "Percent");
         const eng2N1 = SimVar.GetSimVarValue("ENG N1 RPM:2", "Percent");
         // TODO find a better source for the following value ("core speed at or above idle")
@@ -125,7 +127,7 @@ class A32NX_FWC {
         );
         const eng1Or2Running = this.eng1OrTwoRunningConf.write(oneEngRunning, _deltaTime);
         const engOneAndTwoNotRunning = !eng1Or2Running;
-        const hFail = false;
+        const hFail = radioHeight1.isFailureWarning() && radioHeight2.isFailureWarning();
         const adcTestInhib = false;
 
         // ESLD 1.0.60
@@ -137,8 +139,8 @@ class A32NX_FWC {
         const acSpeedAbove80kts = this.speedAbove80KtsMemo.write(ias > 83, ias < 77);
 
         // ESLD 1.0.90
-        const hAbv1500 = radioHeight > 1500;
-        const hAbv800 = radioHeight > 800;
+        const hAbv1500 = radioHeight.isNoComputedData() || radioHeight.value > 1500;
+        const hAbv800 = radioHeight.isNoComputedData() || radioHeight.value > 800;
 
         // ESLD 1.0.79 + 1.0.80
         const eng1TLA = SimVar.GetSimVarValue("L:A32NX_AUTOTHRUST_TLA:1", "number");
@@ -301,22 +303,24 @@ class A32NX_FWC {
     }
 
     _updateLandingMemo(_deltaTime) {
-        const radioHeight = SimVar.GetSimVarValue("RADIO HEIGHT", "Feet");
-        const radioHeightInvalid = false;
+        const radioHeight1 = Arinc429Word.fromSimVarValue("L:A32NX_RA_1_RADIO_ALTITUDE");
+        const radioHeight2 = Arinc429Word.fromSimVarValue("L:A32NX_RA_2_RADIO_ALTITUDE");
+        const radioHeight1Invalid = radioHeight1.isFailureWarning() || radioHeight1.isNoComputedData();
+        const radioHeight2Invalid = radioHeight2.isFailureWarning() || radioHeight2.isNoComputedData();
         const gearDownlocked = SimVar.GetSimVarValue("GEAR TOTAL PCT EXTENDED", "percent") > 0.95;
 
         // FWC ESLD 1.0.190
-        const setBelow2000ft = radioHeight < 2000;
-        const resetBelow2000ft = radioHeight > 2200;
+        const setBelow2000ft = (radioHeight1.value < 2000 && !radioHeight1Invalid) || (radioHeight2.value < 2000 && !radioHeight2Invalid);
+        const resetBelow2000ft = (radioHeight1 > 2200 || radioHeight1Invalid) && (radioHeight2 > 2200 || radioHeight2Invalid);
         const memo2 = this.memoLdgMemo_below2000ft.write(setBelow2000ft, resetBelow2000ft);
 
-        const setLandingMemo = this.memoLdgMemo_conf01.write(!radioHeightInvalid && resetBelow2000ft, _deltaTime);
-        const resetLandingMemo = !(this.flightPhase === 7 || this.flightPhase === 8 || this.flightPhase === 6);
-        const memo1 = this.memoLdgMemo_memory1.write(setLandingMemo, resetLandingMemo);
+        const setInhibitMemo = this.memoLdgMemo_conf01.write(resetBelow2000ft && !radioHeight1Invalid && !radioHeight2Invalid, _deltaTime);
+        const resetInhibitMemo = !(this.flightPhase === 7 || this.flightPhase === 8 || this.flightPhase === 6);
+        const memo1 = this.memoLdgMemo_inhibit.write(setInhibitMemo, resetInhibitMemo);
 
         const showInApproach = memo1 && memo2 && this.flightPhase === 6;
 
-        const invalidRadioMemo = this.memoLdgMemo_conf02.write(radioHeightInvalid && gearDownlocked);
+        const invalidRadioMemo = this.memoLdgMemo_conf02.write(radioHeight1Invalid && radioHeight2Invalid && gearDownlocked && this.flightPhase === 6);
 
         this.ldgMemo = showInApproach || invalidRadioMemo || this.flightPhase === 8 || this.flightPhase === 7;
         SimVar.SetSimVarValue("L:A32NX_FWC_LDGMEMO", "Bool", this.ldgMemo);

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Status.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_Status.js
@@ -23,6 +23,15 @@ var A320_Neo_LowerECAM_Status;
             return SimVar.GetSimVarValue("L:A32NX_ECAM_INOP_SYS_" + _system, "Bool");
         }
 
+        isRadioAltimeterInop(number) {
+            const height = new Arinc429Word(SimVar.GetSimVarValue(`L:A32NX_RA_${number}_RADIO_ALTITUDE`, 'feet'));
+            return height.isFailureWarning();
+        }
+
+        isTcasInop() {
+            return SimVar.GetSimVarValue('L:A32NX_TCAS_FAULT', 'bool');
+        }
+
         constructor() {
             super();
             this.isInitialised = false;
@@ -172,9 +181,21 @@ var A320_Neo_LowerECAM_Status;
                         }
                     },
                     {
+                        message: "RA 1",
+                        isActive: () => {
+                            return this.isRadioAltimeterInop(1) && !this.isRadioAltimeterInop(2);
+                        }
+                    },
+                    {
+                        message: "RA 2",
+                        isActive: () => {
+                            return this.isRadioAltimeterInop(2) && !this.isRadioAltimeterInop(1);
+                        }
+                    },
+                    {
                         message: "RA 1+2",
                         isActive: () => {
-                            return this.isInop("RA_1") && this.isInop("RA_2");
+                            return this.isRadioAltimeterInop(1) && this.isRadioAltimeterInop(2);
                         }
                     },
                     {
@@ -186,7 +207,9 @@ var A320_Neo_LowerECAM_Status;
                     {
                         message: "A/CALL OUT",
                         isActive: () => {
-                            return this.isInop("ACALL_OUT");
+                            return this.isInop("ACALL_OUT") || (
+                                this.isRadioAltimeterInop(1) && this.isRadioAltimeterInop(2)
+                            );
                         }
                     },
                     {
@@ -308,9 +331,15 @@ var A320_Neo_LowerECAM_Status;
                         }
                     },
                     {
+                        message: "GPWS",
+                        isActive: () => {
+                            return this.isRadioAltimeterInop(1) && this.isRadioAltimeterInop(2);
+                        }
+                    },
+                    {
                         message: "TCAS",
                         isActive: () => {
-                            return this.isInop("TCAS");
+                            return this.isTcasInop();
                         }
                     },
                     {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/EICAS/ECAM/A320_Neo_UpperECAM.js
@@ -390,8 +390,6 @@ var A320_Neo_UpperECAM;
                                     "FCTL_PROT",
                                     "REVERSER_1",
                                     "REVERSER_2",
-                                    "RA_1",
-                                    "RA_2",
                                     "SEC_2",
                                     "SEC_3",
                                     "ACALL_OUT",
@@ -1098,6 +1096,22 @@ var A320_Neo_UpperECAM;
                         name: "NAV",
                         messages: [
                             {
+                                message: "RA 1 FAULT",
+                                level: 2,
+                                flightPhasesInhib: [3, 4, 5, 8],
+                                isActive: () => {
+                                    return this.hasRadioAltimeterFailed(1, true);
+                                },
+                            },
+                            {
+                                message: "RA 2 FAULT",
+                                level: 2,
+                                flightPhasesInhib: [3, 4, 5, 8],
+                                isActive: () => {
+                                    return this.hasRadioAltimeterFailed(2, true);
+                                },
+                            },
+                            {
                                 message: "TCAS FAULT",
                                 level: 2,
                                 inopSystems: [
@@ -1105,7 +1119,9 @@ var A320_Neo_UpperECAM;
                                 ],
                                 flightPhasesInhib: [3, 4, 5, 7, 8],
                                 isActive: () => {
-                                    return !this.isInFlightPhase(1, 10) && this.getCachedSimVar('L:A32NX_TCAS_FAULT', 'bool');
+                                    return !this.isInFlightPhase(1, 10) && this.getCachedSimVar('L:A32NX_TCAS_FAULT', 'bool') && !(
+                                        this.hasRadioAltimeterFailed(1) && this.hasRadioAltimeterFailed(2)
+                                    );
                                 },
                             },
                             {
@@ -1962,6 +1978,12 @@ var A320_Neo_UpperECAM;
             const knobValue = this.getCachedSimVar(`L:A32NX_OVHD_ADIRS_IR_${number}_MODE_SELECTOR_KNOB`, "Enum");
             const pitch = new Arinc429Word(this.getCachedSimVar(`L:A32NX_ADIRS_IR_${number}_PITCH`, "Degrees"));
             return knobValue === 2 && !pitch.isNormalOperation();
+        }
+
+        hasRadioAltimeterFailed(number, considerUnpoweredAsOk) {
+            const isUnpowered = !this.getCachedSimVar(`L:A32NX_ELEC_AC_${number}_BUS_IS_POWERED`, "bool");
+            const height = new Arinc429Word(this.getCachedSimVar(`L:A32NX_RA_${number}_RADIO_ALTITUDE`, 'feet'));
+            return height.isFailureWarning() && (!considerUnpoweredAsOk || !isUnpowered);
         }
     }
     A320_Neo_UpperECAM.Display = Display;

--- a/src/failures/src/a320.ts
+++ b/src/failures/src/a320.ts
@@ -15,4 +15,6 @@ export const A320Failure = Object.freeze({
     YellowReservoirReturnLeak: 29008,
     LeftPfdDisplay: 31000,
     RightPfdDisplay: 31001,
+    RadioAltimeter1: 34000,
+    RadioAltimeter2: 34001,
 });

--- a/src/instruments/src/EFB/failures-orchestrator-provider.tsx
+++ b/src/instruments/src/EFB/failures-orchestrator-provider.tsx
@@ -25,6 +25,8 @@ const createOrchestrator = () => new FailuresOrchestrator('A32NX', [
     [A320Failure.GreenReservoirReturnLeak, 'Green reservoir return leak'],
     [A320Failure.BlueReservoirReturnLeak, 'Blue reservoir return leak'],
     [A320Failure.YellowReservoirReturnLeak, 'Yellow reservoir return leak'],
+    [A320Failure.RadioAltimeter1, 'RA 1'],
+    [A320Failure.RadioAltimeter2, 'RA 2'],
 ]);
 
 const Context = React.createContext<FailuresOrchestratorContext>({

--- a/src/instruments/src/PFD/AltitudeIndicator.tsx
+++ b/src/instruments/src/PFD/AltitudeIndicator.tsx
@@ -49,11 +49,16 @@ const LandingElevationIndicator = ({ altitude, FWCFlightPhase }: LandingElevatio
     );
 };
 
-const RadioAltIndicator = ({ radioAlt }) => {
-    if (radioAlt > DisplayRange) {
+interface RadioAltitudeProps {
+    radioAltitude: Arinc429Word,
+    filteredRadioAltitude: number,
+}
+
+const RadioAltIndicator = ({ radioAltitude, filteredRadioAltitude }: RadioAltitudeProps) => {
+    if (filteredRadioAltitude > DisplayRange || radioAltitude.isFailureWarning() || radioAltitude.isNoComputedData()) {
         return null;
     }
-    const offset = (radioAlt - DisplayRange) * DistanceSpacing / ValueSpacing;
+    const offset = (filteredRadioAltitude - DisplayRange) * DistanceSpacing / ValueSpacing;
 
     return (
         <path id="AltTapeGroundReference" className="Fill Red" d={`m131.15 123.56h2.8709v${offset}h-2.8709z`} />
@@ -98,10 +103,11 @@ interface AltitudeIndicatorOfftapeProps {
     targetAlt: number;
     altIsManaged: boolean;
     mode: '' | 'STD' | 'QFE' | 'QNH';
-    radioAlt: number;
+    radioAltitude: Arinc429Word;
+    filteredRadioAltitude: number,
 }
 
-export const AltitudeIndicatorOfftape = ({ altitude, MDA, targetAlt, altIsManaged, mode, radioAlt }: AltitudeIndicatorOfftapeProps) => {
+export const AltitudeIndicatorOfftape = ({ altitude, MDA, targetAlt, altIsManaged, mode, radioAltitude, filteredRadioAltitude }: AltitudeIndicatorOfftapeProps) => {
     const [tcasFail] = useSimVar('L:A32NX_TCAS_FAULT', 'boolean', 200);
 
     const altFailBlock = (
@@ -138,7 +144,7 @@ export const AltitudeIndicatorOfftape = ({ altitude, MDA, targetAlt, altIsManage
             <AltimeterIndicator mode={mode} altitude={altitude} />
             <MetricAltIndicator altitude={altitude} MDA={MDA} targetAlt={targetAlt} altIsManaged={altIsManaged} />
             <path id="AltReadoutBackground" className="BlackFill" d="m130.85 85.308h-13.13v-8.9706h13.13v-2.671h8.8647v14.313h-8.8647z" />
-            <RadioAltIndicator radioAlt={radioAlt} />
+            <RadioAltIndicator radioAltitude={radioAltitude} filteredRadioAltitude={filteredRadioAltitude} />
             <DigitalAltitudeReadout altitude={altitude} MDA={MDA} />
             {tcasFail && tcasFailBlock}
         </g>

--- a/src/instruments/src/PFD/VerticalSpeedIndicator.tsx
+++ b/src/instruments/src/PFD/VerticalSpeedIndicator.tsx
@@ -3,11 +3,12 @@ import { useSimVar } from '@instruments/common/simVars';
 import React from 'react';
 
 interface VerticalSpeedIndicatorProps {
-    radioAlt: number,
     verticalSpeed: Arinc429Word
+    radioAltitude: Arinc429Word,
+    filteredRadioAltitude: number,
 }
 
-export const VerticalSpeedIndicator = ({ radioAlt, verticalSpeed }: VerticalSpeedIndicatorProps) => {
+export const VerticalSpeedIndicator = ({ verticalSpeed, radioAltitude, filteredRadioAltitude }: VerticalSpeedIndicatorProps) => {
     if (!verticalSpeed.isNormalOperation()) {
         return (
             <>
@@ -22,9 +23,14 @@ export const VerticalSpeedIndicator = ({ radioAlt, verticalSpeed }: VerticalSpee
     }
 
     const absVSpeed = Math.abs(verticalSpeed.value);
+    const radioAltitudeValid = !radioAltitude.isNoComputedData() && !radioAltitude.isFailureWarning();
 
     let isAmber = false;
-    if (absVSpeed > 6000 || (radioAlt < 2500 && radioAlt > 1000 && verticalSpeed.value < -2000) || (radioAlt < 1000 && verticalSpeed.value < -1200)) {
+    if (
+        absVSpeed >= 6000
+        || (verticalSpeed.value <= -2000 && radioAltitudeValid && filteredRadioAltitude <= 2500 && filteredRadioAltitude >= 1000)
+        || (verticalSpeed.value <= -1200 && radioAltitudeValid && filteredRadioAltitude <= 1000)
+    ) {
         isAmber = true;
     }
 

--- a/src/systems/a320_systems/src/lib.rs
+++ b/src/systems/a320_systems/src/lib.rs
@@ -4,6 +4,7 @@ mod air_conditioning;
 mod electrical;
 mod fuel;
 mod hydraulic;
+mod navigation;
 mod pneumatic;
 mod power_consumption;
 
@@ -16,10 +17,11 @@ use electrical::{
     A320Electrical, A320ElectricalOverheadPanel, A320EmergencyElectricalOverheadPanel,
     APU_START_MOTOR_BUS_TYPE,
 };
-
 use hydraulic::{A320Hydraulic, A320HydraulicOverheadPanel};
+use navigation::A320RadioAltimeters;
 use power_consumption::A320PowerConsumption;
 use systems::simulation::InitContext;
+
 use systems::{
     apu::{
         Aps3200ApuGenerator, Aps3200StartMotor, AuxiliaryPowerUnit, AuxiliaryPowerUnitFactory,
@@ -63,6 +65,7 @@ pub struct A320 {
     pressurization: Pressurization,
     pressurization_overhead: PressurizationOverheadPanel,
     pneumatic: A320Pneumatic,
+    radio_altimeters: A320RadioAltimeters,
 }
 impl A320 {
     pub fn new(context: &mut InitContext) -> A320 {
@@ -106,6 +109,7 @@ impl A320 {
             pressurization: Pressurization::new(context),
             pressurization_overhead: PressurizationOverheadPanel::new(context),
             pneumatic: A320Pneumatic::new(context),
+            radio_altimeters: A320RadioAltimeters::new(context),
         }
     }
 }
@@ -162,6 +166,9 @@ impl Aircraft for A320 {
             &self.landing_gear,
             self.ext_pwr.output_potential().is_powered(),
         );
+
+        self.radio_altimeters.update(context);
+
         self.pressurization.update(
             context,
             &self.pressurization_overhead,
@@ -236,6 +243,7 @@ impl SimulationElement for A320 {
         self.ext_pwr.accept(visitor);
         self.lgciu1.accept(visitor);
         self.lgciu2.accept(visitor);
+        self.radio_altimeters.accept(visitor);
         self.autobrake_panel.accept(visitor);
         self.hydraulic.accept(visitor);
         self.hydraulic_overhead.accept(visitor);

--- a/src/systems/a320_systems/src/navigation.rs
+++ b/src/systems/a320_systems/src/navigation.rs
@@ -1,0 +1,107 @@
+use systems::navigation::ala52b::{
+    Ala52BAircraftInstallationDelay, Ala52BRadioAltimeter, Ala52BTransceiverPair,
+};
+use systems::navigation::radio_altimeter::AntennaInstallation;
+use systems::shared::ElectricalBusType;
+use systems::simulation::{
+    InitContext, SimulationElement, SimulationElementVisitor, UpdateContext,
+};
+use uom::si::f64::Length;
+use uom::si::length::{foot, meter};
+
+pub struct A320RadioAltimeters {
+    radio_altimeter_1: A320RadioAltimeter,
+    radio_altimeter_2: A320RadioAltimeter,
+}
+
+impl A320RadioAltimeters {
+    pub fn new(context: &mut InitContext) -> Self {
+        Self {
+            radio_altimeter_1: A320RadioAltimeter::new(
+                context,
+                1,
+                ElectricalBusType::AlternatingCurrent(1),
+                AntennaInstallation::new(
+                    // Sim CG minus RA height over ground
+                    Length::new::<foot>(8.617) - Length::new::<meter>(1.8),
+                    // Aft distance from Sim CG
+                    Length::new::<meter>(9.89),
+                    // Electric length of the antennas and cable modeling some material variation
+                    Length::new::<foot>(22.4),
+                ),
+                AntennaInstallation::new(
+                    Length::new::<foot>(8.617) - Length::new::<meter>(1.8),
+                    Length::new::<meter>(9.19),
+                    Length::new::<foot>(22.4),
+                ),
+            ),
+            radio_altimeter_2: A320RadioAltimeter::new(
+                context,
+                2,
+                ElectricalBusType::AlternatingCurrent(2),
+                AntennaInstallation::new(
+                    Length::new::<foot>(8.617) - Length::new::<meter>(1.8),
+                    Length::new::<meter>(11.27),
+                    Length::new::<foot>(21.4),
+                ),
+                AntennaInstallation::new(
+                    Length::new::<foot>(8.617) - Length::new::<meter>(1.8),
+                    Length::new::<meter>(11.96),
+                    Length::new::<foot>(21.4),
+                ),
+            ),
+        }
+    }
+
+    pub fn update(&mut self, context: &UpdateContext) {
+        self.radio_altimeter_1.update(context);
+        self.radio_altimeter_2.update(context);
+    }
+}
+
+impl SimulationElement for A320RadioAltimeters {
+    fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
+        self.radio_altimeter_1.accept(visitor);
+        self.radio_altimeter_2.accept(visitor);
+
+        visitor.visit(self);
+    }
+}
+
+pub struct A320RadioAltimeter {
+    radio_altimeter: Ala52BRadioAltimeter,
+    transceivers: Ala52BTransceiverPair,
+}
+
+impl A320RadioAltimeter {
+    fn new(
+        context: &mut InitContext,
+        number: usize,
+        powered_by: ElectricalBusType,
+        transmitter: AntennaInstallation,
+        receiver: AntennaInstallation,
+    ) -> Self {
+        Self {
+            radio_altimeter: Ala52BRadioAltimeter::new(
+                context,
+                number,
+                Ala52BAircraftInstallationDelay::FiftySevenFeet,
+                powered_by,
+            ),
+            transceivers: Ala52BTransceiverPair::new(context, transmitter, receiver),
+        }
+    }
+
+    fn update(&mut self, context: &UpdateContext) {
+        self.radio_altimeter.update(context, &self.transceivers);
+    }
+}
+
+impl SimulationElement for A320RadioAltimeter {
+    fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
+        self.transceivers.accept(visitor);
+        self.radio_altimeter.accept(visitor);
+
+        visitor.visit(self);
+    }
+}

--- a/src/systems/a320_systems_wasm/src/lib.rs
+++ b/src/systems/a320_systems_wasm/src/lib.rs
@@ -69,6 +69,8 @@ async fn systems(mut gauge: msfs::Gauge) -> Result<(), Box<dyn Error>> {
             29_008,
             FailureType::ReservoirReturnLeak(HydraulicColor::Yellow),
         ),
+        (34_000, FailureType::RadioAltimeter(1)),
+        (34_001, FailureType::RadioAltimeter(2)),
     ])
     .provides_aircraft_variable("ACCELERATION BODY X", "feet per second squared", 0)?
     .provides_aircraft_variable("ACCELERATION BODY Y", "feet per second squared", 0)?
@@ -97,6 +99,7 @@ async fn systems(mut gauge: msfs::Gauge) -> Result<(), Box<dyn Error>> {
     .provides_aircraft_variable("INDICATED ALTITUDE", "Feet", 0)?
     .provides_aircraft_variable("INTERACTIVE POINT OPEN:0", "Percent", 0)?
     .provides_aircraft_variable("INTERACTIVE POINT OPEN:3", "Percent", 0)?
+    .provides_aircraft_variable("PLANE ALT ABOVE GROUND", "Feet", 0)?
     .provides_aircraft_variable("PLANE PITCH DEGREES", "Degrees", 0)?
     .provides_aircraft_variable("PLANE BANK DEGREES", "Degrees", 0)?
     .provides_aircraft_variable("PLANE HEADING DEGREES MAGNETIC", "Degrees", 0)?

--- a/src/systems/systems/src/failures/mod.rs
+++ b/src/systems/systems/src/failures/mod.rs
@@ -7,6 +7,7 @@ pub enum FailureType {
     ReservoirLeak(HydraulicColor),
     ReservoirAirLeak(HydraulicColor),
     ReservoirReturnLeak(HydraulicColor),
+    RadioAltimeter(usize),
 }
 
 pub struct Failure {

--- a/src/systems/systems/src/navigation/ala52b.rs
+++ b/src/systems/systems/src/navigation/ala52b.rs
@@ -1,0 +1,850 @@
+use super::radio_altimeter::{
+    AntennaInstallation, RadioAltimeter, TransceiverPair, TransceiverPairResponse,
+};
+use crate::failures::{Failure, FailureType};
+use crate::shared::arinc429::{Arinc429Word, SignStatus};
+use crate::shared::{random_from_range, ConsumePower, ElectricalBusType, ElectricalBuses};
+use crate::simulation::{
+    InitContext, Read, SimulationElement, SimulationElementVisitor, SimulatorReader,
+    SimulatorWriter, UpdateContext, VariableIdentifier, Write,
+};
+use std::time::Duration;
+use uom::si::angle::degree;
+use uom::si::f64::{Angle, Length, Power, Ratio, Velocity};
+use uom::si::length::foot;
+use uom::si::power::watt;
+use uom::si::ratio::ratio;
+use uom::si::velocity::meter_per_second;
+
+const SPEED_OF_LIGHT_METER_PER_SECOND: f64 = 299_792_458.;
+
+/// This struct represents a highly simplified pair of the transceivers as used by the ALA-52B
+/// system and models some of the rudimentary physical properties like signal travel time, maximum
+/// distance and attitude cutoffs. The pair refers to 1 transmitter system and 1 receiver system.
+/// Both of these systems include their radio wave generator/receiver respectively, their
+/// respective antenna installation, and the cables between the generator/receiver and the antenna.
+pub struct Ala52BTransceiverPair {
+    alt_above_ground_id: VariableIdentifier,
+    pitch_id: VariableIdentifier,
+    bank_id: VariableIdentifier,
+
+    transmitter: AntennaInstallation,
+    receiver: AntennaInstallation,
+
+    alt_above_ground: Length,
+    pitch: Angle,
+    bank: Angle,
+}
+
+impl Ala52BTransceiverPair {
+    const ALT_ABOVE_GROUND: &'static str = "PLANE ALT ABOVE GROUND";
+    const PITCH: &'static str = "PLANE PITCH DEGREES";
+    const BANK: &'static str = "PLANE BANK DEGREES";
+
+    pub fn new(
+        context: &mut InitContext,
+        transmitter: AntennaInstallation,
+        receiver: AntennaInstallation,
+    ) -> Self {
+        Self {
+            alt_above_ground_id: context.get_identifier(Self::ALT_ABOVE_GROUND.to_owned()),
+            pitch_id: context.get_identifier(Self::PITCH.to_owned()),
+            bank_id: context.get_identifier(Self::BANK.to_owned()),
+            transmitter,
+            receiver,
+            alt_above_ground: Length::new::<foot>(0.),
+            pitch: Angle::new::<degree>(0.),
+            bank: Angle::new::<degree>(0.),
+        }
+    }
+
+    /// Returns the height over ground of the physical transmitter antenna.
+    fn transmitter_height_over_ground(&self) -> Length {
+        let vertical_offset = self.pitch.sin() * self.transmitter.z();
+        self.alt_above_ground + vertical_offset - self.transmitter.y()
+    }
+
+    /// Returns the height over ground of the physical receiver antenna.
+    fn receiver_height_over_ground(&self) -> Length {
+        let vertical_offset = self.pitch.sin() * self.receiver.z();
+        self.alt_above_ground + vertical_offset - self.receiver.y()
+    }
+
+    /// Returns the direct distance between the antennas (usually along the aircraft's fuselage)
+    fn distance_between_antennas(&self) -> Length {
+        (self.transmitter.z() - self.receiver.z()).abs()
+    }
+
+    /// Returns the distance between the projected ground tracks of the transmitter and receiver.
+    fn antenna_along_ground_distance(&self) -> Length {
+        self.pitch.cos() * self.distance_between_antennas()
+    }
+}
+
+impl TransceiverPair for Ala52BTransceiverPair {
+    /// Returns the time the signal took to travel from one of the transceivers to the other,
+    /// to the receiver, or [None] if there is no path (or the signal is too weak).
+    /// While it is simplified compared to a proper frequency simulation, you can imagine that the
+    /// measured runtime is already based on the filtered difference between the sent and received
+    /// frequency in an FMCW-based radar.
+    fn response(&self) -> Option<TransceiverPairResponse> {
+        if self.pitch.abs() > Angle::new::<degree>(45.)
+            || self.bank.abs() > Angle::new::<degree>(44.)
+        {
+            return None;
+        }
+
+        // First, we need to determine the shortest path of the radio waves between the two
+        // transceivers. This will usually be based on a reflection on the ground, but one future
+        // failure case might be direct coupling where e.g. contamination leads to the shortest path
+        // being radio waves traveling directly along the fuselage, leading to extremely low
+        // readings.
+
+        // As preparation, calculate the perpendicular distance from both transceivers to the
+        // ground.
+        let a: Length = self.transmitter_height_over_ground();
+        let b: Length = self.receiver_height_over_ground();
+
+        // Perform some 2D geometry to determine the shortest path between the two transceivers and
+        // the ground. The basic idea is that, given two transceivers A, B and a line g representing
+        // the ground. We now would like to determine the length of the shortest path from A to B
+        // via a point on the line. To do this, you can can reflect one of the transceivers B
+        // along the ground g to construct B'. The intersection of the line A-B' with g will result
+        // in the reflection point C in g, and this line A-C-B' now is equal to the shortest path
+        // A-C-B. By then calculating some right angles between A, B', and g, we eventually have a
+        // simple pythagorean triangle where the hypotenuse corresponds to A-C-B', which we can
+        // calculate trivially.
+        let transceiver_along_ground_distance = self.antenna_along_ground_distance();
+        let path_in_air: Length = ((a + b) * (a + b)
+            + transceiver_along_ground_distance * transceiver_along_ground_distance)
+            .sqrt();
+        let shortest_path_length: Length =
+            path_in_air + self.transmitter.electric_length() + self.receiver.electric_length();
+
+        // At this point we've determined the length of the shortest path between the two
+        // transceivers. We now convert it into a travel time.
+
+        // It would be nice if this could be a const, but unfortunately the Velocity constructor is
+        // too complicated for what Rust deems acceptable for a const.
+        let speed_of_light: Velocity =
+            Velocity::new::<meter_per_second>(SPEED_OF_LIGHT_METER_PER_SECOND);
+
+        // While radio waves propagate at the speed of light in vacuum, they travel slower in other
+        // mediums. This correction is called refractive index.
+        // If you want, you can try calculating yourself using
+        // https://www.fig.net/resources/proceedings/fig_proceedings/fig_2002/Js28/JS28_rueger.pdf
+        // However as the index varies by only around 0.01%, the effects on the final radio height
+        // as measured by civil aircraft is negligible.
+        let refractive_radio_index = Ratio::new::<ratio>(1.000293);
+        let speed_of_radio_waves = speed_of_light / refractive_radio_index;
+
+        let travel_time = shortest_path_length / speed_of_radio_waves;
+
+        if shortest_path_length < Length::new::<foot>(10200.) {
+            Some(TransceiverPairResponse::new(travel_time))
+        } else {
+            None
+        }
+    }
+}
+
+impl SimulationElement for Ala52BTransceiverPair {
+    fn read(&mut self, reader: &mut SimulatorReader) {
+        self.alt_above_ground = reader.read(&self.alt_above_ground_id);
+        self.pitch = reader.read(&self.pitch_id);
+        self.bank = reader.read(&self.bank_id);
+    }
+}
+
+/// This enum describes the possible pin settings that the ALA-52B can be configured with. They are
+/// used to calibrate the Radio Altimeter for the length of the cables on the aircraft. It appears
+/// that A320s usually use the 57 feet setting.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Ala52BAircraftInstallationDelay {
+    FortyFeet,
+    FiftySevenFeet,
+    EightyFeet,
+}
+
+impl Ala52BAircraftInstallationDelay {
+    fn delay(&self) -> Length {
+        match self {
+            Ala52BAircraftInstallationDelay::FortyFeet => Length::new::<foot>(40.),
+            Ala52BAircraftInstallationDelay::FiftySevenFeet => Length::new::<foot>(57.),
+            Ala52BAircraftInstallationDelay::EightyFeet => Length::new::<foot>(80.),
+        }
+    }
+}
+
+struct Ala52BRadioAltimeterRuntime {
+    /// If non-Duration::ZERO, the remaining time the runtime needs to initialize itself. Otherwise
+    /// the self-check has been completed.
+    remaining_startup: Duration,
+
+    /// The pin setting for the AID, which calibrates for the length of wires and antennas used for
+    /// the aircraft installation. Memorized during power-up, subsequent pin changes are ignored
+    /// until the unit is restarted (and the runtime recreated).
+    aircraft_installation_delay: Ala52BAircraftInstallationDelay,
+
+    /// The duration since the last upate to out the output.
+    stale_for: Duration,
+
+    /// Whether the main signal processing routine is tracking a target it believes is valid ground.
+    is_tracking_ground: bool,
+
+    /// The measured or assumed ground target. This field alone does assert any validity and may
+    /// contain a non-sensical radio altitude.
+    radio_altitude: Length,
+}
+
+impl Ala52BRadioAltimeterRuntime {
+    const ARINC_429_REFRESH_INTERVAL: Duration = Duration::from_millis(80);
+    const OPERATING_RANGE_MAX_FEET: f64 = 8192.;
+
+    fn new(self_check_time: Duration, aid: Ala52BAircraftInstallationDelay) -> Self {
+        Self {
+            remaining_startup: self_check_time,
+            is_tracking_ground: false,
+            stale_for: Self::ARINC_429_REFRESH_INTERVAL,
+            aircraft_installation_delay: aid,
+            radio_altitude: Length::new::<foot>(Self::OPERATING_RANGE_MAX_FEET),
+        }
+    }
+
+    fn new_running(aid: Ala52BAircraftInstallationDelay) -> Self {
+        Self::new(Duration::ZERO, aid)
+    }
+
+    fn update(&mut self, context: &UpdateContext, transceivers: &impl TransceiverPair) {
+        // First, check if we're still starting up and if so, simulate a wait until all self tests
+        // have completed. As this is always at the start, we don't have to touch the variables
+        // that describe the altitude or ground tracking status (they will have been set accordingly
+        // in the constructor).
+        if let Some(new_remaining) = self.remaining_startup.checked_sub(context.delta()) {
+            self.remaining_startup = new_remaining;
+        } else {
+            self.remaining_startup = Duration::ZERO;
+        }
+
+        // If there's any startup time remaining, do nothing
+        if self.remaining_startup > Duration::ZERO {
+            return;
+        }
+
+        // Update only once per refresh interval
+        if self.stale_for >= Self::ARINC_429_REFRESH_INTERVAL {
+            // Interrogate the transceivers for a response (which might fail if no physical path exists
+            // or some other kind of failure).
+            if let Some(response) = transceivers.response() {
+                let travel_time = response.travel_time();
+
+                let speed: Velocity =
+                    Velocity::new::<meter_per_second>(SPEED_OF_LIGHT_METER_PER_SECOND)
+                        * Ratio::new::<ratio>(0.999707085);
+                let traveled_distance: Length = travel_time * speed;
+                self.radio_altitude = (traveled_distance
+                    - self.aircraft_installation_delay.delay())
+                    / Ratio::new::<ratio>(2.);
+                self.is_tracking_ground = true;
+
+                // Instead of setting it to Duration::ZERO, subtract to ensure that we average out
+                // the correct information rate over multiple refreshes. This means the next update
+                // might come a little sooner. We also use a loop so that we don't fall behind if
+                // the frame rate spikes very high and we get an enormous delta.
+                while self.stale_for >= Self::ARINC_429_REFRESH_INTERVAL {
+                    self.stale_for -= Self::ARINC_429_REFRESH_INTERVAL;
+                }
+            } else {
+                // We lost the ground target, maybe because we're too high or our attitude is too
+                // extreme. While the RA is fully functional, we want to force the measured radio
+                // altitude to be high (>2500) so that systems that don't correctly look at NCD
+                // don't suddenly think we're on the ground (which might happen if e.g. we force it
+                // to zero instead).
+                // Forcing the value to maximum or near-maximum appears to be the real behaviour.
+                self.radio_altitude = Length::new::<foot>(Self::OPERATING_RANGE_MAX_FEET);
+                self.is_tracking_ground = false;
+            }
+        } else {
+            self.stale_for += context.delta();
+        }
+    }
+
+    fn radio_altitude(&self) -> Length {
+        // round to nearest 0.125
+        (self.radio_altitude * Ratio::new::<ratio>(8.)).round::<foot>() / Ratio::new::<ratio>(8.)
+    }
+
+    fn ssm(&self) -> SignStatus {
+        if self.remaining_startup > Duration::ZERO {
+            SignStatus::FailureWarning
+        } else if !self.is_tracking_ground {
+            SignStatus::NoComputedData
+        } else {
+            SignStatus::NormalOperation
+        }
+    }
+}
+
+pub struct Ala52BRadioAltimeter {
+    // Pins
+    #[allow(dead_code)]
+    number: usize,
+    aircraft_installation_delay: Ala52BAircraftInstallationDelay,
+    failure: Failure,
+
+    // Power
+    powered_by: ElectricalBusType,
+    is_powered: bool,
+
+    /// How long the Radio Altimeter can tolerate a power loss and continue functioning.
+    power_holdover: Duration,
+
+    /// How long the Radio Altimeter has been unpowered for.
+    unpowered_for: Duration,
+
+    /// How long the self checks take for runtimes running on this Radio Altimeter.
+    self_check_time: Duration,
+
+    runtime: Option<Ala52BRadioAltimeterRuntime>,
+
+    // Outputs
+    radio_altitude_id: VariableIdentifier,
+}
+
+impl Ala52BRadioAltimeter {
+    const MINIMUM_STARTUP_TIME_MILLIS: u64 = 4_000;
+    const MAXIMUM_STARTUP_TIME_MILLIS: u64 = 6_000;
+    const MINIMUM_POWER_HOLDOVER: u64 = 30_000;
+    const MAXIMUM_POWER_HOLDOVER: u64 = 35_000;
+
+    pub fn new(
+        context: &mut InitContext,
+        number: usize,
+        aircraft_installation_delay: Ala52BAircraftInstallationDelay,
+        powered_by: ElectricalBusType,
+    ) -> Self {
+        let is_powered = context.has_engines_running();
+        Self {
+            number,
+            aircraft_installation_delay,
+            powered_by,
+            is_powered: false,
+            power_holdover: Duration::from_secs_f64(random_from_range(
+                Self::MINIMUM_POWER_HOLDOVER as f64 / 1000.,
+                Self::MAXIMUM_POWER_HOLDOVER as f64 / 1000.,
+            )),
+            unpowered_for: if is_powered {
+                Duration::ZERO
+            } else {
+                Duration::from_millis(Self::MAXIMUM_POWER_HOLDOVER)
+            },
+            self_check_time: Duration::from_secs_f64(random_from_range(
+                Self::MINIMUM_STARTUP_TIME_MILLIS as f64 / 1000.,
+                Self::MAXIMUM_STARTUP_TIME_MILLIS as f64 / 1000.,
+            )),
+
+            runtime: if is_powered {
+                Some(Ala52BRadioAltimeterRuntime::new_running(
+                    aircraft_installation_delay,
+                ))
+            } else {
+                None
+            },
+            failure: Failure::new(FailureType::RadioAltimeter(number)),
+            radio_altitude_id: context.get_identifier(Self::radio_altitude_id(number)),
+        }
+    }
+
+    fn radio_altitude_id(number: usize) -> String {
+        format!("RA_{}_RADIO_ALTITUDE", number)
+    }
+
+    pub fn update(&mut self, context: &UpdateContext, transceivers: &Ala52BTransceiverPair) {
+        if self.is_powered {
+            self.unpowered_for = Duration::ZERO;
+        } else {
+            self.unpowered_for += context.delta();
+        }
+
+        // Check if the internal state (runtime) is lost because either the unit failed, or the
+        // power holdover has been exceed
+        if self.failure.is_active() || self.unpowered_for > self.power_holdover {
+            // Throw away the simulated software runtime
+            self.runtime = None;
+            return;
+        }
+
+        // As long as we're powered, we can proceed normally. If not, we can't run the runtime, but
+        // it's state will be frozen and if power is restored soon enough, we can proceed
+        // immediately without waiting for the runtime to start up again.
+        if self.is_powered {
+            // Either initialize and run or continue running the existing runtime
+            let self_check = self.self_check_time;
+            let aid = self.aircraft_installation_delay;
+            let runtime = self
+                .runtime
+                .get_or_insert_with(|| Ala52BRadioAltimeterRuntime::new(self_check, aid));
+            runtime.update(context, transceivers);
+        }
+    }
+
+    pub fn has_failed(&self) -> bool {
+        self.failure.is_active()
+    }
+}
+
+impl RadioAltimeter for Ala52BRadioAltimeter {
+    fn radio_altitude(&self) -> Arinc429Word<Length> {
+        if !self.is_powered {
+            Arinc429Word::new(Length::new::<foot>(0.), SignStatus::FailureWarning)
+        } else if let Some(runtime) = &self.runtime {
+            let radio_altitude = runtime.radio_altitude();
+            // Perform some sanity checks on the data from the runtime
+            if radio_altitude < Length::new::<foot>(-20.) {
+                Arinc429Word::new(Length::new::<foot>(-20.), SignStatus::FailureWarning)
+            } else if radio_altitude > Length::new::<foot>(8192.) {
+                Arinc429Word::new(Length::new::<foot>(8192.), SignStatus::FailureWarning)
+            } else {
+                Arinc429Word::new(radio_altitude, runtime.ssm())
+            }
+        } else {
+            Arinc429Word::new(Length::new::<foot>(0.), SignStatus::FailureWarning)
+        }
+    }
+}
+
+impl SimulationElement for Ala52BRadioAltimeter {
+    fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
+        self.failure.accept(visitor);
+
+        visitor.visit(self);
+    }
+
+    fn write(&self, writer: &mut SimulatorWriter) {
+        let radio_altitude = self.radio_altitude();
+        writer.write_arinc429(
+            &self.radio_altitude_id,
+            radio_altitude.value(),
+            radio_altitude.ssm(),
+        );
+    }
+
+    fn receive_power(&mut self, buses: &impl ElectricalBuses) {
+        self.is_powered = buses.is_powered(self.powered_by);
+    }
+
+    fn consume_power<T: ConsumePower>(&mut self, _: &UpdateContext, consumption: &mut T) {
+        if !self.has_failed() {
+            consumption.consume_from_bus(self.powered_by, Power::new::<watt>(30.))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::electrical::test::TestElectricitySource;
+    use crate::electrical::{ElectricalBus, Electricity};
+    use crate::shared::{PotentialOrigin, PowerConsumptionReport};
+    use crate::simulation::test::{ReadByName, SimulationTestBed, TestBed, WriteByName};
+    use crate::simulation::{Aircraft, InitContext, SimulationElementVisitor, StartState};
+    use ntest::assert_about_eq;
+    use uom::si::electric_potential::volt;
+    use uom::si::f64::ElectricPotential;
+    use uom::si::length::meter;
+
+    struct TestAircraft {
+        electricity_source: TestElectricitySource,
+        ac_1_bus: ElectricalBus,
+        radio_altimeter_1: Ala52BRadioAltimeter,
+        system_1_transceivers: Ala52BTransceiverPair,
+        is_ac_1_powered: bool,
+        power_consumption: Power,
+    }
+    impl TestAircraft {
+        fn new(context: &mut InitContext) -> Self {
+            Self {
+                electricity_source: TestElectricitySource::powered(
+                    context,
+                    PotentialOrigin::EngineGenerator(1),
+                ),
+                ac_1_bus: ElectricalBus::new(context, ElectricalBusType::AlternatingCurrent(1)),
+                radio_altimeter_1: Ala52BRadioAltimeter::new(
+                    context,
+                    1,
+                    Ala52BAircraftInstallationDelay::FiftySevenFeet,
+                    ElectricalBusType::AlternatingCurrent(1),
+                ),
+                // roughly model the A320 RA 1 transceivers
+                system_1_transceivers: Ala52BTransceiverPair::new(
+                    context,
+                    AntennaInstallation::new(
+                        Length::new::<foot>(8.617) - Length::new::<meter>(1.8),
+                        Length::new::<foot>(9.89),
+                        Length::new::<foot>(22.6),
+                    ),
+                    AntennaInstallation::new(
+                        Length::new::<foot>(8.617) - Length::new::<meter>(1.8),
+                        Length::new::<foot>(9.19),
+                        Length::new::<foot>(22.6),
+                    ),
+                ),
+                is_ac_1_powered: false,
+                power_consumption: Power::new::<watt>(0.),
+            }
+        }
+
+        fn radio_altimeter(&self, number: usize) -> &Ala52BRadioAltimeter {
+            match number {
+                1 => &self.radio_altimeter_1,
+                _ => panic!("The TestAircraft only has one radio altimeter."),
+            }
+        }
+
+        fn set_ac_1_power(&mut self, is_powered: bool) {
+            self.is_ac_1_powered = is_powered;
+        }
+
+        fn power_consumption(&self) -> Power {
+            self.power_consumption
+        }
+    }
+    impl Aircraft for TestAircraft {
+        fn update_before_power_distribution(
+            &mut self,
+            _: &UpdateContext,
+            electricity: &mut Electricity,
+        ) {
+            self.electricity_source
+                .power_with_potential(ElectricPotential::new::<volt>(115.));
+            electricity.supplied_by(&self.electricity_source);
+
+            if self.is_ac_1_powered {
+                electricity.flow(&self.electricity_source, &self.ac_1_bus);
+            }
+        }
+
+        fn update_after_power_distribution(&mut self, context: &UpdateContext) {
+            self.radio_altimeter_1
+                .update(context, &self.system_1_transceivers);
+        }
+    }
+    impl SimulationElement for TestAircraft {
+        fn process_power_consumption_report<T: PowerConsumptionReport>(
+            &mut self,
+            _: &UpdateContext,
+            report: &T,
+        ) {
+            self.power_consumption =
+                report.total_consumption_of(PotentialOrigin::EngineGenerator(1));
+        }
+
+        fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
+            self.system_1_transceivers.accept(visitor);
+            self.radio_altimeter_1.accept(visitor);
+
+            visitor.visit(self);
+        }
+    }
+
+    struct RadioAltimeterTestBed {
+        test_bed: SimulationTestBed<TestAircraft>,
+    }
+
+    impl RadioAltimeterTestBed {
+        fn new() -> Self {
+            let mut ra_test_bed = Self {
+                test_bed: SimulationTestBed::new_with_start_state(
+                    StartState::Cruise,
+                    TestAircraft::new,
+                ),
+            };
+            ra_test_bed = ra_test_bed.level_flight();
+            ra_test_bed = ra_test_bed.above_ground();
+            ra_test_bed = ra_test_bed.powered();
+
+            ra_test_bed
+        }
+
+        fn and(self) -> Self {
+            self
+        }
+
+        fn no_power(mut self) -> Self {
+            self.command(|a| a.set_ac_1_power(false));
+            self
+        }
+
+        fn powered(mut self) -> Self {
+            self.command(|a| a.set_ac_1_power(true));
+            self
+        }
+
+        fn pitch(mut self, pitch: Angle) -> Self {
+            // Confusingly the sim encodes the pitch inversely: 10 degrees pitch up will be encoded
+            // as -10 degrees pitch in the SimVar.
+            self.write_by_name(Ala52BTransceiverPair::PITCH, pitch);
+            self
+        }
+
+        fn bank(mut self, bank: Angle) -> Self {
+            self.write_by_name(Ala52BTransceiverPair::BANK, bank);
+            self
+        }
+
+        fn level_flight(mut self) -> Self {
+            self.write_by_name(Ala52BTransceiverPair::PITCH, Angle::new::<degree>(0.));
+            self.write_by_name(Ala52BTransceiverPair::BANK, Angle::new::<degree>(0.));
+            self
+        }
+
+        fn above_ground(mut self) -> Self {
+            self.write_by_name(
+                Ala52BTransceiverPair::ALT_ABOVE_GROUND,
+                Length::new::<foot>(508.6),
+            );
+            self
+        }
+
+        fn height_over_ground(mut self, height: Length) -> Self {
+            self.write_by_name(Ala52BTransceiverPair::ALT_ABOVE_GROUND, height);
+            self
+        }
+
+        fn measured_height(&mut self, number: usize) -> Arinc429Word<Length> {
+            self.read_arinc429_by_name(&Ala52BRadioAltimeter::radio_altitude_id(number))
+        }
+
+        fn failed_radio_altimeter(mut self, number: usize) -> Self {
+            self.fail(FailureType::RadioAltimeter(number));
+            self
+        }
+
+        fn assert_radio_altimeter_has_failed(&mut self, number: usize) {
+            assert!(self.query(|a| a.radio_altimeter(number).has_failed()));
+        }
+
+        fn assert_radio_altitude(&mut self, number: usize, radio_altitude: Length) {
+            assert_about_eq!(
+                self.measured_height(number).value().get::<foot>(),
+                radio_altitude.get::<foot>(),
+                0.1,
+            );
+        }
+
+        fn assert_radio_altitude_normal_operation(&mut self, number: usize) {
+            assert_eq!(
+                self.measured_height(number).ssm(),
+                SignStatus::NormalOperation
+            );
+        }
+
+        fn assert_radio_altitude_failure_warning(&mut self, number: usize) {
+            assert_eq!(
+                self.measured_height(number).ssm(),
+                SignStatus::FailureWarning
+            );
+        }
+
+        fn assert_radio_altitude_no_computed_data(&mut self, number: usize) {
+            assert_eq!(
+                self.measured_height(number).ssm(),
+                SignStatus::NoComputedData
+            );
+        }
+
+        fn assert_consumed_power(&self, power: Power) {
+            assert_about_eq!(
+                self.query(|a| a.power_consumption()).get::<watt>(),
+                power.get::<watt>()
+            );
+        }
+    }
+    impl TestBed for RadioAltimeterTestBed {
+        type Aircraft = TestAircraft;
+
+        fn test_bed(&self) -> &SimulationTestBed<TestAircraft> {
+            &self.test_bed
+        }
+
+        fn test_bed_mut(&mut self) -> &mut SimulationTestBed<TestAircraft> {
+            &mut self.test_bed
+        }
+    }
+
+    fn test_bed() -> RadioAltimeterTestBed {
+        RadioAltimeterTestBed::new()
+    }
+
+    fn test_bed_with() -> RadioAltimeterTestBed {
+        test_bed()
+    }
+
+    #[test]
+    fn measures_zero_on_ground() {
+        let mut test_bed = test_bed_with().height_over_ground(Length::new::<foot>(8.617));
+        test_bed.run_with_delta(Duration::from_millis(1));
+
+        test_bed.assert_radio_altitude(1, Length::new::<foot>(0.0));
+    }
+
+    #[test]
+    fn measures_the_height_over_ground() {
+        let mut test_bed = test_bed_with().height_over_ground(Length::new::<foot>(508.6));
+        test_bed.run_with_delta(Duration::from_millis(
+            Ala52BRadioAltimeter::MAXIMUM_STARTUP_TIME_MILLIS,
+        ));
+
+        test_bed.assert_radio_altitude_normal_operation(1);
+        test_bed.assert_radio_altitude(1, Length::new::<foot>(500.0));
+    }
+
+    #[test]
+    fn measures_a_negative_reading_during_rotation() {
+        let mut test_bed = test_bed_with()
+            .height_over_ground(Length::new::<foot>(8.617))
+            .pitch(Angle::new::<degree>(-7.));
+
+        test_bed.run_with_delta(Duration::from_millis(
+            Ala52BRadioAltimeter::MAXIMUM_STARTUP_TIME_MILLIS,
+        ));
+
+        test_bed.assert_radio_altitude_normal_operation(1);
+        test_bed.assert_radio_altitude(1, Length::new::<foot>(-1.125));
+    }
+
+    #[test]
+    fn returns_failure_warning_when_unpowered() {
+        let mut test_bed = test_bed_with()
+            .height_over_ground(Length::new::<foot>(500.))
+            .and()
+            .no_power();
+        test_bed.run_with_delta(Duration::from_millis(
+            Ala52BRadioAltimeter::MAXIMUM_STARTUP_TIME_MILLIS,
+        ));
+
+        test_bed.assert_radio_altitude_failure_warning(1);
+    }
+
+    #[test]
+    fn recovers_without_a_startup_delay_after_a_power_holdover() {
+        let mut test_bed = test_bed_with().height_over_ground(Length::new::<foot>(500.));
+        test_bed.run_with_delta(Duration::from_millis(
+            Ala52BRadioAltimeter::MAXIMUM_STARTUP_TIME_MILLIS,
+        ));
+
+        test_bed.command(|a| a.set_ac_1_power(false));
+        test_bed.run_with_delta(Duration::from_millis(
+            Ala52BRadioAltimeter::MINIMUM_POWER_HOLDOVER,
+        ));
+
+        test_bed.command(|a| a.set_ac_1_power(true));
+        test_bed.run_with_delta(Duration::from_millis(1));
+
+        test_bed.assert_radio_altitude_normal_operation(1);
+    }
+
+    #[test]
+    fn restarts_the_startup_delay_after_a_long_power_failure() {
+        let mut test_bed = test_bed_with().height_over_ground(Length::new::<foot>(500.));
+
+        test_bed.run_with_delta(Duration::from_millis(
+            Ala52BRadioAltimeter::MAXIMUM_STARTUP_TIME_MILLIS,
+        ));
+
+        test_bed.command(|a| a.set_ac_1_power(false));
+        test_bed.run_with_delta(Duration::from_millis(
+            Ala52BRadioAltimeter::MAXIMUM_POWER_HOLDOVER + 1,
+        ));
+
+        test_bed.command(|a| a.set_ac_1_power(true));
+        test_bed.run_with_delta(Duration::from_millis(1));
+
+        test_bed.assert_radio_altitude_failure_warning(1);
+
+        test_bed.run_with_delta(Duration::from_millis(
+            Ala52BRadioAltimeter::MAXIMUM_STARTUP_TIME_MILLIS,
+        ));
+
+        test_bed.assert_radio_altitude_normal_operation(1);
+    }
+
+    #[test]
+    fn returns_failure_warning_and_has_failed_when_failed() {
+        let mut test_bed = test_bed_with()
+            .height_over_ground(Length::new::<foot>(500.))
+            .and()
+            .failed_radio_altimeter(1);
+        test_bed.run_with_delta(Duration::from_millis(1));
+
+        test_bed.assert_radio_altitude_failure_warning(1);
+        test_bed.assert_radio_altimeter_has_failed(1);
+
+        test_bed.run_with_delta(Duration::from_millis(
+            Ala52BRadioAltimeter::MAXIMUM_STARTUP_TIME_MILLIS,
+        ));
+
+        test_bed.assert_radio_altitude_failure_warning(1);
+        test_bed.assert_radio_altimeter_has_failed(1);
+    }
+
+    #[test]
+    fn consumes_power_when_operating_normally() {
+        let mut test_bed = test_bed_with().height_over_ground(Length::new::<foot>(500.));
+        test_bed.run_with_delta(Duration::from_millis(
+            Ala52BRadioAltimeter::MAXIMUM_STARTUP_TIME_MILLIS,
+        ));
+
+        test_bed.assert_consumed_power(Power::new::<watt>(30.));
+    }
+
+    #[test]
+    fn does_not_consume_power_when_failed() {
+        let mut test_bed = test_bed_with()
+            .height_over_ground(Length::new::<foot>(500.))
+            .and()
+            .failed_radio_altimeter(1);
+        test_bed.run_with_delta(Duration::from_millis(1));
+
+        test_bed.assert_consumed_power(Power::new::<watt>(0.));
+    }
+
+    #[test]
+    fn returns_ncd_at_extreme_pitch() {
+        let mut test_bed = test_bed_with()
+            .height_over_ground(Length::new::<foot>(500.))
+            .pitch(Angle::new::<degree>(50.));
+
+        test_bed.run_with_delta(Duration::from_millis(
+            Ala52BRadioAltimeter::MAXIMUM_STARTUP_TIME_MILLIS,
+        ));
+
+        test_bed.assert_radio_altitude_no_computed_data(1);
+        test_bed.assert_radio_altitude(1, Length::new::<foot>(8192.));
+    }
+
+    #[test]
+    fn returns_ncd_at_extreme_bank() {
+        let mut test_bed = test_bed_with()
+            .height_over_ground(Length::new::<foot>(500.))
+            .bank(Angle::new::<degree>(50.));
+
+        test_bed.run_with_delta(Duration::from_millis(
+            Ala52BRadioAltimeter::MAXIMUM_STARTUP_TIME_MILLIS,
+        ));
+
+        test_bed.assert_radio_altitude_no_computed_data(1);
+        test_bed.assert_radio_altitude(1, Length::new::<foot>(8192.));
+    }
+
+    #[test]
+    fn returns_ncd_with_max_value_when_started_in_cruise() {
+        let mut test_bed = test_bed_with().height_over_ground(Length::new::<foot>(10000.));
+        test_bed.run_with_delta(Duration::from_millis(
+            Ala52BRadioAltimeter::MAXIMUM_STARTUP_TIME_MILLIS,
+        ));
+
+        test_bed.assert_radio_altitude_no_computed_data(1);
+        test_bed.assert_radio_altitude(1, Length::new::<foot>(8192.));
+    }
+}

--- a/src/systems/systems/src/navigation/mod.rs
+++ b/src/systems/systems/src/navigation/mod.rs
@@ -1,1 +1,3 @@
 pub mod adirs;
+pub mod ala52b;
+pub mod radio_altimeter;

--- a/src/systems/systems/src/navigation/radio_altimeter.rs
+++ b/src/systems/systems/src/navigation/radio_altimeter.rs
@@ -1,0 +1,64 @@
+use crate::shared::arinc429::Arinc429Word;
+use uom::si::f64::{Length, Time};
+
+/// This struct describes the installation of a physical Antenna in relation to an aircraft's
+/// center of gravity.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct AntennaInstallation {
+    y: Length, // negative towards top (from CG), positive towards bottom (from CG)
+    z: Length, // negative towards front (from CG), positive for aft
+    electric_length: Length, // The electric length of the cables and antenna
+}
+
+impl AntennaInstallation {
+    pub fn new(y: Length, z: Length, electric_length: Length) -> Self {
+        Self {
+            y,
+            z,
+            electric_length,
+        }
+    }
+
+    pub fn y(&self) -> Length {
+        self.y
+    }
+
+    pub fn z(&self) -> Length {
+        self.z
+    }
+
+    pub fn electric_length(self) -> Length {
+        self.electric_length
+    }
+}
+
+/// This trait describes a transceiver pair as used in radio altimeters, usually in the C band.
+/// It models the physical transmission of the signal between the transceivers and returns the
+/// response.
+pub trait TransceiverPair {
+    fn response(&self) -> Option<TransceiverPairResponse>;
+}
+
+/// This struct encodes a response from a pair of transceivers. Currently it only encodes a travel
+/// time, which in a modulated continuous wave radar (FMCW) can already be considered the filtered
+/// duration between the transmission and the response. In the future it may also return the
+/// remaining signal strength, which can be used to model the signal loss over various surfaces, or
+/// model an actual frequency response.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TransceiverPairResponse {
+    travel_time: Time,
+}
+
+impl TransceiverPairResponse {
+    pub fn new(travel_time: Time) -> Self {
+        Self { travel_time }
+    }
+
+    pub fn travel_time(&self) -> Time {
+        self.travel_time
+    }
+}
+
+pub trait RadioAltimeter {
+    fn radio_altitude(&self) -> Arinc429Word<Length>;
+}


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #5883

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR introduces a proper dual radio altimeter system featuring more realistic readings during (de)rotation, an accurate refresh rate, and ARINC 429 outputs. It improves the accuracy of the PFD display, and puts a system in place ready for the upcoming FWC to use.

The new radio altimeters are based on the Honeywell ALA-52B, require their appropriate bus to be powered and can be failed using the standard failure system in the EFB. They take a few seconds to start up after being powered.

The existing PFD, FWC, TCAS and GPWS have been updated to use the new radio altimeter sources, including fallback to the other system on failure. Some systems like TCAS will fail outright if no RA is functioning.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Video of new rotation: https://streamable.com/zpb7j3

![image](https://user-images.githubusercontent.com/929769/154262261-a171ff91-433c-451a-9c62-4857d24cfd3f.png)
![image](https://user-images.githubusercontent.com/929769/154270992-df9d9a03-7b2f-4b4c-b8ac-43d272c4fbfe.png)
![image](https://user-images.githubusercontent.com/929769/154849513-27e52438-b995-4ced-8db8-40939d3f6d78.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

- https://fccid.io/AOIALA-52B2/User-Manual/Users-Manual-901606.pdf
- https://avsi.aero/wp-content/uploads/2021/12/Radar-Altimeter-Overview-of-Design-and-Performance.pdf
- https://www.sciencedirect.com/science/article/pii/S1474667015350436/pdf
- https://www.youtube.com/watch?v=ECV3IBkzZLc#t=25s

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
The RAs have a small startup delay after being powered, usually around 5 seconds, but never more than 6. They are hooked up to AC BUS 1 (RA 1) and AC BUS 2 (RA 2), so if you unpower and repower these busses it will take a moment for the RAs to come online. You might get an intermittent RA 1(2) failure after repowering a bus, this is expected as the RA isn't emitting data until it's completely started and ready to go.

Changes were made to the following systems:
- PFD
  - RA annunciation at bottom of PFD
  - Rising Runway symbol near center of PFD
  - Red ribbon in ALT band
  - Threshold for V/S indicator border to change color to amber (easier to trigger amber box near with lower V/S the ground)
- TCAS: uses the new Radio Altimeters to inhibit "Descend" RAs.
- FWC: uses the new Radio Altimeters to calculate flight phases, most noticeable throug T.O INHIBIT and LDG INHIBIT
- GPWS: uses the new Radio Altimeters to generate height callouts and GPWS callouts ("Too Low, Terrain")
- ECAM (EWD) and Status Page: In some cases the FAIL messages are inhibited if they're due to another obvious failure. For example, RA 1 FAULT is inhibited when AC BUS 1 is unpowered, and TCAS FAULT is inhibited when both RAs are unavailable. However, affected systems will always appear on the status page.

The following systems have **not** been touched and are still using the SimVars directly, and will not respond to the new behaviour:
- FCU (special behaviour below 30ft)
- FBW & APs (Flare Law, Autoland etc.)

While this PR doesn't fully model all the impacts and fully accurate ECAM messages, it nevertheless puts the system in place ready to be consumed by the new FWC later.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Before testing, please make sure to read the list of affected systems above.

With RAs normal:
1. On ground, observe values near 0. Some slight discrepancy between the RAs (around 1ft) is allowed.
2. During takeoff at rotation, observe the radio altitude on both PFDs going briefly negative (an extra -1 to -2ft). The F/O PFD is slightly more sensitive to this, as the RAs are further at the back.
3. When flying at high altitudes, ensure TCAS stays available even while at extreme attitudes. You should not see TA ONLY pop up at high altitudes just because you entered an extreme attitude.
4. Make sure TCAS can still be triggered both at high altitudes and if possible, near the ground (Radio Altimeter should inhibit "Descend" at very low altitudes between 1000ft and 2350ft - however TCAS does never issue RAs below 1000ft) - do note however that flying at extreme attitudes near the ground may cause a false reading, and the TCAS would then issue a "Descend" regardless (no inhibitions).
5. When flying over rugged terrain or sharp cliffs, observe the slightly smoothed radio altitude indications on the PFD. There should be no extreme jumps, everthing should be smoothly animated. This includes:
    - RA value at the bottom of the PFD
    - Rising Runway in the center of the PFD near the ground
    - Red ribbon in ALT band
6. When flying close to the terrain, observe the usual GPWS callouts ("Too Low, Terrain") unless in an extreme attitude
7. During approach, observe the LDG MEMO appearing as usual (below 2000ft AGL)
8. During final approach, observe normal "Minimum" callouts (when using RADIO)
9. When landing normally, observe near 0ft RA annunciation on the PFDs at touchdown. During and after derotation you may see 1ft briefly, especially as the aircraft is lurching forward during decellaration and the RAs are slightly farther away from the ground.

With one RA failed:
*RAs can be failed using the EFB's failure page*
1. Observe NAV RA 1(2) FAULT on ECAM - this may be inhibited in certain flight phases
2. All behaviours should be as above, because the systems fall over to the non-failed RA
3. If an RA fails and you unfail it, it'll take approximately 5-6 to come back. If an RA has only failed because it lost power, it'll come back instantly as long as power is restored within about 30 seconds. After that it'll take 5-6 seconds for the full startup.

With dual RA failure:
1. Observe the same warnings as above
2. Observe a flashing RA flag on the PFD when below the transition altitude - note: If you don't have a transition altitude set, it won't flash.
3. Observe a flashing TCAS flag on the PFD, amber TCAS on the ND, and NAV TCAS FAULT on ECAM - this may be inhibited in certain flight phases. This is a knock-on effect of the TCAS failing without RAs.
4. LDG MEMO will only appear once gear is downlocked
5. No Minimums callout when landing with RADIO minimum set, BARO minimum should be unaffected

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
