### PR TITLE
feat: Setting to enable/disable colored METAR in the weather widget

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -165,6 +165,7 @@
 1. [SPEEDS] Fix GS mini not being limited by VFE-5 in CONF FULL -  @donstim (donbikes#4084)
 1. [MCDU] Fix crash when clearing DIR TO waypoint - @tracernz (Mike)
 1. [ATHR] Fix Speed/Mach Idle transition in strong headwind - @IbrahimK42 (IbrahimK42)
+1. [EFB] Added setting for colored METAR in EFB weather widget - @frankkopp (Frank Kopp)
 
 ## 0.7.0
 

--- a/src/instruments/src/EFB/Dashboard/Widgets/ColorMetar.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/ColorMetar.tsx
@@ -34,7 +34,7 @@ export const ColoredMetar = ({ metar }: { metar: MetarParserType }) => {
             );
         case ColorCode.Warning:
             return (
-                <span className="text-red-600">
+                <span className="text-red-400">
                     {metarPart}
                     {' '}
                 </span>

--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -64,7 +64,7 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
     const [metarSource] = usePersistentProperty('CONFIG_METAR_SRC', 'MSFS');
     const source = metarSource === 'MSFS' ? 'MS' : metarSource;
     const [metarError, setErrorMetar] = useState('NO VALID ICAO CHOSEN');
-    const [usingColordMetar] = usePersistentNumberProperty('EFB_USING_COLOREDMETAR', 1);
+    const [usingColoredMetar] = usePersistentNumberProperty('EFB_USING_COLOREDMETAR', 1);
 
     const getBaroTypeForAirport = (icao: string) => (['K', 'C', 'M', 'P', 'RJ', 'RO', 'TI', 'TJ']
         .some((r) => icao.toUpperCase().startsWith(r)) ? 'IN HG' : 'HPA');
@@ -244,7 +244,7 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
                                         {metar.raw_text
                                             ? (
                                                 <>
-                                                    {usingColordMetar
+                                                    {usingColoredMetar
                                                         ? (
                                                             <>
                                                                 <ColoredMetar metar={metar} />

--- a/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/WeatherWidget.tsx
@@ -6,7 +6,7 @@ import { Metar } from '@flybywiresim/api-client';
 import { IconCloud, IconDroplet, IconGauge, IconPoint, IconTemperature, IconWind } from '@tabler/icons';
 import { parseMetar } from '../../Utils/parseMetar';
 import { MetarParserType } from '../../../Common/metarTypes';
-import { usePersistentProperty } from '../../../Common/persistence';
+import { usePersistentNumberProperty, usePersistentProperty } from '../../../Common/persistence';
 import SimpleInput from '../../Components/Form/SimpleInput/SimpleInput';
 import { ColoredMetar } from './ColorMetar';
 
@@ -64,6 +64,7 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
     const [metarSource] = usePersistentProperty('CONFIG_METAR_SRC', 'MSFS');
     const source = metarSource === 'MSFS' ? 'MS' : metarSource;
     const [metarError, setErrorMetar] = useState('NO VALID ICAO CHOSEN');
+    const [usingColordMetar] = usePersistentNumberProperty('EFB_USING_COLOREDMETAR', 1);
 
     const getBaroTypeForAirport = (icao: string) => (['K', 'C', 'M', 'P', 'RJ', 'RO', 'TI', 'TJ']
         .some((r) => icao.toUpperCase().startsWith(r)) ? 'IN HG' : 'HPA');
@@ -243,13 +244,20 @@ const WeatherWidget = (props: WeatherWidgetProps) => {
                                         {metar.raw_text
                                             ? (
                                                 <>
-                                                    <ColoredMetar metar={metar} />
+                                                    {usingColordMetar
+                                                        ? (
+                                                            <>
+                                                                <ColoredMetar metar={metar} />
+                                                            </>
+                                                        ) : (
+                                                            <>
+                                                                {metar.raw_text}
+                                                            </>
+                                                        )}
                                                 </>
                                             ) : (
                                                 <>
                                                     {metarError}
-                                                    {' '}
-                                                    {' '}
                                                 </>
                                             )}
                                     </div>

--- a/src/instruments/src/EFB/Settings/Settings.tsx
+++ b/src/instruments/src/EFB/Settings/Settings.tsx
@@ -826,7 +826,7 @@ const FlyPadPage = () => {
     const [brightnessSetting, setBrightnessSetting] = usePersistentNumberProperty('EFB_BRIGHTNESS', 0);
     const [brightness] = useSimVar('L:A32NX_EFB_BRIGHTNESS', 'number', 500);
     const [usingAutobrightness, setUsingAutobrightness] = usePersistentNumberProperty('EFB_USING_AUTOBRIGHTNESS', 0);
-    const [usingColordMetar, setUsingColoredMetar] = usePersistentNumberProperty('EFB_USING_COLOREDMETAR', 1);
+    const [usingColoredMetar, setUsingColoredMetar] = usePersistentNumberProperty('EFB_USING_COLOREDMETAR', 1);
 
     return (
         <div className="bg-navy-lighter rounded-xl px-6 shadow-lg divide-y divide-gray-700 flex flex-col">
@@ -845,7 +845,7 @@ const FlyPadPage = () => {
             <div className="py-4 flex flex-row justify-between items-center">
                 <span className="text-lg text-gray-300">Colored Metar</span>
                 <div className="flex flex-row items-center py-1.5">
-                    <Toggle value={!!usingColordMetar} onToggle={(value) => setUsingColoredMetar(value ? 1 : 0)} />
+                    <Toggle value={!!usingColoredMetar} onToggle={(value) => setUsingColoredMetar(value ? 1 : 0)} />
                 </div>
             </div>
         </div>

--- a/src/instruments/src/EFB/Settings/Settings.tsx
+++ b/src/instruments/src/EFB/Settings/Settings.tsx
@@ -826,6 +826,7 @@ const FlyPadPage = () => {
     const [brightnessSetting, setBrightnessSetting] = usePersistentNumberProperty('EFB_BRIGHTNESS', 0);
     const [brightness] = useSimVar('L:A32NX_EFB_BRIGHTNESS', 'number', 500);
     const [usingAutobrightness, setUsingAutobrightness] = usePersistentNumberProperty('EFB_USING_AUTOBRIGHTNESS', 0);
+    const [usingColordMetar, setUsingColoredMetar] = usePersistentNumberProperty('EFB_USING_COLOREDMETAR', 1);
 
     return (
         <div className="bg-navy-lighter rounded-xl px-6 shadow-lg divide-y divide-gray-700 flex flex-col">
@@ -839,6 +840,12 @@ const FlyPadPage = () => {
                 <span className="text-lg text-gray-300">Auto Brightness</span>
                 <div className="flex flex-row items-center py-1.5">
                     <Toggle value={!!usingAutobrightness} onToggle={(value) => setUsingAutobrightness(value ? 1 : 0)} />
+                </div>
+            </div>
+            <div className="py-4 flex flex-row justify-between items-center">
+                <span className="text-lg text-gray-300">Colored Metar</span>
+                <div className="flex flex-row items-center py-1.5">
+                    <Toggle value={!!usingColordMetar} onToggle={(value) => setUsingColoredMetar(value ? 1 : 0)} />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes #6751 

## Summary of Changes
This PR adds a setting to the EFB to enable/disable colored METAR display in the Dashboard Weather Widget. 
Also changes the color red to a lighter version after feedback from colorblind user. 

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/16833201/154838176-3124692b-acac-4fd0-9eff-504b98d41cb0.png)

brightness max:
![2022-02-20_15h16_12](https://user-images.githubusercontent.com/16833201/154847362-1d9736bc-014c-442b-8402-cdb05df1417c.png)

brightness min:
![2022-02-20_15h19_10](https://user-images.githubusercontent.com/16833201/154847364-844571b3-ceeb-41f0-803d-a117ae51928e.png)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Test the new setting and check the raw METAR on the weather widget to be either complete in the default white font or colored for severe and very severe values.  

Check readability in various lighting and brightness conditions - esp. the red color was problematic. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
