### PR TITLE
refactor(tcas): Improve traffic draw

### DIFF
--- a/src/instruments/src/ND/elements/Traffic.tsx
+++ b/src/instruments/src/ND/elements/Traffic.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { useSimVar } from '@instruments/common/simVars';
-import React, { FC, useState, useReducer, memo } from 'react';
+import React, { FC, useState, memo } from 'react';
 import { Layer } from '@instruments/common/utils';
 import { TCAS_CONST as TCAS, TaRaIntrusion, TaRaIndex } from '@tcas/lib/TcasConstants';
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
@@ -15,40 +15,31 @@ export type TcasProps = {
     mode: Mode.ARC | Mode.ROSE_NAV | Mode.ROSE_ILS | Mode.ROSE_VOR,
 }
 
-function reducer(state, action) {
-    switch (action.type) {
-    case 'add':
-        return [...state, action.item];
-    case 'remove':
-        return [
-            ...state.slice(0, action.index),
-            ...state.slice(action.index + 1),
-        ];
-    default:
-        throw new Error();
-    }
-}
+type TcasMask = [number, number][];
+
+const TCAS_MASK_ARC: TcasMask = [
+    // ARC
+    [-384, -310], [-384, 0], [-264, 0], [-210, 59], [-210, 143],
+    [210, 143], [210, 0], [267, -61], [384, -61],
+    [384, -310], [340, -355], [300, -390], [240, -431.5],
+    [180, -460], [100, -482], [0, -492], [-100, -482],
+    [-180, -460], [-240, -431.5], [-300, -390], [-340, -355],
+    [-384, -310],
+];
+
+const TCAS_MASK_ROSE: TcasMask = [
+    // ROSE NAV
+    [-340, -227], [-103, -227], [-50, -244],
+    [0, -250], [50, -244], [103, -227], [340, -227],
+    [340, 180], [267, 180], [210, 241], [210, 383],
+    [-210, 383], [-210, 300], [-264, 241], [-340, 241], [-340, -227],
+];
 
 export const Traffic: FC<TcasProps> = ({ mapParams, mode }) => {
-    const [displayTraffic] = useReducer(reducer, []);
-    const [latLong] = useState<Coordinates>({ lat: NaN, long: NaN });
+    const [displayTraffic] = useState([]);
     const [debug] = usePersistentProperty('TCAS_DEBUG', '0');
     const [sensitivity] = useSimVar('L:A32NX_TCAS_SENSITIVITY', 'number', 200);
-    const [tcasMask] = useState<[number, number][]>(mode === Mode.ARC ? [
-        // ARC
-        [-384, -310], [-384, 0], [-264, 0], [-210, 59], [-210, 143],
-        [210, 143], [210, 0], [267, -61], [384, -61],
-        [384, -310], [340, -355], [300, -390], [240, -431.5],
-        [180, -460], [100, -482], [0, -492], [-100, -482],
-        [-180, -460], [-240, -431.5], [-300, -390], [-340, -355],
-        [-384, -310],
-    ] : [
-        // ROSE NAV
-        [-340, -227], [-103, -227], [-50, -244],
-        [0, -250], [50, -244], [103, -227], [340, -227],
-        [340, 180], [267, 180], [210, 241], [210, 383],
-        [-210, 383], [-210, 300], [-264, 241], [-340, 241], [-340, -227],
-    ]);
+    const tcasMask: TcasMask = (mode === Mode.ARC ? TCAS_MASK_ARC : TCAS_MASK_ROSE);
     const x: number = 361.5;
     const y: number = (mode === Mode.ARC) ? 606.5 : 368;
 
@@ -57,8 +48,7 @@ export const Traffic: FC<TcasProps> = ({ mapParams, mode }) => {
         displayTraffic.forEach((traffic: NdTraffic) => traffic.alive = false);
         if (airTraffic) {
             airTraffic.forEach((tf: NdTraffic) => {
-                latLong.lat = tf.lat;
-                latLong.long = tf.lon;
+                const latLong: Coordinates = { lat: tf.lat, long: tf.lon };
                 let [x, y] = mapParams.coordinatesToXYy(latLong);
 
                 const bitfield = tf.bitfield;

--- a/src/instruments/src/ND/elements/Traffic.tsx
+++ b/src/instruments/src/ND/elements/Traffic.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { useSimVar } from '@instruments/common/simVars';
-import React, { FC, useState, memo } from 'react';
+import React, { FC, useState, memo, useEffect } from 'react';
 import { Layer } from '@instruments/common/utils';
 import { TCAS_CONST as TCAS, TaRaIntrusion, TaRaIndex } from '@tcas/lib/TcasConstants';
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
@@ -35,66 +35,52 @@ const TCAS_MASK_ROSE: TcasMask = [
     [-210, 383], [-210, 300], [-264, 241], [-340, 241], [-340, -227],
 ];
 
+const useAirTraffic = (mapParams, mode) : NdTraffic[] => {
+    const [airTraffic, setAirTraffic] = useState<NdTraffic[]>([]);
+    const tcasMask = (mode === Mode.ARC ? TCAS_MASK_ARC : TCAS_MASK_ROSE);
+    useCoherentEvent('A32NX_TCAS_TRAFFIC', (airTrafficString: string) => {
+        const newTraffic = JSON.parse(airTrafficString);
+        setAirTraffic(trafficToDisplay(newTraffic, mapParams, tcasMask));
+    });
+    useEffect(() => {
+        setAirTraffic(trafficToDisplay(airTraffic, mapParams, tcasMask));
+    }, [mapParams?.nmRadius, mode]);
+    return airTraffic;
+};
+
+const trafficToDisplay = (airTraffic, mapParams, tcasMask) => (
+    airTraffic.map((traffic: NdTraffic) => {
+        const latLong: Coordinates = { lat: traffic.lat, long: traffic.lon };
+        let [x, y] = mapParams.coordinatesToXYy(latLong);
+
+        const bitfield = traffic.bitfield;
+        const vertSpeed = Math.round(bitfield / 10);
+        const intrusionLevel = Math.abs(bitfield % 10);
+
+        // TODO FIXME: Full time option installed: For all ranges except in ZOOM ranges, NDRange > 9NM
+        if (!MathUtils.pointInPolygon(x, y, tcasMask)) {
+            if (intrusionLevel < TaRaIntrusion.TA) {
+                traffic.alive = false;
+                return traffic;
+            }
+            const ret: [number, number] | null = MathUtils.intersectWithPolygon(x, y, 0, 0, tcasMask);
+            if (ret) [x, y] = ret;
+        }
+        traffic.alive = true;
+        traffic.vertSpeed = vertSpeed;
+        traffic.posX = x;
+        traffic.posY = y;
+        traffic.intrusionLevel = intrusionLevel as TaRaIntrusion;
+        return traffic;
+    })
+);
+
 export const Traffic: FC<TcasProps> = ({ mapParams, mode }) => {
-    const [displayTraffic] = useState([]);
+    const airTraffic = useAirTraffic(mapParams, mode);
     const [debug] = usePersistentProperty('TCAS_DEBUG', '0');
     const [sensitivity] = useSimVar('L:A32NX_TCAS_SENSITIVITY', 'number', 200);
-    const tcasMask: TcasMask = (mode === Mode.ARC ? TCAS_MASK_ARC : TCAS_MASK_ROSE);
     const x: number = 361.5;
     const y: number = (mode === Mode.ARC) ? 606.5 : 368;
-
-    useCoherentEvent('A32NX_TCAS_TRAFFIC', (airTrafficString: string) => {
-        const airTraffic: NdTraffic[] = JSON.parse(airTrafficString);
-        displayTraffic.forEach((traffic: NdTraffic) => traffic.alive = false);
-        if (airTraffic) {
-            airTraffic.forEach((tf: NdTraffic) => {
-                const latLong: Coordinates = { lat: tf.lat, long: tf.lon };
-                let [x, y] = mapParams.coordinatesToXYy(latLong);
-
-                const bitfield = tf.bitfield;
-                const vertSpeed = Math.round(bitfield / 10);
-                const intrusionLevel = Math.abs(bitfield % 10);
-
-                // TODO FIXME: Full time option installed: For all ranges except in ZOOM ranges, NDRange > 9NM
-                if (!MathUtils.pointInPolygon(x, y, tcasMask)) {
-                    if (intrusionLevel < TaRaIntrusion.TA) {
-                        return;
-                    }
-                    const ret: [number, number] | null = MathUtils.intersectWithPolygon(x, y, 0, 0, tcasMask);
-                    if (ret) [x, y] = ret;
-                }
-
-                const traffic: NdTraffic | undefined = displayTraffic.find((p) => p && p.ID === tf.ID);
-                if (traffic) {
-                    traffic.alive = true;
-                    traffic.intrusionLevel = intrusionLevel as TaRaIntrusion;
-                    traffic.lat = tf.lat;
-                    traffic.lon = tf.lon;
-                    traffic.relativeAlt = tf.relativeAlt;
-                    traffic.vertSpeed = vertSpeed;
-                    traffic.posX = x;
-                    traffic.posY = y;
-                    if (debug !== '0') {
-                        traffic.hidden = tf.hidden;
-                        traffic.seen = tf.seen;
-                        traffic.raTau = tf.raTau;
-                        traffic.taTau = tf.taTau;
-                        traffic.vTau = tf.vTau;
-                        traffic.closureAccel = tf.closureAccel;
-                        traffic.closureRate = tf.closureRate;
-                    }
-                } else {
-                    tf.alive = true;
-                    displayTraffic.push(tf);
-                }
-            });
-        }
-        displayTraffic.forEach((traffic: NdTraffic, index: number) => {
-            if (!traffic.alive) {
-                displayTraffic.splice(index, 1);
-            }
-        });
-    });
 
     if (debug !== '0') {
         const dmodRa: number = mapParams.nmToPx * (TCAS.DMOD[sensitivity || 1][TaRaIndex.RA]);
@@ -168,39 +154,43 @@ export const Traffic: FC<TcasProps> = ({ mapParams, mode }) => {
                         {TCAS.ALIM[sensitivity]}
                     </tspan>
                 </text>
-                {displayTraffic.map((tf) => (
-                    <TrafficIndicatorDebug
-                        key={tf.ID}
-                        x={tf.posX}
-                        y={tf.posY}
-                        relativeAlt={tf.relativeAlt}
-                        vertSpeed={tf.vertSpeed}
-                        intrusionLevel={tf.intrusionLevel}
-                        ID={tf.ID}
-                        hidden={tf.hidden}
-                        seen={tf.seen}
-                        raTau={tf.raTau && tf.raTau < 200 ? tf.raTau?.toFixed(0) : undefined}
-                        taTau={tf.taTau && tf.taTau < 200 ? tf.taTau?.toFixed(0) : undefined}
-                        vTau={tf.vTau && tf.vTau < 200 ? tf.vTau?.toFixed(0) : undefined}
-                        closureAccel={tf.closureAccel?.toFixed(1)}
-                        closureRate={tf.closureRate?.toFixed(1)}
+                {airTraffic.map((tf) => (
+                    tf.alive ? (
+                        <TrafficIndicatorDebug
+                            key={tf.ID}
+                            x={tf.posX}
+                            y={tf.posY}
+                            relativeAlt={tf.relativeAlt}
+                            vertSpeed={tf.vertSpeed}
+                            intrusionLevel={tf.intrusionLevel}
+                            ID={tf.ID}
+                            hidden={tf.hidden}
+                            seen={tf.seen}
+                            raTau={tf.raTau && tf.raTau < 200 ? tf.raTau?.toFixed(0) : undefined}
+                            taTau={tf.taTau && tf.taTau < 200 ? tf.taTau?.toFixed(0) : undefined}
+                            vTau={tf.vTau && tf.vTau < 200 ? tf.vTau?.toFixed(0) : undefined}
+                            closureAccel={tf.closureAccel?.toFixed(1)}
+                            closureRate={tf.closureRate?.toFixed(1)}
 
-                    />
+                        />
+                    ) : null
                 ))}
             </Layer>
         );
     }
     return (
         <Layer x={x} y={y}>
-            {displayTraffic.map((tf) => (
-                <TrafficIndicator
-                    key={tf.ID}
-                    x={tf.posX}
-                    y={tf.posY}
-                    relativeAlt={tf.relativeAlt}
-                    vertSpeed={tf.vertSpeed}
-                    intrusionLevel={tf.intrusionLevel}
-                />
+            {airTraffic.map((tf) => (
+                tf.alive ? (
+                    <TrafficIndicator
+                        key={tf.ID}
+                        x={tf.posX}
+                        y={tf.posY}
+                        relativeAlt={tf.relativeAlt}
+                        vertSpeed={tf.vertSpeed}
+                        intrusionLevel={tf.intrusionLevel}
+                    />
+                ) : null
             ))}
         </Layer>
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Improves the draw response of TCAS traffic on ND on mode and range change.

Received traffic from the computer is kept in state. The `alive` attribute is kept and used for mode and range changes.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

Range change: https://youtu.be/8QzlOwrUDDs?t=439

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): coolll.sk#0022

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Observe ND traffic markers position change:
* immediately on range change
* very shortly after mode change (ARC to ROSE, ROSE to ARC)

To ensure that the previous draw functionality is preserved the traffic markers should keep ~1s cadence update when:
* flying
* changing heading

Observe performance.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
