### PR TITLE
fix: Fixes check for correct ATC source

### DIFF
--- a/src/instruments/src/EFB/ATC/ATC.tsx
+++ b/src/instruments/src/EFB/ATC/ATC.tsx
@@ -24,7 +24,7 @@ export const ATC = () => {
     const [hoppieEnabled, setHoppieEnabled] = useState(SimVar.GetSimVarValue('L:A32NX_HOPPIE_ACTIVE', 'number') === 1 ? 'ENABLED' : 'DISABLED');
 
     const loadAtc = useCallback(() => {
-        if (atisSource !== 'vatsim' && atisSource !== 'ivao') return;
+        if (atisSource.toLowerCase() !== 'vatsim' && atisSource.toLowerCase() !== 'ivao') return;
         apiClient.ATC.get((atisSource as string).toLowerCase()).then((res) => {
             if (!res) return;
             let allAtc : ATCInfoExtended[] = res as ATCInfoExtended[];


### PR DESCRIPTION
## Summary of Changes
#6730 introduce a bug by not converting a string to lower case before comparing.
This fixes this. 

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
EFB ATC page should work as before and show available ATC frequencies. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
