### PR TITLE
fix(lnav): fix HX entry RAD, FC and FD legs, and enroute runway

### DIFF
--- a/src/fmgc/src/efis/EfisSymbols.ts
+++ b/src/fmgc/src/efis/EfisSymbols.ts
@@ -84,6 +84,7 @@ export class EfisSymbols {
         this.lastNearbyFacilitiesVersion = this.nearby.version;
         const fpChanged = this.lastFpVersion !== this.flightPlanManager.currentFlightPlanVersion;
         this.lastFpVersion = this.flightPlanManager.currentFlightPlanVersion;
+        // FIXME map reference point should be per side
         const planCentreIndex = SimVar.GetSimVarValue('L:A32NX_SELECTED_WAYPOINT', 'number');
         const planCentre = this.flightPlanManager.getWaypoint(planCentreIndex)?.infos.coordinates;
         const planCentreChanged = planCentre?.lat !== this.lastPlanCentre?.lat || planCentre?.long !== this.lastPlanCentre?.long;
@@ -125,6 +126,11 @@ export class EfisSymbols {
 
             if (!pposChanged && !trueHeadingChanged && !rangeChange && !modeChange && !efisOptionChange && !nearbyOverlayChanged && !fpChanged && !planCentreChanged) {
                 continue;
+            }
+
+            if (mode === Mode.PLAN && !planCentre) {
+                this.listener.triggerToAllSubscribers(`A32NX_EFIS_${side}_SYMBOLS`, []);
+                return;
             }
 
             const [editAhead, editBehind, editBeside] = this.calculateEditArea(range, mode);

--- a/src/fmgc/src/flightplanning/LegsProcedure.ts
+++ b/src/fmgc/src/flightplanning/LegsProcedure.ts
@@ -23,6 +23,7 @@
  */
 
 import { HoldData, HoldType } from '@fmgc/flightplanning/data/flightplan';
+import { firstSmallCircleIntersection } from 'msfs-geo';
 import { AltitudeDescriptor, FixTypeFlags, LegType } from '../types/fstypes/FSEnums';
 import { FixNamingScheme } from './FixNamingScheme';
 import { GeoMath } from './GeoMath';
@@ -266,18 +267,45 @@ export class LegsProcedure {
   }
 
   /**
-   * Maps a bearing/distance fix in the procedure.
+   * Maps an FC or FD leg in the procedure.
+   * @note FC and FD legs are mapped to CF legs in the real FMS
+   * @todo move the code into the CF leg (maybe static functions fromFc and fromFd to construct the leg)
+   * @todo FD should overfly the termination... needs a messy refactor to do that
    * @param leg The procedure leg to map.
    * @returns The mapped leg.
    */
   public mapBearingAndDistanceFromOrigin(leg: RawProcedureLeg): WayPoint {
-      const origin = this._facilities.get(leg.type === LegType.FD ? leg.originIcao : leg.fixIcao);
-      const originIdent = origin.icao.substring(7, 12).trim();
+    const origin = this._facilities.get(leg.fixIcao);
+    const originIdent = origin.icao.substring(7, 12).trim();
+    const course = leg.trueDegrees ? leg.course : A32NX_Util.magneticToTrue(leg.course, Facilities.getMagVar(origin.lat, origin.lon));
+    // this is the leg length for FC, and the DME distance for FD
+    const refDistance = leg.distance / 1852;
 
-      const course = (leg.type === LegType.FC ? leg.course : leg.theta) + GeoMath.getMagvar(origin.lat, origin.lon);
-      const coordinates = Avionics.Utils.bearingDistanceToCoordinates(course, leg.distance / 1852, origin.lat, origin.lon);
+    let termPoint;
+    let legLength;
+    if (leg.type === LegType.FD) {
+        const recNavaid = this._facilities.get(leg.originIcao);
+        termPoint = firstSmallCircleIntersection(
+            { lat: recNavaid.lat, long: recNavaid.lon },
+            refDistance,
+            { lat: origin.lat, long: origin.lon },
+            course,
+        );
+        legLength = Avionics.Utils.computeGreatCircleDistance(
+            { lat: origin.lat, long: origin.lon },
+            termPoint,
+        );
+    } else { // FC
+        termPoint = Avionics.Utils.bearingDistanceToCoordinates(
+            course,
+            refDistance,
+            origin.lat,
+            origin.lon,
+        );
+        legLength = refDistance;
+    }
 
-      return this.buildWaypoint(`${originIdent.substring(0, 3)}/${Math.trunc(leg.distance / 1852).toString().padStart(2, '0')}`, coordinates);
+    return this.buildWaypoint(`${originIdent.substring(0, 3)}/${Math.round(legLength).toString().padStart(2, '0')}`, termPoint);
   }
 
   /**

--- a/src/fmgc/src/flightplanning/LegsProcedure.ts
+++ b/src/fmgc/src/flightplanning/LegsProcedure.ts
@@ -500,7 +500,7 @@ export class LegsProcedure {
       (waypoint.additionalData.defaultHold as HoldData) = {
           inboundMagneticCourse: leg.trueDegrees ? A32NX_Util.trueToMagnetic(leg.course, magVar) : leg.course,
           turnDirection: leg.turnDirection,
-          distance: leg.distanceMinutes ? undefined : leg.distance,
+          distance: leg.distanceMinutes ? undefined : leg.distance / 1852,
           time: leg.distanceMinutes ? leg.distance : undefined,
           type: HoldType.Database,
       };

--- a/src/fmgc/src/guidance/lnav/transitions/HoldEntryTransition.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/HoldEntryTransition.ts
@@ -165,7 +165,8 @@ export class HoldEntryTransition extends Transition {
         case EntryState.Capture:
             params = courseToFixGuidance(ppos, trueTrack, this.outboundCourse, this.nextLeg.fix.infos.coordinates);
             // TODO for HF get the following leg bank
-            bankNext = maxBank(tas, true);
+            const { sweepAngle } = this.nextLeg.geometry;
+            bankNext = sweepAngle > 0 ? maxBank(tas, true) : -maxBank(tas, true);
             break;
         case EntryState.Done:
             params = this.nextLeg.getGuidanceParameters(ppos, trueTrack, tas, gs);
@@ -222,7 +223,7 @@ export class HoldEntryTransition extends Transition {
             break;
         case EntryState.Straight1:
             params = courseToFixGuidance(ppos, trueTrack, this.straightCourse, this.turn2.itp);
-            bankNext = maxBank(tas, true);
+            bankNext = this.turn2.sweepAngle > 0 ? maxBank(tas, true) : -maxBank(tas, true);
             break;
         case EntryState.Turn2:
             params = arcGuidance(ppos, trueTrack, this.turn2.itp, this.turn2.arcCentre, this.turn2.sweepAngle);

--- a/src/instruments/src/ND/elements/FlightPlan.tsx
+++ b/src/instruments/src/ND/elements/FlightPlan.tsx
@@ -209,8 +209,8 @@ const RunwayMarkerFar: FC<Omit<RunwayMarkerProps, 'lengthPx'>> = memo(({ ident, 
 
     return (
         <g transform={`rotate(${rotation})`} className="White">
-            <rect x={-5} y={-25} width={10} height={25} className="shadow" strokeWidth={2.5} />
-            <rect x={-5} y={-25} width={10} height={25} strokeWidth={2} />
+            <rect x={-5} y={-12.5} width={10} height={25} className="shadow" strokeWidth={2.5} />
+            <rect x={-5} y={-12.5} width={10} height={25} strokeWidth={2} />
             <RunwayIdent ident={ident} rotation={rotation} />
         </g>
     );


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- I made a small mistake in rewriting HX entries, forgetting to account for turn direction in the roll anticipation calculations. This caused a turn in the wrong direction before turning back to the correct direction for left turn holds.
- FC and FD legs were mapped incorrectly from the source data... now the geometry is correct (perfect implementation will need to wait for cfms-20, as I don't want to do two refactors of the magnitude required prior to that).
- Enroute runways weren't shown quite right on the ND (they should be centred on the runway location).
- There was an exception thrown in the FMGC when the map reference point was undefined in plan mode (happens briefly while creating a new flightplan... but whichever part of the FMGC decides the MRP should actually set MRP to PPOS when no F-PLN pages are in use... future PR?)
- The leg length of database holds specified as a distance was not scaled from metres to nautical miles

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
FD legs:
EGPE ILS23 via INS before:
![image](https://user-images.githubusercontent.com/9995998/155712026-ee305ca7-d34f-4a91-b1ff-cdf689e628c9.png)
After:
![image](https://user-images.githubusercontent.com/9995998/155712040-9500cade-b9ef-4a92-88cb-f4e7ba1b1724.png)

ELLX ILS24 via DIK before:
![image](https://user-images.githubusercontent.com/9995998/155712120-8edce40e-bd5c-43bd-9493-ee43ba2a5f68.png)
After (note the VI onto the FACF leg is borked for some reason):
![image](https://user-images.githubusercontent.com/9995998/155717568-008b7e94-a648-455f-b1e8-2a081e4864ca.png)

Enroute range runway after:
![image](https://user-images.githubusercontent.com/9995998/155712263-1ae2af1a-c4cf-4fdc-b485-18afb6325f98.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Test some approaches with FD legs, suggestions (I haven't tested these ones myself):
![image](https://user-images.githubusercontent.com/9995998/155712678-bd79cd98-7285-4a82-b606-f0611efc6b64.png)

and FC legs:
![image](https://user-images.githubusercontent.com/9995998/155712772-789e71b7-30de-47a7-80a7-665a26923868.png)


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
