### PR TITLE
fix(bleed): Engine Thrust Pack Corrections

### DIFF
--- a/src/fadec/src/SimVars.h
+++ b/src/fadec/src/SimVars.h
@@ -236,8 +236,8 @@ class SimVars {
     ThrustLimitClimb = register_named_variable("A32NX_AUTOTHRUST_THRUST_LIMIT_CLB");
     ThrustLimitMct = register_named_variable("A32NX_AUTOTHRUST_THRUST_LIMIT_MCT");
 
-    PacksState1 = register_named_variable("A32NX_PACKS_1_IS_SUPPLYING");
-    PacksState2 = register_named_variable("A32NX_PACKS_2_IS_SUPPLYING");
+    PacksState1 = register_named_variable("A32NX_COND_PACK_FLOW_VALVE_1_IS_OPEN");
+    PacksState2 = register_named_variable("A32NX_COND_PACK_FLOW_VALVE_2_IS_OPEN");
 
     this->setDeveloperState(0);
     this->setEngine1N2(0);

--- a/src/fadec/src/SimVars.h
+++ b/src/fadec/src/SimVars.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /// <summary>
-/// SimConnect data types to send Sim Updated
+/// SimConnect data types to send to Sim Updated
 /// </summary>
 enum DataTypesID {
   PayloadStation1,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR fixes an issue where PACK toggle did not correct engine N1 limits. Pack states were controlled by the A32NX_PACKS_{index}_IS_SUPPLYING LVars; these variables are obsolete. The new A32NX_COND_PACK_FLOW_VALVE_{index}_IS_OPEN is being used for these purposes.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): TazX [Z+2]#0405

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Turning both Packs ON or OFF should see a change in the N1 Limit as per FCOM. 

Easiest way to test is on runway on standard conditions. TOGA Limit drops 0.4% with both Packs On.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
