### PR TITLE
feat(pfd): improved FPV and FPD

### DIFF
--- a/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
+++ b/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
@@ -1,6 +1,11 @@
 import { Arinc429Word } from '@shared/arinc429';
+import { getSmallestAngle } from '@instruments/common/utils.js';
 import React from 'react';
+import { calculateHorizonOffsetFromPitch } from './PFDUtils';
 import { getSimVar } from '../util.js';
+
+const DistanceSpacing = 15;
+const ValueSpacing = 10;
 
 interface AttitudeIndicatorFixedUpperProps {
     pitch: Arinc429Word;
@@ -41,12 +46,16 @@ export const AttitudeIndicatorFixedUpper = ({ pitch, roll }: AttitudeIndicatorFi
 interface AttitudeIndicatorFixedCenterProps {
     pitch: Arinc429Word;
     roll: Arinc429Word;
+    vs: Arinc429Word;
+    gs: Arinc429Word;
+    heading: Arinc429Word;
+    track: Arinc429Word
     isOnGround: boolean;
     FDActive: boolean;
     isAttExcessive: boolean;
 }
 
-export const AttitudeIndicatorFixedCenter = ({ pitch, roll, isOnGround, FDActive, isAttExcessive }: AttitudeIndicatorFixedCenterProps) => {
+export const AttitudeIndicatorFixedCenter = ({ pitch, roll, vs, gs, heading, track, isOnGround, FDActive, isAttExcessive }: AttitudeIndicatorFixedCenterProps) => {
     if (!pitch.isNormalOperation() || !roll.isNormalOperation()) {
         return (
             <text id="AttFailText" className="Blink9Seconds FontLargest Red EndAlign" x="75.893127" y="83.136955">ATT</text>
@@ -74,6 +83,18 @@ export const AttitudeIndicatorFixedCenter = ({ pitch, roll, isOnGround, FDActive
                 <path d="m88.55 86.114h2.5184v-4.0317h12.592v-2.5198h-15.11z" />
                 <path d="m34.153 79.563h15.11v6.5516h-2.5184v-4.0317h-12.592z" />
             </g>
+            <FlightPathVector pitch={pitch} roll={roll} vs={vs} gs={gs} heading={heading} track={track} />
+            {!isAttExcessive && (
+                <FlightPathDirector
+                    pitch={pitch}
+                    roll={roll}
+                    vs={vs}
+                    gs={gs}
+                    heading={heading}
+                    track={track}
+                    FDActive={FDActive}
+                />
+            ) }
         </g>
     );
 };
@@ -132,6 +153,117 @@ const FlightDirector = ({ FDActive }) => {
                 && <path id="FlightDirectorPitch" transform={`translate(0 ${FDPitchOffset})`} d="m49.263 80.823h39.287" />}
             </g>
         </>
+    );
+};
+
+interface FPVProps {
+    pitch: Arinc429Word;
+    roll: Arinc429Word;
+    vs: Arinc429Word;
+    gs: Arinc429Word;
+    heading: Arinc429Word;
+    track: Arinc429Word
+}
+const FlightPathVector = ({ pitch, roll, vs, gs, heading, track }: FPVProps) => {
+    if (!getSimVar('L:A32NX_TRK_FPA_MODE_ACTIVE', 'bool')) {
+        return null;
+    }
+
+    // TODO FPA and DA should come directly from the IR, and not be calculated here.
+    const FPA = Math.atan(vs.value / gs.value * 0.009875) * 180 / Math.PI;
+    const DA = getSmallestAngle(track.value, heading.value);
+
+    const daLimConv = Math.max(Math.min(DA, 21), -21) * DistanceSpacing / ValueSpacing;
+    const pitchSubFpaConv = (calculateHorizonOffsetFromPitch(-pitch.value) - calculateHorizonOffsetFromPitch(FPA));
+    const rollCos = Math.cos(roll.value * Math.PI / 180);
+    const rollSin = Math.sin(roll.value * Math.PI / 180);
+
+    const xOffset = daLimConv * rollCos - pitchSubFpaConv * rollSin;
+    const yOffset = pitchSubFpaConv * rollCos + daLimConv * rollSin;
+
+    return (
+        <g transform={`translate(${xOffset} ${yOffset})`}>
+            <svg x="53.4" y="65.3" width="31px" height="31px" version="1.1" viewBox="0 0 31 31" xmlns="http://www.w3.org/2000/svg">
+                <g>
+                    <path
+                        className="NormalOutline"
+                        // eslint-disable-next-line max-len
+                        d="m17.766 15.501c8.59e-4 -1.2531-1.0142-2.2694-2.2665-2.2694-1.2524 0-2.2674 1.0163-2.2665 2.2694-8.57e-4 1.2531 1.0142 2.2694 2.2665 2.2694 1.2524 0 2.2674-1.0163 2.2665-2.2694z"
+                    />
+                    <path className="ThickOutline" d="m17.766 15.501h5.0367m-9.5698 0h-5.0367m7.3033-2.2678v-2.5199" />
+                    <path
+                        className="NormalStroke Green"
+                        // eslint-disable-next-line max-len
+                        d="m17.766 15.501c8.59e-4 -1.2531-1.0142-2.2694-2.2665-2.2694-1.2524 0-2.2674 1.0163-2.2665 2.2694-8.57e-4 1.2531 1.0142 2.2694 2.2665 2.2694 1.2524 0 2.2674-1.0163 2.2665-2.2694z"
+                    />
+                    <path className="ThickStroke Green" d="m17.766 15.501h5.0367m-9.5698 0h-5.0367m7.3033-2.2678v-2.5199" />
+                </g>
+            </svg>
+        </g>
+    );
+};
+
+interface FPDProps {
+    pitch: Arinc429Word;
+    roll: Arinc429Word;
+    vs: Arinc429Word;
+    gs: Arinc429Word;
+    heading: Arinc429Word;
+    track: Arinc429Word;
+    FDActive: boolean;
+}
+const FlightPathDirector = ({ pitch, roll, vs, gs, heading, track, FDActive }: FPDProps) => {
+    if (!FDActive || !getSimVar('L:A32NX_TRK_FPA_MODE_ACTIVE', 'bool')) {
+        return null;
+    }
+
+    const lateralAPMode = getSimVar('L:A32NX_FMA_LATERAL_MODE', 'number');
+    const verticalAPMode = getSimVar('L:A32NX_FMA_VERTICAL_MODE', 'enum');
+    const showLateralFD = lateralAPMode !== 0 && lateralAPMode !== 34 && lateralAPMode !== 40;
+    const showVerticalFD = verticalAPMode !== 0 && verticalAPMode !== 34;
+
+    if (!showVerticalFD && !showLateralFD) {
+        return null;
+    }
+
+    const FDRollOrder = getSimVar('L:A32NX_FLIGHT_DIRECTOR_BANK', 'number');
+    const FDRollOrderLim = Math.max(Math.min(FDRollOrder, 45), -45);
+    const FDPitchOrder = getSimVar('L:A32NX_FLIGHT_DIRECTOR_PITCH', 'number');
+    const FDPitchOrderLim = Math.max(Math.min(FDPitchOrder, 22.5), -22.5) * 1.9;
+
+    // TODO FPA and DA should come directly from the IR, and not be calculated here.
+    const FPA = Math.atan(vs.value / gs.value * 0.009875) * 180 / Math.PI;
+    const DA = getSmallestAngle(track.value, heading.value);
+
+    const daLimConv = Math.max(Math.min(DA, 21), -21) * DistanceSpacing / ValueSpacing;
+    const pitchSubFpaConv = (calculateHorizonOffsetFromPitch(-pitch.value) - calculateHorizonOffsetFromPitch(FPA));
+    const rollCos = Math.cos(roll.value * Math.PI / 180);
+    const rollSin = Math.sin(roll.value * Math.PI / 180);
+
+    const FDRollOffset = FDRollOrderLim * 0.77;
+    const xOffsetFpv = daLimConv * rollCos - pitchSubFpaConv * rollSin;
+    const yOffsetFpv = pitchSubFpaConv * rollCos + daLimConv * rollSin;
+
+    const xOffset = xOffsetFpv - FDPitchOrderLim * rollSin;
+    const yOffset = yOffsetFpv + FDPitchOrderLim * rollCos;
+
+    return (
+        <g transform={`translate(${xOffset} ${yOffset})`}>
+            <svg x="53.4" y="65.3" width="31px" height="31px" version="1.1" viewBox="0 0 31 31" xmlns="http://www.w3.org/2000/svg">
+                <g transform={`rotate(${FDRollOffset} 15.5 15.5)`} className="CornerRound">
+                    <path
+                        className="NormalOutline"
+                        // eslint-disable-next-line max-len
+                        d="m16.507 15.501a1.0074 1.008 0 1 0-2.0147 0 1.0074 1.008 0 1 0 2.0147 0zm7.5551 0 6.5478-1.5119v3.0238l-6.5478-1.5119m-17.125 0-6.5478-1.5119v3.0238l6.5478-1.5119h17.125"
+                    />
+                    <path
+                        className="NormalStroke Green"
+                        // eslint-disable-next-line max-len
+                        d="m16.507 15.501a1.0074 1.008 0 1 0-2.0147 0 1.0074 1.008 0 1 0 2.0147 0zm7.5551 0 6.5478-1.5119v3.0238l-6.5478-1.5119m-17.125 0-6.5478-1.5119v3.0238l6.5478-1.5119h17.125"
+                    />
+                </g>
+            </svg>
+        </g>
     );
 };
 

--- a/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
+++ b/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
@@ -64,7 +64,6 @@ export const AttitudeIndicatorFixedCenter = ({ pitch, roll, vs, gs, heading, tra
 
     return (
         <g id="AttitudeSymbolsGroup">
-            <path className="Yellow Fill" d="m115.52 80.067v1.5119h-8.9706v-1.5119z" />
             <SidestickIndicator isOnGround={isOnGround} />
             <path className="BlackFill" d="m67.647 82.083v-2.5198h2.5184v2.5198z" />
             {!isAttExcessive && (

--- a/src/instruments/src/PFD/AttitudeIndicatorHorizon.tsx
+++ b/src/instruments/src/PFD/AttitudeIndicatorHorizon.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { Arinc429Word } from '@shared/arinc429';
 import { useUpdate } from '@instruments/common/hooks';
-import { getSmallestAngle } from '@instruments/common/utils';
 import {
     calculateHorizonOffsetFromPitch,
     calculateVerticalOffsetFromRoll,
@@ -154,94 +153,6 @@ export const Horizon = ({ pitch, roll, heading, isOnGround, radioAlt, decisionHe
             )}
             {!isAttExcessive
             && <RadioAltAndDH radioAlt={radioAlt} decisionHeight={decisionHeight} roll={roll} />}
-            <FlightPathVector />
-            {!isAttExcessive
-            && <FlightPathDirector FDActive={FDActive} />}
-        </g>
-    );
-};
-
-const FlightPathVector = () => {
-    if (!getSimVar('L:A32NX_TRK_FPA_MODE_ACTIVE', 'bool')) {
-        return null;
-    }
-
-    const roll = getSimVar('PLANE BANK DEGREES', 'degrees');
-    const pitch = -getSimVar('PLANE PITCH DEGREES', 'degrees');
-    const AOA = getSimVar('INCIDENCE ALPHA', 'degrees');
-    const FPA = pitch - (Math.cos(roll * Math.PI / 180) * AOA);
-    const DA = getSmallestAngle(getSimVar('GPS GROUND TRUE TRACK', 'degrees'), getSimVar('GPS GROUND TRUE HEADING', 'degrees'));
-
-    const xOffset = Math.max(Math.min(DA, 21), -21) * DistanceSpacing / ValueSpacing;
-    const yOffset = calculateHorizonOffsetFromPitch(pitch) - calculateHorizonOffsetFromPitch(FPA);
-
-    return (
-        <g transform={`translate(${xOffset} ${yOffset})`}>
-            <svg x="53.4" y="65.3" width="31px" height="31px" version="1.1" viewBox="0 0 31 31" xmlns="http://www.w3.org/2000/svg">
-                <g transform={`rotate(${-roll} 15.5 15.5)`}>
-                    <path
-                        className="NormalOutline"
-                        // eslint-disable-next-line max-len
-                        d="m17.766 15.501c8.59e-4 -1.2531-1.0142-2.2694-2.2665-2.2694-1.2524 0-2.2674 1.0163-2.2665 2.2694-8.57e-4 1.2531 1.0142 2.2694 2.2665 2.2694 1.2524 0 2.2674-1.0163 2.2665-2.2694z"
-                    />
-                    <path className="ThickOutline" d="m17.766 15.501h5.0367m-9.5698 0h-5.0367m7.3033-2.2678v-2.5199" />
-                    <path
-                        className="NormalStroke Green"
-                        // eslint-disable-next-line max-len
-                        d="m17.766 15.501c8.59e-4 -1.2531-1.0142-2.2694-2.2665-2.2694-1.2524 0-2.2674 1.0163-2.2665 2.2694-8.57e-4 1.2531 1.0142 2.2694 2.2665 2.2694 1.2524 0 2.2674-1.0163 2.2665-2.2694z"
-                    />
-                    <path className="ThickStroke Green" d="m17.766 15.501h5.0367m-9.5698 0h-5.0367m7.3033-2.2678v-2.5199" />
-                </g>
-            </svg>
-        </g>
-    );
-};
-
-const FlightPathDirector = ({ FDActive }) => {
-    if (!FDActive || !getSimVar('L:A32NX_TRK_FPA_MODE_ACTIVE', 'bool')) {
-        return null;
-    }
-
-    const lateralAPMode = getSimVar('L:A32NX_FMA_LATERAL_MODE', 'number');
-    const verticalAPMode = getSimVar('L:A32NX_FMA_VERTICAL_MODE', 'enum');
-    const showLateralFD = lateralAPMode !== 0 && lateralAPMode !== 34 && lateralAPMode !== 40;
-    const showVerticalFD = verticalAPMode !== 0 && verticalAPMode !== 34;
-
-    if (!showVerticalFD && !showLateralFD) {
-        return null;
-    }
-
-    const FDRollOrder = getSimVar('L:A32NX_FLIGHT_DIRECTOR_BANK', 'number');
-    const currentRoll = getSimVar('PLANE BANK DEGREES', 'degrees');
-    const FDRollOffset = (FDRollOrder - currentRoll) * 0.77;
-
-    const DA = getSmallestAngle(getSimVar('GPS GROUND TRUE TRACK', 'degrees'), getSimVar('GPS GROUND TRUE HEADING', 'degrees'));
-
-    const xOffset = Math.max(Math.min(DA, 21), -21) * DistanceSpacing / ValueSpacing;
-
-    const FDPitchOrder = getSimVar('L:A32NX_FLIGHT_DIRECTOR_PITCH', 'number');
-    const currentPitch = -getSimVar('PLANE PITCH DEGREES', 'degrees');
-    const AOA = getSimVar('INCIDENCE ALPHA', 'degrees');
-    const FPA = currentPitch - (Math.cos(currentRoll * Math.PI / 180) * AOA);
-
-    const yOffset = calculateHorizonOffsetFromPitch(currentPitch) - calculateHorizonOffsetFromPitch(FPA) + (FDPitchOrder) * 0.44;
-
-    return (
-        <g transform={`translate(${xOffset} ${yOffset})`}>
-            <svg x="53.4" y="65.3" width="31px" height="31px" version="1.1" viewBox="0 0 31 31" xmlns="http://www.w3.org/2000/svg">
-                <g transform={`rotate(${FDRollOffset} 15.5 15.5)`} className="CornerRound">
-                    <path
-                        className="NormalOutline"
-                        // eslint-disable-next-line max-len
-                        d="m16.507 15.501a1.0074 1.008 0 1 0-2.0147 0 1.0074 1.008 0 1 0 2.0147 0zm7.5551 0 6.5478-1.5119v3.0238l-6.5478-1.5119m-17.125 0-6.5478-1.5119v3.0238l6.5478-1.5119h17.125"
-                    />
-                    <path
-                        className="NormalStroke Green"
-                        // eslint-disable-next-line max-len
-                        d="m16.507 15.501a1.0074 1.008 0 1 0-2.0147 0 1.0074 1.008 0 1 0 2.0147 0zm7.5551 0 6.5478-1.5119v3.0238l-6.5478-1.5119m-17.125 0-6.5478-1.5119v3.0238l6.5478-1.5119h17.125"
-                    />
-                </g>
-            </svg>
         </g>
     );
 };

--- a/src/instruments/src/PFD/LandingSystemIndicator.tsx
+++ b/src/instruments/src/PFD/LandingSystemIndicator.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { getSimVar } from '../util.js';
 import { LagFilter } from './PFDUtils';
 
-export function LandingSystem({ LSButtonPressed }) {
+export function LandingSystem({ LSButtonPressed, pitch, roll }) {
     let showVDev = false;
 
     if (!LSButtonPressed) {
@@ -27,6 +27,8 @@ export function LandingSystem({ LSButtonPressed }) {
                     <LDevIndicator />
                 </g>
             )}
+            { (LSButtonPressed || (pitch.isNormalOperation() && roll.isNormalOperation()))
+                && <path className="Yellow Fill" d="m115.52 80.067v1.5119h-8.9706v-1.5119z" />}
         </g>
     );
 }

--- a/src/instruments/src/PFD/index.tsx
+++ b/src/instruments/src/PFD/index.tsx
@@ -96,6 +96,7 @@ export const PFD: React.FC = () => {
 
     const heading = useArinc429Var(`L:A32NX_ADIRS_IR_${inertialReferenceSource}_HEADING`);
     const groundTrack = useArinc429Var(`L:A32NX_ADIRS_IR_${inertialReferenceSource}_TRACK`);
+    const groundSpeed = useArinc429Var(`L:A32NX_ADIRS_IR_${inertialReferenceSource}_GROUND_SPEED`);
 
     const radioAlt = getSimVar('PLANE ALT ABOVE GROUND MINUS CG', 'feet');
     const decisionHeight = getSimVar('L:AIRLINER_DECISION_HEIGHT', 'feet');
@@ -173,6 +174,17 @@ export const PFD: React.FC = () => {
                     decisionHeight={decisionHeight}
                     isAttExcessive={isAttExcessive}
                 />
+                <AttitudeIndicatorFixedCenter
+                    pitch={pitch}
+                    roll={roll}
+                    vs={inertialVerticalSpeed}
+                    gs={groundSpeed}
+                    heading={heading}
+                    track={groundTrack}
+                    isOnGround={isOnGround}
+                    FDActive={FDActive}
+                    isAttExcessive={isAttExcessive}
+                />
                 <path
                     id="Mask1"
                     className="BackgroundFill"
@@ -198,7 +210,6 @@ export const PFD: React.FC = () => {
                 />
                 <LandingSystem LSButtonPressed={lsButtonPressed} />
                 <AttitudeIndicatorFixedUpper pitch={pitch} roll={roll} />
-                <AttitudeIndicatorFixedCenter pitch={pitch} roll={roll} isOnGround={isOnGround} FDActive={FDActive} isAttExcessive={isAttExcessive} />
                 <VerticalSpeedIndicator radioAlt={radioAlt} verticalSpeed={verticalSpeed} />
                 <HeadingOfftape ILSCourse={ILSCourse} groundTrack={groundTrack} heading={heading} selectedHeading={selectedHeading} />
                 <AltitudeIndicatorOfftape altitude={altitude} radioAlt={radioAlt} MDA={mda} targetAlt={targetAlt} altIsManaged={isManaged} mode={pressureMode} />

--- a/src/instruments/src/PFD/index.tsx
+++ b/src/instruments/src/PFD/index.tsx
@@ -208,7 +208,7 @@ export const PFD: React.FC = () => {
                     // eslint-disable-next-line max-len
                     d="m32.138 145.34h73.536v10.382h-73.536zm0-44.092c7.4164 13.363 21.492 21.652 36.768 21.652 15.277 0 29.352-8.2886 36.768-21.652v-40.859c-7.4164-13.363-21.492-21.652-36.768-21.652-15.277 0-29.352 8.2886-36.768 21.652zm-32.046 57.498h158.66v-158.75h-158.66zm115.14-35.191v-85.473h20.344v85.473zm-113.33 0v-85.473h27.548v85.473z"
                 />
-                <LandingSystem LSButtonPressed={lsButtonPressed} />
+                <LandingSystem LSButtonPressed={lsButtonPressed} pitch={pitch} roll={roll} />
                 <AttitudeIndicatorFixedUpper pitch={pitch} roll={roll} />
                 <VerticalSpeedIndicator radioAlt={radioAlt} verticalSpeed={verticalSpeed} />
                 <HeadingOfftape ILSCourse={ILSCourse} groundTrack={groundTrack} heading={heading} selectedHeading={selectedHeading} />


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR aims to improves the FPV (flight path vector, bird) and FPD (flight path director) in the following ways:
* Firstly, the FPA is now no longer the aerodynamic FPA (AOA + pitch), but the kinematic FPA (atan(VS / GS)).
* Improved behaviour in gusty weather: The bird no longer jumps around as erratically
* The roll and pitch commands of the FPD are improved:
  * The roll command now actually displays the desired roll angle, instead of being scaled down slightly like before this PR
  * The pitch command now actually points to the desired pitch angle.
* Improved drawing priority: The FPA/FPD is now rendered above the fixed aircraft symbol (the yellow/black aircraft shape) and the rising ground (the lower "earth-colored" sector that rises as the radio height decreases). I'm not entirely sure about the exact drawing order here, but this should pose an improvement for now.

Also there is a small secondary improvement: The glideslope yellow reference line now also shows, when the LS button is pressed and the attitude is invalid. Previously, it only showed when the attitude was valid. While I don't have a 100% sure reference on this, it would make sense that the LS data is available even with invalid attitude data, which includes the reference line.

The FPA and DA should normally be calculated directly in the IR, but as this isn't implemented yet, I'm doing it in the PFD.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before: https://streamable.com/awoxiq
After (The changed drawing priority is not yet implemented here): https://streamable.com/dpl498

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
