### PR TITLE
fix: do not crash pfd when ls frequency = 0

### DIFF
--- a/src/instruments/src/PFD/LandingSystemIndicator.tsx
+++ b/src/instruments/src/PFD/LandingSystemIndicator.tsx
@@ -42,6 +42,12 @@ const LandingSystemInfo = ({ displayed }) => {
     const identText = getSimVar('NAV IDENT:3', 'string');
 
     const freqTextSplit = (Math.round(getSimVar('NAV FREQUENCY:3', 'MHz') * 1000) / 1000).toString().split('.');
+
+    // temporary fix when NAV FREQUENCY:3 returns 0
+    if (freqTextSplit.length < 2) {
+        return null;
+    }
+
     const freqTextLeading = freqTextSplit[0];
     const freqTextTrailing = freqTextSplit[1].padEnd(2, '0');
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
For a short moment, NAV FREQUENCY:3 can return 0 which crashes the PFD as it tries to split that frequency for displaying. This PR adds a check that the frequency is splitted correctly and aborts further execution if it's invalid.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Enable the LS info on the PFD and enter different ILS frequencies (in range, out of range, valid and invalid combinations) and make sure the PFD stays on all the time and shows valid information.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
