### PR TITLE
refactor(ap): Remove useless ini file settings

### DIFF
--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -1706,16 +1706,6 @@ bool FlyByWireInterface::updateAltimeterSetting(double sampleTime) {
   return true;
 }
 
-double FlyByWireInterface::getHeadingAngleError(double u1, double u2) {
-  double dPsi_1 = fmod(u1 - u2 + 360.0, 360.0);
-  double dPsi_2 = fmod(360.0 - dPsi_1, 360.0);
-  if (dPsi_1 < dPsi_2) {
-    return -dPsi_1;
-  } else {
-    return dPsi_2;
-  }
-}
-
 double FlyByWireInterface::getTcasModeAvailable() {
   auto state = idTcasMode->get();
   auto isTaOnly = idTcasTaOnly->get();

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -145,8 +145,6 @@ void FlyByWireInterface::loadConfiguration() {
 
   // --------------------------------------------------------------------------
   // load values - autopilot
-  customFlightGuidanceEnabled = INITypeConversion::getBoolean(iniStructure, "AUTOPILOT", "CUSTOM_FLIGHT_GUIDANCE_ENABLED", true);
-  gpsCourseToSteerEnabled = INITypeConversion::getBoolean(iniStructure, "AUTOPILOT", "GPS_COURSE_TO_STEER_ENABLED", true);
   idMinimumSimulationRate->set(INITypeConversion::getDouble(iniStructure, "AUTOPILOT", "MINIMUM_SIMULATION_RATE", 1));
   idMaximumSimulationRate->set(INITypeConversion::getDouble(iniStructure, "AUTOPILOT", "MAXIMUM_SIMULATION_RATE", 4));
   limitSimulationRateByPerformance = INITypeConversion::getBoolean(iniStructure, "AUTOPILOT", "LIMIT_SIMULATION_RATE_BY_PERFORMANCE", true);
@@ -154,8 +152,6 @@ void FlyByWireInterface::loadConfiguration() {
   idRadioReceiverUsage->set(INITypeConversion::getBoolean(iniStructure, "AUTOPILOT", "CALCULATED_LOCALIZER_AND_GLIDESLOPE_ENABLED", false));
 
   // print configuration into console
-  cout << "WASM: AUTOPILOT : CUSTOM_FLIGHT_GUIDANCE_ENABLED              = " << customFlightGuidanceEnabled << endl;
-  cout << "WASM: AUTOPILOT : GPS_COURSE_TO_STEER_ENABLED                 = " << gpsCourseToSteerEnabled << endl;
   cout << "WASM: AUTOPILOT : MINIMUM_SIMULATION_RATE                     = " << idMinimumSimulationRate->get() << endl;
   cout << "WASM: AUTOPILOT : MAXIMUM_SIMULATION_RATE                     = " << idMaximumSimulationRate->get() << endl;
   cout << "WASM: AUTOPILOT : LIMIT_SIMULATION_RATE_BY_PERFORMANCE        = " << limitSimulationRateByPerformance << endl;
@@ -474,23 +470,6 @@ bool FlyByWireInterface::readDataAndLocalVariables(double sampleTime) {
   // update simulation rate limits
   simConnectInterface.updateSimulationRateLimits(idMinimumSimulationRate->get(), idMaximumSimulationRate->get());
 
-  // get or calculate XTK and TAE
-  if (customFlightGuidanceEnabled) {
-    flightGuidanceCrossTrackError = idFlightGuidanceCrossTrackError->get();
-    flightGuidanceTrackAngleError = idFlightGuidanceTrackAngleError->get();
-    flightGuidancePhiPreCommand = idFlightGuidancePhiCommand->get();
-  } else {
-    if (gpsCourseToSteerEnabled) {
-      flightGuidanceCrossTrackError = 0;
-      flightGuidanceTrackAngleError = getHeadingAngleError(simData.Psi_magnetic_deg, simData.gpsCourseToSteer);
-      flightGuidancePhiPreCommand = 0;
-    } else {
-      flightGuidanceCrossTrackError = simData.gpsWpCrossTrack;
-      flightGuidanceTrackAngleError = simData.gpsWpTrackAngleError;
-      flightGuidancePhiPreCommand = 0;
-    }
-  }
-
   // read local variables and update client data
   // update client data for flight guidance
   if (!autopilotStateMachineEnabled || !autopilotLawsEnabled) {
@@ -499,7 +478,7 @@ bool FlyByWireInterface::readDataAndLocalVariables(double sampleTime) {
                                                          idFmgcV_APP->get(),
                                                          idFmgcV_LS->get(),
                                                          idFmgcV_MAX->get(),
-                                                         customFlightGuidanceEnabled ? 1.0 : simData.gpsIsFlightPlanActive,
+                                                         idFlightGuidanceAvailable->get(),
                                                          idFmgcAltitudeConstraint->get(),
                                                          idFmgcThrustReductionAltitude->get(),
                                                          idFmgcThrustReductionAltitudeGoAround->get(),
@@ -513,9 +492,9 @@ bool FlyByWireInterface::readDataAndLocalVariables(double sampleTime) {
                                                          idFcuSelectedVs->get(),
                                                          idFcuSelectedFpa->get(),
                                                          idFcuSelectedHeading->get(),
-                                                         flightGuidanceCrossTrackError,
-                                                         flightGuidanceTrackAngleError,
-                                                         flightGuidancePhiPreCommand,
+                                                         idFlightGuidanceCrossTrackError->get(),
+                                                         idFlightGuidanceTrackAngleError->get(),
+                                                         idFlightGuidancePhiCommand->get(),
                                                          idFlightGuidancePhiLimit->get(),
                                                          static_cast<unsigned long long>(idFlightGuidanceRequestedVerticalMode->get()),
                                                          idFlightGuidanceTargetAltitude->get(),
@@ -781,17 +760,16 @@ bool FlyByWireInterface::updateAutopilotStateMachine(double sampleTime) {
     autopilotStateMachineInput.in.data.nav_gs_position.lat = simData.nav_gs_pos.Latitude;
     autopilotStateMachineInput.in.data.nav_gs_position.lon = simData.nav_gs_pos.Longitude;
     autopilotStateMachineInput.in.data.nav_gs_position.alt = simData.nav_gs_pos.Altitude;
-    autopilotStateMachineInput.in.data.flight_guidance_xtk_nmi = flightGuidanceCrossTrackError;
-    autopilotStateMachineInput.in.data.flight_guidance_tae_deg = flightGuidanceTrackAngleError;
-    autopilotStateMachineInput.in.data.flight_guidance_phi_deg = flightGuidancePhiPreCommand;
+    autopilotStateMachineInput.in.data.flight_guidance_xtk_nmi = idFlightGuidanceCrossTrackError->get();
+    autopilotStateMachineInput.in.data.flight_guidance_tae_deg = idFlightGuidanceTrackAngleError->get();
+    autopilotStateMachineInput.in.data.flight_guidance_phi_deg = idFlightGuidancePhiCommand->get();
     autopilotStateMachineInput.in.data.flight_guidance_phi_limit_deg = idFlightGuidancePhiLimit->get();
     autopilotStateMachineInput.in.data.flight_phase = idFmgcFlightPhase->get();
     autopilotStateMachineInput.in.data.V2_kn = idFmgcV2->get();
     autopilotStateMachineInput.in.data.VAPP_kn = idFmgcV_APP->get();
     autopilotStateMachineInput.in.data.VLS_kn = idFmgcV_LS->get();
     autopilotStateMachineInput.in.data.VMAX_kn = idFmgcV_MAX->get();
-    autopilotStateMachineInput.in.data.is_flight_plan_available =
-        customFlightGuidanceEnabled ? idFlightGuidanceAvailable->get() : simData.gpsIsFlightPlanActive;
+    autopilotStateMachineInput.in.data.is_flight_plan_available = idFlightGuidanceAvailable->get();
     autopilotStateMachineInput.in.data.altitude_constraint_ft = idFmgcAltitudeConstraint->get();
     autopilotStateMachineInput.in.data.thrust_reduction_altitude = idFmgcThrustReductionAltitude->get();
     autopilotStateMachineInput.in.data.thrust_reduction_altitude_go_around = idFmgcThrustReductionAltitudeGoAround->get();
@@ -1153,17 +1131,16 @@ bool FlyByWireInterface::updateAutopilotLaws(double sampleTime) {
     autopilotLawsInput.in.data.nav_gs_position.lat = simData.nav_gs_pos.Latitude;
     autopilotLawsInput.in.data.nav_gs_position.lon = simData.nav_gs_pos.Longitude;
     autopilotLawsInput.in.data.nav_gs_position.alt = simData.nav_gs_pos.Altitude;
-    autopilotLawsInput.in.data.flight_guidance_xtk_nmi = flightGuidanceCrossTrackError;
-    autopilotLawsInput.in.data.flight_guidance_tae_deg = flightGuidanceTrackAngleError;
-    autopilotLawsInput.in.data.flight_guidance_phi_deg = flightGuidancePhiPreCommand;
+    autopilotLawsInput.in.data.flight_guidance_xtk_nmi = idFlightGuidanceCrossTrackError->get();
+    autopilotLawsInput.in.data.flight_guidance_tae_deg = idFlightGuidanceTrackAngleError->get();
+    autopilotLawsInput.in.data.flight_guidance_phi_deg = idFlightGuidancePhiCommand->get();
     autopilotLawsInput.in.data.flight_guidance_phi_limit_deg = idFlightGuidancePhiLimit->get();
     autopilotLawsInput.in.data.flight_phase = idFmgcFlightPhase->get();
     autopilotLawsInput.in.data.V2_kn = idFmgcV2->get();
     autopilotLawsInput.in.data.VAPP_kn = idFmgcV_APP->get();
     autopilotLawsInput.in.data.VLS_kn = idFmgcV_LS->get();
     autopilotLawsInput.in.data.VMAX_kn = idFmgcV_MAX->get();
-    autopilotLawsInput.in.data.is_flight_plan_available =
-        customFlightGuidanceEnabled ? idFlightGuidanceAvailable->get() : simData.gpsIsFlightPlanActive;
+    autopilotLawsInput.in.data.is_flight_plan_available = idFlightGuidanceAvailable->get();
     autopilotLawsInput.in.data.altitude_constraint_ft = idFmgcAltitudeConstraint->get();
     autopilotLawsInput.in.data.thrust_reduction_altitude = idFmgcThrustReductionAltitude->get();
     autopilotLawsInput.in.data.thrust_reduction_altitude_go_around = idFmgcThrustReductionAltitudeGoAround->get();

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -47,8 +47,6 @@ class FlyByWireInterface {
   double targetSimulationRate = 1;
   bool targetSimulationRateModified = false;
 
-  bool customFlightGuidanceEnabled = false;
-  bool gpsCourseToSteerEnabled = false;
   bool autopilotStateMachineEnabled = false;
   bool autopilotLawsEnabled = false;
   bool flyByWireEnabled = false;
@@ -69,10 +67,6 @@ class FlyByWireInterface {
 
   bool autolandWarningLatch = false;
   bool autolandWarningTriggered = false;
-
-  double flightGuidanceCrossTrackError = 0.0;
-  double flightGuidanceTrackAngleError = 0.0;
-  double flightGuidancePhiPreCommand = 0.0;
 
   double flightControlsKeyChangeAileron = 0.0;
   double flightControlsKeyChangeElevator = 0.0;

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -335,8 +335,6 @@ class FlyByWireInterface {
 
   bool updateAltimeterSetting(double sampleTime);
 
-  double getHeadingAngleError(double u1, double u2);
-
   double getTcasModeAvailable();
 
   double getTcasAdvisoryState();


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR removes two INI file settings related to the custom FMS implementation, namely if the custom FM variables should be used for AP computations or not. Since the cFMS is on master for a long time, this setting is now useless so I removed it.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
* There should be no functional changes, this is only a refactor. Simply make sure that the NAV mode still correctly follows the flight plan.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
