### PR TITLE
fix(atsu): Fixes in DEPART REQ and MESSAGES

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_DepartReq.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_DepartReq.js
@@ -60,9 +60,13 @@ class CDUAocDepartReq {
             mcdu.pdcMessage.Callsign = mcdu.atsuManager.flightNumber();
             flightNo = mcdu.pdcMessage.Callsign + "[color]green";
         }
-        if (mcdu.flightPlanManager.getDestination() && mcdu.flightPlanManager.getDestination().ident) {
+        if (mcdu.flightPlanManager.getOrigin() && mcdu.flightPlanManager.getOrigin().ident) {
             mcdu.pdcMessage.Origin = mcdu.flightPlanManager.getOrigin().ident;
+        }
+        if (mcdu.flightPlanManager.getDestination() && mcdu.flightPlanManager.getDestination().ident) {
             mcdu.pdcMessage.Destination = mcdu.flightPlanManager.getDestination().ident;
+        }
+        if (mcdu.pdcMessage.Origin !== "" && mcdu.pdcMessage.Destination !== "") {
             fromTo = mcdu.pdcMessage.Origin + "/" + mcdu.pdcMessage.Destination + "[color]cyan";
         }
         if (mcdu.pdcMessage.Station !== "") {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_MessagesSent.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_MessagesSent.js
@@ -55,7 +55,7 @@ class CDUAocMessagesSent {
                 if (messages[offset - 5 + i]) {
                     if (value === FMCMainDisplay.clrValue) {
                         mcdu.atsuManager.removeMessage(messages[offset - 5 + i].UniqueMessageID);
-                        CDUAocMessagesSent.ShowPage(mcdu, null, page);
+                        CDUAocMessagesSent.ShowPage(mcdu);
                     } else {
                         CDUAocMessageSentDetail.ShowPage(mcdu, messages, offset - 5 + i);
                     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes two Sentry-issues

## Summary of Changes
Fixes a mid-flight crash when the origin airport is not defined.
Fixes a crash after a message is deleted in the SENT MESSAGES menu

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Sven [de en]

## Testing instructions
- Test if PDC still works
- Test if DEPART REQ page is shown if origin or destination is missing
- Delete a message in MESSAGES SENT and MESSAGES RECEIVED in AOC menu

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
