### PR TITLE
feat: AP and ATHR improvements

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -158,6 +158,9 @@
 1. [AP] Fix Target Altitude to be set in all FM requested modes - @IbrahimK42 (IbrahimK42)
 1. [AP] Fix G/S condition - @aguther (Andreas Guther)
 1. [DUs] Override MSFS menu animation setting for display units - @tracernz (Mike)
+1. [AP] Furhter improved FLARE law for various conditions - @aguther (Andreas Guther)
+1. [SOUNDS] Use estimated landing rate for touchdown sound selection - @aguther (Andreas Guther)
+1. [ATHR] Increase spool up/down speed for THR IDLE and THR CLB to better match real plane - @aguther (Andreas Guther)
 
 ## 0.7.0
 

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -1696,6 +1696,11 @@ In the variables below, {number} should be replaced with one item in the set: { 
     - Indicates the selected heading on the FCU, instantly updated
     - In case of managed heading mode, the value is -1
 
+- A32NX_AUTOPILOT_H_DOT_RADIO
+    - Number (Feet per minute)
+    - Indicates the current estimated vertical speed relative to the runway
+    - Important: the signal is only usable above the runway and is not to be used elsewhere
+
 - A32NX_FCU_SPD_MANAGED_DASHES
   - Boolean
   - Indicates if managed speed/mach mode is active and a numerical value is not displayed

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/sound/sound.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/sound/sound.xml
@@ -1580,42 +1580,42 @@
 
         <Sound WwiseEvent="smoothtouch" FadeOutType="2" FadeOutTime="0.5" WwiseData="true" Continuous="false" ViewPoint="Inside" NodeName="PEDALS_LEFT" SimVar="SIM ON GROUND" Units="BOOLEAN" Index="0">
             <Range LowerBound="1.0" />
-            <Requires SimVar="VERTICAL SPEED" Units="FEET PER MINUTE" Index="0">
+            <Requires LocalVar="A32NX_AUTOPILOT_H_DOT_RADIO" Units="number" Index="0">
                 <Range LowerBound="-150" UpperBound="-50" />
             </Requires>
         </Sound>
 
         <Sound WwiseEvent="medtouch" FadeOutType="2" FadeOutTime="0.5" WwiseData="true" Continuous="false" ViewPoint="Inside" NodeName="PEDALS_LEFT" SimVar="SIM ON GROUND" Units="BOOLEAN" Index="0">
             <Range LowerBound="1.0" />
-            <Requires SimVar="VERTICAL SPEED" Units="FEET PER MINUTE" Index="0">
+            <Requires LocalVar="A32NX_AUTOPILOT_H_DOT_RADIO" Units="number" Index="0">
                 <Range LowerBound="-350" UpperBound="-151" />
             </Requires>
         </Sound>
 
         <Sound WwiseEvent="firmtouch" FadeOutType="2" FadeOutTime="0.5" WwiseData="true" Continuous="false" ViewPoint="Inside" NodeName="PEDALS_LEFT" SimVar="SIM ON GROUND" Units="BOOLEAN" Index="0">
             <Range LowerBound="1.0" />
-            <Requires SimVar="VERTICAL SPEED" Units="FEET PER MINUTE" Index="0">
+            <Requires LocalVar="A32NX_AUTOPILOT_H_DOT_RADIO" Units="number" Index="0">
                 <Range UpperBound="-351" />
             </Requires>
         </Sound>
 
         <Sound WwiseEvent="cabtouchsmooth" FadeOutType="2" FadeOutTime="0.5" WwiseData="true" Continuous="false" ViewPoint="Inside" NodeName="HublotIn002" SimVar="SIM ON GROUND" Units="BOOLEAN" Index="0">
             <Range LowerBound="1.0" />
-            <Requires SimVar="VERTICAL SPEED" Units="FEET PER MINUTE" Index="0">
+            <Requires LocalVar="A32NX_AUTOPILOT_H_DOT_RADIO" Units="number" Index="0">
                 <Range LowerBound="-150" UpperBound="-50" />
             </Requires>
         </Sound>
 
         <Sound WwiseEvent="cabtouchmed" FadeOutType="2" FadeOutTime="0.5" WwiseData="true" Continuous="false" ViewPoint="Inside" NodeName="HublotIn002" SimVar="SIM ON GROUND" Units="BOOLEAN" Index="0">
             <Range LowerBound="1.0" />
-            <Requires SimVar="VERTICAL SPEED" Units="FEET PER MINUTE" Index="0">
+            <Requires LocalVar="A32NX_AUTOPILOT_H_DOT_RADIO" Units="number" Index="0">
                 <Range LowerBound="-350" UpperBound="-151" />
             </Requires>
         </Sound>
 
         <Sound WwiseEvent="cabtouchhard" FadeOutType="2" FadeOutTime="0.5" WwiseData="true" Continuous="false" ViewPoint="Inside" NodeName="HublotIn002" SimVar="SIM ON GROUND" Units="BOOLEAN" Index="0">
             <Range LowerBound="1.0" />
-            <Requires SimVar="VERTICAL SPEED" Units="FEET PER MINUTE" Index="0">
+            <Requires LocalVar="A32NX_AUTOPILOT_H_DOT_RADIO" Units="number" Index="0">
                 <Range UpperBound="-351" />
             </Requires>
         </Sound>

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -107,7 +107,6 @@ class FlyByWireInterface {
   bool developmentLocalVariablesEnabled = false;
   bool useCalculatedLocalizerAndGlideSlope = false;
   std::unique_ptr<LocalVariable> idDevelopmentAutoland_condition_Flare;
-  std::unique_ptr<LocalVariable> idDevelopmentAutoland_H_dot_radio_fpm;
   std::unique_ptr<LocalVariable> idDevelopmentAutoland_H_dot_c_fpm;
   std::unique_ptr<LocalVariable> idDevelopmentAutoland_delta_Theta_H_dot_deg;
   std::unique_ptr<LocalVariable> idDevelopmentAutoland_delta_Theta_bz_deg;
@@ -167,6 +166,8 @@ class FlyByWireInterface {
   std::unique_ptr<LocalVariable> idAutopilotActive_2;
 
   std::unique_ptr<LocalVariable> idAutopilotAutothrustMode;
+
+  std::unique_ptr<LocalVariable> idAutopilot_H_dot_radio;
 
   std::unique_ptr<LocalVariable> idFcuTrkFpaModeActive;
   std::unique_ptr<LocalVariable> idFcuSelectedFpa;
@@ -313,6 +314,7 @@ class FlyByWireInterface {
   std::unique_ptr<LocalVariable> idAileronPositionRight;
   std::shared_ptr<AnimationAileronHandler> animationAileronHandler;
 
+  std::unique_ptr<LocalVariable> idRadioReceiverUsage;
   std::unique_ptr<LocalVariable> idRadioReceiverLocalizerValid;
   std::unique_ptr<LocalVariable> idRadioReceiverLocalizerDeviation;
   std::unique_ptr<LocalVariable> idRadioReceiverLocalizerDistance;

--- a/src/fbw/src/model/AutopilotLaws.cpp
+++ b/src/fbw/src/model/AutopilotLaws.cpp
@@ -433,31 +433,32 @@ void AutopilotLawsModelClass::step()
   real_T b_L;
   real_T b_R;
   real_T distance_m;
-  real_T rtb_Add3_a;
+  real_T rtb_Add3_aj;
   real_T rtb_Add3_g;
   real_T rtb_Add3_i;
-  real_T rtb_Add3_no;
-  real_T rtb_Add5_l;
-  real_T rtb_Cos1_fn;
+  real_T rtb_Add3_j4;
+  real_T rtb_Add3_lz;
   real_T rtb_Cos1_pk;
   real_T rtb_Cos_i;
-  real_T rtb_Divide;
   real_T rtb_FD_h;
+  real_T rtb_Gain1_na;
   real_T rtb_Gain4_m;
   real_T rtb_GainTheta;
   real_T rtb_GainTheta1;
-  real_T rtb_Gain_lg;
-  real_T rtb_Gain_nrh;
+  real_T rtb_Gain_dn;
+  real_T rtb_Gain_ej3;
+  real_T rtb_Gain_l4;
   real_T rtb_Product_dh;
   real_T rtb_Saturation;
   real_T rtb_Sum1_g;
   real_T rtb_Sum3_m3;
-  real_T rtb_Sum_ia;
-  real_T rtb_Sum_if;
+  real_T rtb_Sum_es;
+  real_T rtb_Sum_i;
+  real_T rtb_Sum_kq;
   real_T rtb_Vz;
-  real_T rtb_Y_g;
-  real_T rtb_Y_j;
-  real_T rtb_Y_pt;
+  real_T rtb_Y_d;
+  real_T rtb_Y_k;
+  real_T rtb_Y_n0;
   real_T rtb_dme;
   real_T rtb_error_d;
   real_T rtb_lo_b;
@@ -466,7 +467,7 @@ void AutopilotLawsModelClass::step()
   int32_T i;
   int32_T low_i;
   int32_T low_ip1;
-  int32_T rtb_Saturation_o;
+  int32_T rtb_fpmtoms;
   int32_T rtb_on_ground;
   boolean_T guard1{ false };
 
@@ -474,7 +475,7 @@ void AutopilotLawsModelClass::step()
   boolean_T rtb_Delay_j;
   boolean_T rtb_valid;
   boolean_T rtb_valid_d;
-  rtb_Saturation_o = ((AutopilotLaws_U.in.input.enabled_AP1 != 0.0) || (AutopilotLaws_U.in.input.enabled_AP2 != 0.0));
+  rtb_fpmtoms = ((AutopilotLaws_U.in.input.enabled_AP1 != 0.0) || (AutopilotLaws_U.in.input.enabled_AP2 != 0.0));
   rtb_GainTheta = AutopilotLaws_P.GainTheta_Gain * AutopilotLaws_U.in.data.Theta_deg;
   rtb_GainTheta1 = AutopilotLaws_P.GainTheta1_Gain * AutopilotLaws_U.in.data.Phi_deg;
   rtb_dme = 0.017453292519943295 * rtb_GainTheta;
@@ -490,9 +491,9 @@ void AutopilotLawsModelClass::step()
   result_tmp[7] = -a;
   result_tmp[2] = 0.0;
   distance_m = std::cos(rtb_dme);
-  rtb_Y_pt = 1.0 / distance_m;
-  result_tmp[5] = rtb_Y_pt * a;
-  result_tmp[8] = rtb_Y_pt * b_R;
+  rtb_Add3_j4 = 1.0 / distance_m;
+  result_tmp[5] = rtb_Add3_j4 * a;
+  result_tmp[8] = rtb_Add3_j4 * b_R;
   rtb_error_d = AutopilotLaws_P.Gain_Gain_de * AutopilotLaws_U.in.data.p_rad_s * AutopilotLaws_P.Gainpk_Gain;
   rtb_Saturation = AutopilotLaws_P.Gain_Gain_d * AutopilotLaws_U.in.data.q_rad_s * AutopilotLaws_P.Gainqk_Gain;
   Phi2 = AutopilotLaws_P.Gain_Gain_m * AutopilotLaws_U.in.data.r_rad_s;
@@ -552,9 +553,9 @@ void AutopilotLawsModelClass::step()
     b_R = -b_L;
   }
 
-  rtb_Y_pt = std::cos(rtb_error_d);
+  rtb_Add3_j4 = std::cos(rtb_error_d);
   rtb_error_d = std::sin(rtb_error_d);
-  L = mod_mvZvttxs(mod_mvZvttxs(mod_mvZvttxs(std::atan2(std::sin(R) * L, rtb_Y_pt * std::sin(Phi2) - rtb_error_d * L *
+  L = mod_mvZvttxs(mod_mvZvttxs(mod_mvZvttxs(std::atan2(std::sin(R) * L, rtb_Add3_j4 * std::sin(Phi2) - rtb_error_d * L *
     std::cos(R)) * 57.295779513082323 + 360.0)) + 360.0) + 360.0;
   Phi2 = mod_mvZvttxs((mod_mvZvttxs(mod_mvZvttxs(mod_mvZvttxs(mod_mvZvttxs(AutopilotLaws_U.in.data.nav_loc_deg - b_R) +
     360.0)) + 360.0) - L) + 360.0);
@@ -597,12 +598,13 @@ void AutopilotLawsModelClass::step()
   distance_m = std::sin((AutopilotLaws_U.in.data.nav_gs_position.lon - AutopilotLaws_U.in.data.aircraft_position.lon) *
                         0.017453292519943295 / 2.0);
   L = std::cos(Phi2);
-  a = rtb_Y_pt * L * distance_m * distance_m + a * a;
+  R = rtb_Add3_j4;
+  a = rtb_Add3_j4 * L * distance_m * distance_m + a * a;
   distance_m = std::atan2(std::sqrt(a), std::sqrt(1.0 - a)) * 2.0 * 6.371E+6;
   a = AutopilotLaws_U.in.data.aircraft_position.alt - AutopilotLaws_U.in.data.nav_gs_position.alt;
   distance_m = std::sqrt(distance_m * distance_m + a * a);
   rtb_Saturation = 0.017453292519943295 * AutopilotLaws_U.in.data.nav_gs_position.lon - rtb_Saturation;
-  rtb_Saturation = std::atan2(std::sin(rtb_Saturation) * L, rtb_Y_pt * std::sin(Phi2) - rtb_error_d * L * std::cos
+  rtb_Saturation = std::atan2(std::sin(rtb_Saturation) * L, rtb_Add3_j4 * std::sin(Phi2) - rtb_error_d * L * std::cos
     (rtb_Saturation)) * 57.295779513082323;
   if (rtb_Saturation + 360.0 == 0.0) {
     rtb_error_d = 0.0;
@@ -732,7 +734,7 @@ void AutopilotLawsModelClass::step()
   rtb_Compare_jy = (AutopilotLaws_U.in.data.altimeter_setting_left_mbar != AutopilotLaws_DWork.DelayInput1_DSTATE);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_DWork.DelayInput1_DSTATE_g;
   AutopilotLaws_Y.out = AutopilotLaws_P.ap_laws_output_MATLABStruct;
-  AutopilotLaws_Y.out.output.ap_on = rtb_Saturation_o;
+  AutopilotLaws_Y.out.output.ap_on = rtb_fpmtoms;
   AutopilotLaws_Y.out.time = AutopilotLaws_U.in.time;
   AutopilotLaws_Y.out.data.aircraft_position = AutopilotLaws_U.in.data.aircraft_position;
   AutopilotLaws_Y.out.data.Theta_deg = rtb_GainTheta;
@@ -825,11 +827,11 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_DWork.DelayInput1_DSTATE = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE,
     AutopilotLaws_P.Constant3_Value_b);
   b_R = AutopilotLaws_U.in.data.nav_loc_deg - AutopilotLaws_U.in.data.nav_loc_magvar_deg;
-  Phi2 = rt_modd(rt_modd(b_R, AutopilotLaws_P.Constant3_Value_n) + AutopilotLaws_P.Constant3_Value_n,
-                 AutopilotLaws_P.Constant3_Value_n);
-  rtb_Saturation = rt_modd((AutopilotLaws_DWork.DelayInput1_DSTATE - (Phi2 + AutopilotLaws_P.Constant3_Value_i)) +
+  rtb_lo_b = rt_modd(rt_modd(b_R, AutopilotLaws_P.Constant3_Value_n) + AutopilotLaws_P.Constant3_Value_n,
+                     AutopilotLaws_P.Constant3_Value_n);
+  rtb_Saturation = rt_modd((AutopilotLaws_DWork.DelayInput1_DSTATE - (rtb_lo_b + AutopilotLaws_P.Constant3_Value_i)) +
     AutopilotLaws_P.Constant3_Value_i, AutopilotLaws_P.Constant3_Value_i);
-  a = rt_modd(AutopilotLaws_P.Constant3_Value_i - rtb_Saturation, AutopilotLaws_P.Constant3_Value_i);
+  Phi2 = rt_modd(AutopilotLaws_P.Constant3_Value_i - rtb_Saturation, AutopilotLaws_P.Constant3_Value_i);
   if (AutopilotLaws_P.ManualSwitch_CurrentSetting == 1) {
     rtb_error_d = AutopilotLaws_P.Constant_Value;
   } else {
@@ -837,10 +839,10 @@ void AutopilotLawsModelClass::step()
   }
 
   rtb_valid = (rtb_error_d == AutopilotLaws_P.CompareToConstant2_const);
-  if (rtb_Saturation < a) {
+  if (rtb_Saturation < Phi2) {
     rtb_Saturation *= AutopilotLaws_P.Gain1_Gain;
   } else {
-    rtb_Saturation = AutopilotLaws_P.Gain_Gain * a;
+    rtb_Saturation = AutopilotLaws_P.Gain_Gain * Phi2;
   }
 
   rtb_Saturation = std::abs(rtb_Saturation);
@@ -857,7 +859,7 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.limit = 15.0;
   }
 
-  AutopilotLaws_MATLABFunction(AutopilotLaws_P.tau_Value, AutopilotLaws_P.zeta_Value, &rtb_Y_g, &rtb_lo_k);
+  AutopilotLaws_MATLABFunction(AutopilotLaws_P.tau_Value, AutopilotLaws_P.zeta_Value, &R, &rtb_lo_k);
   if (rtb_dme > AutopilotLaws_P.Saturation_UpperSat_b) {
     rtb_Saturation = AutopilotLaws_P.Saturation_UpperSat_b;
   } else if (rtb_dme < AutopilotLaws_P.Saturation_LowerSat_n) {
@@ -866,29 +868,29 @@ void AutopilotLawsModelClass::step()
     rtb_Saturation = rtb_dme;
   }
 
-  rtb_Divide = std::sin(AutopilotLaws_P.Gain1_Gain_f * AutopilotLaws_U.in.data.nav_loc_error_deg) * rtb_Saturation *
+  rtb_Saturation = std::sin(AutopilotLaws_P.Gain1_Gain_f * AutopilotLaws_U.in.data.nav_loc_error_deg) * rtb_Saturation *
     AutopilotLaws_P.Gain_Gain_h * rtb_lo_k / AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Divide > AutopilotLaws_DWork.limit) {
-    rtb_Divide = AutopilotLaws_DWork.limit;
-  } else if (rtb_Divide < -AutopilotLaws_DWork.limit) {
-    rtb_Divide = -AutopilotLaws_DWork.limit;
-  }
-
   AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_DWork.DelayInput1_DSTATE - (rt_modd(rt_modd
-    (AutopilotLaws_U.in.data.nav_loc_error_deg + Phi2, AutopilotLaws_P.Constant3_Value_c2) +
+    (AutopilotLaws_U.in.data.nav_loc_error_deg + rtb_lo_b, AutopilotLaws_P.Constant3_Value_c2) +
     AutopilotLaws_P.Constant3_Value_c2, AutopilotLaws_P.Constant3_Value_c2) + AutopilotLaws_P.Constant3_Value_p)) +
     AutopilotLaws_P.Constant3_Value_p;
-  rtb_Saturation = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_p);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant3_Value_p - rtb_Saturation;
   Phi2 = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_p);
-  if (rtb_Saturation < Phi2) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_p * rtb_Saturation;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant3_Value_p - Phi2;
+  a = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_p);
+  if (Phi2 < a) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_p * Phi2;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain_Gain_a * Phi2;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain_Gain_a * a;
+  }
+
+  if (rtb_Saturation > AutopilotLaws_DWork.limit) {
+    rtb_Saturation = AutopilotLaws_DWork.limit;
+  } else if (rtb_Saturation < -AutopilotLaws_DWork.limit) {
+    rtb_Saturation = -AutopilotLaws_DWork.limit;
   }
 
   AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_P.Gain2_Gain_i * AutopilotLaws_DWork.DelayInput1_DSTATE +
-    rtb_Divide) * rtb_Y_g;
+    rtb_Saturation) * R;
   a = AutopilotLaws_DWork.DelayInput1_DSTATE * AutopilotLaws_U.in.data.V_gnd_kn;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_nr * AutopilotLaws_U.in.data.nav_loc_error_deg;
   rtb_Saturation = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
@@ -967,9 +969,9 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_DWork.DelayInput1_DSTATE = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE,
     AutopilotLaws_P.Constant3_Value_if);
   AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_P.Constant3_Value_if;
-  R = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_if);
+  L = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_if);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_U.in.data.Psi_true_deg + AutopilotLaws_P.Constant3_Value_m;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (R - AutopilotLaws_DWork.DelayInput1_DSTATE) +
+  AutopilotLaws_DWork.DelayInput1_DSTATE = (L - AutopilotLaws_DWork.DelayInput1_DSTATE) +
     AutopilotLaws_P.Constant3_Value_m;
   rtb_dme = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_m);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant3_Value_m - rtb_dme;
@@ -1011,14 +1013,14 @@ void AutopilotLawsModelClass::step()
   b_R = rtb_dme * AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain_Gain_o5 * result[2];
   b_L = AutopilotLaws_P.Gain1_Gain_o * b_R + AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_MATLABFunction_m(AutopilotLaws_U.in.input.Psi_c_deg, rtb_dme, b_L, &b_R, &rtb_lo_b,
+  AutopilotLaws_MATLABFunction_m(AutopilotLaws_U.in.input.Psi_c_deg, rtb_dme, b_L, &rtb_Y_k, &rtb_lo_b,
     &AutopilotLaws_DWork.sf_MATLABFunction_m);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_U.in.data.Psi_magnetic_track_deg +
     AutopilotLaws_P.Constant3_Value_k;
   AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_U.in.input.Psi_c_deg - AutopilotLaws_DWork.DelayInput1_DSTATE)
     + AutopilotLaws_P.Constant3_Value_k;
-  Phi2 = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_k);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant3_Value_k - Phi2;
+  b_R = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Constant3_Value_k);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant3_Value_k - b_R;
   AutopilotLaws_DWork.DelayInput1_DSTATE = rt_modd(AutopilotLaws_DWork.DelayInput1_DSTATE,
     AutopilotLaws_P.Constant3_Value_k);
   rtb_valid_d = ((rtb_error_d == AutopilotLaws_P.CompareToConstant4_const) == AutopilotLaws_P.CompareToConstant_const_e);
@@ -1041,28 +1043,28 @@ void AutopilotLawsModelClass::step()
     rtb_Delay_j = AutopilotLaws_DWork.Delay_DSTATE_h5[100U - i];
   }
 
-  AutopilotLaws_Chart(Phi2, AutopilotLaws_P.Gain_Gain_p * AutopilotLaws_DWork.DelayInput1_DSTATE, rtb_valid_d !=
+  AutopilotLaws_Chart(b_R, AutopilotLaws_P.Gain_Gain_p * AutopilotLaws_DWork.DelayInput1_DSTATE, rtb_valid_d !=
                       rtb_Delay_j, &rtb_dme, &AutopilotLaws_DWork.sf_Chart_ba);
   AutopilotLaws_DWork.DelayInput1_DSTATE = look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn,
     AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_o, AutopilotLaws_P.ScheduledGain_Table_e, 6U);
-  Phi2 = rtb_dme * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  b_R = rtb_dme * AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain_Gain_l * result[2];
-  rtb_Sum_if = AutopilotLaws_P.Gain1_Gain_i4 * Phi2 + AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_MATLABFunction_m(AutopilotLaws_U.in.input.Psi_c_deg, rtb_dme, rtb_Sum_if, &rtb_Y_pt, &rtb_lo_k,
+  rtb_Sum_i = AutopilotLaws_P.Gain1_Gain_i4 * b_R + AutopilotLaws_DWork.DelayInput1_DSTATE;
+  AutopilotLaws_MATLABFunction_m(AutopilotLaws_U.in.input.Psi_c_deg, rtb_dme, rtb_Sum_i, &rtb_Y_d, &rtb_lo_k,
     &AutopilotLaws_DWork.sf_MATLABFunction_e);
-  AutopilotLaws_MATLABFunction(AutopilotLaws_P.tau_Value_c, AutopilotLaws_P.zeta_Value_h, &Phi2, &rtb_Divide);
+  AutopilotLaws_MATLABFunction(AutopilotLaws_P.tau_Value_c, AutopilotLaws_P.zeta_Value_h, &rtb_Gain1_na, &Phi2);
   AutopilotLaws_RateLimiter(AutopilotLaws_U.in.data.flight_guidance_phi_deg, AutopilotLaws_P.RateLimiterVariableTs_up,
     AutopilotLaws_P.RateLimiterVariableTs_lo, AutopilotLaws_U.in.time.dt,
-    AutopilotLaws_P.RateLimiterVariableTs_InitialCondition, &rtb_Y_g, &AutopilotLaws_DWork.sf_RateLimiter);
-  AutopilotLaws_LagFilter(rtb_Y_g, AutopilotLaws_P.LagFilter_C1, AutopilotLaws_U.in.time.dt, &L,
+    AutopilotLaws_P.RateLimiterVariableTs_InitialCondition, &R, &AutopilotLaws_DWork.sf_RateLimiter);
+  AutopilotLaws_LagFilter(R, AutopilotLaws_P.LagFilter_C1, AutopilotLaws_U.in.time.dt, &b_R,
     &AutopilotLaws_DWork.sf_LagFilter);
   AutopilotLaws_LagFilter(AutopilotLaws_U.in.data.nav_loc_error_deg, AutopilotLaws_P.LagFilter2_C1,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_g, &AutopilotLaws_DWork.sf_LagFilter_h);
-  rtb_dme = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain * rtb_Y_g;
+    AutopilotLaws_U.in.time.dt, &R, &AutopilotLaws_DWork.sf_LagFilter_h);
+  rtb_dme = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain * R;
   AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_dme - AutopilotLaws_DWork.Delay_DSTATE_e;
   AutopilotLaws_DWork.DelayInput1_DSTATE /= AutopilotLaws_U.in.time.dt;
-  AutopilotLaws_LagFilter(rtb_Y_g + AutopilotLaws_P.Gain3_Gain_i * AutopilotLaws_DWork.DelayInput1_DSTATE,
-    AutopilotLaws_P.LagFilter_C1_n, AutopilotLaws_U.in.time.dt, &rtb_Y_j, &AutopilotLaws_DWork.sf_LagFilter_m);
+  AutopilotLaws_LagFilter(R + AutopilotLaws_P.Gain3_Gain_i * AutopilotLaws_DWork.DelayInput1_DSTATE,
+    AutopilotLaws_P.LagFilter_C1_n, AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_LagFilter_m);
   rtb_Delay_j = (AutopilotLaws_U.in.data.H_radio_ft <= AutopilotLaws_P.CompareToConstant_const_d);
   switch (static_cast<int32_T>(rtb_error_d)) {
    case 0:
@@ -1070,34 +1072,34 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 1:
-    if (b_L > b_R) {
-      b_L = b_R;
+    if (b_L > rtb_Y_k) {
+      b_L = rtb_Y_k;
     } else if (b_L < rtb_lo_b) {
       b_L = rtb_lo_b;
     }
     break;
 
    case 2:
-    if (rtb_Sum_if > rtb_Y_pt) {
-      b_L = rtb_Y_pt;
-    } else if (rtb_Sum_if < rtb_lo_k) {
+    if (rtb_Sum_i > rtb_Y_d) {
+      b_L = rtb_Y_d;
+    } else if (rtb_Sum_i < rtb_lo_k) {
       b_L = rtb_lo_k;
     } else {
-      b_L = rtb_Sum_if;
+      b_L = rtb_Sum_i;
     }
     break;
 
    case 3:
-    rtb_Add3_i = AutopilotLaws_P.Gain_Gain_c * AutopilotLaws_U.in.data.flight_guidance_xtk_nmi * rtb_Divide /
+    rtb_Add3_j4 = AutopilotLaws_P.Gain_Gain_c * AutopilotLaws_U.in.data.flight_guidance_xtk_nmi * Phi2 /
       AutopilotLaws_U.in.data.V_gnd_kn;
-    if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat) {
-      rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat;
-    } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat) {
-      rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat;
+    if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat) {
+      rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat;
+    } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat) {
+      rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat;
     }
 
-    b_L = L - (AutopilotLaws_P.Gain2_Gain * AutopilotLaws_U.in.data.flight_guidance_tae_deg + rtb_Add3_i) * Phi2 *
-      AutopilotLaws_U.in.data.V_gnd_kn;
+    b_L = b_R - (AutopilotLaws_P.Gain2_Gain * AutopilotLaws_U.in.data.flight_guidance_tae_deg + rtb_Add3_j4) *
+      rtb_Gain1_na * AutopilotLaws_U.in.data.V_gnd_kn;
     break;
 
    case 4:
@@ -1114,27 +1116,27 @@ void AutopilotLawsModelClass::step()
       b_R = AutopilotLaws_P.Gain_Gain_g * Phi2;
     }
 
-    b_R = rt_modd((rt_modd(rt_modd(AutopilotLaws_U.in.data.Psi_magnetic_track_deg + b_R,
-      AutopilotLaws_P.Constant3_Value_d) + AutopilotLaws_P.Constant3_Value_d, AutopilotLaws_P.Constant3_Value_d) - (R +
+    Phi2 = rt_modd((rt_modd(rt_modd(AutopilotLaws_U.in.data.Psi_magnetic_track_deg + b_R,
+      AutopilotLaws_P.Constant3_Value_d) + AutopilotLaws_P.Constant3_Value_d, AutopilotLaws_P.Constant3_Value_d) - (L +
       AutopilotLaws_P.Constant3_Value_c)) + AutopilotLaws_P.Constant3_Value_c, AutopilotLaws_P.Constant3_Value_c);
-    Phi2 = rt_modd(AutopilotLaws_P.Constant3_Value_c - b_R, AutopilotLaws_P.Constant3_Value_c);
-    if (b_R < Phi2) {
-      b_R *= AutopilotLaws_P.Gain1_Gain_g;
+    b_R = rt_modd(AutopilotLaws_P.Constant3_Value_c - Phi2, AutopilotLaws_P.Constant3_Value_c);
+    if (Phi2 < b_R) {
+      Phi2 *= AutopilotLaws_P.Gain1_Gain_g;
     } else {
-      b_R = AutopilotLaws_P.Gain_Gain_f * Phi2;
+      Phi2 = AutopilotLaws_P.Gain_Gain_f * b_R;
     }
 
     if (rtb_Delay_j) {
-      L = AutopilotLaws_P.k_beta_Phi_Gain * AutopilotLaws_U.in.data.beta_deg;
+      b_R = AutopilotLaws_P.k_beta_Phi_Gain * AutopilotLaws_U.in.data.beta_deg;
     } else {
-      L = AutopilotLaws_P.Constant1_Value_fk;
+      b_R = AutopilotLaws_P.Constant1_Value_fk;
     }
 
-    b_L = (std::sin(AutopilotLaws_P.Gain1_Gain_b * b_R) * AutopilotLaws_U.in.data.V_gnd_kn *
-           AutopilotLaws_P.Gain2_Gain_g + rtb_Y_j * look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn,
+    b_L = (std::sin(AutopilotLaws_P.Gain1_Gain_b * Phi2) * AutopilotLaws_U.in.data.V_gnd_kn *
+           AutopilotLaws_P.Gain2_Gain_g + rtb_Y_n0 * look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn,
             AutopilotLaws_P.ScheduledGain2_BreakpointsForDimension1, AutopilotLaws_P.ScheduledGain2_Table, 6U) *
            AutopilotLaws_P.Gain4_Gain * look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft,
-            AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_e, AutopilotLaws_P.ScheduledGain_Table_p, 4U)) + L;
+            AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_e, AutopilotLaws_P.ScheduledGain_Table_p, 4U)) + b_R;
     if (b_L > AutopilotLaws_P.Saturation1_UpperSat) {
       b_L = AutopilotLaws_P.Saturation1_UpperSat;
     } else if (b_L < AutopilotLaws_P.Saturation1_LowerSat) {
@@ -1177,7 +1179,7 @@ void AutopilotLawsModelClass::step()
   }
 
   AutopilotLaws_LagFilter(AutopilotLaws_P.Gain_Gain_lu * (AutopilotLaws_DWork.DelayInput1_DSTATE - rtb_GainTheta1),
-    AutopilotLaws_P.LagFilter_C1_a, AutopilotLaws_U.in.time.dt, &b_R, &AutopilotLaws_DWork.sf_LagFilter_mp);
+    AutopilotLaws_P.LagFilter_C1_a, AutopilotLaws_U.in.time.dt, &rtb_Y_k, &AutopilotLaws_DWork.sf_LagFilter_mp);
   if (!AutopilotLaws_DWork.pY_not_empty_d) {
     AutopilotLaws_DWork.pY_g = AutopilotLaws_P.RateLimiterVariableTs_InitialCondition_i;
     AutopilotLaws_DWork.pY_not_empty_d = true;
@@ -1187,57 +1189,57 @@ void AutopilotLawsModelClass::step()
     abs(AutopilotLaws_P.RateLimiterVariableTs_up_n) * AutopilotLaws_U.in.time.dt), -std::abs
     (AutopilotLaws_P.RateLimiterVariableTs_lo_k) * AutopilotLaws_U.in.time.dt);
   if (AutopilotLaws_DWork.pY_g > AutopilotLaws_P.Saturation_UpperSat_k) {
-    rtb_Divide = AutopilotLaws_P.Saturation_UpperSat_k;
+    rtb_Sum_kq = AutopilotLaws_P.Saturation_UpperSat_k;
   } else if (AutopilotLaws_DWork.pY_g < AutopilotLaws_P.Saturation_LowerSat_f3) {
-    rtb_Divide = AutopilotLaws_P.Saturation_LowerSat_f3;
+    rtb_Sum_kq = AutopilotLaws_P.Saturation_LowerSat_f3;
   } else {
-    rtb_Divide = AutopilotLaws_DWork.pY_g;
+    rtb_Sum_kq = AutopilotLaws_DWork.pY_g;
   }
 
-  rtb_Saturation = (AutopilotLaws_P.Gain_Gain_b * result[2] * rtb_Divide + (AutopilotLaws_P.Constant_Value_a -
-    rtb_Divide) * (AutopilotLaws_P.Gain4_Gain_o * AutopilotLaws_U.in.data.beta_deg)) + AutopilotLaws_P.Gain5_Gain_o *
+  rtb_Saturation = (AutopilotLaws_P.Gain_Gain_b * result[2] * rtb_Sum_kq + (AutopilotLaws_P.Constant_Value_a -
+    rtb_Sum_kq) * (AutopilotLaws_P.Gain4_Gain_o * AutopilotLaws_U.in.data.beta_deg)) + AutopilotLaws_P.Gain5_Gain_o *
     rtb_Saturation;
-  if (rtb_Saturation_o > AutopilotLaws_P.Switch_Threshold_n) {
+  if (rtb_fpmtoms > AutopilotLaws_P.Switch_Threshold_n) {
     switch (static_cast<int32_T>(rtb_error_d)) {
      case 0:
-      Phi2 = AutopilotLaws_P.beta1_Value;
+      rtb_lo_b = AutopilotLaws_P.beta1_Value;
       break;
 
      case 1:
-      Phi2 = AutopilotLaws_P.beta1_Value_h;
+      rtb_lo_b = AutopilotLaws_P.beta1_Value_h;
       break;
 
      case 2:
-      Phi2 = AutopilotLaws_P.beta1_Value_l;
+      rtb_lo_b = AutopilotLaws_P.beta1_Value_l;
       break;
 
      case 3:
-      Phi2 = AutopilotLaws_P.beta1_Value_m;
+      rtb_lo_b = AutopilotLaws_P.beta1_Value_m;
       break;
 
      case 4:
-      Phi2 = AutopilotLaws_P.beta1_Value_d;
+      rtb_lo_b = AutopilotLaws_P.beta1_Value_d;
       break;
 
      case 5:
-      Phi2 = AutopilotLaws_P.beta1_Value_hy;
+      rtb_lo_b = AutopilotLaws_P.beta1_Value_hy;
       break;
 
      default:
-      Phi2 = AutopilotLaws_P.Gain3_Gain * rtb_Saturation;
+      rtb_lo_b = AutopilotLaws_P.Gain3_Gain * rtb_Saturation;
       break;
     }
   } else {
-    Phi2 = AutopilotLaws_P.Constant1_Value;
+    rtb_lo_b = AutopilotLaws_P.Constant1_Value;
   }
 
   if (rtb_Delay_j) {
-    L = AutopilotLaws_P.Gain_Gain_ae * distance_m + AutopilotLaws_P.Gain1_Gain_k * AutopilotLaws_U.in.data.beta_deg;
+    b_R = AutopilotLaws_P.Gain_Gain_ae * distance_m + AutopilotLaws_P.Gain1_Gain_k * AutopilotLaws_U.in.data.beta_deg;
   } else {
-    L = AutopilotLaws_P.Constant1_Value_fk;
+    b_R = AutopilotLaws_P.Constant1_Value_fk;
   }
 
-  AutopilotLaws_LagFilter(L, AutopilotLaws_P.LagFilter1_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_pt,
+  AutopilotLaws_LagFilter(b_R, AutopilotLaws_P.LagFilter1_C1, AutopilotLaws_U.in.time.dt, &rtb_Y_d,
     &AutopilotLaws_DWork.sf_LagFilter_c);
   switch (static_cast<int32_T>(rtb_error_d)) {
    case 0:
@@ -1261,12 +1263,12 @@ void AutopilotLawsModelClass::step()
     break;
 
    case 5:
-    if (rtb_Y_pt > AutopilotLaws_P.Saturation_UpperSat_e) {
+    if (rtb_Y_d > AutopilotLaws_P.Saturation_UpperSat_e) {
       rtb_Saturation = AutopilotLaws_P.Saturation_UpperSat_e;
-    } else if (rtb_Y_pt < AutopilotLaws_P.Saturation_LowerSat_f) {
+    } else if (rtb_Y_d < AutopilotLaws_P.Saturation_LowerSat_f) {
       rtb_Saturation = AutopilotLaws_P.Saturation_LowerSat_f;
     } else {
-      rtb_Saturation = rtb_Y_pt;
+      rtb_Saturation = rtb_Y_d;
     }
     break;
 
@@ -1275,9 +1277,9 @@ void AutopilotLawsModelClass::step()
     break;
   }
 
-  AutopilotLaws_LagFilter(rtb_Saturation, AutopilotLaws_P.LagFilter_C1_k, AutopilotLaws_U.in.time.dt, &L,
+  AutopilotLaws_LagFilter(rtb_Saturation, AutopilotLaws_P.LagFilter_C1_k, AutopilotLaws_U.in.time.dt, &b_R,
     &AutopilotLaws_DWork.sf_LagFilter_h2);
-  AutopilotLaws_DWork.icLoad = ((rtb_Saturation_o == 0) || AutopilotLaws_DWork.icLoad);
+  AutopilotLaws_DWork.icLoad = ((rtb_fpmtoms == 0) || AutopilotLaws_DWork.icLoad);
   if (AutopilotLaws_DWork.icLoad) {
     AutopilotLaws_DWork.Delay_DSTATE_h = rtb_GainTheta1;
   }
@@ -1288,35 +1290,35 @@ void AutopilotLawsModelClass::step()
   AutopilotLaws_DWork.Delay_DSTATE_h += std::fmax(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.Gain1_Gain_kf *
     AutopilotLaws_P.Constant2_Value_h * AutopilotLaws_U.in.time.dt);
   AutopilotLaws_LagFilter(AutopilotLaws_DWork.Delay_DSTATE_h, AutopilotLaws_P.LagFilter_C1_l, AutopilotLaws_U.in.time.dt,
-    &rtb_Y_j, &AutopilotLaws_DWork.sf_LagFilter_o);
-  AutopilotLaws_RateLimiter(static_cast<real_T>(rtb_Saturation_o), AutopilotLaws_P.RateLimiterVariableTs_up_b,
+    &rtb_Y_n0, &AutopilotLaws_DWork.sf_LagFilter_o);
+  AutopilotLaws_RateLimiter(static_cast<real_T>(rtb_fpmtoms), AutopilotLaws_P.RateLimiterVariableTs_up_b,
     AutopilotLaws_P.RateLimiterVariableTs_lo_b, AutopilotLaws_U.in.time.dt,
-    AutopilotLaws_P.RateLimiterVariableTs_InitialCondition_il, &rtb_Y_pt, &AutopilotLaws_DWork.sf_RateLimiter_d);
-  if (rtb_Y_pt > AutopilotLaws_P.Saturation_UpperSat_m) {
+    AutopilotLaws_P.RateLimiterVariableTs_InitialCondition_il, &rtb_Y_d, &AutopilotLaws_DWork.sf_RateLimiter_d);
+  if (rtb_Y_d > AutopilotLaws_P.Saturation_UpperSat_m) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_m;
-  } else if (rtb_Y_pt < AutopilotLaws_P.Saturation_LowerSat_fw) {
+  } else if (rtb_Y_d < AutopilotLaws_P.Saturation_LowerSat_fw) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_fw;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_pt;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_d;
   }
 
-  rtb_error_d = rtb_Y_j * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_error_d = rtb_Y_n0 * AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_ii - AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE *= rtb_GainTheta1;
   AutopilotLaws_DWork.DelayInput1_DSTATE += rtb_error_d;
   AutopilotLaws_Y.out.output.Phi_loc_c = a;
-  rtb_Add3_i = AutopilotLaws_P.Gain_Gain_m3 * Phi2;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_c) {
+  rtb_Add3_j4 = AutopilotLaws_P.Gain_Gain_m3 * rtb_lo_b;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_c) {
     AutopilotLaws_Y.out.output.Nosewheel_c = AutopilotLaws_P.Saturation_UpperSat_c;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_d) {
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_d) {
     AutopilotLaws_Y.out.output.Nosewheel_c = AutopilotLaws_P.Saturation_LowerSat_d;
   } else {
-    AutopilotLaws_Y.out.output.Nosewheel_c = rtb_Add3_i;
+    AutopilotLaws_Y.out.output.Nosewheel_c = rtb_Add3_j4;
   }
 
-  AutopilotLaws_Y.out.output.flight_director.Beta_c_deg = L;
+  AutopilotLaws_Y.out.output.flight_director.Beta_c_deg = b_R;
   AutopilotLaws_Y.out.output.autopilot.Beta_c_deg = rtb_Saturation;
-  AutopilotLaws_Y.out.output.flight_director.Phi_c_deg = b_R;
+  AutopilotLaws_Y.out.output.flight_director.Phi_c_deg = rtb_Y_k;
   AutopilotLaws_Y.out.output.autopilot.Phi_c_deg = AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_WashoutFilter(rtb_GainTheta, AutopilotLaws_P.WashoutFilter_C1, AutopilotLaws_U.in.time.dt, &b_R,
     &AutopilotLaws_DWork.sf_WashoutFilter_f);
@@ -1344,8 +1346,8 @@ void AutopilotLawsModelClass::step()
   }
 
   AutopilotLaws_LagFilter(AutopilotLaws_B.u - AutopilotLaws_U.in.data.H_ft, AutopilotLaws_P.LagFilter_C1_ai,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_pt, &AutopilotLaws_DWork.sf_LagFilter_g);
-  AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_P.Gain_Gain_ft * rtb_Y_pt;
+    AutopilotLaws_U.in.time.dt, &rtb_Y_d, &AutopilotLaws_DWork.sf_LagFilter_g);
+  AutopilotLaws_DWork.DelayInput1_DSTATE += AutopilotLaws_P.Gain_Gain_ft * rtb_Y_d;
   if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_n) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_n;
   } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_d4) {
@@ -1361,14 +1363,14 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_n5;
   }
 
-  rtb_Add3_i = Phi2 / AutopilotLaws_DWork.DelayInput1_DSTATE;
-  if (rtb_Add3_i > 1.0) {
-    rtb_Add3_i = 1.0;
-  } else if (rtb_Add3_i < -1.0) {
-    rtb_Add3_i = -1.0;
+  rtb_Add3_j4 = Phi2 / AutopilotLaws_DWork.DelayInput1_DSTATE;
+  if (rtb_Add3_j4 > 1.0) {
+    rtb_Add3_j4 = 1.0;
+  } else if (rtb_Add3_j4 < -1.0) {
+    rtb_Add3_j4 = -1.0;
   }
 
-  a = AutopilotLaws_P.Gain_Gain_k * std::asin(rtb_Add3_i);
+  a = AutopilotLaws_P.Gain_Gain_k * std::asin(rtb_Add3_j4);
   rtb_Compare_jy = (rtb_error_d == AutopilotLaws_P.CompareToConstant1_const);
   if (!AutopilotLaws_DWork.wasActive_not_empty_p) {
     AutopilotLaws_DWork.wasActive_c = rtb_Compare_jy;
@@ -1422,201 +1424,203 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_nr;
   }
 
-  rtb_Add3_i = Phi2 / AutopilotLaws_DWork.DelayInput1_DSTATE;
-  if (rtb_Add3_i > 1.0) {
-    rtb_Add3_i = 1.0;
-  } else if (rtb_Add3_i < -1.0) {
-    rtb_Add3_i = -1.0;
+  rtb_Add3_j4 = Phi2 / AutopilotLaws_DWork.DelayInput1_DSTATE;
+  if (rtb_Add3_j4 > 1.0) {
+    rtb_Add3_j4 = 1.0;
+  } else if (rtb_Add3_j4 < -1.0) {
+    rtb_Add3_j4 = -1.0;
   }
 
-  L = AutopilotLaws_P.Gain_Gain_es * std::asin(rtb_Add3_i);
+  Phi2 = AutopilotLaws_P.Gain_Gain_es * std::asin(rtb_Add3_j4);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain * AutopilotLaws_U.in.data.H_dot_ft_min;
-  rtb_Add3_i = AutopilotLaws_P.kntoms_Gain_m * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_j) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_j;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_i) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_i;
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_m * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_j) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_j;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_i) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_i;
   }
 
-  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Add3_i) *
+  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Add3_j4) *
     AutopilotLaws_P.Gain_Gain_e3;
-  Phi2 = AutopilotLaws_P.Gain1_Gain_c * rtb_GainTheta1;
+  rtb_lo_b = AutopilotLaws_P.Gain1_Gain_c * rtb_GainTheta1;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain * (AutopilotLaws_P.GStoGS_CAS_Gain * (AutopilotLaws_P.ktstomps_Gain *
-    AutopilotLaws_U.in.data.V_gnd_kn)), AutopilotLaws_P.WashoutFilter_C1_e, AutopilotLaws_U.in.time.dt, &rtb_Y_pt,
+    AutopilotLaws_U.in.data.V_gnd_kn)), AutopilotLaws_P.WashoutFilter_C1_e, AutopilotLaws_U.in.time.dt, &rtb_Y_d,
     &AutopilotLaws_DWork.sf_WashoutFilter);
-  rtb_Add3_i = AutopilotLaws_P.kntoms_Gain_b * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_ei) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_ei;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_dz) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_dz;
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_b * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_ei) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_ei;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_dz) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_dz;
   }
 
-  AutopilotLaws_LeadLagFilter(rtb_Y_pt - AutopilotLaws_P.g_Gain * (AutopilotLaws_P.Gain1_Gain_lp *
+  AutopilotLaws_LeadLagFilter(rtb_Y_d - AutopilotLaws_P.g_Gain * (AutopilotLaws_P.Gain1_Gain_lp *
     (AutopilotLaws_P.Gain_Gain_am * ((AutopilotLaws_P.Gain1_Gain_go * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_lx *
     (AutopilotLaws_P.Gain_Gain_c1 * std::atan(AutopilotLaws_P.fpmtoms_Gain_g * AutopilotLaws_U.in.data.H_dot_ft_min /
-    rtb_Add3_i))) * (AutopilotLaws_P.Constant_Value_dy - std::cos(Phi2)) + std::sin(Phi2) * std::sin
+    rtb_Add3_j4))) * (AutopilotLaws_P.Constant_Value_dy - std::cos(rtb_lo_b)) + std::sin(rtb_lo_b) * std::sin
     (AutopilotLaws_P.Gain1_Gain_pf * AutopilotLaws_U.in.data.Psi_magnetic_track_deg - AutopilotLaws_P.Gain1_Gain_e *
      AutopilotLaws_U.in.data.Psi_magnetic_deg)))), AutopilotLaws_P.HighPassFilter_C1, AutopilotLaws_P.HighPassFilter_C2,
-    AutopilotLaws_P.HighPassFilter_C3, AutopilotLaws_P.HighPassFilter_C4, AutopilotLaws_U.in.time.dt, &rtb_Y_j,
+    AutopilotLaws_P.HighPassFilter_C3, AutopilotLaws_P.HighPassFilter_C4, AutopilotLaws_U.in.time.dt, &rtb_Y_n0,
     &AutopilotLaws_DWork.sf_LeadLagFilter);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_b * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1, AutopilotLaws_P.LowPassFilter_C2, AutopilotLaws_P.LowPassFilter_C3,
-    AutopilotLaws_P.LowPassFilter_C4, AutopilotLaws_U.in.time.dt, &rtb_Y_pt, &AutopilotLaws_DWork.sf_LeadLagFilter_o);
-  Phi2 = (rtb_Y_j + rtb_Y_pt) * AutopilotLaws_P.ug_Gain;
-  rtb_Divide = AutopilotLaws_P.Gain1_Gain_bf * AutopilotLaws_DWork.DelayInput1_DSTATE;
-  R = Phi2 + rtb_Divide;
-  b_L = AutopilotLaws_P.Constant3_Value_nq - AutopilotLaws_P.Constant4_Value;
-  rtb_Y_g = (AutopilotLaws_P.Gain1_Gain_ik * Phi2 + rtb_Divide) * AutopilotLaws_P.Gain_Gain_aj;
-  if (b_L > AutopilotLaws_P.Switch_Threshold_l) {
-    Phi2 = AutopilotLaws_P.Constant1_Value_g;
+    AutopilotLaws_P.LowPassFilter_C4, AutopilotLaws_U.in.time.dt, &rtb_Y_d, &AutopilotLaws_DWork.sf_LeadLagFilter_o);
+  rtb_lo_b = (rtb_Y_n0 + rtb_Y_d) * AutopilotLaws_P.ug_Gain;
+  rtb_Sum_kq = AutopilotLaws_P.Gain1_Gain_bf * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  L = rtb_lo_b + rtb_Sum_kq;
+  R = AutopilotLaws_P.Constant3_Value_nq - AutopilotLaws_P.Constant4_Value;
+  b_L = (AutopilotLaws_P.Gain1_Gain_ik * rtb_lo_b + rtb_Sum_kq) * AutopilotLaws_P.Gain_Gain_aj;
+  if (R > AutopilotLaws_P.Switch_Threshold_l) {
+    rtb_lo_b = AutopilotLaws_P.Constant1_Value_g;
   } else {
-    Phi2 = AutopilotLaws_P.Gain5_Gain * rtb_Y_g;
+    rtb_lo_b = AutopilotLaws_P.Gain5_Gain * b_L;
   }
 
-  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &rtb_Y_pt);
-  rtb_lo_k = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_pt) * AutopilotLaws_P.Gain1_Gain_oz;
-  if (rtb_lo_k <= Phi2) {
-    if (b_L > AutopilotLaws_P.Switch1_Threshold) {
-      Phi2 = AutopilotLaws_P.Constant_Value_g;
+  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &rtb_Y_d);
+  rtb_Gain1_na = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_d) * AutopilotLaws_P.Gain1_Gain_oz;
+  if (rtb_Gain1_na <= rtb_lo_b) {
+    if (R > AutopilotLaws_P.Switch1_Threshold) {
+      rtb_lo_b = AutopilotLaws_P.Constant_Value_g;
     } else {
-      Phi2 = AutopilotLaws_P.Gain6_Gain * rtb_Y_g;
+      rtb_lo_b = AutopilotLaws_P.Gain6_Gain * b_L;
     }
 
-    if (rtb_lo_k >= Phi2) {
-      Phi2 = rtb_lo_k;
+    if (rtb_Gain1_na >= rtb_lo_b) {
+      rtb_lo_b = rtb_Gain1_na;
     }
   }
 
-  rtb_Y_g = (AutopilotLaws_P.Gain_Gain_b0 * R - AutopilotLaws_DWork.DelayInput1_DSTATE) + Phi2;
+  b_L = (AutopilotLaws_P.Gain_Gain_b0 * L - AutopilotLaws_DWork.DelayInput1_DSTATE) + rtb_lo_b;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain_a * AutopilotLaws_U.in.data.H_dot_ft_min;
-  rtb_Add3_i = AutopilotLaws_P.kntoms_Gain_p * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_h) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_h;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_e) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_e;
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_p * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_h) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_h;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_e) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_e;
   }
 
-  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Add3_i) *
+  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Add3_j4) *
     AutopilotLaws_P.Gain_Gain_d4;
-  Phi2 = AutopilotLaws_P.Gain1_Gain_j0 * rtb_GainTheta1;
+  rtb_lo_b = AutopilotLaws_P.Gain1_Gain_j0 * rtb_GainTheta1;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_h * (AutopilotLaws_P.GStoGS_CAS_Gain_m *
     (AutopilotLaws_P.ktstomps_Gain_g * AutopilotLaws_U.in.data.V_gnd_kn)), AutopilotLaws_P.WashoutFilter_C1_e4,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_pt, &AutopilotLaws_DWork.sf_WashoutFilter_d);
-  rtb_Add3_i = AutopilotLaws_P.kntoms_Gain_l * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_i) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_i;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_h) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_h;
+    AutopilotLaws_U.in.time.dt, &rtb_Y_d, &AutopilotLaws_DWork.sf_WashoutFilter_d);
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_l * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_i) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_i;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_h) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_h;
   }
 
-  AutopilotLaws_LeadLagFilter(rtb_Y_pt - AutopilotLaws_P.g_Gain_h * (AutopilotLaws_P.Gain1_Gain_dv *
+  AutopilotLaws_LeadLagFilter(rtb_Y_d - AutopilotLaws_P.g_Gain_h * (AutopilotLaws_P.Gain1_Gain_dv *
     (AutopilotLaws_P.Gain_Gain_id * ((AutopilotLaws_P.Gain1_Gain_kd * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_o4 *
     (AutopilotLaws_P.Gain_Gain_bs * std::atan(AutopilotLaws_P.fpmtoms_Gain_c * AutopilotLaws_U.in.data.H_dot_ft_min /
-    rtb_Add3_i))) * (AutopilotLaws_P.Constant_Value_c - std::cos(Phi2)) + std::sin(Phi2) * std::sin
+    rtb_Add3_j4))) * (AutopilotLaws_P.Constant_Value_c - std::cos(rtb_lo_b)) + std::sin(rtb_lo_b) * std::sin
     (AutopilotLaws_P.Gain1_Gain_bk * AutopilotLaws_U.in.data.Psi_magnetic_track_deg - AutopilotLaws_P.Gain1_Gain_lxx *
      AutopilotLaws_U.in.data.Psi_magnetic_deg)))), AutopilotLaws_P.HighPassFilter_C1_e,
     AutopilotLaws_P.HighPassFilter_C2_c, AutopilotLaws_P.HighPassFilter_C3_f, AutopilotLaws_P.HighPassFilter_C4_c,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_j, &AutopilotLaws_DWork.sf_LeadLagFilter_h);
+    AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_LeadLagFilter_h);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_i * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_n, AutopilotLaws_P.LowPassFilter_C2_a, AutopilotLaws_P.LowPassFilter_C3_o,
-    AutopilotLaws_P.LowPassFilter_C4_o, AutopilotLaws_U.in.time.dt, &rtb_Y_pt, &AutopilotLaws_DWork.sf_LeadLagFilter_m);
-  Phi2 = (rtb_Y_j + rtb_Y_pt) * AutopilotLaws_P.ug_Gain_a;
-  rtb_Divide = AutopilotLaws_P.Gain1_Gain_hm * AutopilotLaws_DWork.DelayInput1_DSTATE;
-  R = Phi2 + rtb_Divide;
-  b_L = AutopilotLaws_P.Constant1_Value_b4 - AutopilotLaws_P.Constant2_Value_c;
-  rtb_lo_k = (AutopilotLaws_P.Gain1_Gain_mz * Phi2 + rtb_Divide) * AutopilotLaws_P.Gain_Gain_ie;
-  if (b_L > AutopilotLaws_P.Switch_Threshold_b) {
-    Phi2 = AutopilotLaws_P.Constant1_Value_a;
+    AutopilotLaws_P.LowPassFilter_C4_o, AutopilotLaws_U.in.time.dt, &rtb_Y_d, &AutopilotLaws_DWork.sf_LeadLagFilter_m);
+  rtb_lo_b = (rtb_Y_n0 + rtb_Y_d) * AutopilotLaws_P.ug_Gain_a;
+  rtb_Sum_kq = AutopilotLaws_P.Gain1_Gain_hm * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  L = rtb_lo_b + rtb_Sum_kq;
+  R = AutopilotLaws_P.Constant1_Value_b4 - AutopilotLaws_P.Constant2_Value_c;
+  rtb_Gain1_na = (AutopilotLaws_P.Gain1_Gain_mz * rtb_lo_b + rtb_Sum_kq) * AutopilotLaws_P.Gain_Gain_ie;
+  if (R > AutopilotLaws_P.Switch_Threshold_b) {
+    rtb_lo_b = AutopilotLaws_P.Constant1_Value_a;
   } else {
-    Phi2 = AutopilotLaws_P.Gain5_Gain_l * rtb_lo_k;
+    rtb_lo_b = AutopilotLaws_P.Gain5_Gain_l * rtb_Gain1_na;
   }
 
-  rtb_Gain_nrh = AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.data.VMAX_kn;
-  rtb_lo_b = rtb_Gain_nrh * AutopilotLaws_P.Gain1_Gain_f1;
-  if (rtb_lo_b <= Phi2) {
-    if (b_L > AutopilotLaws_P.Switch1_Threshold_f) {
-      Phi2 = AutopilotLaws_P.Constant_Value_p;
+  rtb_Y_d = AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.data.VMAX_kn;
+  rtb_lo_k = rtb_Y_d * AutopilotLaws_P.Gain1_Gain_f1;
+  if (rtb_lo_k <= rtb_lo_b) {
+    if (R > AutopilotLaws_P.Switch1_Threshold_f) {
+      rtb_lo_b = AutopilotLaws_P.Constant_Value_p;
     } else {
-      Phi2 = AutopilotLaws_P.Gain6_Gain_j * rtb_lo_k;
+      rtb_lo_b = AutopilotLaws_P.Gain6_Gain_j * rtb_Gain1_na;
     }
 
-    if (rtb_lo_b >= Phi2) {
-      Phi2 = rtb_lo_b;
+    if (rtb_lo_k >= rtb_lo_b) {
+      rtb_lo_b = rtb_lo_k;
     }
   }
 
-  Phi2 += AutopilotLaws_P.Gain_Gain_kj * R - AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_SpeedProtectionSignalSelection(&AutopilotLaws_Y.out, L, AutopilotLaws_P.VS_Gain * L, rtb_Y_g,
-    AutopilotLaws_P.Gain_Gain_m0 * rtb_Y_g, Phi2, AutopilotLaws_P.Gain_Gain_lr * Phi2, AutopilotLaws_P.Constant_Value_ig,
-    &b_L, &R);
+  rtb_lo_b += AutopilotLaws_P.Gain_Gain_kj * L - AutopilotLaws_DWork.DelayInput1_DSTATE;
+  AutopilotLaws_SpeedProtectionSignalSelection(&AutopilotLaws_Y.out, Phi2, AutopilotLaws_P.VS_Gain * Phi2, b_L,
+    AutopilotLaws_P.Gain_Gain_m0 * b_L, rtb_lo_b, AutopilotLaws_P.Gain_Gain_lr * rtb_lo_b,
+    AutopilotLaws_P.Constant_Value_ig, &R, &L);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain_p * AutopilotLaws_U.in.data.H_dot_ft_min;
-  rtb_Add3_i = AutopilotLaws_P.kntoms_Gain_f * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_eik) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_eik;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_a) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_a;
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_f * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_eik) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_eik;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_a) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_a;
   }
 
-  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Add3_i) *
+  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Add3_j4) *
     AutopilotLaws_P.Gain_Gain_e33;
-  Phi2 = AutopilotLaws_P.Gain1_Gain_ok * AutopilotLaws_DWork.DelayInput1_DSTATE;
-  L = AutopilotLaws_P.Gain1_Gain_jd * rtb_GainTheta1;
-  rtb_Add3_i = AutopilotLaws_P.kntoms_Gain_a * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_f) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_f;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_c) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_c;
+  rtb_lo_b = AutopilotLaws_P.Gain1_Gain_ok * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  Phi2 = AutopilotLaws_P.Gain1_Gain_jd * rtb_GainTheta1;
+  b_L = std::cos(Phi2);
+  rtb_lo_k = std::sin(Phi2);
+  Phi2 = AutopilotLaws_P.ktstomps_Gain_f * AutopilotLaws_U.in.data.V_gnd_kn;
+  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_m * (AutopilotLaws_P.GStoGS_CAS_Gain_l * Phi2),
+    AutopilotLaws_P.WashoutFilter_C1_k, AutopilotLaws_U.in.time.dt, &rtb_Gain1_na,
+    &AutopilotLaws_DWork.sf_WashoutFilter_nq);
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_a * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_f) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_f;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_c) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_c;
   }
 
-  rtb_Y_g = (AutopilotLaws_P.Gain1_Gain_dh * rtb_GainTheta - std::atan(AutopilotLaws_P.fpmtoms_Gain_h *
-              AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Add3_i) * AutopilotLaws_P.Gain_Gain_nq *
-             AutopilotLaws_P.Gain1_Gain_cv) * (AutopilotLaws_P.Constant_Value_l - std::cos(L));
-  rtb_lo_k = std::sin(L);
-  rtb_Divide = AutopilotLaws_P.Gain1_Gain_id * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
-  rtb_lo_b = rtb_Divide - AutopilotLaws_P.Gain1_Gain_ct * AutopilotLaws_U.in.data.Psi_magnetic_deg;
-  L = AutopilotLaws_P.ktstomps_Gain_f * AutopilotLaws_U.in.data.V_gnd_kn;
-  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_m * (AutopilotLaws_P.GStoGS_CAS_Gain_l * L),
-    AutopilotLaws_P.WashoutFilter_C1_k, AutopilotLaws_U.in.time.dt, &L, &AutopilotLaws_DWork.sf_WashoutFilter_nq);
-  AutopilotLaws_LeadLagFilter(L - AutopilotLaws_P.g_Gain_j * (AutopilotLaws_P.Gain1_Gain_ca *
-    (AutopilotLaws_P.Gain_Gain_ms * (rtb_Y_g + rtb_lo_k * std::sin(rtb_lo_b)))), AutopilotLaws_P.HighPassFilter_C1_b,
+  AutopilotLaws_LeadLagFilter(rtb_Gain1_na - AutopilotLaws_P.g_Gain_j * (AutopilotLaws_P.Gain1_Gain_ca *
+    (AutopilotLaws_P.Gain_Gain_ms * ((AutopilotLaws_P.Gain1_Gain_dh * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_cv *
+    (AutopilotLaws_P.Gain_Gain_nq * std::atan(AutopilotLaws_P.fpmtoms_Gain_h * AutopilotLaws_U.in.data.H_dot_ft_min /
+    rtb_Add3_j4))) * (AutopilotLaws_P.Constant_Value_l - b_L) + rtb_lo_k * std::sin(AutopilotLaws_P.Gain1_Gain_id *
+    AutopilotLaws_U.in.data.Psi_magnetic_track_deg - AutopilotLaws_P.Gain1_Gain_ct *
+    AutopilotLaws_U.in.data.Psi_magnetic_deg)))), AutopilotLaws_P.HighPassFilter_C1_b,
     AutopilotLaws_P.HighPassFilter_C2_g, AutopilotLaws_P.HighPassFilter_C3_n, AutopilotLaws_P.HighPassFilter_C4_b,
-    AutopilotLaws_U.in.time.dt, &rtb_Divide, &AutopilotLaws_DWork.sf_LeadLagFilter_es);
+    AutopilotLaws_U.in.time.dt, &Phi2, &AutopilotLaws_DWork.sf_LeadLagFilter_es);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_j * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_d, AutopilotLaws_P.LowPassFilter_C2_p, AutopilotLaws_P.LowPassFilter_C3_a,
-    AutopilotLaws_P.LowPassFilter_C4_b, AutopilotLaws_U.in.time.dt, &L, &AutopilotLaws_DWork.sf_LeadLagFilter_ja);
-  L = (rtb_Divide + L) * AutopilotLaws_P.ug_Gain_o;
-  rtb_Y_g = (AutopilotLaws_P.Gain1_Gain_hu * L + Phi2) * AutopilotLaws_P.Gain_Gain_bn;
+    AutopilotLaws_P.LowPassFilter_C4_b, AutopilotLaws_U.in.time.dt, &rtb_Gain1_na,
+    &AutopilotLaws_DWork.sf_LeadLagFilter_ja);
+  Phi2 = (Phi2 + rtb_Gain1_na) * AutopilotLaws_P.ug_Gain_o;
+  b_L = (AutopilotLaws_P.Gain1_Gain_hu * Phi2 + rtb_lo_b) * AutopilotLaws_P.Gain_Gain_bn;
   AutopilotLaws_Voter1(AutopilotLaws_U.in.data.VLS_kn, AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VMAX_kn,
-                       &rtb_lo_k);
-  rtb_lo_k = (AutopilotLaws_U.in.data.V_ias_kn - rtb_lo_k) * AutopilotLaws_P.Gain1_Gain_hz;
-  rtb_Compare_jy = ((distance_m > AutopilotLaws_P.CompareToConstant6_const) && (rtb_Y_g <
-    AutopilotLaws_P.CompareToConstant5_const_a) && (rtb_lo_k < AutopilotLaws_P.CompareToConstant2_const_d) &&
+                       &rtb_Gain1_na);
+  rtb_Gain1_na = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Gain1_na) * AutopilotLaws_P.Gain1_Gain_hz;
+  rtb_Compare_jy = ((distance_m > AutopilotLaws_P.CompareToConstant6_const) && (b_L <
+    AutopilotLaws_P.CompareToConstant5_const_a) && (rtb_Gain1_na < AutopilotLaws_P.CompareToConstant2_const_d) &&
                     (rtb_error_d == AutopilotLaws_P.CompareToConstant2_const_e));
-  Phi2 += L;
+  rtb_lo_b += Phi2;
   if (rtb_Compare_jy) {
-    L = AutopilotLaws_P.Constant_Value_f;
+    Phi2 = AutopilotLaws_P.Constant_Value_f;
   } else {
     if (distance_m > AutopilotLaws_P.CompareToConstant_const_l) {
-      L = AutopilotLaws_P.Constant1_Value_c;
+      Phi2 = AutopilotLaws_P.Constant1_Value_c;
     } else {
-      L = AutopilotLaws_P.Gain5_Gain_k * rtb_Y_g;
+      Phi2 = AutopilotLaws_P.Gain5_Gain_k * b_L;
     }
 
-    if (rtb_lo_k <= L) {
+    if (rtb_Gain1_na <= Phi2) {
       if (distance_m > AutopilotLaws_P.CompareToConstant4_const_o) {
-        L = std::fmax(AutopilotLaws_P.Constant2_Value, AutopilotLaws_P.Gain1_Gain_kg * rtb_Y_g);
+        Phi2 = std::fmax(AutopilotLaws_P.Constant2_Value, AutopilotLaws_P.Gain1_Gain_kg * b_L);
       } else {
-        L = AutopilotLaws_P.Gain6_Gain_a * rtb_Y_g;
+        Phi2 = AutopilotLaws_P.Gain6_Gain_a * b_L;
       }
 
-      if (rtb_lo_k >= L) {
-        L = rtb_lo_k;
+      if (rtb_Gain1_na >= Phi2) {
+        Phi2 = rtb_Gain1_na;
       }
     }
   }
 
-  rtb_lo_k = (AutopilotLaws_P.Gain_Gain_d4y * Phi2 - AutopilotLaws_DWork.DelayInput1_DSTATE) + L;
-  rtb_Add3_i = AutopilotLaws_P.kntoms_Gain_n * AutopilotLaws_U.in.data.V_tas_kn;
+  rtb_lo_k = (AutopilotLaws_P.Gain_Gain_d4y * rtb_lo_b - AutopilotLaws_DWork.DelayInput1_DSTATE) + Phi2;
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_n * AutopilotLaws_U.in.data.V_tas_kn;
   if (distance_m < 0.0) {
     Phi2 = -1.0;
   } else if (distance_m > 0.0) {
@@ -1625,37 +1629,37 @@ void AutopilotLawsModelClass::step()
     Phi2 = distance_m;
   }
 
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_ju) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_ju;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_gw) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_gw;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_ju) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_ju;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_gw) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_gw;
   }
 
-  rtb_Add3_i = (Phi2 * AutopilotLaws_P.Constant3_Value_ix - AutopilotLaws_U.in.data.H_dot_ft_min) *
-    AutopilotLaws_P.ftmintoms_Gain_d / rtb_Add3_i;
-  if (rtb_Add3_i > 1.0) {
-    rtb_Add3_i = 1.0;
-  } else if (rtb_Add3_i < -1.0) {
-    rtb_Add3_i = -1.0;
+  rtb_Add3_j4 = (Phi2 * AutopilotLaws_P.Constant3_Value_ix - AutopilotLaws_U.in.data.H_dot_ft_min) *
+    AutopilotLaws_P.ftmintoms_Gain_d / rtb_Add3_j4;
+  if (rtb_Add3_j4 > 1.0) {
+    rtb_Add3_j4 = 1.0;
+  } else if (rtb_Add3_j4 < -1.0) {
+    rtb_Add3_j4 = -1.0;
   }
 
-  rtb_lo_b = AutopilotLaws_P.Gain_Gain_nz * std::asin(rtb_Add3_i);
-  rtb_Add3_i = AutopilotLaws_P.kntoms_Gain_au * AutopilotLaws_U.in.data.V_tas_kn;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_l) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_l;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_hm) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_hm;
+  rtb_Sum_i = AutopilotLaws_P.Gain_Gain_nz * std::asin(rtb_Add3_j4);
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_au * AutopilotLaws_U.in.data.V_tas_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_l) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_l;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_hm) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_hm;
   }
 
-  rtb_Sum_if = AutopilotLaws_U.in.input.H_dot_c_fpm - AutopilotLaws_U.in.data.H_dot_ft_min;
-  rtb_Add3_i = rtb_Sum_if * AutopilotLaws_P.ftmintoms_Gain_l / rtb_Add3_i;
-  if (rtb_Add3_i > 1.0) {
-    rtb_Add3_i = 1.0;
-  } else if (rtb_Add3_i < -1.0) {
-    rtb_Add3_i = -1.0;
+  rtb_Gain_ej3 = AutopilotLaws_U.in.input.H_dot_c_fpm - AutopilotLaws_U.in.data.H_dot_ft_min;
+  rtb_Add3_j4 = rtb_Gain_ej3 * AutopilotLaws_P.ftmintoms_Gain_l / rtb_Add3_j4;
+  if (rtb_Add3_j4 > 1.0) {
+    rtb_Add3_j4 = 1.0;
+  } else if (rtb_Add3_j4 < -1.0) {
+    rtb_Add3_j4 = -1.0;
   }
 
-  rtb_Divide = AutopilotLaws_P.Gain_Gain_ey * std::asin(rtb_Add3_i);
+  rtb_Gain_dn = AutopilotLaws_P.Gain_Gain_ey * std::asin(rtb_Add3_j4);
   if (!AutopilotLaws_DWork.prevVerticalLaw_not_empty) {
     AutopilotLaws_DWork.prevVerticalLaw = AutopilotLaws_U.in.input.vertical_law;
     AutopilotLaws_DWork.prevVerticalLaw_not_empty = true;
@@ -1672,15 +1676,15 @@ void AutopilotLawsModelClass::step()
     ((AutopilotLaws_U.in.input.H_dot_c_fpm == 0.0) && (AutopilotLaws_U.in.input.vertical_law == 4.0) &&
      AutopilotLaws_DWork.islevelOffActive));
   if (AutopilotLaws_U.in.input.vertical_mode == 50.0) {
-    rtb_Y_pt = 0.3;
+    rtb_Add3_j4 = 0.3;
   } else if (AutopilotLaws_DWork.islevelOffActive) {
-    rtb_Y_pt = 0.1;
+    rtb_Add3_j4 = 0.1;
   } else {
-    rtb_Y_pt = 0.05;
+    rtb_Add3_j4 = 0.05;
   }
 
-  rtb_Y_g = 9.81 / (AutopilotLaws_U.in.data.V_tas_kn * 0.51444444444444448);
-  rtb_Y_pt = rtb_Y_g * rtb_Y_pt * 57.295779513082323;
+  b_L = 9.81 / (AutopilotLaws_U.in.data.V_tas_kn * 0.51444444444444448);
+  rtb_Y_n0 = b_L * rtb_Add3_j4 * 57.295779513082323;
   AutopilotLaws_DWork.prevVerticalLaw = AutopilotLaws_U.in.input.vertical_law;
   AutopilotLaws_DWork.prevTarget = AutopilotLaws_U.in.input.H_dot_c_fpm;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_o * AutopilotLaws_U.in.data.V_gnd_kn;
@@ -1690,64 +1694,65 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_cd;
   }
 
-  L = std::atan(AutopilotLaws_P.fpmtoms_Gain_o * AutopilotLaws_U.in.data.H_dot_ft_min /
-                AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_lx;
+  Phi2 = std::atan(AutopilotLaws_P.fpmtoms_Gain_o * AutopilotLaws_U.in.data.H_dot_ft_min /
+                   AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_lx;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_jn * rtb_GainTheta;
-  rtb_Add3_i = AutopilotLaws_P.kntoms_Gain_d * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_hb) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_hb;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_k) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_k;
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_d * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_hb) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_hb;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_k) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_k;
   }
 
-  rtb_Add5_l = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_e *
-    AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Add3_i) * AutopilotLaws_P.Gain_Gain_in * AutopilotLaws_P.Gain1_Gain_ps;
+  rtb_lo_b = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_e *
+    AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Add3_j4) * AutopilotLaws_P.Gain_Gain_in * AutopilotLaws_P.Gain1_Gain_ps;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_hi * rtb_GainTheta1;
   rtb_Cos_i = std::cos(AutopilotLaws_DWork.DelayInput1_DSTATE);
   rtb_Cos1_pk = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_da * AutopilotLaws_U.in.data.Psi_magnetic_deg;
-  Phi2 = AutopilotLaws_P.Gain1_Gain_hg * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
-  rtb_Add3_g = Phi2 - AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Add3_g = AutopilotLaws_P.Gain1_Gain_hg * AutopilotLaws_U.in.data.Psi_magnetic_track_deg -
+    AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.ktstomps_Gain_m * AutopilotLaws_U.in.data.V_gnd_kn;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_k * (AutopilotLaws_P.GStoGS_CAS_Gain_k *
     AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.WashoutFilter_C1_o, AutopilotLaws_U.in.time.dt,
-    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_WashoutFilter_fs);
-  AutopilotLaws_LeadLagFilter(AutopilotLaws_DWork.DelayInput1_DSTATE - AutopilotLaws_P.g_Gain_m *
-    (AutopilotLaws_P.Gain1_Gain_kdq * (AutopilotLaws_P.Gain_Gain_b5 * (rtb_Add5_l * (AutopilotLaws_P.Constant_Value_od -
-    rtb_Cos_i) + rtb_Cos1_pk * std::sin(rtb_Add3_g)))), AutopilotLaws_P.HighPassFilter_C1_g,
-    AutopilotLaws_P.HighPassFilter_C2_l, AutopilotLaws_P.HighPassFilter_C3_j, AutopilotLaws_P.HighPassFilter_C4_i,
-    AutopilotLaws_U.in.time.dt, &Phi2, &AutopilotLaws_DWork.sf_LeadLagFilter_b);
+    &rtb_Gain1_na, &AutopilotLaws_DWork.sf_WashoutFilter_fs);
+  AutopilotLaws_LeadLagFilter(rtb_Gain1_na - AutopilotLaws_P.g_Gain_m * (AutopilotLaws_P.Gain1_Gain_kdq *
+    (AutopilotLaws_P.Gain_Gain_b5 * (rtb_lo_b * (AutopilotLaws_P.Constant_Value_od - rtb_Cos_i) + rtb_Cos1_pk * std::sin
+    (rtb_Add3_g)))), AutopilotLaws_P.HighPassFilter_C1_g, AutopilotLaws_P.HighPassFilter_C2_l,
+    AutopilotLaws_P.HighPassFilter_C3_j, AutopilotLaws_P.HighPassFilter_C4_i, AutopilotLaws_U.in.time.dt,
+    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_LeadLagFilter_b);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_c * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_m, AutopilotLaws_P.LowPassFilter_C2_l, AutopilotLaws_P.LowPassFilter_C3_i,
-    AutopilotLaws_P.LowPassFilter_C4_k, AutopilotLaws_U.in.time.dt, &AutopilotLaws_DWork.DelayInput1_DSTATE,
+    AutopilotLaws_P.LowPassFilter_C4_k, AutopilotLaws_U.in.time.dt, &rtb_Gain1_na,
     &AutopilotLaws_DWork.sf_LeadLagFilter_kq);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (Phi2 + AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.ug_Gain_aa;
-  Phi2 = AutopilotLaws_P.Gain1_Gain_gf * L;
-  rtb_Add5_l = AutopilotLaws_DWork.DelayInput1_DSTATE + Phi2;
-  rtb_Cos_i = AutopilotLaws_P.Constant3_Value_h1 - AutopilotLaws_P.Constant4_Value_f;
-  rtb_Cos1_pk = (AutopilotLaws_P.Gain1_Gain_ov * AutopilotLaws_DWork.DelayInput1_DSTATE + Phi2) *
+  AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_Gain1_na) *
+    AutopilotLaws_P.ug_Gain_aa;
+  rtb_lo_b = AutopilotLaws_P.Gain1_Gain_gf * Phi2;
+  rtb_Cos_i = AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_lo_b;
+  rtb_Cos1_pk = AutopilotLaws_P.Constant3_Value_h1 - AutopilotLaws_P.Constant4_Value_f;
+  rtb_lo_b = (AutopilotLaws_P.Gain1_Gain_ov * AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_lo_b) *
     AutopilotLaws_P.Gain_Gain_jy;
-  if (rtb_Cos_i > AutopilotLaws_P.Switch_Threshold_o) {
+  if (rtb_Cos1_pk > AutopilotLaws_P.Switch_Threshold_o) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant1_Value_m5;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain_h * rtb_Cos1_pk;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain_h * rtb_lo_b;
   }
 
-  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &Phi2);
-  Phi2 = (AutopilotLaws_U.in.data.V_ias_kn - Phi2) * AutopilotLaws_P.Gain1_Gain_dvi;
-  if (Phi2 <= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-    if (rtb_Cos_i > AutopilotLaws_P.Switch1_Threshold_c) {
+  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &rtb_Gain1_na);
+  rtb_Gain1_na = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Gain1_na) * AutopilotLaws_P.Gain1_Gain_dvi;
+  if (rtb_Gain1_na <= AutopilotLaws_DWork.DelayInput1_DSTATE) {
+    if (rtb_Cos1_pk > AutopilotLaws_P.Switch1_Threshold_c) {
       AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_b;
     } else {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain_ai * rtb_Cos1_pk;
+      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain_ai * rtb_lo_b;
     }
 
-    if (Phi2 >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = Phi2;
+    if (rtb_Gain1_na >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
+      AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Gain1_na;
     }
   }
 
-  rtb_Cos1_pk = (AutopilotLaws_P.Gain_Gain_j * rtb_Add5_l - L) + AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Add3_g = (AutopilotLaws_P.Gain_Gain_j * rtb_Cos_i - Phi2) + AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_bq * AutopilotLaws_U.in.data.V_gnd_kn;
   if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_ba) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_ba;
@@ -1755,65 +1760,67 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_p;
   }
 
-  L = std::atan(AutopilotLaws_P.fpmtoms_Gain_p3 * AutopilotLaws_U.in.data.H_dot_ft_min /
-                AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_py;
+  Phi2 = std::atan(AutopilotLaws_P.fpmtoms_Gain_p3 * AutopilotLaws_U.in.data.H_dot_ft_min /
+                   AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_py;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_hk * rtb_GainTheta;
-  rtb_Add3_i = AutopilotLaws_P.kntoms_Gain_l5 * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_b3) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_b3;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_es) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_es;
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_l5 * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_b3) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_b3;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_es) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_es;
   }
 
-  rtb_Add5_l = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_j *
-    AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Add3_i) * AutopilotLaws_P.Gain_Gain_e5 * AutopilotLaws_P.Gain1_Gain_ja;
+  rtb_lo_b = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_j *
+    AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Add3_j4) * AutopilotLaws_P.Gain_Gain_e5 * AutopilotLaws_P.Gain1_Gain_ja;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_er * rtb_GainTheta1;
   rtb_Cos_i = std::cos(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  rtb_Add3_g = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
+  rtb_Cos1_pk = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_fl * AutopilotLaws_U.in.data.Psi_magnetic_deg;
-  Phi2 = AutopilotLaws_P.Gain1_Gain_ero * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
-  rtb_Add3_i = Phi2 - AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Add3_i = AutopilotLaws_P.Gain1_Gain_ero * AutopilotLaws_U.in.data.Psi_magnetic_track_deg -
+    AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.ktstomps_Gain_a * AutopilotLaws_U.in.data.V_gnd_kn;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_i * (AutopilotLaws_P.GStoGS_CAS_Gain_n *
     AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.WashoutFilter_C1_p, AutopilotLaws_U.in.time.dt,
-    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_WashoutFilter_j);
-  AutopilotLaws_LeadLagFilter(AutopilotLaws_DWork.DelayInput1_DSTATE - AutopilotLaws_P.g_Gain_g *
-    (AutopilotLaws_P.Gain1_Gain_hv * (AutopilotLaws_P.Gain_Gain_mx * (rtb_Add5_l * (AutopilotLaws_P.Constant_Value_ia -
-    rtb_Cos_i) + rtb_Add3_g * std::sin(rtb_Add3_i)))), AutopilotLaws_P.HighPassFilter_C1_n,
-    AutopilotLaws_P.HighPassFilter_C2_m, AutopilotLaws_P.HighPassFilter_C3_k, AutopilotLaws_P.HighPassFilter_C4_h,
-    AutopilotLaws_U.in.time.dt, &Phi2, &AutopilotLaws_DWork.sf_LeadLagFilter_c);
+    &rtb_Gain1_na, &AutopilotLaws_DWork.sf_WashoutFilter_j);
+  AutopilotLaws_LeadLagFilter(rtb_Gain1_na - AutopilotLaws_P.g_Gain_g * (AutopilotLaws_P.Gain1_Gain_hv *
+    (AutopilotLaws_P.Gain_Gain_mx * (rtb_lo_b * (AutopilotLaws_P.Constant_Value_ia - rtb_Cos_i) + rtb_Cos1_pk * std::sin
+    (rtb_Add3_i)))), AutopilotLaws_P.HighPassFilter_C1_n, AutopilotLaws_P.HighPassFilter_C2_m,
+    AutopilotLaws_P.HighPassFilter_C3_k, AutopilotLaws_P.HighPassFilter_C4_h, AutopilotLaws_U.in.time.dt,
+    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_LeadLagFilter_c);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_o * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_l, AutopilotLaws_P.LowPassFilter_C2_c, AutopilotLaws_P.LowPassFilter_C3_g,
-    AutopilotLaws_P.LowPassFilter_C4_d, AutopilotLaws_U.in.time.dt, &AutopilotLaws_DWork.DelayInput1_DSTATE,
+    AutopilotLaws_P.LowPassFilter_C4_d, AutopilotLaws_U.in.time.dt, &rtb_Gain1_na,
     &AutopilotLaws_DWork.sf_LeadLagFilter_p);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (Phi2 + AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.ug_Gain_f;
-  Phi2 = AutopilotLaws_P.Gain1_Gain_ot * L;
-  rtb_Add5_l = AutopilotLaws_DWork.DelayInput1_DSTATE + Phi2;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_Gain1_na) *
+    AutopilotLaws_P.ug_Gain_f;
+  rtb_lo_b = AutopilotLaws_P.Gain1_Gain_ot * Phi2;
+  rtb_Gain1_na = AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_lo_b;
   rtb_Cos_i = AutopilotLaws_P.Constant1_Value_d - AutopilotLaws_P.Constant2_Value_k;
-  Phi2 = (AutopilotLaws_P.Gain1_Gain_ou * AutopilotLaws_DWork.DelayInput1_DSTATE + Phi2) * AutopilotLaws_P.Gain_Gain_jg;
+  rtb_lo_b = (AutopilotLaws_P.Gain1_Gain_ou * AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_lo_b) *
+    AutopilotLaws_P.Gain_Gain_jg;
   if (rtb_Cos_i > AutopilotLaws_P.Switch_Threshold_a) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant1_Value_mi;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain_g * Phi2;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain_g * rtb_lo_b;
   }
 
-  rtb_Add3_g = rtb_Gain_nrh * AutopilotLaws_P.Gain1_Gain_gy;
-  if (rtb_Add3_g <= AutopilotLaws_DWork.DelayInput1_DSTATE) {
+  rtb_Cos1_pk = rtb_Y_d * AutopilotLaws_P.Gain1_Gain_gy;
+  if (rtb_Cos1_pk <= AutopilotLaws_DWork.DelayInput1_DSTATE) {
     if (rtb_Cos_i > AutopilotLaws_P.Switch1_Threshold_b) {
       AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_ow;
     } else {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain_c * Phi2;
+      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain_c * rtb_lo_b;
     }
 
-    if (rtb_Add3_g >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Add3_g;
+    if (rtb_Cos1_pk >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
+      AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Cos1_pk;
     }
   }
 
-  Phi2 = (AutopilotLaws_P.Gain_Gain_dm * rtb_Add5_l - L) + AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_SpeedProtectionSignalSelection(&AutopilotLaws_Y.out, rtb_Divide, std::fmax(-rtb_Y_pt, std::fmin(rtb_Y_pt,
-    AutopilotLaws_P.VS_Gain_h * rtb_Divide)), rtb_Cos1_pk, AutopilotLaws_P.Gain_Gain_h4 * rtb_Cos1_pk, Phi2,
-    AutopilotLaws_P.Gain_Gain_eq * Phi2, AutopilotLaws_P.Constant_Value_ga, &rtb_Cos_i, &rtb_Add5_l);
+  Phi2 = (AutopilotLaws_P.Gain_Gain_dm * rtb_Gain1_na - Phi2) + AutopilotLaws_DWork.DelayInput1_DSTATE;
+  AutopilotLaws_SpeedProtectionSignalSelection(&AutopilotLaws_Y.out, rtb_Gain_dn, std::fmax(-rtb_Y_n0, std::fmin
+    (rtb_Y_n0, AutopilotLaws_P.VS_Gain_h * rtb_Gain_dn)), rtb_Add3_g, AutopilotLaws_P.Gain_Gain_h4 * rtb_Add3_g, Phi2,
+    AutopilotLaws_P.Gain_Gain_eq * Phi2, AutopilotLaws_P.Constant_Value_ga, &rtb_Cos1_pk, &rtb_Cos_i);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_c * AutopilotLaws_U.in.data.V_gnd_kn;
   if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_oz) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_oz;
@@ -1821,7 +1828,7 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_ou;
   }
 
-  rtb_Cos1_pk = AutopilotLaws_U.in.input.FPA_c_deg - std::atan(AutopilotLaws_P.fpmtoms_Gain_ps *
+  rtb_Gain_dn = AutopilotLaws_U.in.input.FPA_c_deg - std::atan(AutopilotLaws_P.fpmtoms_Gain_ps *
     AutopilotLaws_U.in.data.H_dot_ft_min / AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_gt;
   if (!AutopilotLaws_DWork.prevVerticalLaw_not_empty_n) {
     AutopilotLaws_DWork.prevVerticalLaw_b = AutopilotLaws_U.in.input.vertical_law;
@@ -1839,12 +1846,12 @@ void AutopilotLawsModelClass::step()
     ((AutopilotLaws_U.in.input.FPA_c_deg == 0.0) && (AutopilotLaws_U.in.input.vertical_law == 5.0) &&
      AutopilotLaws_DWork.islevelOffActive_k));
   if (AutopilotLaws_DWork.islevelOffActive_k) {
-    rtb_Y_pt = 0.1;
+    rtb_Add3_j4 = 0.1;
   } else {
-    rtb_Y_pt = 0.05;
+    rtb_Add3_j4 = 0.05;
   }
 
-  rtb_Y_pt = rtb_Y_g * rtb_Y_pt * 57.295779513082323;
+  rtb_Y_n0 = b_L * rtb_Add3_j4 * 57.295779513082323;
   AutopilotLaws_DWork.prevVerticalLaw_b = AutopilotLaws_U.in.input.vertical_law;
   AutopilotLaws_DWork.prevTarget_k = AutopilotLaws_U.in.input.FPA_c_deg;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_cv * AutopilotLaws_U.in.data.V_gnd_kn;
@@ -1854,55 +1861,55 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_a4;
   }
 
-  L = std::atan(AutopilotLaws_P.fpmtoms_Gain_d * AutopilotLaws_U.in.data.H_dot_ft_min /
-                AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_hv;
+  Phi2 = std::atan(AutopilotLaws_P.fpmtoms_Gain_d * AutopilotLaws_U.in.data.H_dot_ft_min /
+                   AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_hv;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_ej * rtb_GainTheta;
-  rtb_Add3_i = AutopilotLaws_P.kntoms_Gain_k * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_pj) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_pj;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_py) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_py;
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_k * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_pj) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_pj;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_py) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_py;
   }
 
-  Phi2 = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_f *
-    AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Add3_i) * AutopilotLaws_P.Gain_Gain_bf * AutopilotLaws_P.Gain1_Gain_jv;
+  rtb_lo_b = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_f *
+    AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Add3_j4) * AutopilotLaws_P.Gain_Gain_bf * AutopilotLaws_P.Gain1_Gain_jv;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_gfa * rtb_GainTheta1;
-  rtb_Divide = std::cos(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  rtb_Add3_g = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
+  rtb_Add3_g = std::cos(AutopilotLaws_DWork.DelayInput1_DSTATE);
+  rtb_Add3_i = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_kw * AutopilotLaws_U.in.data.Psi_magnetic_deg;
-  rtb_Add3_i = AutopilotLaws_P.Gain1_Gain_j4 * AutopilotLaws_U.in.data.Psi_magnetic_track_deg -
+  rtb_Add3_j4 = AutopilotLaws_P.Gain1_Gain_j4 * AutopilotLaws_U.in.data.Psi_magnetic_track_deg -
     AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.ktstomps_Gain_j4 * AutopilotLaws_U.in.data.V_gnd_kn;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_kb * (AutopilotLaws_P.GStoGS_CAS_Gain_o *
-    AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.WashoutFilter_C1_j, AutopilotLaws_U.in.time.dt, &rtb_Y_j,
+    AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.WashoutFilter_C1_j, AutopilotLaws_U.in.time.dt, &rtb_Y_k,
     &AutopilotLaws_DWork.sf_WashoutFilter_h);
-  AutopilotLaws_LeadLagFilter(rtb_Y_j - AutopilotLaws_P.g_Gain_l * (AutopilotLaws_P.Gain1_Gain_n4 *
-    (AutopilotLaws_P.Gain_Gain_bc * (Phi2 * (AutopilotLaws_P.Constant_Value_lf - rtb_Divide) + rtb_Add3_g * std::sin
-    (rtb_Add3_i)))), AutopilotLaws_P.HighPassFilter_C1_i, AutopilotLaws_P.HighPassFilter_C2_h,
-    AutopilotLaws_P.HighPassFilter_C3_m, AutopilotLaws_P.HighPassFilter_C4_n, AutopilotLaws_U.in.time.dt,
-    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_LeadLagFilter_e);
+  AutopilotLaws_LeadLagFilter(rtb_Y_k - AutopilotLaws_P.g_Gain_l * (AutopilotLaws_P.Gain1_Gain_n4 *
+    (AutopilotLaws_P.Gain_Gain_bc * (rtb_lo_b * (AutopilotLaws_P.Constant_Value_lf - rtb_Add3_g) + rtb_Add3_i * std::sin
+    (rtb_Add3_j4)))), AutopilotLaws_P.HighPassFilter_C1_i, AutopilotLaws_P.HighPassFilter_C2_h,
+    AutopilotLaws_P.HighPassFilter_C3_m, AutopilotLaws_P.HighPassFilter_C4_n, AutopilotLaws_U.in.time.dt, &rtb_Gain1_na,
+    &AutopilotLaws_DWork.sf_LeadLagFilter_e);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_k * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_l4, AutopilotLaws_P.LowPassFilter_C2_po, AutopilotLaws_P.LowPassFilter_C3_f,
-    AutopilotLaws_P.LowPassFilter_C4_dt, AutopilotLaws_U.in.time.dt, &rtb_Y_j, &AutopilotLaws_DWork.sf_LeadLagFilter_kp);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_Y_j) *
-    AutopilotLaws_P.ug_Gain_n;
-  Phi2 = AutopilotLaws_P.Gain1_Gain_b1 * L;
-  rtb_Divide = AutopilotLaws_DWork.DelayInput1_DSTATE + Phi2;
+    AutopilotLaws_P.LowPassFilter_C4_dt, AutopilotLaws_U.in.time.dt, &rtb_Y_k, &AutopilotLaws_DWork.sf_LeadLagFilter_kp);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = (rtb_Gain1_na + rtb_Y_k) * AutopilotLaws_P.ug_Gain_n;
+  rtb_lo_b = AutopilotLaws_P.Gain1_Gain_b1 * Phi2;
+  rtb_Gain1_na = AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_lo_b;
   rtb_Add3_g = AutopilotLaws_P.Constant3_Value_nk - AutopilotLaws_P.Constant4_Value_o;
-  Phi2 = (AutopilotLaws_P.Gain1_Gain_on * AutopilotLaws_DWork.DelayInput1_DSTATE + Phi2) * AutopilotLaws_P.Gain_Gain_hy;
+  rtb_lo_b = (AutopilotLaws_P.Gain1_Gain_on * AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_lo_b) *
+    AutopilotLaws_P.Gain_Gain_hy;
   if (rtb_Add3_g > AutopilotLaws_P.Switch_Threshold_d) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant1_Value_m;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain_b * Phi2;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain_b * rtb_lo_b;
   }
 
-  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &rtb_Y_j);
-  rtb_Add3_i = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_j) * AutopilotLaws_P.Gain1_Gain_m1;
+  AutopilotLaws_V_LSSpeedSelection1(AutopilotLaws_U.in.input.V_c_kn, AutopilotLaws_U.in.data.VLS_kn, &rtb_Y_k);
+  rtb_Add3_i = (AutopilotLaws_U.in.data.V_ias_kn - rtb_Y_k) * AutopilotLaws_P.Gain1_Gain_m1;
   if (rtb_Add3_i <= AutopilotLaws_DWork.DelayInput1_DSTATE) {
     if (rtb_Add3_g > AutopilotLaws_P.Switch1_Threshold_d) {
       AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_p0;
     } else {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain_n * Phi2;
+      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain_n * rtb_lo_b;
     }
 
     if (rtb_Add3_i >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
@@ -1910,7 +1917,7 @@ void AutopilotLawsModelClass::step()
     }
   }
 
-  rtb_Add3_i = (AutopilotLaws_P.Gain_Gain_d0 * rtb_Divide - L) + AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Add3_g = (AutopilotLaws_P.Gain_Gain_d0 * rtb_Gain1_na - Phi2) + AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_hi * AutopilotLaws_U.in.data.V_gnd_kn;
   if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_cv) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_cv;
@@ -1918,347 +1925,346 @@ void AutopilotLawsModelClass::step()
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_hd;
   }
 
-  L = std::atan(AutopilotLaws_P.fpmtoms_Gain_o2 * AutopilotLaws_U.in.data.H_dot_ft_min /
-                AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_pp;
+  Phi2 = std::atan(AutopilotLaws_P.fpmtoms_Gain_o2 * AutopilotLaws_U.in.data.H_dot_ft_min /
+                   AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_pp;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_iw * rtb_GainTheta;
-  rtb_Divide = AutopilotLaws_P.kntoms_Gain_i * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Divide > AutopilotLaws_P.Saturation_UpperSat_nu) {
-    rtb_Divide = AutopilotLaws_P.Saturation_UpperSat_nu;
-  } else if (rtb_Divide < AutopilotLaws_P.Saturation_LowerSat_ae) {
-    rtb_Divide = AutopilotLaws_P.Saturation_LowerSat_ae;
+  rtb_Sum_kq = AutopilotLaws_P.kntoms_Gain_i * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Sum_kq > AutopilotLaws_P.Saturation_UpperSat_nu) {
+    rtb_Sum_kq = AutopilotLaws_P.Saturation_UpperSat_nu;
+  } else if (rtb_Sum_kq < AutopilotLaws_P.Saturation_LowerSat_ae) {
+    rtb_Sum_kq = AutopilotLaws_P.Saturation_LowerSat_ae;
   }
 
-  Phi2 = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_hz *
-    AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Divide) * AutopilotLaws_P.Gain_Gain_ej * AutopilotLaws_P.Gain1_Gain_lw;
+  rtb_lo_b = AutopilotLaws_DWork.DelayInput1_DSTATE - std::atan(AutopilotLaws_P.fpmtoms_Gain_hz *
+    AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Sum_kq) * AutopilotLaws_P.Gain_Gain_ej * AutopilotLaws_P.Gain1_Gain_lw;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_ky * rtb_GainTheta1;
-  rtb_Divide = std::cos(AutopilotLaws_DWork.DelayInput1_DSTATE);
-  rtb_Add3_g = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
+  rtb_Add3_i = std::cos(AutopilotLaws_DWork.DelayInput1_DSTATE);
+  rtb_Add3_j4 = std::sin(AutopilotLaws_DWork.DelayInput1_DSTATE);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_nrn * AutopilotLaws_U.in.data.Psi_magnetic_deg;
-  rtb_Add3_a = AutopilotLaws_P.Gain1_Gain_ip * AutopilotLaws_U.in.data.Psi_magnetic_track_deg -
+  rtb_Add3_lz = AutopilotLaws_P.Gain1_Gain_ip * AutopilotLaws_U.in.data.Psi_magnetic_track_deg -
     AutopilotLaws_DWork.DelayInput1_DSTATE;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.ktstomps_Gain_l * AutopilotLaws_U.in.data.V_gnd_kn;
   AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_ip * (AutopilotLaws_P.GStoGS_CAS_Gain_e *
-    AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.WashoutFilter_C1_c, AutopilotLaws_U.in.time.dt, &rtb_Y_j,
+    AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.WashoutFilter_C1_c, AutopilotLaws_U.in.time.dt, &rtb_Y_k,
     &AutopilotLaws_DWork.sf_WashoutFilter_g5);
-  AutopilotLaws_LeadLagFilter(rtb_Y_j - AutopilotLaws_P.g_Gain_hq * (AutopilotLaws_P.Gain1_Gain_mx *
-    (AutopilotLaws_P.Gain_Gain_d3 * (Phi2 * (AutopilotLaws_P.Constant_Value_fo - rtb_Divide) + rtb_Add3_g * std::sin
-    (rtb_Add3_a)))), AutopilotLaws_P.HighPassFilter_C1_d, AutopilotLaws_P.HighPassFilter_C2_i,
-    AutopilotLaws_P.HighPassFilter_C3_d, AutopilotLaws_P.HighPassFilter_C4_nr, AutopilotLaws_U.in.time.dt,
-    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_LeadLagFilter_j);
+  AutopilotLaws_LeadLagFilter(rtb_Y_k - AutopilotLaws_P.g_Gain_hq * (AutopilotLaws_P.Gain1_Gain_mx *
+    (AutopilotLaws_P.Gain_Gain_d3 * (rtb_lo_b * (AutopilotLaws_P.Constant_Value_fo - rtb_Add3_i) + rtb_Add3_j4 * std::
+    sin(rtb_Add3_lz)))), AutopilotLaws_P.HighPassFilter_C1_d, AutopilotLaws_P.HighPassFilter_C2_i,
+    AutopilotLaws_P.HighPassFilter_C3_d, AutopilotLaws_P.HighPassFilter_C4_nr, AutopilotLaws_U.in.time.dt, &rtb_Gain1_na,
+    &AutopilotLaws_DWork.sf_LeadLagFilter_j);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_mh * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_e, AutopilotLaws_P.LowPassFilter_C2_i, AutopilotLaws_P.LowPassFilter_C3_o5,
-    AutopilotLaws_P.LowPassFilter_C4_f, AutopilotLaws_U.in.time.dt, &rtb_Y_j, &AutopilotLaws_DWork.sf_LeadLagFilter_a);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = (AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_Y_j) *
-    AutopilotLaws_P.ug_Gain_e;
-  Phi2 = AutopilotLaws_P.Gain1_Gain_be * L;
-  rtb_Divide = AutopilotLaws_DWork.DelayInput1_DSTATE + Phi2;
-  rtb_Add3_g = AutopilotLaws_P.Constant1_Value_o - AutopilotLaws_P.Constant2_Value_hd;
-  rtb_Y_j = (AutopilotLaws_P.Gain1_Gain_nj * AutopilotLaws_DWork.DelayInput1_DSTATE + Phi2) *
+    AutopilotLaws_P.LowPassFilter_C4_f, AutopilotLaws_U.in.time.dt, &rtb_Y_k, &AutopilotLaws_DWork.sf_LeadLagFilter_a);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = (rtb_Gain1_na + rtb_Y_k) * AutopilotLaws_P.ug_Gain_e;
+  rtb_lo_b = AutopilotLaws_P.Gain1_Gain_be * Phi2;
+  rtb_Gain1_na = AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_lo_b;
+  rtb_Add3_i = AutopilotLaws_P.Constant1_Value_o - AutopilotLaws_P.Constant2_Value_hd;
+  rtb_lo_b = (AutopilotLaws_P.Gain1_Gain_nj * AutopilotLaws_DWork.DelayInput1_DSTATE + rtb_lo_b) *
     AutopilotLaws_P.Gain_Gain_aq;
-  if (rtb_Add3_g > AutopilotLaws_P.Switch_Threshold_g) {
+  if (rtb_Add3_i > AutopilotLaws_P.Switch_Threshold_g) {
     AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant1_Value_f;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain_a * rtb_Y_j;
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain_a * rtb_lo_b;
   }
 
-  Phi2 = AutopilotLaws_P.Gain1_Gain_fle * rtb_Gain_nrh;
-  if (Phi2 <= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-    if (rtb_Add3_g > AutopilotLaws_P.Switch1_Threshold_h) {
+  rtb_Y_d *= AutopilotLaws_P.Gain1_Gain_fle;
+  if (rtb_Y_d <= AutopilotLaws_DWork.DelayInput1_DSTATE) {
+    if (rtb_Add3_i > AutopilotLaws_P.Switch1_Threshold_h) {
       AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_i;
     } else {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain_g * rtb_Y_j;
+      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain_g * rtb_lo_b;
     }
 
-    if (Phi2 >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = Phi2;
+    if (rtb_Y_d >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
+      AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Y_d;
     }
   }
 
-  Phi2 = (AutopilotLaws_P.Gain_Gain_gx * rtb_Divide - L) + AutopilotLaws_DWork.DelayInput1_DSTATE;
-  AutopilotLaws_SpeedProtectionSignalSelection(&AutopilotLaws_Y.out, rtb_Cos1_pk, std::fmax(-rtb_Y_pt, std::fmin
-    (rtb_Y_pt, AutopilotLaws_P.Gain_Gain_c3 * rtb_Cos1_pk)), rtb_Add3_i, AutopilotLaws_P.Gain_Gain_fnw * rtb_Add3_i,
-    Phi2, AutopilotLaws_P.Gain_Gain_ko * Phi2, AutopilotLaws_P.Constant_Value_fov, &rtb_FD_h, &rtb_Add3_g);
-  rtb_Gain_nrh = AutopilotLaws_P.Gain2_Gain_m * AutopilotLaws_U.in.data.H_dot_ft_min *
+  Phi2 = (AutopilotLaws_P.Gain_Gain_gx * rtb_Gain1_na - Phi2) + AutopilotLaws_DWork.DelayInput1_DSTATE;
+  AutopilotLaws_SpeedProtectionSignalSelection(&AutopilotLaws_Y.out, rtb_Gain_dn, std::fmax(-rtb_Y_n0, std::fmin
+    (rtb_Y_n0, AutopilotLaws_P.Gain_Gain_c3 * rtb_Gain_dn)), rtb_Add3_g, AutopilotLaws_P.Gain_Gain_fnw * rtb_Add3_g,
+    Phi2, AutopilotLaws_P.Gain_Gain_ko * Phi2, AutopilotLaws_P.Constant_Value_fov, &rtb_FD_h, &rtb_Add3_i);
+  rtb_Gain_dn = AutopilotLaws_P.Gain2_Gain_m * AutopilotLaws_U.in.data.H_dot_ft_min *
     AutopilotLaws_P.DiscreteDerivativeVariableTs1_Gain;
-  L = rtb_Gain_nrh - AutopilotLaws_DWork.Delay_DSTATE_hi;
-  AutopilotLaws_LagFilter(L / AutopilotLaws_U.in.time.dt, AutopilotLaws_P.LagFilter2_C1_k, AutopilotLaws_U.in.time.dt,
-    &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_LagFilter_bx);
-  AutopilotLaws_WashoutFilter(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.WashoutFilter1_C1,
-    AutopilotLaws_U.in.time.dt, &L, &AutopilotLaws_DWork.sf_WashoutFilter_n);
+  Phi2 = rtb_Gain_dn - AutopilotLaws_DWork.Delay_DSTATE_hi;
+  AutopilotLaws_LagFilter(Phi2 / AutopilotLaws_U.in.time.dt, AutopilotLaws_P.LagFilter2_C1_k, AutopilotLaws_U.in.time.dt,
+    &Phi2, &AutopilotLaws_DWork.sf_LagFilter_bx);
+  AutopilotLaws_WashoutFilter(Phi2, AutopilotLaws_P.WashoutFilter1_C1, AutopilotLaws_U.in.time.dt, &rtb_Gain1_na,
+    &AutopilotLaws_DWork.sf_WashoutFilter_n);
   rtb_Delay_j = ((AutopilotLaws_U.in.input.vertical_mode == AutopilotLaws_P.CompareGSTRACK_const) ||
                  (AutopilotLaws_U.in.input.vertical_mode == AutopilotLaws_P.CompareGSTRACK2_const));
-  AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain4_Gain_g * L, rtb_Delay_j, &Phi2);
+  AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain4_Gain_g * rtb_Gain1_na, rtb_Delay_j, &rtb_Gain1_na);
   AutopilotLaws_LagFilter(AutopilotLaws_U.in.data.nav_gs_error_deg, AutopilotLaws_P.LagFilter1_C1_p,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_j, &AutopilotLaws_DWork.sf_LagFilter_cu);
-  rtb_Cos1_pk = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain_o * rtb_Y_j;
+    AutopilotLaws_U.in.time.dt, &rtb_Y_k, &AutopilotLaws_DWork.sf_LagFilter_cu);
+  rtb_Add3_g = AutopilotLaws_P.DiscreteDerivativeVariableTs_Gain_o * rtb_Y_k;
   AutopilotLaws_DWork.DelayInput1_DSTATE = look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft,
     AutopilotLaws_P.ScheduledGain2_BreakpointsForDimension1_h, AutopilotLaws_P.ScheduledGain2_Table_f, 4U);
-  AutopilotLaws_LagFilter(rtb_Y_j + (rtb_Cos1_pk - AutopilotLaws_DWork.Delay_DSTATE_n) / AutopilotLaws_U.in.time.dt *
+  AutopilotLaws_LagFilter(rtb_Y_k + (rtb_Add3_g - AutopilotLaws_DWork.Delay_DSTATE_n) / AutopilotLaws_U.in.time.dt *
     AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.LagFilter_C1_m, AutopilotLaws_U.in.time.dt,
     &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_LagFilter_j);
-  L = look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft, AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_ec,
-                    AutopilotLaws_P.ScheduledGain_Table_l, 6U);
-  AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain3_Gain_c * (Phi2 + AutopilotLaws_DWork.DelayInput1_DSTATE * L),
+  AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain3_Gain_c * (rtb_Gain1_na +
+    AutopilotLaws_DWork.DelayInput1_DSTATE * look1_binlxpw(AutopilotLaws_U.in.data.H_radio_ft,
+    AutopilotLaws_P.ScheduledGain_BreakpointsForDimension1_ec, AutopilotLaws_P.ScheduledGain_Table_l, 6U)),
     (AutopilotLaws_U.in.data.H_radio_ft > AutopilotLaws_P.CompareToConstant_const_k) &&
-    AutopilotLaws_U.in.data.nav_gs_valid, &rtb_Divide);
+    AutopilotLaws_U.in.data.nav_gs_valid, &rtb_Sum_kq);
   AutopilotLaws_storevalue(rtb_error_d == AutopilotLaws_P.CompareToConstant6_const_e,
-    AutopilotLaws_Y.out.data.nav_gs_deg, &L, &AutopilotLaws_DWork.sf_storevalue_g);
-  if (L > AutopilotLaws_P.Saturation_UpperSat_e0) {
-    L = AutopilotLaws_P.Saturation_UpperSat_e0;
-  } else if (L < AutopilotLaws_P.Saturation_LowerSat_ph) {
-    L = AutopilotLaws_P.Saturation_LowerSat_ph;
+    AutopilotLaws_Y.out.data.nav_gs_deg, &rtb_Gain1_na, &AutopilotLaws_DWork.sf_storevalue_g);
+  if (rtb_Gain1_na > AutopilotLaws_P.Saturation_UpperSat_e0) {
+    Phi2 = AutopilotLaws_P.Saturation_UpperSat_e0;
+  } else if (rtb_Gain1_na < AutopilotLaws_P.Saturation_LowerSat_ph) {
+    Phi2 = AutopilotLaws_P.Saturation_LowerSat_ph;
+  } else {
+    Phi2 = rtb_Gain1_na;
   }
 
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain_g4 * AutopilotLaws_U.in.data.H_dot_ft_min;
-  Phi2 = AutopilotLaws_P.kntoms_Gain_k4 * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (Phi2 > AutopilotLaws_P.Saturation_UpperSat_eb) {
-    Phi2 = AutopilotLaws_P.Saturation_UpperSat_eb;
-  } else if (Phi2 < AutopilotLaws_P.Saturation_LowerSat_gk) {
-    Phi2 = AutopilotLaws_P.Saturation_LowerSat_gk;
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_k4 * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_eb) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_eb;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_gk) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_gk;
   }
 
-  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / Phi2) *
+  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Add3_j4) *
     AutopilotLaws_P.Gain_Gain_ow;
-  AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain2_Gain_l * (L - AutopilotLaws_DWork.DelayInput1_DSTATE),
-    rtb_Delay_j, &Phi2);
-  AutopilotLaws_Voter1(rtb_Divide + Phi2, AutopilotLaws_P.Gain1_Gain_d4 * ((L + AutopilotLaws_P.Bias_Bias) -
-    AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.Gain_Gain_eyl * ((L + AutopilotLaws_P.Bias1_Bias) -
-    AutopilotLaws_DWork.DelayInput1_DSTATE), &rtb_Y_pt);
-  rtb_Product_dh = rtb_Y_pt * look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn,
+  AutopilotLaws_SignalEnablerGSTrack(AutopilotLaws_P.Gain2_Gain_l * (Phi2 - AutopilotLaws_DWork.DelayInput1_DSTATE),
+    rtb_Delay_j, &rtb_Gain1_na);
+  AutopilotLaws_Voter1(rtb_Sum_kq + rtb_Gain1_na, AutopilotLaws_P.Gain1_Gain_d4 * ((Phi2 + AutopilotLaws_P.Bias_Bias) -
+    AutopilotLaws_DWork.DelayInput1_DSTATE), AutopilotLaws_P.Gain_Gain_eyl * ((Phi2 + AutopilotLaws_P.Bias1_Bias) -
+    AutopilotLaws_DWork.DelayInput1_DSTATE), &rtb_lo_b);
+  rtb_Product_dh = rtb_lo_b * look1_binlxpw(AutopilotLaws_U.in.data.V_tas_kn,
     AutopilotLaws_P.ScheduledGain1_BreakpointsForDimension1, AutopilotLaws_P.ScheduledGain1_Table, 6U);
   rtb_Gain4_m = (rtb_GainTheta - AutopilotLaws_P.Constant2_Value_f) * AutopilotLaws_P.Gain4_Gain_oy;
-  rtb_Y_j = AutopilotLaws_P.Gain5_Gain_c * AutopilotLaws_U.in.data.bz_m_s2;
+  rtb_Y_k = AutopilotLaws_P.Gain5_Gain_c * AutopilotLaws_U.in.data.bz_m_s2;
   AutopilotLaws_WashoutFilter(AutopilotLaws_U.in.data.bx_m_s2, AutopilotLaws_P.WashoutFilter_C1_m,
-    AutopilotLaws_U.in.time.dt, &rtb_Y_pt, &AutopilotLaws_DWork.sf_WashoutFilter_g);
+    AutopilotLaws_U.in.time.dt, &rtb_Y_n0, &AutopilotLaws_DWork.sf_WashoutFilter_g);
   rtb_Delay_j = (rtb_error_d == AutopilotLaws_P.CompareToConstant7_const);
-  L = AutopilotLaws_P.kntofpm_Gain * AutopilotLaws_U.in.data.V_gnd_kn;
-  rtb_Divide = AutopilotLaws_P.maxslope_Gain * L;
   AutopilotLaws_LagFilter(AutopilotLaws_U.in.data.H_dot_ft_min, AutopilotLaws_P.LagFilterH_C1,
-    AutopilotLaws_U.in.time.dt, &L, &AutopilotLaws_DWork.sf_LagFilter_a);
+    AutopilotLaws_U.in.time.dt, &rtb_Y_d, &AutopilotLaws_DWork.sf_LagFilter_a);
+  Phi2 = rtb_Y_d - AutopilotLaws_P.kntofpm_Gain * AutopilotLaws_U.in.data.V_gnd_kn * AutopilotLaws_P.maxslope_Gain;
   AutopilotLaws_LeadLagFilter(AutopilotLaws_U.in.data.H_radio_ft, AutopilotLaws_P.LeadLagFilter_C1,
     AutopilotLaws_P.LeadLagFilter_C2, AutopilotLaws_P.LeadLagFilter_C3, AutopilotLaws_P.LeadLagFilter_C4,
-    AutopilotLaws_U.in.time.dt, &AutopilotLaws_DWork.DelayInput1_DSTATE, &AutopilotLaws_DWork.sf_LeadLagFilter_k);
-  AutopilotLaws_LagFilter(AutopilotLaws_DWork.DelayInput1_DSTATE, AutopilotLaws_P.LagFilter1_C1_d,
-    AutopilotLaws_U.in.time.dt, &Phi2, &AutopilotLaws_DWork.sf_LagFilter_cs);
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain7_Gain_l * Phi2;
-  rtb_Add3_a = std::fmax(L - rtb_Divide, AutopilotLaws_DWork.DelayInput1_DSTATE);
+    AutopilotLaws_U.in.time.dt, &rtb_Y_d, &AutopilotLaws_DWork.sf_LeadLagFilter_k);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_oa * rtb_Y_d;
+  rtb_Add3_lz = std::fmax(Phi2, AutopilotLaws_DWork.DelayInput1_DSTATE);
   if (!AutopilotLaws_DWork.wasActive_not_empty) {
     AutopilotLaws_DWork.wasActive = rtb_Delay_j;
     AutopilotLaws_DWork.wasActive_not_empty = true;
   }
 
   if ((!AutopilotLaws_DWork.wasActive) && rtb_Delay_j) {
-    Phi2 = std::abs(rtb_Add3_a) / 60.0;
-    AutopilotLaws_DWork.Tau = AutopilotLaws_U.in.data.H_radio_ft / (Phi2 - 2.5);
-    AutopilotLaws_DWork.H_bias = AutopilotLaws_DWork.Tau * Phi2 - AutopilotLaws_U.in.data.H_radio_ft;
+    rtb_lo_b = std::abs(rtb_Add3_lz) / 60.0;
+    AutopilotLaws_DWork.Tau = AutopilotLaws_U.in.data.H_radio_ft / (rtb_lo_b - 2.5);
+    AutopilotLaws_DWork.H_bias = AutopilotLaws_DWork.Tau * rtb_lo_b - AutopilotLaws_U.in.data.H_radio_ft;
   }
 
   if (rtb_Delay_j) {
     rtb_Vz = -1.0 / AutopilotLaws_DWork.Tau * (AutopilotLaws_U.in.data.H_radio_ft + AutopilotLaws_DWork.H_bias) * 60.0;
   } else {
-    rtb_Vz = rtb_Add3_a;
+    rtb_Vz = rtb_Add3_lz;
   }
 
   AutopilotLaws_DWork.wasActive = rtb_Delay_j;
   AutopilotLaws_LeadLagFilter(rtb_Vz, AutopilotLaws_P.LeadLagFilter_C1_a, AutopilotLaws_P.LeadLagFilter_C2_p,
-    AutopilotLaws_P.LeadLagFilter_C3_m, AutopilotLaws_P.LeadLagFilter_C4_k, AutopilotLaws_U.in.time.dt, &Phi2,
+    AutopilotLaws_P.LeadLagFilter_C3_m, AutopilotLaws_P.LeadLagFilter_C4_k, AutopilotLaws_U.in.time.dt, &rtb_Gain1_na,
     &AutopilotLaws_DWork.sf_LeadLagFilter_hp);
-  L = AutopilotLaws_P.kntoms_Gain_av * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (L > AutopilotLaws_P.Saturation_UpperSat_i0) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_i0;
-  } else if (L < AutopilotLaws_P.Saturation_LowerSat_nd) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_nd;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_av * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_i0) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_i0;
+  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_nd) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_nd;
   } else {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = L;
+    rtb_Add3_j4 = AutopilotLaws_DWork.DelayInput1_DSTATE;
   }
 
-  if (L > AutopilotLaws_P.Saturation_UpperSat_ew) {
-    L = AutopilotLaws_P.Saturation_UpperSat_ew;
-  } else if (L < AutopilotLaws_P.Saturation_LowerSat_an) {
-    L = AutopilotLaws_P.Saturation_LowerSat_an;
+  rtb_lo_b = AutopilotLaws_P.ftmintoms_Gain_k * rtb_Gain1_na / rtb_Add3_j4;
+  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_ew) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_ew;
+  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_an) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_an;
   }
 
-  rtb_Add3_i = AutopilotLaws_P.ftmintoms_Gain_k * Phi2 / AutopilotLaws_DWork.DelayInput1_DSTATE;
-  L = (rtb_Vz - rtb_Add3_a) * AutopilotLaws_P.ftmintoms_Gain_j / L;
-  if (rtb_Add3_i > 1.0) {
-    rtb_Add3_i = 1.0;
-  } else if (rtb_Add3_i < -1.0) {
-    rtb_Add3_i = -1.0;
+  rtb_Add3_j4 = (rtb_Vz - rtb_Add3_lz) * AutopilotLaws_P.ftmintoms_Gain_j / AutopilotLaws_DWork.DelayInput1_DSTATE;
+  if (rtb_lo_b > 1.0) {
+    rtb_lo_b = 1.0;
+  } else if (rtb_lo_b < -1.0) {
+    rtb_lo_b = -1.0;
   }
 
-  if (L > 1.0) {
-    L = 1.0;
-  } else if (L < -1.0) {
-    L = -1.0;
+  if (rtb_Add3_j4 > 1.0) {
+    rtb_Add3_j4 = 1.0;
+  } else if (rtb_Add3_j4 < -1.0) {
+    rtb_Add3_j4 = -1.0;
   }
 
-  rtb_Sum1_g = AutopilotLaws_P.Gain_Gain_gr * std::asin(rtb_Add3_i) * AutopilotLaws_P.Gain1_Gain_ml +
-    AutopilotLaws_P.Gain_Gain_by * std::asin(L) * AutopilotLaws_P.Gain2_Gain_mj;
+  rtb_Sum1_g = AutopilotLaws_P.Gain_Gain_gr * std::asin(rtb_lo_b) * AutopilotLaws_P.Gain1_Gain_ml +
+    AutopilotLaws_P.Gain_Gain_by * std::asin(rtb_Add3_j4) * AutopilotLaws_P.Gain2_Gain_mj;
   rtb_uDLookupTable_m = look1_binlxpw(AutopilotLaws_U.in.data.total_weight_kg, AutopilotLaws_P.uDLookupTable_bp01Data,
     AutopilotLaws_P.uDLookupTable_tableData, 3U);
   AutopilotLaws_LagFilter(AutopilotLaws_U.in.data.H_dot_ft_min, AutopilotLaws_P.LagFilterH1_C1,
-    AutopilotLaws_U.in.time.dt, &L, &AutopilotLaws_DWork.sf_LagFilter_b);
+    AutopilotLaws_U.in.time.dt, &rtb_Gain1_na, &AutopilotLaws_DWork.sf_LagFilter_b);
   AutopilotLaws_DWork.pY_not_empty = ((!rtb_Delay_j) || (!AutopilotLaws_DWork.pY_not_empty) ||
     AutopilotLaws_DWork.pY_not_empty);
-  rtb_Add3_i = AutopilotLaws_P.kntoms1_Gain * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_dp) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_dp;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_f1) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_f1;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms1_Gain * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_dp) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_dp;
+  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_f1) {
+    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_f1;
   }
 
-  rtb_Gain_lg = std::asin(0.0 / rtb_Add3_i) * AutopilotLaws_P.Gain_Gain_owa;
-  rtb_Sum_ia = AutopilotLaws_P.Constant1_Value_o0 - rtb_GainTheta;
+  rtb_Gain_l4 = std::asin(0.0 / AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_owa;
+  rtb_Sum_es = AutopilotLaws_P.Constant1_Value_o0 - rtb_GainTheta;
   rtb_Sum3_m3 = AutopilotLaws_P.Constant2_Value_kz - AutopilotLaws_U.in.data.H_ind_ft;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.kntoms_Gain_bh * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (AutopilotLaws_DWork.DelayInput1_DSTATE > AutopilotLaws_P.Saturation_UpperSat_pd) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_UpperSat_pd;
-  } else if (AutopilotLaws_DWork.DelayInput1_DSTATE < AutopilotLaws_P.Saturation_LowerSat_l) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Saturation_LowerSat_l;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.fpmtoms_Gain_po * AutopilotLaws_U.in.data.H_dot_ft_min;
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_bh * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_pd) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_pd;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_l) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_l;
   }
 
-  L = std::atan(AutopilotLaws_P.fpmtoms_Gain_po * AutopilotLaws_U.in.data.H_dot_ft_min /
-                AutopilotLaws_DWork.DelayInput1_DSTATE) * AutopilotLaws_P.Gain_Gain_cr;
-  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_ga * L;
-  Phi2 = AutopilotLaws_P.Gain1_Gain_hm2 * rtb_GainTheta1;
-  rtb_GainTheta1 = std::cos(Phi2);
-  rtb_Cos1_fn = std::sin(Phi2);
-  rtb_Divide = AutopilotLaws_P.Gain1_Gain_it * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
-  rtb_Add3_no = rtb_Divide - AutopilotLaws_P.Gain1_Gain_a * AutopilotLaws_U.in.data.Psi_magnetic_deg;
-  Phi2 = AutopilotLaws_P.ktstomps_Gain_k5 * AutopilotLaws_U.in.data.V_gnd_kn;
-  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_f * (AutopilotLaws_P.GStoGS_CAS_Gain_j * Phi2),
-    AutopilotLaws_P.WashoutFilter_C1_cn, AutopilotLaws_U.in.time.dt, &Phi2, &AutopilotLaws_DWork.sf_WashoutFilter_i);
-  rtb_Add3_i = AutopilotLaws_P.kntoms_Gain_py * AutopilotLaws_U.in.data.V_gnd_kn;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_ec) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_ec;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_m) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_m;
+  AutopilotLaws_DWork.DelayInput1_DSTATE = std::atan(AutopilotLaws_DWork.DelayInput1_DSTATE / rtb_Add3_j4) *
+    AutopilotLaws_P.Gain_Gain_cr;
+  rtb_lo_b = AutopilotLaws_P.Gain1_Gain_ga * AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_Gain1_na = AutopilotLaws_P.Gain1_Gain_hm2 * rtb_GainTheta1;
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_py * AutopilotLaws_U.in.data.V_gnd_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_ec) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_ec;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_m) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_m;
   }
 
-  AutopilotLaws_LeadLagFilter(Phi2 - AutopilotLaws_P.g_Gain_p * (AutopilotLaws_P.Gain1_Gain_mxw *
-    (AutopilotLaws_P.Gain_Gain_er * ((AutopilotLaws_P.Gain1_Gain_ol * rtb_GainTheta - AutopilotLaws_P.Gain1_Gain_ln *
-    (AutopilotLaws_P.Gain_Gain_hc * std::atan(AutopilotLaws_P.fpmtoms_Gain_k * AutopilotLaws_U.in.data.H_dot_ft_min /
-    rtb_Add3_i))) * (AutopilotLaws_P.Constant_Value_h - rtb_GainTheta1) + rtb_Cos1_fn * std::sin(rtb_Add3_no)))),
+  rtb_GainTheta1 = (AutopilotLaws_P.Gain1_Gain_ol * rtb_GainTheta - std::atan(AutopilotLaws_P.fpmtoms_Gain_k *
+    AutopilotLaws_U.in.data.H_dot_ft_min / rtb_Add3_j4) * AutopilotLaws_P.Gain_Gain_hc * AutopilotLaws_P.Gain1_Gain_ln) *
+    (AutopilotLaws_P.Constant_Value_h - std::cos(rtb_Gain1_na));
+  rtb_Add3_j4 = std::sin(rtb_Gain1_na);
+  rtb_Sum_kq = AutopilotLaws_P.Gain1_Gain_it * AutopilotLaws_U.in.data.Psi_magnetic_track_deg;
+  rtb_Add3_aj = rtb_Sum_kq - AutopilotLaws_P.Gain1_Gain_a * AutopilotLaws_U.in.data.Psi_magnetic_deg;
+  rtb_Gain1_na = AutopilotLaws_P.ktstomps_Gain_k5 * AutopilotLaws_U.in.data.V_gnd_kn;
+  AutopilotLaws_WashoutFilter(AutopilotLaws_P._Gain_f * (AutopilotLaws_P.GStoGS_CAS_Gain_j * rtb_Gain1_na),
+    AutopilotLaws_P.WashoutFilter_C1_cn, AutopilotLaws_U.in.time.dt, &rtb_Gain1_na,
+    &AutopilotLaws_DWork.sf_WashoutFilter_i);
+  AutopilotLaws_LeadLagFilter(rtb_Gain1_na - AutopilotLaws_P.g_Gain_p * (AutopilotLaws_P.Gain1_Gain_mxw *
+    (AutopilotLaws_P.Gain_Gain_er * (rtb_GainTheta1 + rtb_Add3_j4 * std::sin(rtb_Add3_aj)))),
     AutopilotLaws_P.HighPassFilter_C1_gw, AutopilotLaws_P.HighPassFilter_C2_e, AutopilotLaws_P.HighPassFilter_C3_di,
-    AutopilotLaws_P.HighPassFilter_C4_a, AutopilotLaws_U.in.time.dt, &rtb_Divide,
+    AutopilotLaws_P.HighPassFilter_C4_a, AutopilotLaws_U.in.time.dt, &rtb_Sum_kq,
     &AutopilotLaws_DWork.sf_LeadLagFilter_g);
   AutopilotLaws_LeadLagFilter(AutopilotLaws_P.ktstomps_Gain_mf * AutopilotLaws_U.in.data.V_ias_kn,
     AutopilotLaws_P.LowPassFilter_C1_d1, AutopilotLaws_P.LowPassFilter_C2_e, AutopilotLaws_P.LowPassFilter_C3_l,
-    AutopilotLaws_P.LowPassFilter_C4_a, AutopilotLaws_U.in.time.dt, &Phi2, &AutopilotLaws_DWork.sf_LeadLagFilter_n);
-  Phi2 = (rtb_Divide + Phi2) * AutopilotLaws_P.ug_Gain_c;
-  rtb_GainTheta1 = (AutopilotLaws_P.Gain1_Gain_nc * Phi2 + AutopilotLaws_DWork.DelayInput1_DSTATE) *
-    AutopilotLaws_P.Gain_Gain_bg;
-  rtb_Divide = (AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.input.V_c_kn) * AutopilotLaws_P.Gain1_Gain_ke;
+    AutopilotLaws_P.LowPassFilter_C4_a, AutopilotLaws_U.in.time.dt, &rtb_Gain1_na,
+    &AutopilotLaws_DWork.sf_LeadLagFilter_n);
+  rtb_Gain1_na = (rtb_Sum_kq + rtb_Gain1_na) * AutopilotLaws_P.ug_Gain_c;
+  rtb_GainTheta1 = (AutopilotLaws_P.Gain1_Gain_nc * rtb_Gain1_na + rtb_lo_b) * AutopilotLaws_P.Gain_Gain_bg;
+  rtb_Add3_j4 = (AutopilotLaws_U.in.data.V_ias_kn - AutopilotLaws_U.in.input.V_c_kn) * AutopilotLaws_P.Gain1_Gain_ke;
   rtb_Delay_j = ((rtb_Sum3_m3 > AutopilotLaws_P.CompareToConstant6_const_d) && (rtb_GainTheta1 <
-    AutopilotLaws_P.CompareToConstant5_const_h) && (rtb_Divide < AutopilotLaws_P.CompareToConstant2_const_j) &&
+    AutopilotLaws_P.CompareToConstant5_const_h) && (rtb_Add3_j4 < AutopilotLaws_P.CompareToConstant2_const_j) &&
                  (rtb_error_d == AutopilotLaws_P.CompareToConstant8_const));
-  Phi2 += AutopilotLaws_DWork.DelayInput1_DSTATE;
+  rtb_lo_b += rtb_Gain1_na;
   if (rtb_Delay_j) {
-    AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant_Value_o;
+    rtb_Gain1_na = AutopilotLaws_P.Constant_Value_o;
   } else {
     if (rtb_Sum3_m3 > AutopilotLaws_P.CompareToConstant_const_h) {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Constant1_Value_g5;
+      rtb_Gain1_na = AutopilotLaws_P.Constant1_Value_g5;
     } else {
-      AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain5_Gain_n * rtb_GainTheta1;
+      rtb_Gain1_na = AutopilotLaws_P.Gain5_Gain_n * rtb_GainTheta1;
     }
 
-    if (rtb_Divide <= AutopilotLaws_DWork.DelayInput1_DSTATE) {
+    if (rtb_Add3_j4 <= rtb_Gain1_na) {
       if (rtb_Sum3_m3 > AutopilotLaws_P.CompareToConstant4_const_e) {
-        AutopilotLaws_DWork.DelayInput1_DSTATE = std::fmax(AutopilotLaws_P.Constant2_Value_m,
-          AutopilotLaws_P.Gain1_Gain_m * rtb_GainTheta1);
+        rtb_Gain1_na = std::fmax(AutopilotLaws_P.Constant2_Value_m, AutopilotLaws_P.Gain1_Gain_m * rtb_GainTheta1);
       } else {
-        AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain6_Gain_fa * rtb_GainTheta1;
+        rtb_Gain1_na = AutopilotLaws_P.Gain6_Gain_fa * rtb_GainTheta1;
       }
 
-      if (rtb_Divide >= AutopilotLaws_DWork.DelayInput1_DSTATE) {
-        AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_Divide;
+      if (rtb_Add3_j4 >= rtb_Gain1_na) {
+        rtb_Gain1_na = rtb_Add3_j4;
       }
     }
   }
 
-  rtb_GainTheta1 = (AutopilotLaws_P.Gain_Gain_c2 * Phi2 - L) + AutopilotLaws_DWork.DelayInput1_DSTATE;
-  rtb_Add3_i = AutopilotLaws_P.kntoms_Gain_om * AutopilotLaws_U.in.data.V_tas_kn;
+  rtb_GainTheta1 = (AutopilotLaws_P.Gain_Gain_c2 * rtb_lo_b - AutopilotLaws_DWork.DelayInput1_DSTATE) + rtb_Gain1_na;
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_om * AutopilotLaws_U.in.data.V_tas_kn;
   if (rtb_Sum3_m3 < 0.0) {
-    Phi2 = -1.0;
+    rtb_lo_b = -1.0;
   } else if (rtb_Sum3_m3 > 0.0) {
-    Phi2 = 1.0;
+    rtb_lo_b = 1.0;
   } else {
-    Phi2 = rtb_Sum3_m3;
+    rtb_lo_b = rtb_Sum3_m3;
   }
 
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_ed) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_ed;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_ee) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_ee;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_ed) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_ed;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_ee) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_ee;
   }
 
-  rtb_Add3_i = (Phi2 * AutopilotLaws_P.Constant3_Value_ew - AutopilotLaws_U.in.data.H_dot_ft_min) *
-    AutopilotLaws_P.ftmintoms_Gain_m / rtb_Add3_i;
-  if (rtb_Add3_i > 1.0) {
-    rtb_Add3_i = 1.0;
-  } else if (rtb_Add3_i < -1.0) {
-    rtb_Add3_i = -1.0;
+  rtb_Add3_j4 = (rtb_lo_b * AutopilotLaws_P.Constant3_Value_ew - AutopilotLaws_U.in.data.H_dot_ft_min) *
+    AutopilotLaws_P.ftmintoms_Gain_m / rtb_Add3_j4;
+  if (rtb_Add3_j4 > 1.0) {
+    rtb_Add3_j4 = 1.0;
+  } else if (rtb_Add3_j4 < -1.0) {
+    rtb_Add3_j4 = -1.0;
   }
 
-  rtb_Cos1_fn = AutopilotLaws_P.Gain_Gain_kon * std::asin(rtb_Add3_i);
-  rtb_Add3_i = AutopilotLaws_P.kntoms_Gain_iw * AutopilotLaws_U.in.data.V_tas_kn;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_jt) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_jt;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_ih) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_ih;
+  rtb_Add3_aj = AutopilotLaws_P.Gain_Gain_kon * std::asin(rtb_Add3_j4);
+  rtb_Add3_j4 = AutopilotLaws_P.kntoms_Gain_iw * AutopilotLaws_U.in.data.V_tas_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_jt) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_jt;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_ih) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_ih;
   }
 
-  rtb_Add3_i = (AutopilotLaws_P.Constant_Value_iaf - AutopilotLaws_U.in.data.H_dot_ft_min) *
-    AutopilotLaws_P.ftmintoms_Gain_lv / rtb_Add3_i;
-  if (rtb_Add3_i > 1.0) {
-    rtb_Add3_i = 1.0;
-  } else if (rtb_Add3_i < -1.0) {
-    rtb_Add3_i = -1.0;
+  rtb_Add3_j4 = (AutopilotLaws_P.Constant_Value_iaf - AutopilotLaws_U.in.data.H_dot_ft_min) *
+    AutopilotLaws_P.ftmintoms_Gain_lv / rtb_Add3_j4;
+  if (rtb_Add3_j4 > 1.0) {
+    rtb_Add3_j4 = 1.0;
+  } else if (rtb_Add3_j4 < -1.0) {
+    rtb_Add3_j4 = -1.0;
   }
 
-  rtb_Divide = AutopilotLaws_P.Gain_Gain_o1 * std::asin(rtb_Add3_i);
+  rtb_Sum_kq = AutopilotLaws_P.Gain_Gain_o1 * std::asin(rtb_Add3_j4);
   if (rtb_Delay_j) {
-    L = rtb_GainTheta1;
+    rtb_Gain1_na = rtb_GainTheta1;
   } else if (rtb_Sum3_m3 > AutopilotLaws_P.Switch_Threshold_k) {
-    L = std::fmax(rtb_GainTheta1, rtb_Cos1_fn);
+    rtb_Gain1_na = std::fmax(rtb_GainTheta1, rtb_Add3_aj);
   } else {
-    L = std::fmin(rtb_GainTheta1, rtb_Cos1_fn);
+    rtb_Gain1_na = std::fmin(rtb_GainTheta1, rtb_Add3_aj);
   }
 
-  AutopilotLaws_Voter1(rtb_Sum_ia, L, rtb_Divide, &Phi2);
-  L = rtb_Sum_if;
+  AutopilotLaws_Voter1(rtb_Sum_es, rtb_Gain1_na, rtb_Sum_kq, &rtb_lo_b);
+  rtb_Gain1_na = rtb_Gain_ej3;
   AutopilotLaws_LagFilter(AutopilotLaws_U.in.input.H_c_ft - AutopilotLaws_U.in.data.H_ft, AutopilotLaws_P.LagFilter_C1_b,
-    AutopilotLaws_U.in.time.dt, &L, &AutopilotLaws_DWork.sf_LagFilter_d);
-  rtb_Add3_i = AutopilotLaws_P.Gain2_Gain_hq * L;
-  L = AutopilotLaws_P.kntoms_Gain_j * AutopilotLaws_U.in.data.V_tas_kn;
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_f3) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_f3;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_b) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_b;
+    AutopilotLaws_U.in.time.dt, &rtb_Gain1_na, &AutopilotLaws_DWork.sf_LagFilter_d);
+  rtb_Add3_j4 = AutopilotLaws_P.Gain2_Gain_hq * rtb_Gain1_na;
+  rtb_Gain1_na = AutopilotLaws_P.kntoms_Gain_j * AutopilotLaws_U.in.data.V_tas_kn;
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_f3) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_f3;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_b) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_b;
   }
 
-  if (L > AutopilotLaws_P.Saturation_UpperSat_nuy) {
-    L = AutopilotLaws_P.Saturation_UpperSat_nuy;
-  } else if (L < AutopilotLaws_P.Saturation_LowerSat_dj) {
-    L = AutopilotLaws_P.Saturation_LowerSat_dj;
+  if (rtb_Gain1_na > AutopilotLaws_P.Saturation_UpperSat_nuy) {
+    rtb_Gain1_na = AutopilotLaws_P.Saturation_UpperSat_nuy;
+  } else if (rtb_Gain1_na < AutopilotLaws_P.Saturation_LowerSat_dj) {
+    rtb_Gain1_na = AutopilotLaws_P.Saturation_LowerSat_dj;
   }
 
-  rtb_Add3_i = ((AutopilotLaws_P.Gain_Gain_pe * rtb_Sum_if + rtb_Add3_i) - AutopilotLaws_U.in.data.H_dot_ft_min) *
-    AutopilotLaws_P.ftmintoms_Gain_kr / L;
-  if (rtb_Add3_i > 1.0) {
-    rtb_Add3_i = 1.0;
-  } else if (rtb_Add3_i < -1.0) {
-    rtb_Add3_i = -1.0;
+  rtb_Add3_j4 = ((AutopilotLaws_P.Gain_Gain_pe * rtb_Gain_ej3 + rtb_Add3_j4) - AutopilotLaws_U.in.data.H_dot_ft_min) *
+    AutopilotLaws_P.ftmintoms_Gain_kr / rtb_Gain1_na;
+  if (rtb_Add3_j4 > 1.0) {
+    rtb_Add3_j4 = 1.0;
+  } else if (rtb_Add3_j4 < -1.0) {
+    rtb_Add3_j4 = -1.0;
   }
 
-  rtb_Sum_if = AutopilotLaws_P.Gain_Gain_fs * std::asin(rtb_Add3_i);
+  rtb_Gain_ej3 = AutopilotLaws_P.Gain_Gain_fs * std::asin(rtb_Add3_j4);
   switch (static_cast<int32_T>(rtb_error_d)) {
    case 0:
-    b_L = AutopilotLaws_P.Constant_Value_d;
+    R = AutopilotLaws_P.Constant_Value_d;
     break;
 
    case 1:
-    b_L = a;
+    R = a;
     break;
 
    case 2:
@@ -2266,201 +2272,207 @@ void AutopilotLawsModelClass::step()
 
    case 3:
     if (rtb_Compare_jy) {
-      b_L = rtb_lo_k;
+      R = rtb_lo_k;
     } else if (distance_m > AutopilotLaws_P.Switch_Threshold) {
-      b_L = std::fmax(rtb_lo_k, rtb_lo_b);
+      R = std::fmax(rtb_lo_k, rtb_Sum_i);
     } else {
-      b_L = std::fmin(rtb_lo_k, rtb_lo_b);
+      R = std::fmin(rtb_lo_k, rtb_Sum_i);
     }
     break;
 
    case 4:
-    b_L = rtb_Cos_i;
+    R = rtb_Cos1_pk;
     break;
 
    case 5:
-    b_L = rtb_FD_h;
+    R = rtb_FD_h;
     break;
 
    case 6:
-    b_L = AutopilotLaws_P.Gain1_Gain_d * rtb_Product_dh;
+    R = AutopilotLaws_P.Gain1_Gain_d * rtb_Product_dh;
     break;
 
    case 7:
     if (rtb_on_ground > AutopilotLaws_P.Switch1_Threshold_j) {
-      b_L = AutopilotLaws_P.Gain2_Gain_h * rtb_Gain4_m;
+      R = AutopilotLaws_P.Gain2_Gain_h * rtb_Gain4_m;
     } else {
-      b_L = std::fmax((AutopilotLaws_P.Gain1_Gain_i * rtb_Y_pt + rtb_Y_j) + rtb_Sum1_g * rtb_uDLookupTable_m,
-                      rtb_Gain_lg) * AutopilotLaws_P.Gain6_Gain_f;
+      R = std::fmax((AutopilotLaws_P.Gain1_Gain_i * rtb_Y_n0 + rtb_Y_k) + rtb_Sum1_g * rtb_uDLookupTable_m, rtb_Gain_l4)
+        * AutopilotLaws_P.Gain6_Gain_f;
     }
     break;
 
    case 8:
-    b_L = Phi2;
+    R = rtb_lo_b;
     break;
 
    default:
-    b_L = rtb_Sum_if;
+    R = rtb_Gain_ej3;
     break;
   }
 
-  if (b_L > AutopilotLaws_P.Constant1_Value_i) {
-    L = AutopilotLaws_P.Constant1_Value_i;
+  if (R > AutopilotLaws_P.Constant1_Value_i) {
+    rtb_Gain1_na = AutopilotLaws_P.Constant1_Value_i;
   } else {
-    L = AutopilotLaws_P.Gain1_Gain_n * AutopilotLaws_P.Constant1_Value_i;
-    if (b_L >= L) {
-      L = b_L;
+    rtb_Gain1_na = AutopilotLaws_P.Gain1_Gain_n * AutopilotLaws_P.Constant1_Value_i;
+    if (R >= rtb_Gain1_na) {
+      rtb_Gain1_na = R;
     }
   }
 
-  AutopilotLaws_RateLimiter(L - b_R, AutopilotLaws_P.RateLimiterVariableTs1_up,
+  AutopilotLaws_RateLimiter(rtb_Gain1_na - b_R, AutopilotLaws_P.RateLimiterVariableTs1_up,
     AutopilotLaws_P.RateLimiterVariableTs1_lo, AutopilotLaws_U.in.time.dt,
-    AutopilotLaws_P.RateLimiterVariableTs1_InitialCondition, &L, &AutopilotLaws_DWork.sf_RateLimiter_h);
-  AutopilotLaws_LagFilter(L, AutopilotLaws_P.LagFilter_C1_g, AutopilotLaws_U.in.time.dt, &Phi2,
+    AutopilotLaws_P.RateLimiterVariableTs1_InitialCondition, &rtb_Gain1_na, &AutopilotLaws_DWork.sf_RateLimiter_h);
+  AutopilotLaws_LagFilter(rtb_Gain1_na, AutopilotLaws_P.LagFilter_C1_g, AutopilotLaws_U.in.time.dt, &rtb_lo_b,
     &AutopilotLaws_DWork.sf_LagFilter_p);
-  AutopilotLaws_DWork.icLoad_f = ((rtb_Saturation_o == 0) || AutopilotLaws_DWork.icLoad_f);
+  AutopilotLaws_DWork.icLoad_f = ((rtb_fpmtoms == 0) || AutopilotLaws_DWork.icLoad_f);
   if (AutopilotLaws_DWork.icLoad_f) {
     AutopilotLaws_DWork.Delay_DSTATE_h2 = rtb_GainTheta;
   }
 
-  AutopilotLaws_VSLimiter(AutopilotLaws_P.VS_Gain_n * a, &AutopilotLaws_Y.out, &L);
+  AutopilotLaws_VSLimiter(AutopilotLaws_P.VS_Gain_n * a, &AutopilotLaws_Y.out, &rtb_Gain1_na);
   if (!rtb_Compare_jy) {
     if (distance_m > AutopilotLaws_P.Switch_Threshold_h) {
-      rtb_lo_k = std::fmax(rtb_lo_k, AutopilotLaws_P.VS_Gain_j * rtb_lo_b);
+      rtb_lo_k = std::fmax(rtb_lo_k, AutopilotLaws_P.VS_Gain_j * rtb_Sum_i);
     } else {
-      rtb_lo_k = std::fmin(rtb_lo_k, AutopilotLaws_P.VS_Gain_j * rtb_lo_b);
+      rtb_lo_k = std::fmin(rtb_lo_k, AutopilotLaws_P.VS_Gain_j * rtb_Sum_i);
     }
   }
 
-  AutopilotLaws_VSLimiter(AutopilotLaws_P.Gain_Gain_k2 * rtb_lo_k, &AutopilotLaws_Y.out, &a);
-  AutopilotLaws_VSLimiter_f(rtb_Product_dh, &AutopilotLaws_Y.out, &b_L);
-  distance_m = AutopilotLaws_P.Gain3_Gain_l * rtb_Y_pt;
-  rtb_lo_k = AutopilotLaws_P.VS_Gain_e * rtb_Sum1_g;
+  AutopilotLaws_VSLimiter(AutopilotLaws_P.Gain_Gain_k2 * rtb_lo_k, &AutopilotLaws_Y.out, &distance_m);
+  AutopilotLaws_VSLimiter_f(rtb_Product_dh, &AutopilotLaws_Y.out, &rtb_lo_k);
+  a = AutopilotLaws_P.Gain3_Gain_l * rtb_Y_n0;
+  R = AutopilotLaws_P.VS_Gain_e * rtb_Sum1_g;
   AutopilotLaws_WashoutFilter(rtb_Saturation, AutopilotLaws_P.WashoutFilter1_C1_h, AutopilotLaws_U.in.time.dt, &b_R,
     &AutopilotLaws_DWork.sf_WashoutFilter_k);
-  rtb_Add3_i = std::abs(b_R);
-  if (rtb_Add3_i > AutopilotLaws_P.Saturation_UpperSat_ig) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_UpperSat_ig;
-  } else if (rtb_Add3_i < AutopilotLaws_P.Saturation_LowerSat_ous) {
-    rtb_Add3_i = AutopilotLaws_P.Saturation_LowerSat_ous;
+  rtb_Add3_j4 = std::abs(b_R);
+  if (rtb_Add3_j4 > AutopilotLaws_P.Saturation_UpperSat_ig) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_UpperSat_ig;
+  } else if (rtb_Add3_j4 < AutopilotLaws_P.Saturation_LowerSat_ous) {
+    rtb_Add3_j4 = AutopilotLaws_P.Saturation_LowerSat_ous;
   }
 
-  rtb_Saturation = AutopilotLaws_P.Gain_Gain_j0 * rtb_Add3_i;
+  rtb_Saturation = AutopilotLaws_P.Gain_Gain_j0 * rtb_Add3_j4;
   if (rtb_on_ground <= AutopilotLaws_P.Switch_Threshold_c) {
-    rtb_Gain4_m = std::fmax(((rtb_Y_j + distance_m) + rtb_uDLookupTable_m * rtb_lo_k) + rtb_Saturation,
-      AutopilotLaws_P.VS1_Gain * rtb_Gain_lg);
+    rtb_Gain4_m = std::fmax(((rtb_Y_k + a) + rtb_uDLookupTable_m * R) + rtb_Saturation, AutopilotLaws_P.VS1_Gain *
+      rtb_Gain_l4);
   }
 
   AutopilotLaws_VSLimiter_f(rtb_Gain4_m, &AutopilotLaws_Y.out, &b_R);
   if (!rtb_Delay_j) {
     if (rtb_Sum3_m3 > AutopilotLaws_P.Switch_Threshold_hz) {
-      rtb_GainTheta1 = std::fmax(rtb_GainTheta1, AutopilotLaws_P.VS_Gain_n5 * rtb_Cos1_fn);
+      rtb_GainTheta1 = std::fmax(rtb_GainTheta1, AutopilotLaws_P.VS_Gain_n5 * rtb_Add3_aj);
     } else {
-      rtb_GainTheta1 = std::fmin(rtb_GainTheta1, AutopilotLaws_P.VS_Gain_n5 * rtb_Cos1_fn);
+      rtb_GainTheta1 = std::fmin(rtb_GainTheta1, AutopilotLaws_P.VS_Gain_n5 * rtb_Add3_aj);
     }
   }
 
-  AutopilotLaws_Voter1(rtb_Sum_ia, AutopilotLaws_P.Gain_Gain_o2 * rtb_GainTheta1, AutopilotLaws_P.VS_Gain_nx *
-                       rtb_Divide, &rtb_lo_b);
-  AutopilotLaws_VSLimiter(rtb_lo_b, &AutopilotLaws_Y.out, &rtb_GainTheta1);
+  AutopilotLaws_Voter1(rtb_Sum_es, AutopilotLaws_P.Gain_Gain_o2 * rtb_GainTheta1, AutopilotLaws_P.VS_Gain_nx *
+                       rtb_Sum_kq, &rtb_Sum_i);
+  AutopilotLaws_VSLimiter(rtb_Sum_i, &AutopilotLaws_Y.out, &rtb_GainTheta1);
   if (AutopilotLaws_U.in.input.vertical_mode == 24.0) {
-    rtb_Y_pt = 0.15;
+    rtb_Add3_j4 = 0.15;
   } else {
-    rtb_Y_pt = 0.1;
+    rtb_Add3_j4 = 0.1;
   }
 
-  rtb_Y_pt = rtb_Y_g * rtb_Y_pt * 57.295779513082323;
+  rtb_Y_n0 = b_L * rtb_Add3_j4 * 57.295779513082323;
   switch (static_cast<int32_T>(rtb_error_d)) {
    case 0:
-    L = AutopilotLaws_P.Constant_Value_d;
+    rtb_Gain1_na = AutopilotLaws_P.Constant_Value_d;
     break;
 
    case 1:
     break;
 
    case 2:
-    L = R;
+    rtb_Gain1_na = L;
     break;
 
    case 3:
-    L = a;
+    rtb_Gain1_na = distance_m;
     break;
 
    case 4:
-    L = rtb_Add5_l;
+    rtb_Gain1_na = rtb_Cos_i;
     break;
 
    case 5:
-    L = rtb_Add3_g;
+    rtb_Gain1_na = rtb_Add3_i;
     break;
 
    case 6:
-    L = b_L;
+    rtb_Gain1_na = rtb_lo_k;
     break;
 
    case 7:
-    L = b_R;
+    rtb_Gain1_na = b_R;
     break;
 
    case 8:
-    L = rtb_GainTheta1;
+    rtb_Gain1_na = rtb_GainTheta1;
     break;
 
    default:
-    L = std::fmax(-rtb_Y_pt, std::fmin(rtb_Y_pt, AutopilotLaws_P.VS_Gain_ne * rtb_Sum_if));
+    rtb_Gain1_na = std::fmax(-rtb_Y_n0, std::fmin(rtb_Y_n0, AutopilotLaws_P.VS_Gain_ne * rtb_Gain_ej3));
     break;
   }
 
-  L += rtb_GainTheta;
-  if (L > AutopilotLaws_P.Constant1_Value_i) {
-    L = AutopilotLaws_P.Constant1_Value_i;
+  rtb_Gain1_na += rtb_GainTheta;
+  if (rtb_Gain1_na > AutopilotLaws_P.Constant1_Value_i) {
+    rtb_Gain1_na = AutopilotLaws_P.Constant1_Value_i;
   } else {
     rtb_GainTheta1 = AutopilotLaws_P.Gain1_Gain_m4 * AutopilotLaws_P.Constant1_Value_i;
-    if (L < rtb_GainTheta1) {
-      L = rtb_GainTheta1;
+    if (rtb_Gain1_na < rtb_GainTheta1) {
+      rtb_Gain1_na = rtb_GainTheta1;
     }
   }
 
-  rtb_GainTheta1 = rtb_Y_g * 0.3 * 57.295779513082323;
+  rtb_GainTheta1 = b_L * 0.3 * 57.295779513082323;
   AutopilotLaws_DWork.DelayInput1_DSTATE = rtb_GainTheta1 * AutopilotLaws_U.in.time.dt;
-  L = std::fmin(L - AutopilotLaws_DWork.Delay_DSTATE_h2, AutopilotLaws_DWork.DelayInput1_DSTATE);
+  rtb_Gain1_na = std::fmin(rtb_Gain1_na - AutopilotLaws_DWork.Delay_DSTATE_h2, AutopilotLaws_DWork.DelayInput1_DSTATE);
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain1_Gain_i0 * rtb_GainTheta1;
   AutopilotLaws_DWork.DelayInput1_DSTATE *= AutopilotLaws_U.in.time.dt;
-  AutopilotLaws_DWork.Delay_DSTATE_h2 += std::fmax(L, AutopilotLaws_DWork.DelayInput1_DSTATE);
+  AutopilotLaws_DWork.Delay_DSTATE_h2 += std::fmax(rtb_Gain1_na, AutopilotLaws_DWork.DelayInput1_DSTATE);
   AutopilotLaws_LagFilter(AutopilotLaws_DWork.Delay_DSTATE_h2, AutopilotLaws_P.LagFilter_C1_i,
     AutopilotLaws_U.in.time.dt, &b_R, &AutopilotLaws_DWork.sf_LagFilter_gn);
-  AutopilotLaws_RateLimiter(static_cast<real_T>(rtb_Saturation_o), AutopilotLaws_P.RateLimiterVariableTs_up_i,
+  AutopilotLaws_RateLimiter(static_cast<real_T>(rtb_fpmtoms), AutopilotLaws_P.RateLimiterVariableTs_up_i,
     AutopilotLaws_P.RateLimiterVariableTs_lo_o, AutopilotLaws_U.in.time.dt,
-    AutopilotLaws_P.RateLimiterVariableTs_InitialCondition_p, &L, &AutopilotLaws_DWork.sf_RateLimiter_eb);
-  if (L > AutopilotLaws_P.Saturation_UpperSat_ix) {
-    L = AutopilotLaws_P.Saturation_UpperSat_ix;
-  } else if (L < AutopilotLaws_P.Saturation_LowerSat_eq) {
-    L = AutopilotLaws_P.Saturation_LowerSat_eq;
+    AutopilotLaws_P.RateLimiterVariableTs_InitialCondition_p, &rtb_Gain1_na, &AutopilotLaws_DWork.sf_RateLimiter_eb);
+  if (rtb_Gain1_na > AutopilotLaws_P.Saturation_UpperSat_ix) {
+    rtb_Gain1_na = AutopilotLaws_P.Saturation_UpperSat_ix;
+  } else if (rtb_Gain1_na < AutopilotLaws_P.Saturation_LowerSat_eq) {
+    rtb_Gain1_na = AutopilotLaws_P.Saturation_LowerSat_eq;
   }
 
-  AutopilotLaws_Y.out.output.flight_director.Theta_c_deg = Phi2;
-  AutopilotLaws_Y.out.output.autopilot.Theta_c_deg = (AutopilotLaws_P.Constant_Value_i4 - L) * rtb_GainTheta + b_R * L;
+  rtb_GainTheta1 = b_R * rtb_Gain1_na;
+  AutopilotLaws_LagFilter(rtb_Y_d, AutopilotLaws_P.LagFilter1_C1_d, AutopilotLaws_U.in.time.dt, &b_R,
+    &AutopilotLaws_DWork.sf_LagFilter_cs);
+  AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_P.Gain7_Gain_l * b_R;
+  AutopilotLaws_Y.out.output.flight_director.Theta_c_deg = rtb_lo_b;
+  AutopilotLaws_Y.out.output.autopilot.Theta_c_deg = (AutopilotLaws_P.Constant_Value_i4 - rtb_Gain1_na) * rtb_GainTheta
+    + rtb_GainTheta1;
   AutopilotLaws_Y.out.output.flare_law.condition_Flare = ((AutopilotLaws_U.in.data.H_radio_ft < 60.0) &&
-    ((AutopilotLaws_U.in.data.H_radio_ft * 15.0 <= std::abs(rtb_Add3_a)) || (AutopilotLaws_U.in.data.H_radio_ft <= 45.0)));
-  AutopilotLaws_Y.out.output.flare_law.H_dot_radio_fpm = rtb_Add3_a;
+    ((AutopilotLaws_U.in.data.H_radio_ft * 15.0 <= std::abs(std::fmax(AutopilotLaws_DWork.DelayInput1_DSTATE, Phi2))) ||
+     (AutopilotLaws_U.in.data.H_radio_ft <= 45.0)));
+  AutopilotLaws_Y.out.output.flare_law.H_dot_radio_fpm = rtb_Add3_lz;
   AutopilotLaws_Y.out.output.flare_law.H_dot_c_fpm = rtb_Vz;
-  AutopilotLaws_Y.out.output.flare_law.delta_Theta_H_dot_deg = rtb_lo_k;
-  AutopilotLaws_Y.out.output.flare_law.delta_Theta_bz_deg = rtb_Y_j;
-  AutopilotLaws_Y.out.output.flare_law.delta_Theta_bx_deg = distance_m;
+  AutopilotLaws_Y.out.output.flare_law.delta_Theta_H_dot_deg = R;
+  AutopilotLaws_Y.out.output.flare_law.delta_Theta_bz_deg = rtb_Y_k;
+  AutopilotLaws_Y.out.output.flare_law.delta_Theta_bx_deg = a;
   AutopilotLaws_Y.out.output.flare_law.delta_Theta_beta_c_deg = rtb_Saturation;
   AutopilotLaws_DWork.DelayInput1_DSTATE = AutopilotLaws_U.in.data.altimeter_setting_left_mbar;
   AutopilotLaws_DWork.DelayInput1_DSTATE_g = AutopilotLaws_U.in.data.altimeter_setting_right_mbar;
-  for (rtb_Saturation_o = 0; rtb_Saturation_o < 99; rtb_Saturation_o++) {
-    AutopilotLaws_DWork.Delay_DSTATE_l[rtb_Saturation_o] = AutopilotLaws_DWork.Delay_DSTATE_l[rtb_Saturation_o + 1];
-    AutopilotLaws_DWork.Delay_DSTATE_h5[rtb_Saturation_o] = AutopilotLaws_DWork.Delay_DSTATE_h5[rtb_Saturation_o + 1];
+  for (rtb_fpmtoms = 0; rtb_fpmtoms < 99; rtb_fpmtoms++) {
+    AutopilotLaws_DWork.Delay_DSTATE_l[rtb_fpmtoms] = AutopilotLaws_DWork.Delay_DSTATE_l[rtb_fpmtoms + 1];
+    AutopilotLaws_DWork.Delay_DSTATE_h5[rtb_fpmtoms] = AutopilotLaws_DWork.Delay_DSTATE_h5[rtb_fpmtoms + 1];
   }
 
   AutopilotLaws_DWork.Delay_DSTATE_l[99] = rtb_valid;
   AutopilotLaws_DWork.Delay_DSTATE_h5[99] = rtb_valid_d;
   AutopilotLaws_DWork.Delay_DSTATE_e = rtb_dme;
   AutopilotLaws_DWork.icLoad = false;
-  AutopilotLaws_DWork.Delay_DSTATE_hi = rtb_Gain_nrh;
-  AutopilotLaws_DWork.Delay_DSTATE_n = rtb_Cos1_pk;
+  AutopilotLaws_DWork.Delay_DSTATE_hi = rtb_Gain_dn;
+  AutopilotLaws_DWork.Delay_DSTATE_n = rtb_Add3_g;
   AutopilotLaws_DWork.icLoad_f = false;
 }
 

--- a/src/fbw/src/model/AutopilotLaws.h
+++ b/src/fbw/src/model/AutopilotLaws.h
@@ -216,7 +216,6 @@ class AutopilotLawsModelClass
     real_T WashoutFilter_C1_m;
     real_T LagFilterH_C1;
     real_T LeadLagFilter_C1;
-    real_T LagFilter1_C1_d;
     real_T LeadLagFilter_C1_a;
     real_T LagFilterH1_C1;
     real_T WashoutFilter_C1_cn;
@@ -226,6 +225,7 @@ class AutopilotLawsModelClass
     real_T LagFilter_C1_g;
     real_T WashoutFilter1_C1_h;
     real_T LagFilter_C1_i;
+    real_T LagFilter1_C1_d;
     real_T HighPassFilter_C2;
     real_T LowPassFilter_C2;
     real_T HighPassFilter_C2_c;
@@ -815,7 +815,7 @@ class AutopilotLawsModelClass
     real_T Gain5_Gain_c;
     real_T kntofpm_Gain;
     real_T maxslope_Gain;
-    real_T Gain7_Gain_l;
+    real_T Gain1_Gain_oa;
     real_T ftmintoms_Gain_k;
     real_T kntoms_Gain_av;
     real_T Saturation_UpperSat_i0;
@@ -897,6 +897,7 @@ class AutopilotLawsModelClass
     real_T Saturation_UpperSat_ix;
     real_T Saturation_LowerSat_eq;
     real_T Constant_Value_i4;
+    real_T Gain7_Gain_l;
     boolean_T Delay_InitialCondition;
     boolean_T Delay_InitialCondition_b;
     uint8_T ManualSwitch_CurrentSetting;

--- a/src/fbw/src/model/AutopilotLaws_data.cpp
+++ b/src/fbw/src/model/AutopilotLaws_data.cpp
@@ -253,8 +253,6 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
 
   15.0,
 
-  4.0,
-
   15.0,
 
   0.033333333333333333,
@@ -272,6 +270,8 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
   6.0,
 
   2.0,
+
+  4.0,
 
   0.0,
 
@@ -1624,6 +1624,8 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
   0.0,
 
   1.0,
+
+  60.0,
 
   false,
 

--- a/src/fbw/src/model/Autothrust_data.cpp
+++ b/src/fbw/src/model/Autothrust_data.cpp
@@ -242,7 +242,7 @@ AutothrustModelClass::Parameters_Autothrust_T AutothrustModelClass::Autothrust_P
   -3.0,
 
 
-  { 10.0, 10.0, 1.5, 1.5, 0.8, 0.5, 0.5 },
+  { 10.0, 10.0, 1.0, 1.0, 1.0, 1.0, 1.0 },
 
 
   { 0.0, 20.0, 30.0, 45.0, 60.0, 80.0, 100.0 },
@@ -254,7 +254,7 @@ AutothrustModelClass::Parameters_Autothrust_T AutothrustModelClass::Autothrust_P
   -10.0,
 
 
-  { 10.0, 10.0, 1.25, 1.25, 0.8, 0.5, 0.5 },
+  { 10.0, 10.0, 1.0, 1.0, 1.0, 1.0, 1.0 },
 
 
   { 0.0, 20.0, 30.0, 40.0, 60.0, 80.0, 100.0 },


### PR DESCRIPTION
## Summary of Changes

### ATHR
Increase speed of spool up/down of engines for ATHR modes `THR IDLE` and `THR CLB` to better match real-life (see on discord channel ATA-22).

### AP
Improved (again) the FLARE law for Autoland capability. Landings are now a bit harder but better match the target touchdown point. The touchdown sound is now using the landing rate instead of plain vertical speed which is more realistic in cases of sloped runways. 

## Testing instructions
- fly level and engage OP CLB
- fly level and engage OP DES
- do several Autoland

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
