### PR TITLE
fix(bleed): fix pack flow valves not closing when switching to ignition

### DIFF
--- a/src/systems/a320_systems_wasm/src/lib.rs
+++ b/src/systems/a320_systems_wasm/src/lib.rs
@@ -116,6 +116,7 @@ async fn systems(mut gauge: msfs::Gauge) -> Result<(), Box<dyn Error>> {
     .provides_aircraft_variable("TURB ENG CORRECTED N1", "Percent", 2)?
     .provides_aircraft_variable("TURB ENG CORRECTED N2", "Percent", 1)?
     .provides_aircraft_variable("TURB ENG CORRECTED N2", "Percent", 2)?
+    .provides_aircraft_variable("TURB ENG IGNITION SWITCH EX1", "Enum", 1)?
     .provides_aircraft_variable("UNLIMITED FUEL", "Bool", 0)?
     .provides_aircraft_variable("VELOCITY WORLD Y", "feet per minute", 0)?
     .with_aspect(|builder| {

--- a/src/systems/systems/src/air_conditioning/acs_controller.rs
+++ b/src/systems/systems/src/air_conditioning/acs_controller.rs
@@ -671,9 +671,9 @@ impl<const ZONES: usize> PackFlowController<ZONES> {
             && (pneumatic.engine_mode_selector() != EngineModeSelector::Ignition)
             && !engine_fire_push_buttons.is_released(1)
             && !pressurization_overhead.ditching_is_on();
-            // && ! pack 1 overheat
-            // Flow Control Valve 2
-            self.fcv_2_open_allowed = acs_overhead.pack_pushbuttons_state()[1]
+        // && ! pack 1 overheat
+        // Flow Control Valve 2
+        self.fcv_2_open_allowed = acs_overhead.pack_pushbuttons_state()[1]
             && !(pneumatic.right_engine_state() == EngineState::Starting)
             && (!(pneumatic.left_engine_state() == EngineState::Starting)
                 || !pneumatic.engine_crossbleed_is_on())
@@ -697,14 +697,14 @@ impl<const ZONES: usize> PackFlowController<ZONES> {
                     || (engines[1].corrected_n1() >= Ratio::new::<percent>(15.)
                         && pneumatic_overhead.right_engine_bleed_pushbutton_is_auto()
                         && pneumatic.engine_crossbleed_is_on()))
-                    || pneumatic.apu_bleed_is_on(),
+                    || pneumatic.apu_bleed_is_on()),
             self.fcv_2_open_allowed
                 && (((engines[1].corrected_n1() >= Ratio::new::<percent>(15.)
                     && pneumatic_overhead.right_engine_bleed_pushbutton_is_auto())
                     || (engines[0].corrected_n1() >= Ratio::new::<percent>(15.)
                         && pneumatic_overhead.left_engine_bleed_pushbutton_is_auto()
                         && pneumatic.engine_crossbleed_is_on()))
-                    || pneumatic.apu_bleed_is_on(),
+                    || pneumatic.apu_bleed_is_on()),
         ]
     }
 

--- a/src/systems/systems/src/air_conditioning/acs_controller.rs
+++ b/src/systems/systems/src/air_conditioning/acs_controller.rs
@@ -668,7 +668,9 @@ impl<const ZONES: usize> PackFlowController<ZONES> {
             && !(pneumatic.left_engine_state() == EngineState::Starting)
             && (!(pneumatic.right_engine_state() == EngineState::Starting)
                 || !pneumatic.engine_crossbleed_is_on())
-            && (pneumatic.engine_mode_selector() != EngineModeSelector::Ignition)
+            && (pneumatic.engine_mode_selector() != EngineModeSelector::Ignition
+                || (pneumatic.left_engine_state() != EngineState::Off
+                    && pneumatic.left_engine_state() != EngineState::Shutting))
             && !engine_fire_push_buttons.is_released(1)
             && !pressurization_overhead.ditching_is_on();
         // && ! pack 1 overheat
@@ -677,7 +679,10 @@ impl<const ZONES: usize> PackFlowController<ZONES> {
             && !(pneumatic.right_engine_state() == EngineState::Starting)
             && (!(pneumatic.left_engine_state() == EngineState::Starting)
                 || !pneumatic.engine_crossbleed_is_on())
-            && (pneumatic.engine_mode_selector() != EngineModeSelector::Ignition || !pneumatic.engine_crossbleed_is_on())
+            && (pneumatic.engine_mode_selector() != EngineModeSelector::Ignition
+                || !pneumatic.engine_crossbleed_is_on()
+                || (pneumatic.right_engine_state() != EngineState::Off
+                    && pneumatic.right_engine_state() != EngineState::Shutting))
             && !engine_fire_push_buttons.is_released(2)
             && !pressurization_overhead.ditching_is_on();
         // && ! pack 2 overheat

--- a/src/systems/systems/src/air_conditioning/acs_controller.rs
+++ b/src/systems/systems/src/air_conditioning/acs_controller.rs
@@ -668,14 +668,16 @@ impl<const ZONES: usize> PackFlowController<ZONES> {
             && !(pneumatic.left_engine_state() == EngineState::Starting)
             && (!(pneumatic.right_engine_state() == EngineState::Starting)
                 || !pneumatic.engine_crossbleed_is_on())
+            && (pneumatic.engine_mode_selector() != EngineModeSelector::Ignition)
             && !engine_fire_push_buttons.is_released(1)
             && !pressurization_overhead.ditching_is_on();
-        // && ! pack 1 overheat
-        // Flow Control Valve 2
-        self.fcv_2_open_allowed = acs_overhead.pack_pushbuttons_state()[1]
+            // && ! pack 1 overheat
+            // Flow Control Valve 2
+            self.fcv_2_open_allowed = acs_overhead.pack_pushbuttons_state()[1]
             && !(pneumatic.right_engine_state() == EngineState::Starting)
             && (!(pneumatic.left_engine_state() == EngineState::Starting)
                 || !pneumatic.engine_crossbleed_is_on())
+            && (pneumatic.engine_mode_selector() != EngineModeSelector::Ignition || !pneumatic.engine_crossbleed_is_on())
             && !engine_fire_push_buttons.is_released(2)
             && !pressurization_overhead.ditching_is_on();
         // && ! pack 2 overheat
@@ -695,16 +697,14 @@ impl<const ZONES: usize> PackFlowController<ZONES> {
                     || (engines[1].corrected_n1() >= Ratio::new::<percent>(15.)
                         && pneumatic_overhead.right_engine_bleed_pushbutton_is_auto()
                         && pneumatic.engine_crossbleed_is_on()))
-                    || (pneumatic.apu_bleed_is_on()
-                        && pneumatic.engine_mode_selector() != EngineModeSelector::Ignition)),
+                    || pneumatic.apu_bleed_is_on(),
             self.fcv_2_open_allowed
                 && (((engines[1].corrected_n1() >= Ratio::new::<percent>(15.)
                     && pneumatic_overhead.right_engine_bleed_pushbutton_is_auto())
                     || (engines[0].corrected_n1() >= Ratio::new::<percent>(15.)
                         && pneumatic_overhead.left_engine_bleed_pushbutton_is_auto()
                         && pneumatic.engine_crossbleed_is_on()))
-                    || (pneumatic.apu_bleed_is_on()
-                        && pneumatic.engine_mode_selector() != EngineModeSelector::Ignition)),
+                    || pneumatic.apu_bleed_is_on(),
         ]
     }
 

--- a/src/systems/systems/src/pneumatic/mod.rs
+++ b/src/systems/systems/src/pneumatic/mod.rs
@@ -524,6 +524,26 @@ pub trait PressurizeableReservoir {
     fn available_volume(&self) -> Volume;
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EngineModeSelector {
+    Crank = 0,
+    Norm = 1,
+    Ignition = 2,
+}
+
+read_write_enum!(EngineModeSelector);
+
+impl From<f64> for EngineModeSelector {
+    fn from(value: f64) -> Self {
+        match value as u8 {
+            0 => EngineModeSelector::Crank,
+            1 => EngineModeSelector::Norm,
+            2 => EngineModeSelector::Ignition,
+            _ => panic!("Engine mode selector position not recognized."),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/systems/systems/src/shared/mod.rs
+++ b/src/systems/systems/src/shared/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     electrical::{ElectricalElement, ElectricitySource, Potential},
-    pneumatic::{EngineState, PneumaticValveSignal},
+    pneumatic::{EngineModeSelector, EngineState, PneumaticValveSignal},
     simulation::UpdateContext,
 };
 
@@ -123,6 +123,7 @@ pub trait PneumaticBleed {
 pub trait EngineStartState {
     fn left_engine_state(&self) -> EngineState;
     fn right_engine_state(&self) -> EngineState;
+    fn engine_mode_selector(&self) -> EngineModeSelector;
 }
 
 pub trait EngineBleedPushbutton {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
There was an issue in the pack flow valve control logic that had it remain until an engine master switch was turned on, instead of closing the valves when the engine mode selector is switched to IGN. This PR should fix this behavior.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![image](https://user-images.githubusercontent.com/22713769/155862415-46f674db-097d-4644-a494-62f8a661904e.png)


<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BlueberryKing#6641

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Make sure you can still start an engine.
- Make sure that you cannot hear the packs anymore when you turn the engine mode selector to ignition.
- Make sure the packs come back after engine start.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
