### PR TITLE
fix: Web MCDU Interface fullscreen mode showing background

### DIFF
--- a/src/mcdu-server/client/src/App.jsx
+++ b/src/mcdu-server/client/src/App.jsx
@@ -66,11 +66,11 @@ function App() {
     }
 
     return (
-        <div className={fullscreen ? 'fullscreen' : 'normal'}>
-            <div className="App" style={{ backgroundImage: `url(${backgroundImageUrl})` }}>
-                <WebsocketContext.Provider value={{ sendMessage, lastMessage, readyState }}>
-                    {!fullscreen && (
-                        <>
+        <>
+            {!fullscreen && (
+                <div className="normal">
+                    <div className="App" style={{ backgroundImage: `url(${backgroundImageUrl})` }}>
+                        <WebsocketContext.Provider value={{ sendMessage, lastMessage, readyState }}>
                             <McduScreen content={content} />
                             <McduButtons sound={sound} />
                             <div className="button-grid" style={{ left: `${184 / 10.61}%`, top: `${158 / 16.50}%`, width: `${706 / 10.61}%`, height: `${60 / 16.50}%` }}>
@@ -83,16 +83,22 @@ function App() {
                                     <div className="button" title="Dark" onClick={() => setDark(!dark)} />
                                 </div>
                             </div>
-                        </>
-                    )}
-                    {fullscreen && (
-                        <div title="Exit fullscreen" onClick={() => setFullscreen(false)}>
-                            <McduScreen content={content} />
-                        </div>
-                    )}
-                </WebsocketContext.Provider>
-            </div>
-        </div>
+                        </WebsocketContext.Provider>
+                    </div>
+                </div>
+            )}
+            {fullscreen && (
+                <div className="fullscreen">
+                    <div className="App">
+                        <WebsocketContext.Provider value={{ sendMessage, lastMessage, readyState }}>
+                            <div title="Exit fullscreen" onClick={() => setFullscreen(false)}>
+                                <McduScreen content={content} />
+                            </div>
+                        </WebsocketContext.Provider>
+                    </div>
+                </div>
+            )}
+        </>
     );
 }
 


### PR DESCRIPTION
## Summary of Changes
This PR fixes a small issue where the Web MCDU showed the background MCDU image in "fullscreen mode".

## Screenshots (if necessary)
Before fix:
![image](https://user-images.githubusercontent.com/16833201/156529908-d8894a88-22c1-49a9-9d76-698afc6a841b.png)

After fix: 
![image](https://user-images.githubusercontent.com/16833201/156529602-85930a77-3aa1-421c-89fc-81ee01fbc886.png)

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Start the MCDU Server and open the MCDU in a browser or remote device. 
To enter the "fullscreen mode" either click on the display title or add "/fullscreen" to the URL (http://localhost:8125/fullscreen).
Check that there is no background in the fullscreen mode. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
