### PR TITLE
fix(athr): improved condition to transition CLB limit from FLX TO

### DIFF
--- a/src/fadec/src/EngineControl.h
+++ b/src/fadec/src/EngineControl.h
@@ -951,7 +951,7 @@ class EngineControl {
       isFlexActive = false;
     }
 
-    if (isFlexActive && prevThrustLimitType == 3 && thrustLimitType == 1) {
+    if (isFlexActive && !isTransitionActive && thrustLimitType == 1) {
       isTransitionActive = true;
       transitionStartTime = simulationTime;
       transitionFactor = 0.2;


### PR DESCRIPTION
## Summary of Changes
There has been at least one report in experimental version that the CLB thrust limit was not restored to normal from FLX reduction. It ended for the user not being able to climb beyond FL2070.

To avoid this situation the condition to trigger the transition has been revisited.

## Testing instructions
- do a FLX TO
- after thrust reduction altitude and lever being set from FLX/MCT detent to CLB detent, the transition should start after 10 s (thrust will increase)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
