### PR TITLE
fix: selected speed not accepted

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
@@ -395,7 +395,7 @@ class A320_Neo_FCU_Speed extends A320_Neo_FCU_Component {
         }
         SimVar.SetSimVarValue("K:SPEED_SLOT_INDEX_SET", "number", 1);
         this.inSelection = false;
-        this.isSelectedValueActive = false;
+        this.isSelectedValueActive = true;
         this.isTargetManaged = false;
     }
 


### PR DESCRIPTION
Fixes #6818

## Summary of Changes
This PR fixes the above mentioned issue.

## Testing instructions
- in flight
- put speed to managed
- turn the speed knob, select a speed different from current airspeed
- pull speed knob
- selected speed should become selected airspeed

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
