### PR TITLE
feat: improved flare behavior in normal law

### DIFF
--- a/src/fbw/src/model/FlyByWire_data.cpp
+++ b/src/fbw/src/model/FlyByWire_data.cpp
@@ -573,7 +573,7 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P{
 
   4.0,
 
-  1.0,
+  2.0,
 
   1.0,
 
@@ -639,7 +639,7 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P{
 
   0.0,
 
-  0.1,
+  0.06,
 
   0.0,
 


### PR DESCRIPTION
## Summary of Changes
This PR aims to improve the flare behavior in manual flight. For this purpose the authority of the underlying pitch attitude law has been reduced.

## Testing instructions
- perform several manual landings with different weights and CG positions

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
