### PR TITLE
fix(fmgc): workaround navigraph/su8 missed legs issue

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -178,6 +178,7 @@
 1. [MCDU] Improved Remote MCDU communication by reducing update frequency - @frankkopp (Frank Kopp)
 1. [FLIGHTMODEL] Additional flight model improvements to better match real airplane performance data - @donstim (donbikes#4084)
 1. [FMGC] Re-implement altitude and speed constraints - @tracernz (Mike)
+1. [FMGC] Workaround for Navigraph 2202 rev2/SU8 missed approach legs - @tracernz (Mike)
 
 ## 0.7.0
 

--- a/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
+++ b/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
@@ -23,7 +23,7 @@
  */
 
 import { HoldData, WaypointStats } from '@fmgc/flightplanning/data/flightplan';
-import { AltitudeDescriptor, LegType, TurnDirection } from '../types/fstypes/FSEnums';
+import { AltitudeDescriptor, LegType, FixTypeFlags } from '../types/fstypes/FSEnums';
 import { FlightPlanSegment, SegmentType } from './FlightPlanSegment';
 import { LegsProcedure } from './LegsProcedure';
 import { RawDataMapper } from './RawDataMapper';
@@ -1039,7 +1039,13 @@ export class ManagedFlightPlan {
         }
 
         if (approachIndex !== -1) {
-            legs.push(...destinationInfo.approaches[approachIndex].finalLegs);
+            const finalLegs = destinationInfo.approaches[approachIndex].finalLegs.slice();
+            for (let i = 0; i < finalLegs.length; i++) {
+                if (finalLegs[i].fixTypeFlags & FixTypeFlags.MAP) {
+                    finalLegs.splice(i + 1);
+                }
+            }
+            legs.push(...finalLegs);
             missedLegs.push(...destinationInfo.approaches[approachIndex].missedLegs);
         }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
With Navigraph cycle 2202 rev.2 and Sim Update 8, some of the missed approach legs are included in the final approach segment (and also the missed approach segment). We workaround this by discarding all final approach legs after the missed approach point.

We should consider a 0.7.5 stable with this patch cherry-picked.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Check RJTT ILS34L-Z via CREAM... and some others. Make sure no missed approach legs are loaded as part of the approach, and that all final approach legs are included.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
