### PR TITLE
fix: lnav improvements

### DIFF
--- a/src/fmgc/src/efis/EfisSymbols.ts
+++ b/src/fmgc/src/efis/EfisSymbols.ts
@@ -270,7 +270,7 @@ export class EfisSymbols {
             const formatConstraintSpeed = (speed: number, prefix: string = '') => `${prefix}${Math.floor(speed)}KT`;
 
             for (const [index, leg] of this.guidanceController.activeGeometry.legs.entries()) {
-                if (leg.terminationWaypoint && leg.displayedOnMap) {
+                if (!leg.isNull && leg.terminationWaypoint && leg.displayedOnMap) {
                     if (!(leg.terminationWaypoint instanceof WayPoint)) {
                         const isActive = index === this.guidanceController.activeLegIndex;
 

--- a/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
+++ b/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
@@ -845,6 +845,8 @@ export class ManagedFlightPlan {
         // Set origin fix coordinates to runway beginning coordinates
         if (origin && selectedOriginRunwayIndex !== -1) {
             origin.infos.coordinates = airportInfo.oneWayRunways[selectedOriginRunwayIndex].beginningCoordinates;
+            origin.additionalData.runwayElevation = airportInfo.oneWayRunways[selectedOriginRunwayIndex].elevation * 3.2808399;
+            origin.additionalData.runwayLength = airportInfo.oneWayRunways[selectedOriginRunwayIndex].length;
         }
 
         if (departureIndex !== -1 && runwayIndex !== -1) {

--- a/src/fmgc/src/guidance/Guidable.ts
+++ b/src/fmgc/src/guidance/Guidable.ts
@@ -1,14 +1,54 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
 import { GuidanceParameters } from '@fmgc/guidance/ControlLaws';
 import { PathVector, pathVectorLength, pathVectorPoint, PathVectorType } from '@fmgc/guidance/lnav/PathVector';
 
+/**
+ * A `Guidable` is a part of an LNAV path. It can be either a leg or a transition.
+ */
 export abstract class Guidable {
+    /**
+     * Whether the guidable should be considered for map display, guidance and sequencing
+     *
+     * For a transition, this indicates that the transition between the legs is selected but has no geometry.
+     * For a leg, this indicates that geometry conditions cause the leg to be skipped.
+     */
+    isNull = false
+
+    /**
+     * The first valid guidable that precedes this one. This takes into account the `isNull` property, meaning other
+     * guidables can exist before this one but would not be referred to by this property if they were to be null.
+     */
+    inboundGuidable: Guidable;
+
+    /**
+     * The first valid guidable that succeeds this one. This takes into account the `isNull` property, meaning other
+     * guidables can exist after this one but would not be referred to by this property if they were to be null.
+     */
+    outboundGuidable: Guidable;
+
     protected constructor() {
+    }
+
+    /**
+     * Used to update the {@link inboundGuidable} and {@link outboundGuidable} properties.
+     */
+    setNeighboringGuidables(inbound: Guidable, outbound: Guidable) {
+        this.inboundGuidable = inbound;
+        this.outboundGuidable = outbound;
     }
 
     abstract getPathStartPoint(): Coordinates | undefined;
 
     getPathEndPoint(): Coordinates | undefined {
+        if (this.isNull) {
+            return this.inboundGuidable.getPathEndPoint();
+        }
+
         if (this.predictedPath) {
             for (let i = this.predictedPath.length - 1; i >= 0; i--) {
                 const vector = this.predictedPath[i];
@@ -34,19 +74,27 @@ export abstract class Guidable {
      * @param isActive          whether the guidable is being flown
      * @param tas               predicted true airspeed speed of the current leg (for a leg) or the next leg (for a transition) in knots
      * @param gs                predicted ground speed of the current leg
-     * @param ppos              present position coordinates
+     * @param ppos              the current position of the aircraft
      * @param trueTrack         true ground track
      * @param previousGuidable  previous guidable before leg
      * @param nextGuidable      next guidable after leg
      */
     abstract recomputeWithParameters(isActive: boolean, tas: Knots, gs: Knots, ppos: Coordinates, trueTrack: DegreesTrue, previousGuidable: Guidable, nextGuidable: Guidable): void;
 
+    /**
+     * Obtains guidance parameters that will be sent to the FG when this guidable is active (or being captured by a previous guidable)
+     *
+     * @param ppos     the current position of the aircraft
+     * @param trueTrack true ground track
+     * @param tas       true air speed
+     * @param gs        ground speed
+     */
     abstract getGuidanceParameters(ppos: Coordinates, trueTrack: Degrees, tas: Knots, gs: Knots): GuidanceParameters | undefined;
 
     /**
      * Calculates directed DTG parameter
      *
-     * @param ppos {LatLong} the current position of the aircraft
+     * @param ppos the current position of the aircraft
      */
     abstract getDistanceToGo(ppos: Coordinates): NauticalMiles | undefined;
 
@@ -70,7 +118,10 @@ export abstract class Guidable {
     }
 
     /**
-     * Path vectors for drawing on the ND
+     * Path vectors for the predicted path.
+     *
+     * This path always represents what is being drawn on the ND, and is used for the vast majority of prediction computations. It is
+     * however not always representative of guidance, for example in case of path capture or course capture transitions or CX/VX legs.
      */
     abstract get predictedPath(): PathVector[] | undefined;
 

--- a/src/fmgc/src/guidance/GuidanceController.ts
+++ b/src/fmgc/src/guidance/GuidanceController.ts
@@ -307,7 +307,10 @@ export class GuidanceController {
      */
     updateGeometries() {
         this.updateActiveGeometry();
-        this.updateTemporaryGeometry();
+
+        if (this.flightPlanManager.getFlightPlan(FlightPlans.Temporary)) {
+            this.updateTemporaryGeometry();
+        }
 
         this.recomputeGeometries();
 
@@ -341,8 +344,8 @@ export class GuidanceController {
     }
 
     recomputeGeometries() {
-        const tas = SimVar.GetSimVarValue(LnavConfig.DEBUG_USE_SPEED_LVARS ? 'L:A32NX_DEBUG_FM_TAS' : 'AIRSPEED TRUE', 'Knots');
-        const gs = SimVar.GetSimVarValue(LnavConfig.DEBUG_USE_SPEED_LVARS ? 'L:A32NX_DEBUG_FM_GS' : 'GPS GROUND SPEED', 'Knots');
+        const tas = SimVar.GetSimVarValue('AIRSPEED TRUE', 'Knots');
+        const gs = SimVar.GetSimVarValue('GPS GROUND SPEED', 'Knots');
         const trueTrack = SimVar.GetSimVarValue('GPS GROUND TRACK', 'degrees');
 
         if (this.activeGeometry) {
@@ -398,9 +401,9 @@ export class GuidanceController {
     setHoldSpeed(tas: Knots) {
         let holdLeg: HMLeg;
         if (this.isManualHoldActive()) {
-            holdLeg = this.activeGeometry.legs.get(this.activeLegIndex) as HMLeg;
+            holdLeg = this.activeGeometry.legs.get(this.activeLegIndex) as unknown as HMLeg;
         } else if (this.isManualHoldNext()) {
-            holdLeg = this.activeGeometry.legs.get(this.activeLegIndex + 1) as HMLeg;
+            holdLeg = this.activeGeometry.legs.get(this.activeLegIndex + 1) as unknown as HMLeg;
         }
 
         if (holdLeg) {

--- a/src/fmgc/src/guidance/GuidanceController.ts
+++ b/src/fmgc/src/guidance/GuidanceController.ts
@@ -12,7 +12,6 @@ import { EfisState } from '@fmgc/guidance/FmsState';
 import { EfisSide, Mode, rangeSettings } from '@shared/NavigationDisplay';
 import { TaskCategory, TaskQueue } from '@fmgc/guidance/TaskQueue';
 import { HMLeg } from '@fmgc/guidance/lnav/legs/HX';
-import { LnavConfig } from '@fmgc/guidance/LnavConfig';
 import { SimVarString } from '@shared/simvar';
 import { getFlightPhaseManager } from '@fmgc/flightphase';
 import { FmgcFlightPhase } from '@shared/flightphase';

--- a/src/fmgc/src/guidance/GuidanceManager.ts
+++ b/src/fmgc/src/guidance/GuidanceManager.ts
@@ -99,8 +99,9 @@ export class GuidanceManager {
             if (to.additionalData.legType === LegType.CA || to.additionalData.legType === LegType.VA) {
                 const course = to.additionalData.vectorsCourse;
                 const altitude = to.additionalData.vectorsAltitude;
+                const extraLength = (from.additionalData.runwayLength ?? 0) / (2 * 1852);
 
-                return new CALeg(course, altitude, metadata, segment);
+                return new CALeg(course, altitude, metadata, segment, extraLength);
             }
 
             if (to.additionalData.legType === LegType.CI || to.additionalData.legType === LegType.VI) {

--- a/src/fmgc/src/guidance/LnavConfig.ts
+++ b/src/fmgc/src/guidance/LnavConfig.ts
@@ -15,7 +15,7 @@ export const LnavConfig = {
     /**
      * Coefficient applied to all transition turn radii
      */
-    TURN_RADIUS_FACTOR: 1.1,
+    TURN_RADIUS_FACTOR: 1.0,
 
     /**
      * The number of transitions to compute after the active leg (-1: no limit, compute all transitions)

--- a/src/fmgc/src/guidance/lnav/CommonGeometry.ts
+++ b/src/fmgc/src/guidance/lnav/CommonGeometry.ts
@@ -175,11 +175,11 @@ export function maxTad(tas: Knots | undefined): NauticalMiles {
     }
 
     if (tas <= 100) {
-        return 5;
+        return 4;
     } if (tas >= 100 && tas <= 400) {
-        return (tas / 100) * 5;
+        return (tas / 100) * 4;
     }
-    return 20;
+    return 16;
 }
 
 export function courseToFixDistanceToGo(ppos: Coordinates, course: Degrees, fix: Coordinates): NauticalMiles {
@@ -209,8 +209,14 @@ export function courseToFixGuidance(ppos: Coordinates, trueTrack: Degrees, cours
     };
 }
 
+export enum PointSide {
+    Before,
+    After,
+}
+
 /**
- * Returns the side of a fix (considering a course inbound to that fix) a point is lying on
+ * Returns the side of a fix (considering a course inbound to that fix) a point is lying on, assuming they lie on the same
+ * great circle.
  *
  * @param fix    destination fix
  * @param course course to the fix
@@ -218,16 +224,16 @@ export function courseToFixGuidance(ppos: Coordinates, trueTrack: Degrees, cours
  *
  * @returns `-1` if the point is before the fix, `1` if the point is after the fix
  */
-export function sideOfPointOnCourseToFix(fix: Coordinates, course: DegreesTrue, point: Coordinates): -1 | 1 {
+export function sideOfPointOnCourseToFix(fix: Coordinates, course: DegreesTrue, point: Coordinates): PointSide {
     const bearingFixPoint = bearingTo(fix, point);
 
     const onOtherSide = Math.abs(MathUtils.diffAngle(bearingFixPoint, course)) < 3;
 
     if (onOtherSide) {
-        return 1;
+        return PointSide.After;
     }
 
-    return -1;
+    return PointSide.Before;
 }
 
 function getAlongTrackDistanceTo(start: Coordinates, end: Coordinates, ppos: Coordinates): number {
@@ -308,4 +314,8 @@ export function arcLength(radius: NauticalMiles, sweepAngle: Degrees): NauticalM
     const circumference = 2 * Math.PI * radius;
 
     return circumference / 360 * Math.abs(sweepAngle);
+}
+
+export function reciprocal(course: Degrees): Degrees {
+    return Avionics.Utils.clampAngle(course + 180);
 }

--- a/src/fmgc/src/guidance/lnav/LnavDriver.ts
+++ b/src/fmgc/src/guidance/lnav/LnavDriver.ts
@@ -19,8 +19,7 @@ import { VMLeg } from '@fmgc/guidance/lnav/legs/VM';
 import { XFLeg } from '@fmgc/guidance/lnav/legs/XF';
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
 import { FmgcFlightPhase } from '@shared/flightphase';
-import { GuidanceController } from '../GuidanceController';
-import { GuidanceComponent } from '../GuidanceComponent';
+import { GuidanceController, GuidanceComponent } from '@fmgc/guidance';
 
 /**
  * Represents the current turn state of the LNAV driver
@@ -363,8 +362,7 @@ export class LnavDriver implements GuidanceComponent {
                 withinSequencingArea = Math.abs(params.crossTrackError) < 7 && Math.abs(params.trackAngleError) < 90;
             }
 
-            if (canSequence && withinSequencingArea && geometry.shouldSequenceLeg(activeLegIdx, this.ppos)) {
-                const currentLeg = activeLeg;
+            if ((canSequence && withinSequencingArea && geometry.shouldSequenceLeg(activeLegIdx, this.ppos)) || activeLeg.isNull) {
                 const outboundTransition = geometry.transitions.get(activeLegIdx);
                 const nextLeg = geometry.legs.get(activeLegIdx + 1);
                 const followingLeg = geometry.legs.get(activeLegIdx + 2);
@@ -373,15 +371,15 @@ export class LnavDriver implements GuidanceComponent {
                     // FIXME we should stop relying on discos in the wpt objects, but for now it's fiiiiiine
                     // Hard-coded check for TF leg after the disco for now - only case where we don't wanna
                     // sequence this way is VM
-                    if (currentLeg instanceof XFLeg && currentLeg.fix.endsInDiscontinuity) {
-                        this.sequenceDiscontinuity(currentLeg);
+                    if (activeLeg instanceof XFLeg && activeLeg.fix.endsInDiscontinuity) {
+                        this.sequenceDiscontinuity(activeLeg);
                     } else {
-                        this.sequenceLeg(currentLeg, outboundTransition);
+                        this.sequenceLeg(activeLeg, outboundTransition);
                     }
-                    geometry.onLegSequenced(currentLeg, nextLeg, followingLeg);
+                    geometry.onLegSequenced(activeLeg, nextLeg, followingLeg);
                 } else {
-                    this.sequenceDiscontinuity(currentLeg);
-                    geometry.onLegSequenced(currentLeg, nextLeg, followingLeg);
+                    this.sequenceDiscontinuity(activeLeg);
+                    geometry.onLegSequenced(activeLeg, nextLeg, followingLeg);
                 }
             }
         }
@@ -413,14 +411,14 @@ export class LnavDriver implements GuidanceComponent {
     private updateEfisData(activeLeg: Leg, gs: Knots) {
         const termination = activeLeg instanceof XFLeg ? activeLeg.fix.infos.coordinates : activeLeg.getPathEndPoint();
 
-        const efisBearing = A32NX_Util.trueToMagnetic(
+        const efisBearing = termination ? A32NX_Util.trueToMagnetic(
             Avionics.Utils.computeGreatCircleHeading(this.ppos, termination),
             Facilities.getMagVar(this.ppos.lat, this.ppos.long),
-        );
+        ) : -1;
 
         // Don't compute distance and ETA for XM legs
-        const efisDistance = activeLeg instanceof VMLeg ? null : Avionics.Utils.computeGreatCircleDistance(this.ppos, termination);
-        const efisEta = activeLeg instanceof VMLeg ? null : LnavDriver.legEta(this.ppos, gs, termination);
+        const efisDistance = activeLeg instanceof VMLeg ? -1 : Avionics.Utils.computeGreatCircleDistance(this.ppos, termination);
+        const efisEta = activeLeg instanceof VMLeg ? -1 : LnavDriver.legEta(this.ppos, gs, termination);
 
         // FIXME should be NCD if no FM position
 

--- a/src/fmgc/src/guidance/lnav/PseudoWaypoints.ts
+++ b/src/fmgc/src/guidance/lnav/PseudoWaypoints.ts
@@ -1,3 +1,8 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
 import { GuidanceComponent } from '@fmgc/guidance/GuidanceComponent';
 import { PseudoWaypoint, PseudoWaypointSequencingAction } from '@fmgc/guidance/PsuedoWaypoint';
 import { VnavConfig, VnavDescentMode } from '@fmgc/guidance/vnav/VnavConfig';
@@ -243,7 +248,7 @@ export class PseudoWaypoints implements GuidanceComponent {
         for (let i = wptCount - 1; i > 0; i--) {
             const leg = path.legs.get(i);
 
-            if (!leg) {
+            if (!leg || leg.isNull) {
                 continue;
             }
 

--- a/src/fmgc/src/guidance/lnav/Transition.ts
+++ b/src/fmgc/src/guidance/lnav/Transition.ts
@@ -1,3 +1,8 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
 import { Guidable } from '@fmgc/guidance/Guidable';
 import { Leg } from '@fmgc/guidance/lnav/legs/Leg';
@@ -13,9 +18,15 @@ export enum TransitionState {
 export abstract class Transition extends Guidable {
     abstract isAbeam(ppos: LatLongData): boolean;
 
-    public previousLeg: Leg;
+    protected constructor(
+        public previousLeg: Leg,
+        public nextLeg: Leg,
+    ) {
+        super();
 
-    public nextLeg: Leg;
+        this.inboundGuidable = previousLeg;
+        this.outboundGuidable = nextLeg;
+    }
 
     public isFrozen = false;
 
@@ -23,7 +34,21 @@ export abstract class Transition extends Guidable {
         this.isFrozen = true;
     }
 
-    recomputeWithParameters(_isActive: boolean, _tas: Knots, _gs: MetresPerSecond, _ppos: Coordinates, _trueTrack: DegreesTrue, _previousGuidable: Guidable, _nextGuidable: Guidable) {
+    /**
+     * Used to update the {@link previousLeg} and {@link nextLeg} properties.
+     */
+    setNeighboringLegs(previous: Leg, next: Leg) {
+        this.previousLeg = previous;
+        this.nextLeg = next;
+    }
+
+    recomputeWithParameters(
+        _isActive: boolean,
+        _tas: Knots,
+        _gs: MetresPerSecond,
+        _ppos: Coordinates,
+        _trueTrack: DegreesTrue,
+    ) {
         // Default impl.
     }
 
@@ -36,8 +61,4 @@ export abstract class Transition extends Guidable {
     abstract get distance(): NauticalMiles;
 
     abstract get repr(): string;
-
-    get isNull(): boolean {
-        return false;
-    }
 }

--- a/src/fmgc/src/guidance/lnav/legs/CF.ts
+++ b/src/fmgc/src/guidance/lnav/legs/CF.ts
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
-import { Guidable } from '@fmgc/guidance/Guidable';
 import { SegmentType } from '@fmgc/flightplanning/FlightPlanSegment';
 import { GuidanceParameters } from '@fmgc/guidance/ControlLaws';
 import { courseToFixDistanceToGo, courseToFixGuidance } from '@fmgc/guidance/lnav/CommonGeometry';
@@ -15,6 +14,7 @@ import { Geo } from '@fmgc/utils/Geo';
 import { FixedRadiusTransition } from '@fmgc/guidance/lnav/transitions/FixedRadiusTransition';
 import { DmeArcTransition } from '@fmgc/guidance/lnav/transitions/DmeArcTransition';
 import { LegMetadata } from '@fmgc/guidance/lnav/legs/index';
+import { IFLeg } from '@fmgc/guidance/lnav/legs/IF';
 import { PathVector, PathVectorType } from '../PathVector';
 
 export class CFLeg extends XFLeg {
@@ -32,6 +32,10 @@ export class CFLeg extends XFLeg {
     }
 
     getPathStartPoint(): Coordinates | undefined {
+        if (this.inboundGuidable instanceof IFLeg) {
+            return this.inboundGuidable.fix.infos.coordinates;
+        }
+
         if (this.inboundGuidable instanceof Transition && this.inboundGuidable.isComputed) {
             return this.inboundGuidable.getPathEndPoint();
         }
@@ -81,10 +85,13 @@ export class CFLeg extends XFLeg {
         return this.computedPath;
     }
 
-    recomputeWithParameters(isActive: boolean, _tas: Knots, _gs: Knots, ppos: Coordinates, _trueTrack: DegreesTrue, previousGuidable: Guidable, nextGuidable: Guidable) {
-        this.inboundGuidable = previousGuidable;
-        this.outboundGuidable = nextGuidable;
-
+    recomputeWithParameters(
+        _isActive: boolean,
+        _tas: Knots,
+        _gs: Knots,
+        _ppos: Coordinates,
+        _trueTrack: DegreesTrue,
+    ) {
         // Is start point after the fix ?
         if (this.overshot) {
             this.computedPath = [{

--- a/src/fmgc/src/guidance/lnav/legs/CI.ts
+++ b/src/fmgc/src/guidance/lnav/legs/CI.ts
@@ -4,10 +4,9 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
-import { Guidable } from '@fmgc/guidance/Guidable';
 import { SegmentType } from '@fmgc/flightplanning/FlightPlanSegment';
 import { ControlLaw, GuidanceParameters } from '@fmgc/guidance/ControlLaws';
-import { courseToFixDistanceToGo } from '@fmgc/guidance/lnav/CommonGeometry';
+import { courseToFixDistanceToGo, PointSide, sideOfPointOnCourseToFix } from '@fmgc/guidance/lnav/CommonGeometry';
 import { Geo } from '@fmgc/utils/Geo';
 import { LnavConfig } from '@fmgc/guidance/LnavConfig';
 import { Leg } from '@fmgc/guidance/lnav/legs/Leg';
@@ -46,22 +45,20 @@ export class CILeg extends Leg {
         return 'INTCPT';
     }
 
-    private inboundGuidable: Guidable | undefined;
-
-    private outboundGuidable: Guidable | undefined;
-
     getPathStartPoint(): Coordinates | undefined {
         if (this.inboundGuidable instanceof IFLeg) {
             return this.inboundGuidable.fix.infos.coordinates;
-        } if (this.inboundGuidable && this.inboundGuidable.isComputed) {
+        }
+
+        if (this.inboundGuidable && this.inboundGuidable.isComputed) {
             return this.inboundGuidable.getPathEndPoint();
         }
 
-        throw new Error('[CRLeg] No computed inbound guidable.');
+        throw new Error('[CILeg] No computed inbound guidable.');
     }
 
     getPathEndPoint(): Coordinates | undefined {
-        if (this.outboundGuidable instanceof FixedRadiusTransition && !this.outboundGuidable.isReverted && this.outboundGuidable.isComputed) {
+        if (this.outboundGuidable instanceof FixedRadiusTransition && this.outboundGuidable.isComputed) {
             return this.outboundGuidable.getPathStartPoint();
         }
 
@@ -76,39 +73,52 @@ export class CILeg extends Leg {
         return this.computedPath;
     }
 
-    mustBeDeleted = false;
-
-    recomputeWithParameters(isActive: boolean, _tas: Knots, _gs: Knots, ppos: Coordinates, _trueTrack: DegreesTrue, previousGuidable: Guidable, nextGuidable: Guidable) {
-        this.inboundGuidable = previousGuidable;
-        this.outboundGuidable = nextGuidable;
-
+    recomputeWithParameters(
+        _isActive: boolean,
+        _tas: Knots,
+        _gs: Knots,
+        _ppos: Coordinates,
+        _trueTrack: DegreesTrue,
+    ) {
         this.intercept = Geo.legIntercept(
             this.getPathStartPoint(),
             this.course,
             this.nextLeg,
         );
 
-        this.computedPath = [{
-            type: PathVectorType.Line,
-            startPoint: this.getPathStartPoint(),
-            endPoint: this.getPathEndPoint(),
-        }];
+        const side = sideOfPointOnCourseToFix(this.intercept, this.outboundCourse, this.getPathStartPoint());
+        const overshot = side === PointSide.After;
 
-        this.isComputed = true;
+        if (this.intercept && !Number.isNaN(this.intercept.lat) && !overshot) {
+            this.isNull = false;
 
-        if (LnavConfig.DEBUG_PREDICTED_PATH) {
-            this.computedPath.push(
-                {
-                    type: PathVectorType.DebugPoint,
-                    startPoint: this.getPathStartPoint(),
-                    annotation: 'CI START',
-                },
-                {
-                    type: PathVectorType.DebugPoint,
-                    startPoint: this.getPathEndPoint(),
-                    annotation: 'CI END',
-                },
-            );
+            this.computedPath = [{
+                type: PathVectorType.Line,
+                startPoint: this.getPathStartPoint(),
+                endPoint: this.getPathEndPoint(),
+            }];
+
+            this.isComputed = true;
+
+            if (LnavConfig.DEBUG_PREDICTED_PATH) {
+                this.computedPath.push(
+                    {
+                        type: PathVectorType.DebugPoint,
+                        startPoint: this.getPathStartPoint(),
+                        annotation: 'CI START',
+                    },
+                    {
+                        type: PathVectorType.DebugPoint,
+                        startPoint: this.getPathEndPoint(),
+                        annotation: 'CI END',
+                    },
+                );
+            }
+        } else {
+            this.computedPath.length = 0;
+
+            this.isNull = true;
+            this.isComputed = true;
         }
     }
 

--- a/src/fmgc/src/guidance/lnav/legs/CR.ts
+++ b/src/fmgc/src/guidance/lnav/legs/CR.ts
@@ -4,12 +4,12 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
-import { Guidable } from '@fmgc/guidance/Guidable';
 import { SegmentType } from '@fmgc/flightplanning/FlightPlanSegment';
 import { GuidanceParameters } from '@fmgc/guidance/ControlLaws';
 import {
     courseToFixDistanceToGo,
     courseToFixGuidance,
+    PointSide,
     sideOfPointOnCourseToFix,
 } from '@fmgc/guidance/lnav/CommonGeometry';
 import { Geo } from '@fmgc/utils/Geo';
@@ -44,10 +44,6 @@ export class CRLeg extends Leg {
         return this.origin.ident.substring(0, 3) + this.origin.theta.toFixed(0);
     }
 
-    private inboundGuidable: Guidable | undefined;
-
-    private outboundGuidable: Guidable | undefined;
-
     getPathStartPoint(): Coordinates | undefined {
         if (this.inboundGuidable && this.inboundGuidable.isComputed) {
             return this.inboundGuidable.getPathEndPoint();
@@ -64,10 +60,13 @@ export class CRLeg extends Leg {
         return this.computedPath;
     }
 
-    recomputeWithParameters(isActive: boolean, _tas: Knots, _gs: Knots, ppos: Coordinates, _trueTrack: DegreesTrue, previousGuidable: Guidable, nextGuidable: Guidable) {
-        this.inboundGuidable = previousGuidable;
-        this.outboundGuidable = nextGuidable;
-
+    recomputeWithParameters(
+        _isActive: boolean,
+        _tas: Knots,
+        _gs: Knots,
+        _ppos: Coordinates,
+        _trueTrack: DegreesTrue,
+    ) {
         this.intercept = Geo.doublePlaceBearingIntercept(
             this.getPathStartPoint(),
             this.origin.coordinates,
@@ -75,27 +74,37 @@ export class CRLeg extends Leg {
             this.radial,
         );
 
-        this.computedPath = [{
-            type: PathVectorType.Line,
-            startPoint: this.getPathStartPoint(),
-            endPoint: this.intercept,
-        }];
+        const overshot = distanceTo(this.getPathStartPoint(), this.intercept) >= 5_000;
 
-        this.isComputed = true;
+        if (this.intercept && !overshot) {
+            this.computedPath = [{
+                type: PathVectorType.Line,
+                startPoint: this.getPathStartPoint(),
+                endPoint: this.intercept,
+            }];
 
-        if (LnavConfig.DEBUG_PREDICTED_PATH) {
-            this.computedPath.push(
-                {
-                    type: PathVectorType.DebugPoint,
-                    startPoint: this.getPathStartPoint(),
-                    annotation: 'CR START',
-                },
-                {
-                    type: PathVectorType.DebugPoint,
-                    startPoint: this.getPathEndPoint(),
-                    annotation: 'CR END',
-                },
-            );
+            this.isNull = false;
+            this.isComputed = true;
+
+            if (LnavConfig.DEBUG_PREDICTED_PATH) {
+                this.computedPath.push(
+                    {
+                        type: PathVectorType.DebugPoint,
+                        startPoint: this.getPathStartPoint(),
+                        annotation: 'CR START',
+                    },
+                    {
+                        type: PathVectorType.DebugPoint,
+                        startPoint: this.getPathEndPoint(),
+                        annotation: 'CR END',
+                    },
+                );
+            }
+        } else {
+            this.predictedPath.length = 0;
+
+            this.isNull = true;
+            this.isComputed = true;
         }
     }
 
@@ -105,7 +114,7 @@ export class CRLeg extends Leg {
     get overshot(): boolean {
         const side = sideOfPointOnCourseToFix(this.intercept, this.outboundCourse, this.getPathStartPoint());
 
-        return side === 1;
+        return side === PointSide.After;
     }
 
     get inboundCourse(): Degrees {

--- a/src/fmgc/src/guidance/lnav/legs/DF.ts
+++ b/src/fmgc/src/guidance/lnav/legs/DF.ts
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
-import { Guidable } from '@fmgc/guidance/Guidable';
 import { SegmentType } from '@fmgc/flightplanning/FlightPlanSegment';
 import { GuidanceParameters } from '@fmgc/guidance/ControlLaws';
 import { XFLeg } from '@fmgc/guidance/lnav/legs/XF';
@@ -57,11 +56,13 @@ export class DFLeg extends XFLeg {
         );
     }
 
-    recomputeWithParameters(_isActive: boolean, _tas: Knots, _gs: Knots, _ppos: Coordinates, _trueTrack: DegreesTrue, previousGuidable: Guidable, nextGuidable: Guidable) {
-        // We don't really do anything here
-        this.inboundGuidable = previousGuidable;
-        this.outboundGuidable = nextGuidable;
-
+    recomputeWithParameters(
+        _isActive: boolean,
+        _tas: Knots,
+        _gs: Knots,
+        _ppos: Coordinates,
+        _trueTrack: DegreesTrue,
+    ) {
         const newStart = this.inboundGuidable?.getPathEndPoint() ?? this.estimateStartPoint();
 
         // Adjust the start point if we can
@@ -80,12 +81,12 @@ export class DFLeg extends XFLeg {
                 {
                     type: PathVectorType.DebugPoint,
                     startPoint: this.start,
-                    annotation: 'DF_START',
+                    annotation: 'DF START',
                 },
                 {
                     type: PathVectorType.DebugPoint,
                     startPoint: this.getPathEndPoint(),
-                    annotation: 'DF_END',
+                    annotation: 'DF END',
                 },
             );
         }

--- a/src/fmgc/src/guidance/lnav/legs/IF.ts
+++ b/src/fmgc/src/guidance/lnav/legs/IF.ts
@@ -4,14 +4,12 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
-import { Guidable } from '@fmgc/guidance/Guidable';
 import { SegmentType } from '@fmgc/flightplanning/FlightPlanSegment';
 import { GuidanceParameters } from '@fmgc/guidance/ControlLaws';
 import { XFLeg } from '@fmgc/guidance/lnav/legs/XF';
 import { PathVector } from '@fmgc/guidance/lnav/PathVector';
-import { Leg } from '@fmgc/guidance/lnav/legs/Leg';
-import { Transition } from '@fmgc/guidance/lnav/Transition';
 import { LegMetadata } from '@fmgc/guidance/lnav/legs/index';
+import { Leg } from '@fmgc/guidance/lnav/legs/Leg';
 
 export class IFLeg extends XFLeg {
     constructor(
@@ -36,14 +34,10 @@ export class IFLeg extends XFLeg {
         return this.fix.infos.coordinates;
     }
 
-    private nextGuidable: Leg | undefined;
-
-    recomputeWithParameters(_isActive: boolean, _tas: Knots, _gs: Knots, _ppos: Coordinates, _trueTrack: DegreesTrue, _previousGuidable: Guidable, nextGuidable: Guidable) {
-        if (nextGuidable instanceof Transition) {
-            throw new Error(`IF nextGuidable must be a leg (is ${nextGuidable.constructor})`);
+    recomputeWithParameters(_isActive: boolean, _tas: Knots, _gs: Knots, _ppos: Coordinates, _trueTrack: DegreesTrue) {
+        if (!(this.outboundGuidable instanceof Leg)) {
+            throw new Error(`IF outboundGuidable must be a leg (is ${this.outboundGuidable?.constructor})`);
         }
-
-        this.nextGuidable = nextGuidable as Leg;
 
         this.isComputed = true;
     }
@@ -65,7 +59,7 @@ export class IFLeg extends XFLeg {
     }
 
     getGuidanceParameters(ppos: Coordinates, trueTrack: Degrees, tas: Knots, gs: Knots): GuidanceParameters | undefined {
-        return this.nextGuidable?.getGuidanceParameters(ppos, trueTrack, tas, gs) ?? undefined;
+        return this.outboundGuidable?.getGuidanceParameters(ppos, trueTrack, tas, gs) ?? undefined;
     }
 
     getNominalRollAngle(_gs): Degrees | undefined {

--- a/src/fmgc/src/guidance/lnav/legs/Leg.ts
+++ b/src/fmgc/src/guidance/lnav/legs/Leg.ts
@@ -25,7 +25,9 @@ export abstract class Leg extends Guidable {
 
     abstract get ident(): string
 
-    displayedOnMap: boolean = true
+    isNull = false
+
+    displayedOnMap = true
 
     predictedTas: Knots
 
@@ -36,7 +38,13 @@ export abstract class Leg extends Guidable {
     }
 
     /** @inheritDoc */
-    recomputeWithParameters(_isActive: boolean, _tas: Knots, _gs: Knots, _ppos: Coordinates, _trueTrack: DegreesTrue, _previousGuidable: Guidable, _nextGuidable: Guidable): void {
+    recomputeWithParameters(
+        _isActive: boolean,
+        _tas: Knots,
+        _gs: Knots,
+        _ppos: Coordinates,
+        _trueTrack: DegreesTrue,
+    ): void {
         // Default impl.
     }
 

--- a/src/fmgc/src/guidance/lnav/legs/TF.ts
+++ b/src/fmgc/src/guidance/lnav/legs/TF.ts
@@ -8,7 +8,6 @@ import { MathUtils } from '@shared/MathUtils';
 import { SegmentType } from '@fmgc/wtsdk';
 import { WaypointConstraintType } from '@fmgc/flightplanning/FlightPlanManager';
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
-import { Guidable } from '@fmgc/guidance/Guidable';
 import { XFLeg } from '@fmgc/guidance/lnav/legs/XF';
 import { courseToFixDistanceToGo, fixToFixGuidance, getIntermediatePoint } from '@fmgc/guidance/lnav/CommonGeometry';
 import { LnavConfig } from '@fmgc/guidance/LnavConfig';
@@ -61,10 +60,13 @@ export class TFLeg extends XFLeg {
         return this.inboundGuidable?.isComputed ? this.inboundGuidable.getPathEndPoint() : this.from.infos.coordinates;
     }
 
-    recomputeWithParameters(_isActive: boolean, _tas: Knots, _gs: Knots, _ppos: Coordinates, _trueTrack: DegreesTrue, previousGuidable: Guidable, nextGuidable: Guidable) {
-        this.inboundGuidable = previousGuidable;
-        this.outboundGuidable = nextGuidable;
-
+    recomputeWithParameters(
+        _isActive: boolean,
+        _tas: Knots,
+        _gs: Knots,
+        _ppos: Coordinates,
+        _trueTrack: DegreesTrue,
+    ) {
         const startPoint = this.getPathStartPoint();
         const endPoint = this.getPathEndPoint();
 

--- a/src/fmgc/src/guidance/lnav/legs/VM.ts
+++ b/src/fmgc/src/guidance/lnav/legs/VM.ts
@@ -8,7 +8,6 @@ import { SegmentType } from '@fmgc/wtsdk';
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
 import { Leg } from '@fmgc/guidance/lnav/legs/Leg';
 import { PathVector, PathVectorType } from '@fmgc/guidance/lnav/PathVector';
-import { Guidable } from '@fmgc/guidance/Guidable';
 import { LegMetadata } from '@fmgc/guidance/lnav/legs/index';
 
 /**
@@ -53,14 +52,7 @@ export class VMLeg extends Leg {
         );
     }
 
-    private inboundGuidable: Guidable | undefined;
-
-    private outboundGuidable: Guidable | undefined;
-
-    recomputeWithParameters(_isActive: boolean, _tas: Knots, _gs: Knots, _ppos: Coordinates, _trueTrack: DegreesTrue, _previousGuidable: Guidable, _nextGuidable: Guidable) {
-        this.inboundGuidable = _previousGuidable;
-        this.outboundGuidable = _nextGuidable;
-
+    recomputeWithParameters(_isActive: boolean, _tas: Knots, _gs: Knots, _ppos: Coordinates, _trueTrack: DegreesTrue) {
         this.predictedPath.length = 0;
         this.predictedPath.push(
             {

--- a/src/fmgc/src/guidance/lnav/legs/XF.ts
+++ b/src/fmgc/src/guidance/lnav/legs/XF.ts
@@ -5,9 +5,8 @@
 
 import { Leg } from '@fmgc/guidance/lnav/legs/Leg';
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
-import { Guidable } from '@fmgc/guidance/Guidable';
 import { distanceTo } from 'msfs-geo';
-import { sideOfPointOnCourseToFix } from '@fmgc/guidance/lnav/CommonGeometry';
+import { PointSide, sideOfPointOnCourseToFix } from '@fmgc/guidance/lnav/CommonGeometry';
 import { FixedRadiusTransition } from '@fmgc/guidance/lnav/transitions/FixedRadiusTransition';
 import { DmeArcTransition } from '@fmgc/guidance/lnav/transitions/DmeArcTransition';
 
@@ -17,10 +16,6 @@ export abstract class XFLeg extends Leg {
     ) {
         super();
     }
-
-    protected inboundGuidable: Guidable | undefined;
-
-    protected outboundGuidable: Guidable | undefined;
 
     getPathEndPoint(): Coordinates | undefined {
         if (this.outboundGuidable instanceof FixedRadiusTransition && this.outboundGuidable.isComputed) {
@@ -52,7 +47,7 @@ export abstract class XFLeg extends Leg {
     get overshot(): boolean {
         const side = sideOfPointOnCourseToFix(this.fix.infos.coordinates, this.outboundCourse, this.getPathStartPoint());
 
-        return side === 1;
+        return side === PointSide.After;
     }
 
     get distanceToTermination(): NauticalMiles {

--- a/src/fmgc/src/guidance/lnav/transitions/CourseCaptureTransition.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/CourseCaptureTransition.ts
@@ -16,11 +16,10 @@ import { Coordinates } from '@fmgc/flightplanning/data/geo';
 import { Constants } from '@shared/Constants';
 import { Geo } from '@fmgc/utils/Geo';
 import { PathVector, PathVectorType } from '@fmgc/guidance/lnav/PathVector';
-import { Guidable } from '@fmgc/guidance/Guidable';
 import { TurnDirection } from '@fmgc/types/fstypes/FSEnums';
 import { LnavConfig } from '@fmgc/guidance/LnavConfig';
 import { AFLeg } from '@fmgc/guidance/lnav/legs/AF';
-import { arcDistanceToGo, maxBank } from '../CommonGeometry';
+import { arcDistanceToGo, arcLength, maxBank } from '../CommonGeometry';
 import { CFLeg } from '../legs/CF';
 import { CRLeg } from '../legs/CR';
 import { CILeg } from '../legs/CI';
@@ -35,12 +34,10 @@ const tan = (input: Degrees) => Math.tan(input * (Math.PI / 180));
  */
 export class CourseCaptureTransition extends Transition {
     constructor(
-        previousLeg: PrevLeg,
-        nextLeg: NextLeg | TFLeg, // FIXME temporary
+        public previousLeg: PrevLeg,
+        public nextLeg: NextLeg | TFLeg, // FIXME temporary
     ) {
-        super();
-        this.previousLeg = previousLeg;
-        this.nextLeg = nextLeg;
+        super(previousLeg, nextLeg);
     }
 
     private terminator: Coordinates | undefined;
@@ -81,15 +78,12 @@ export class CourseCaptureTransition extends Transition {
 
     public predictedPath: PathVector[] = [];
 
-    recomputeWithParameters(_isActive: boolean, tas: Knots, gs: Knots, ppos: Coordinates, _trueTrack: DegreesTrue, previousGuidable: Guidable, nextGuidable: Guidable) {
-        this.previousLeg = previousGuidable as PrevLeg;
-        this.nextLeg = nextGuidable as NextLeg;
-
+    recomputeWithParameters(_isActive: boolean, tas: Knots, gs: Knots, ppos: Coordinates, _trueTrack: DegreesTrue) {
         const termFix = this.previousLeg.getPathEndPoint();
 
         let courseChange;
         let initialTurningPoint;
-        if (!previousGuidable) {
+        if (!this.inboundGuidable) {
             if (this.courseVariation <= 90) {
                 courseChange = this.deltaTrack;
             } else if (Math.sign(this.courseVariation) === Math.sign(this.deltaTrack)) {
@@ -129,9 +123,12 @@ export class CourseCaptureTransition extends Transition {
                 endPoint: this.endPoint,
             });
 
+            this.isNull = true;
+
             return;
         }
 
+        this.isNull = false;
         this.isArc = true;
         this.startPoint = initialTurningPoint;
         this.center = turnCenter;
@@ -177,8 +174,11 @@ export class CourseCaptureTransition extends Transition {
     }
 
     get distance(): NauticalMiles {
-        const circumference = 2 * Math.PI * this.radius;
-        return circumference / 360 * this.angle;
+        if (this.isNull) {
+            return 0;
+        }
+
+        return arcLength(this.radius, this.angle);
     }
 
     getTurningPoints(): [Coordinates, Coordinates] {
@@ -191,9 +191,9 @@ export class CourseCaptureTransition extends Transition {
         return arcDistanceToGo(ppos, itp, this.center, this.clockwise ? this.angle : -this.angle);
     }
 
-    getGuidanceParameters(ppos: LatLongAlt, trueTrack: number, tas: Knots): GuidanceParameters | null {
+    getGuidanceParameters(ppos: LatLongAlt, trueTrack: number, tas: Knots, gs: Knots): GuidanceParameters | null {
         // FIXME PPOS guidance and all...
-        return this.nextLeg.getGuidanceParameters(ppos, trueTrack, tas);
+        return this.nextLeg.getGuidanceParameters(ppos, trueTrack, tas, gs);
     }
 
     getNominalRollAngle(gs: Knots): Degrees {

--- a/src/fmgc/src/guidance/lnav/transitions/DmeArcTransition.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/DmeArcTransition.ts
@@ -12,7 +12,6 @@ import { CFLeg } from '@fmgc/guidance/lnav/legs/CF';
 import { arcDistanceToGo, arcGuidance, maxBank } from '@fmgc/guidance/lnav/CommonGeometry';
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
 import { MathUtils } from '@shared/MathUtils';
-import { Guidable } from '@fmgc/guidance/Guidable';
 import { bearingTo, closestSmallCircleIntersection, placeBearingDistance } from 'msfs-geo';
 import { PathVector, pathVectorLength, PathVectorType } from '@fmgc/guidance/lnav/PathVector';
 import { GuidanceParameters } from '@fmgc/guidance/ControlLaws';
@@ -29,12 +28,10 @@ export class DmeArcTransition extends Transition {
     predictedPath: PathVector[] = [];
 
     constructor(
-        previousLeg: DmeArcTransitionPreviousLeg,
-        nextLeg: DmeArcTransitionNextLeg,
+        public previousLeg: DmeArcTransitionPreviousLeg,
+        public nextLeg: DmeArcTransitionNextLeg,
     ) {
-        super();
-        this.previousLeg = previousLeg;
-        this.nextLeg = nextLeg;
+        super(previousLeg, nextLeg);
     }
 
     getPathStartPoint(): Coordinates | undefined {
@@ -57,7 +54,7 @@ export class DmeArcTransition extends Transition {
 
     private clockwise: boolean | undefined
 
-    recomputeWithParameters(_isActive: boolean, tas: Knots, gs: MetresPerSecond, _ppos: Coordinates, _trueTrack: DegreesTrue, _previousGuidable: Guidable, _nextGuidable: Guidable) {
+    recomputeWithParameters(_isActive: boolean, tas: Knots, gs: MetresPerSecond, _ppos: Coordinates, _trueTrack: DegreesTrue) {
         if (this.isFrozen) {
             return;
         }

--- a/src/fmgc/src/guidance/lnav/transitions/FixedRadiusTransition.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/FixedRadiusTransition.ts
@@ -10,7 +10,6 @@ import { Transition } from '@fmgc/guidance/lnav/Transition';
 import { PathCaptureTransition } from '@fmgc/guidance/lnav/transitions/PathCaptureTransition';
 import { GuidanceParameters } from '@fmgc/guidance/ControlLaws';
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
-import { Guidable } from '@fmgc/guidance/Guidable';
 import { CILeg } from '@fmgc/guidance/lnav/legs/CI';
 import { arcDistanceToGo, arcGuidance, arcLength, maxBank, minBank } from '@fmgc/guidance/lnav/CommonGeometry';
 import { TurnDirection } from '@fmgc/types/fstypes/FSEnums';
@@ -51,7 +50,7 @@ export class FixedRadiusTransition extends Transition {
         public previousLeg: PrevLeg, // FIXME temporary
         public nextLeg: NextLeg, // FIXME temporary
     ) {
-        super();
+        super(previousLeg, nextLeg);
     }
 
     get isReverted(): boolean {
@@ -82,22 +81,13 @@ export class FixedRadiusTransition extends Transition {
         throw Error('?');
     }
 
-    get isNull(): boolean {
-        return this.distance < 0.01;
-    }
-
-    private legIntercept: Coordinates;
-
-    recomputeWithParameters(isActive: boolean, tas: Knots, gs: Knots, ppos: Coordinates, trueTrack: DegreesTrue, previousGuidable: Guidable, nextGuidable: Guidable) {
+    recomputeWithParameters(isActive: boolean, tas: Knots, gs: Knots, ppos: Coordinates, trueTrack: DegreesTrue) {
         if (this.isFrozen) {
             if (DEBUG) {
                 console.log('[FMS/Geometry] Not recomputing Type I transition as it is frozen.');
             }
             return;
         }
-
-        this.previousLeg = previousGuidable as PrevLeg;
-        this.nextLeg = nextGuidable as NextLeg;
 
         // Sweep angle
         this.sweepAngle = MathUtils.diffAngle(this.previousLeg.outboundCourse, this.nextLeg.inboundCourse);
@@ -136,13 +126,13 @@ export class FixedRadiusTransition extends Transition {
         const previousLegOvershot = 'overshot' in this.previousLeg && this.previousLeg.overshot;
 
         if (shouldRevert && !previousLegOvershot) {
-            const shouldHaveTad = !this.previousLeg.overflyTermFix && !notLinedUp && tooBigForPrevious;
+            const shouldHaveTad = !this.previousLeg.overflyTermFix && !notLinedUp && (tooBigForPrevious || tooBigForNext);
 
             if (!this.revertTo) {
                 const reverted = new PathCaptureTransition(this.previousLeg, this.nextLeg);
 
                 reverted.startWithTad = shouldHaveTad;
-                reverted.recomputeWithParameters(isActive, tas, gs, ppos, trueTrack, previousGuidable, nextGuidable);
+                reverted.recomputeWithParameters(isActive, tas, gs, ppos, trueTrack);
 
                 const reversionTad = reverted.tad;
                 const fixDtg = this.previousLeg.getDistanceToGo(ppos) + this.tad;
@@ -155,7 +145,7 @@ export class FixedRadiusTransition extends Transition {
                 }
             } else {
                 this.revertTo.startWithTad = shouldHaveTad;
-                this.revertTo.recomputeWithParameters(isActive, tas, gs, ppos, trueTrack, previousGuidable, nextGuidable);
+                this.revertTo.recomputeWithParameters(isActive, tas, gs, ppos, trueTrack);
                 this.isComputed = this.revertTo.isComputed;
                 return;
             }
@@ -167,7 +157,7 @@ export class FixedRadiusTransition extends Transition {
             const fixDtg = this.previousLeg.getDistanceToGo(ppos) + this.revertTo.tad;
 
             // Only de-revert if there is space for the fixed radius TAD
-            if (fixDtg > this.tad + 0.05) {
+            if (fixDtg > this.tad + 0.05 || !isActive) {
                 this.revertTo = undefined;
             }
         }

--- a/src/fmgc/src/guidance/lnav/transitions/HoldEntryTransition.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/HoldEntryTransition.ts
@@ -13,7 +13,6 @@ import { TurnDirection } from '@fmgc/types/fstypes/FSEnums';
 import { GuidanceParameters, LateralPathGuidance } from '@fmgc/guidance/ControlLaws';
 import { ControlLaw } from '@shared/autopilot';
 import { Geometry } from '@fmgc/guidance/Geometry';
-import { Guidable } from '@fmgc/guidance/Guidable';
 import { CFLeg } from '@fmgc/guidance/lnav/legs/CF';
 import { LnavConfig } from '@fmgc/guidance/LnavConfig';
 import { AFLeg } from '@fmgc/guidance/lnav/legs/AF';
@@ -70,11 +69,7 @@ export class HoldEntryTransition extends Transition {
         public nextLeg: HALeg | HFLeg | HMLeg,
         _predictWithCurrentSpeed: boolean = true, // TODO we don't need this?
     ) {
-        super();
-    }
-
-    get isNull(): boolean {
-        return this.entry === EntryType.Null;
+        super(previousLeg, nextLeg);
     }
 
     get distance(): NauticalMiles {
@@ -789,7 +784,7 @@ export class HoldEntryTransition extends Transition {
         });
     }
 
-    recomputeWithParameters(isActive: boolean, _tas: Knots, _gs: Knots, _ppos: Coordinates, _trueTrack: DegreesTrue, previousGuidable: Guidable, nextGuidable: Guidable): void {
+    recomputeWithParameters(isActive: boolean, _tas: Knots, _gs: Knots, _ppos: Coordinates, _trueTrack: DegreesTrue): void {
         // TODO only HX leg drives this
 
         const hxInbound = this.outboundCourse;
@@ -802,9 +797,6 @@ export class HoldEntryTransition extends Transition {
             return;
         }
 
-        this.previousLeg = previousGuidable as any;
-        this.nextLeg = nextGuidable as any;
-
         if (isActive && !this.frozen) {
             this.frozen = true;
         }
@@ -816,8 +808,11 @@ export class HoldEntryTransition extends Transition {
         if (!this.previousLeg || entryAngle >= -3 && entryAngle <= 3) {
             this.computeNullEntry();
             this.setHxEntry();
+            this.isNull = true;
             return;
         }
+
+        this.isNull = false;
 
         // parallel entry is always used when entering from opposite of hold course...
         // we give a 3 degree tolerance to allow for mag var, calculation errors etc.

--- a/src/fmgc/src/guidance/lnav/transitions/PathCaptureTransition.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/PathCaptureTransition.ts
@@ -16,7 +16,6 @@ import { Geo } from '@fmgc/utils/Geo';
 import { PathVector, PathVectorType } from '@fmgc/guidance/lnav/PathVector';
 import { CourseChange } from '@fmgc/guidance/lnav/transitions/utilss/CourseChange';
 import { Constants } from '@shared/Constants';
-import { Guidable } from '@fmgc/guidance/Guidable';
 import { LnavConfig } from '@fmgc/guidance/LnavConfig';
 import { TurnDirection } from '@fmgc/types/fstypes/FSEnums';
 import {
@@ -24,6 +23,8 @@ import {
     getIntermediatePoint,
     maxBank,
     maxTad,
+    PointSide,
+    reciprocal,
     sideOfPointOnCourseToFix,
 } from '@fmgc/guidance/lnav/CommonGeometry';
 import { ControlLaw } from '@shared/autopilot';
@@ -31,6 +32,7 @@ import { AFLeg } from '@fmgc/guidance/lnav/legs/AF';
 import {
     bearingTo,
     distanceTo,
+    firstSmallCircleIntersection,
     placeBearingDistance,
     placeBearingIntersection,
     smallCircleGreatCircleIntersection,
@@ -61,7 +63,7 @@ export class PathCaptureTransition extends Transition {
         public previousLeg: PrevLeg | ReversionLeg,
         public nextLeg: NextLeg,
     ) {
-        super();
+        super(previousLeg, nextLeg);
     }
 
     startWithTad = false
@@ -90,35 +92,32 @@ export class PathCaptureTransition extends Transition {
 
     private forcedTurnComplete = false;
 
-    recomputeWithParameters(_isActive: boolean, tas: Knots, gs: Knots, _ppos: Coordinates, _trueTrack: DegreesTrue, previousGuidable: Guidable, nextGuidable: Guidable) {
+    recomputeWithParameters(_isActive: boolean, tas: Knots, gs: Knots, _ppos: Coordinates, _trueTrack: DegreesTrue) {
         if (this.isFrozen) {
             return;
         }
 
-        this.previousLeg = previousGuidable as PrevLeg | ReversionLeg;
-        this.nextLeg = nextGuidable as NextLeg;
-
-        if (!(previousGuidable instanceof Leg)) {
+        if (!(this.inboundGuidable instanceof Leg)) {
             throw new Error('[FMS/Geometry/PathCapture] previousGuidable must be a leg');
         }
 
-        const targetTrack = previousGuidable.outboundCourse;
+        const targetTrack = this.inboundGuidable.outboundCourse;
 
         const naturalTurnDirectionSign = Math.sign(MathUtils.diffAngle(targetTrack, this.nextLeg.inboundCourse));
 
-        let prevLegTermination: LatLongAlt | Coordinates;
+        let prevLegTermFix: LatLongAlt | Coordinates;
         if (this.previousLeg instanceof AFLeg) {
-            prevLegTermination = this.previousLeg.arcEndPoint;
+            prevLegTermFix = this.previousLeg.arcEndPoint;
         } else {
-            prevLegTermination = this.previousLeg.terminationWaypoint instanceof WayPoint ? this.previousLeg.terminationWaypoint.infos.coordinates : this.previousLeg.terminationWaypoint;
+            prevLegTermFix = this.previousLeg.terminationWaypoint instanceof WayPoint ? this.previousLeg.terminationWaypoint.infos.coordinates : this.previousLeg.terminationWaypoint;
         }
 
         // Start the transition before the termination fix if we are reverted because of an overshoot
         let initialTurningPoint: Coordinates;
         if (this.startWithTad) {
-            const prevLegStraightLength = this.previousLeg.distanceToTermination;
+            const prevLegDistanceToTerm = this.previousLeg.distanceToTermination;
 
-            this.tad = Math.min(maxTad(tas), prevLegStraightLength - 0.05);
+            this.tad = Math.min(maxTad(tas), prevLegDistanceToTerm - 0.05);
 
             // If we are inbound of a TF leg, we use getIntermediatePoint in order to get more accurate results
             if ('from' in this.previousLeg) {
@@ -131,14 +130,14 @@ export class PathCaptureTransition extends Transition {
                 initialTurningPoint = getIntermediatePoint(start, end, ratio);
             } else {
                 initialTurningPoint = placeBearingDistance(
-                    prevLegTermination,
-                    Avionics.Utils.clampAngle(this.previousLeg.outboundCourse + 180),
+                    prevLegTermFix,
+                    reciprocal(this.previousLeg.outboundCourse),
                     this.tad,
                 );
             }
         } else {
             this.tad = 0;
-            initialTurningPoint = prevLegTermination;
+            initialTurningPoint = prevLegTermFix;
         }
 
         const distanceFromItp: NauticalMiles = Geo.distanceToLeg(initialTurningPoint, this.nextLeg);
@@ -158,12 +157,16 @@ export class PathCaptureTransition extends Transition {
                 endPoint: this.previousLeg.getPathEndPoint(),
             });
 
+            this.isNull = true;
+
             this.distance = 0;
 
             this.isComputed = true;
 
             return;
         }
+
+        this.isNull = false;
 
         // If track change is very similar to a 45 degree intercept, we do a direct intercept
         if (Math.abs(deltaTrack) > 42 && Math.abs(deltaTrack) < 48 && distanceFromItp > 0.01) {
@@ -208,12 +211,11 @@ export class PathCaptureTransition extends Transition {
         if (distanceLimit <= Math.abs(turnCenterDistance) && Math.abs(turnCenterDistance) < radius) {
             const radiusToLeg = radius - Math.abs(turnCenterDistance);
 
-            let intercept;
+            let intercept: Coordinates;
 
             // If we are inbound of a TF leg, we use the TF leg ref fix for our small circle intersect in order to get
             // more accurate results
             if ('from' in this.nextLeg) {
-                // const intersects = smallCircleGreatCircleIntersection(turnCenter, radius, initialTurningPoint, this.nextLeg.outboundCourse);
                 const intersects = smallCircleGreatCircleIntersection(turnCenter, radius, this.nextLeg.from.infos.coordinates, this.nextLeg.outboundCourse);
 
                 if (intersects) {
@@ -226,7 +228,7 @@ export class PathCaptureTransition extends Transition {
                     }
                 }
             } else {
-                intercept = smallCircleGreatCircleIntersection(turnCenter, radius, this.nextLeg.getPathEndPoint(), this.nextLeg.outboundCourse + 180);
+                intercept = firstSmallCircleIntersection(turnCenter, radius, this.nextLeg.getPathEndPoint(), reciprocal(this.nextLeg.outboundCourse));
             }
 
             // If the difference between the radius and turnCenterDistance is very small, we might not find an intercept using the circle.
@@ -329,7 +331,7 @@ export class PathCaptureTransition extends Transition {
             intercept = Geo.legIntercept(finalTurningPoint, targetTrack + courseChange, this.nextLeg);
         }
 
-        const overshot = sideOfPointOnCourseToFix(finalTurningPoint, targetTrack + courseChange, intercept) === -1;
+        const overshot = sideOfPointOnCourseToFix(finalTurningPoint, targetTrack + courseChange, intercept) === PointSide.Before;
 
         this.itp = initialTurningPoint;
         this.ftp = finalTurningPoint;
@@ -350,12 +352,6 @@ export class PathCaptureTransition extends Transition {
             this.predictedPath.push({
                 type: PathVectorType.Line,
                 startPoint: finalTurningPoint,
-                endPoint: intercept,
-            });
-        } else {
-            this.predictedPath.push({
-                type: PathVectorType.Line,
-                startPoint: intercept,
                 endPoint: intercept,
             });
         }
@@ -433,7 +429,7 @@ export class PathCaptureTransition extends Transition {
     }
 
     isAbeam(ppos: LatLongData): boolean {
-        return this.forcedTurnRequired && !this.forcedTurnComplete && this.previousLeg.getDistanceToGo(ppos) <= 0;
+        return !this.isNull && this.forcedTurnRequired && !this.forcedTurnComplete && this.previousLeg.getDistanceToGo(ppos) <= 0;
     }
 
     distance = 0;

--- a/src/fmgc/src/guidance/lnav/transitions/utilss/CourseChange.ts
+++ b/src/fmgc/src/guidance/lnav/transitions/utilss/CourseChange.ts
@@ -68,6 +68,6 @@ export class CourseChange {
         turnCenterDistance: NauticalMiles,
         trackChange: Degrees,
     ): Degrees {
-        return turnDirection * (45 - Math.abs(trackChange));
+        return trackChange + (turnDirection > 0 ? 45 : -45);
     }
 }

--- a/src/fmgc/src/guidance/vnav/CoarsePredictions.ts
+++ b/src/fmgc/src/guidance/vnav/CoarsePredictions.ts
@@ -1,5 +1,4 @@
-// Copyright (c) 2021-2022 FlyByWire Simulations
-// Copyright (c) 2021-2022 Synaptic Simulations
+// Copyright (c) 2022 FlyByWire Simulations
 //
 // SPDX-License-Identifier: GPL-3.0
 

--- a/src/fmgc/src/guidance/vnav/CoarsePredictions.ts
+++ b/src/fmgc/src/guidance/vnav/CoarsePredictions.ts
@@ -1,6 +1,12 @@
+// Copyright (c) 2021-2022 FlyByWire Simulations
+// Copyright (c) 2021-2022 Synaptic Simulations
+//
+// SPDX-License-Identifier: GPL-3.0
+
 import { GuidanceController } from '@fmgc/guidance/GuidanceController';
 import { FlightPlans } from '@fmgc/flightplanning/FlightPlanManager';
 import { AtmosphericConditions } from '@fmgc/guidance/vnav/AtmosphericConditions';
+import { LnavConfig } from '@fmgc/guidance/LnavConfig';
 
 /**
  * This class exists to provide very coarse predictions for
@@ -14,6 +20,12 @@ export class CoarsePredictions {
             const wp = flightPlanManager.getWaypoint(i, FlightPlans.Active, true);
             const leg = guidanceController.activeGeometry.legs.get(i);
             if (!wp || !leg) {
+                continue;
+            }
+
+            if (LnavConfig.DEBUG_USE_SPEED_LVARS) {
+                leg.predictedTas = SimVar.GetSimVarValue('L:A32NX_DEBUG_FM_TAS', 'knots');
+                leg.predictedGs = SimVar.GetSimVarValue('L:A32NX_DEBUG_FM_GS', 'knots');
                 continue;
             }
 

--- a/src/fmgc/src/utils/Geo.ts
+++ b/src/fmgc/src/utils/Geo.ts
@@ -7,7 +7,13 @@ import { computeDestinationPoint as geolibDestPoint } from 'geolib';
 import { Coordinates } from '@fmgc/flightplanning/data/geo';
 import { MathUtils } from '@shared/MathUtils';
 import { Leg } from '@fmgc/guidance/lnav/legs/Leg';
-import { bearingTo, distanceTo, placeBearingDistance, smallCircleGreatCircleIntersection } from 'msfs-geo';
+import {
+    bearingTo,
+    distanceTo,
+    placeBearingDistance,
+    smallCircleGreatCircleIntersection,
+    placeBearingIntersection,
+} from 'msfs-geo';
 import { AFLeg } from '@fmgc/guidance/lnav/legs/AF';
 import { TFLeg } from '@fmgc/guidance/lnav/legs/TF';
 
@@ -26,7 +32,7 @@ export class Geo {
     }
 
     static distanceToLeg(from: Coordinates, leg: Leg): NauticalMiles {
-        const intersections1 = A32NX_Util.bothGreatCircleIntersections(
+        const intersections1 = placeBearingIntersection(
             from,
             Avionics.Utils.clampAngle(leg.outboundCourse - 90),
             leg.getPathEndPoint(),
@@ -51,7 +57,7 @@ export class Geo {
             return Math.min(d1, d2);
         }
 
-        const intersections2 = A32NX_Util.bothGreatCircleIntersections(
+        const intersections2 = placeBearingIntersection(
             from,
             Avionics.Utils.clampAngle(leg.outboundCourse - 90),
             legStartReference,
@@ -83,7 +89,7 @@ export class Geo {
             throw new Error('[FMS/LNAV] Cannot compute leg intercept if leg end point or outbound course are undefined');
         }
 
-        const intersections1 = A32NX_Util.bothGreatCircleIntersections(
+        const intersections1 = placeBearingIntersection(
             from,
             Avionics.Utils.clampAngle(bearing),
             'fix' in leg ? leg.fix.infos.coordinates : leg.getPathEndPoint(),
@@ -100,7 +106,7 @@ export class Geo {
             return d1 > d2 ? intersections1[1] : intersections1[0];
         }
 
-        const intersections2 = A32NX_Util.bothGreatCircleIntersections(
+        const intersections2 = placeBearingIntersection(
             from,
             Avionics.Utils.clampAngle(bearing),
             leg.getPathStartPoint(),

--- a/src/instruments/src/ND/elements/ToWaypointIndicator.tsx
+++ b/src/instruments/src/ND/elements/ToWaypointIndicator.tsx
@@ -53,14 +53,14 @@ export const ToWaypointIndicator: FC<ToWaypointIndicatorProps> = memo(({ side })
                 <text x={-9} y={0} fontSize={25} className="White" textAnchor="end">{ident}</text>
             )}
 
-            {bearing && Number.isFinite(bearing) && (
+            {bearing && bearing !== -1 && Number.isFinite(bearing) && (
                 <>
                     <text x={54} y={0} fontSize={25} className="Green" textAnchor="end">{(Math.round(bearing)).toString().padStart(3, '0')}</text>
                     <text x={73} y={2} fontSize={25} className="Cyan" textAnchor="end">&deg;</text>
                 </>
             )}
 
-            {distance && Number.isFinite(distance) && (
+            {distance && distance !== -1 && Number.isFinite(distance) && (
                 <>
                     {distance < 20 ? (
                         <>
@@ -78,7 +78,7 @@ export const ToWaypointIndicator: FC<ToWaypointIndicatorProps> = memo(({ side })
                 </>
             )}
 
-            {utc && (
+            {eta !== -1 && utc && (
                 <text x={72} y={62} fontSize={25} className="Green" textAnchor="end">{utc}</text>
             )}
         </Layer>


### PR DESCRIPTION
## Summary of Changes

* Allow legs to be marked as null
* Mark CI legs as null when no intercept is found
* Mark CD legs as null when they are too long (in practice, when the radial is passed before the inbound transition is complete)
* Improve path capture TAD behaviour after getting new IRL references
* Improve path capture intersection calculations at near-zero longitudes
* Improve length of CA legs following airports (credit @tracernz)
* Refactor some code regarding geometry computations

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
