### PR TITLE
fix: path capture tad

### DIFF
--- a/src/fmgc/src/guidance/lnav/transitions/FixedRadiusTransition.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/FixedRadiusTransition.ts
@@ -127,14 +127,15 @@ export class FixedRadiusTransition extends Transition {
         const tooBigForNext = 'from' in this.nextLeg ? distanceTo(this.nextLeg.from.infos.coordinates, this.nextLeg.to.infos.coordinates) < this.tad + 0.1 : false;
         const notLinedUp = Math.abs(prevLegTermDistanceToNextLeg) >= 0.25; // "reasonable" distance
 
+        // in some circumstances we revert to a path capture transition where the fixed radius won't work well
+        const shouldRevert = Math.abs(this.sweepAngle) <= 3
+            || Math.abs(this.sweepAngle) > 175
+            || this.previousLeg.overflyTermFix || forcedTurn || tooBigForPrevious || tooBigForNext || notLinedUp;
+
         // We do not revert to a path capture if the previous leg was overshot anyway - draw the normal fixed radius turn
         const previousLegOvershot = 'overshot' in this.previousLeg && this.previousLeg.overshot;
 
-        // in some circumstances we revert to a path capture transition where the fixed radius won't work well
-        if (Math.abs(this.sweepAngle) <= 3
-            || Math.abs(this.sweepAngle) > 175
-            || this.previousLeg.overflyTermFix || forcedTurn || (tooBigForPrevious && !previousLegOvershot) || tooBigForNext || notLinedUp
-        ) {
+        if (shouldRevert && !previousLegOvershot) {
             const shouldHaveTad = !this.previousLeg.overflyTermFix && !notLinedUp && tooBigForPrevious;
 
             if (!this.revertTo) {

--- a/src/fmgc/src/guidance/lnav/transitions/PathCaptureTransition.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/PathCaptureTransition.ts
@@ -124,8 +124,9 @@ export class PathCaptureTransition extends Transition {
             if ('from' in this.previousLeg) {
                 const start = this.previousLeg.from.infos.coordinates;
                 const end = this.previousLeg.to.infos.coordinates;
+                const length = distanceTo(start, end);
 
-                const ratio = this.tad / distanceTo(start, end);
+                const ratio = (length - this.tad) / length;
 
                 initialTurningPoint = getIntermediatePoint(start, end, ratio);
             } else {


### PR DESCRIPTION
## Summary of Changes

* Fixes an issue with path capture transitions wrongly having TAD in some edge cases (previous overshot + very low or very high sweep angle + too big for previous leg), causing some corrupted drawing
* Fixes an issue with wrong orthodromic calculations when placing the ITP of path captures that have TAD

**Before**

![image](https://user-images.githubusercontent.com/4503241/156281848-fea428b1-4c8f-4bc9-bd0c-278e8ba7b380.png)

**After** (keep in mind the speed prediction is still wrong here, not the scope of this PR)
![image](https://user-images.githubusercontent.com/4503241/156281656-15c64c31-eeb2-49e4-8582-968bf3f1e142.png)

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

* Test various departures at high speed

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
