### PR TITLE
fix: add missing bind call on function value

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -1220,7 +1220,7 @@ class FMCMainDisplay extends BaseAirliners {
         }
         if (_event === "VS") {
             const dist = this.flightPlanManager.getDistanceToDestination();
-            this.flightPhaseManager.handleFcuVSKnob(dist, this._onStepClimbDescent);
+            this.flightPhaseManager.handleFcuVSKnob(dist, this._onStepClimbDescent.bind(this));
         }
     }
 


### PR DESCRIPTION

Fixes #6764

## Summary of Changes

* Adds a missing `bind` call to a function passed in as a value

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

* Make sure no errors occur while pressing the V/S knob to initiate a step descent.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
