### PR TITLE
fix(fmgc): fix discontinuity guidance logic

### DIFF
--- a/src/fmgc/src/flightplanning/FlightPlanManager.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanManager.ts
@@ -376,7 +376,8 @@ export class FlightPlanManager {
      */
     public setActiveWaypointIndex(index: number, callback = EmptyCallback.Void, fplnIndex = this._currentFlightPlanIndex): void {
         const currentFlightPlan = this._flightPlans[fplnIndex];
-        if (index >= 0 && index < currentFlightPlan.length) {
+        // we allow the last leg to be sequenced therefore the index can be 1 past the end of the plan length
+        if (index >= 0 && index <= currentFlightPlan.length) {
             currentFlightPlan.activeWaypointIndex = index;
             Coherent.call('SET_ACTIVE_WAYPOINT_INDEX', index + 1).catch(console.error);
 

--- a/src/fmgc/src/guidance/lnav/LnavDriver.ts
+++ b/src/fmgc/src/guidance/lnav/LnavDriver.ts
@@ -475,22 +475,29 @@ export class LnavDriver implements GuidanceComponent {
         const lateralModel = SimVar.GetSimVarValue('L:A32NX_FMA_LATERAL_MODE', 'Enum');
         const verticalMode = SimVar.GetSimVarValue('L:A32NX_FMA_VERTICAL_MODE', 'Enum');
 
+        let reverted = false;
+
         if (lateralModel === LateralMode.NAV) {
             // Set HDG (current heading)
             SimVar.SetSimVarValue('H:A320_Neo_FCU_HDG_PULL', 'number', 0);
             SimVar.SetSimVarValue('L:A32NX_AUTOPILOT_HEADING_SELECTED', 'number', Simplane.getHeadingMagnetic());
+            reverted = true;
         }
 
-        // Vertical mode is DES, OP DES, CLB or OP CLB
-        if (verticalMode === VerticalMode.DES || verticalMode === VerticalMode.OP_DES
-            || verticalMode === VerticalMode.CLB || verticalMode === VerticalMode.OP_CLB
-        ) {
-            // Set V/S
+        if (verticalMode === VerticalMode.DES) {
+            // revert to V/S
             SimVar.SetSimVarValue('H:A320_Neo_FCU_VS_PULL', 'number', 0);
+            reverted = true;
+        } else if (verticalMode === VerticalMode.CLB) {
+            // revert to OP CLB
+            SimVar.SetSimVarValue('H:A320_Neo_FCU_ALT_PULL', 'number', 0);
+            reverted = true;
         }
 
-        // Triple click
-        Coherent.call('PLAY_INSTRUMENT_SOUND', '3click').catch(console.error);
+        if (reverted) {
+            // Triple click
+            Coherent.call('PLAY_INSTRUMENT_SOUND', '3click').catch(console.error);
+        }
 
         this.sequenceLeg(_leg, null);
     }

--- a/src/fmgc/src/guidance/lnav/LnavDriver.ts
+++ b/src/fmgc/src/guidance/lnav/LnavDriver.ts
@@ -379,6 +379,9 @@ export class LnavDriver implements GuidanceComponent {
                         this.sequenceLeg(currentLeg, outboundTransition);
                     }
                     geometry.onLegSequenced(currentLeg, nextLeg, followingLeg);
+                } else {
+                    this.sequenceDiscontinuity(currentLeg);
+                    geometry.onLegSequenced(currentLeg, nextLeg, followingLeg);
                 }
             }
         }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Sequence a discontinuity after the last leg of the flight plan.
- Revert to correct vertical guidance modes.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
AMM 22

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Create a flightplan with only a departure and then a discontinuity... fly past the end of it (in a managed climb) and ensure the guidance reverts to HDG and OP CLB mode.
Setup a STAR but delete a leg to create a discontinuity.. fly past it in managed descent and make sure the guidance reverts to HDG and V/S.
Fly a normal approach and make sure everything is fine as you pass the runway threshold (lateral guidance will revert here if in NAV mode, as the missed approach segment is not available in this older flight plan manager).

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
