### PR TITLE
feat(pfd): AUTO BRAKE label

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## 0.8.0
 
+1. [PFD] Included Auto BRK messages in PFD as latest real life update - @brainshot (brainshot)
 1. [FBW] Improved speed dependent roll law model - @IbrahimK42 (IbrahimK42)
 1. [SOUND] Pack sounds use new APU model variables - @tracernz (Mike)
 1. [HYD] Hydraulic system updated. Multiple sections. Better regulation - @Crocket63 (crocket)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## 0.8.0
 
-1. [PFD] Included Auto BRK messages in PFD as latest real life update - @brainshot (brainshot)
+1. [PFD] Added Auto BRK messages to the FMA - @brainshot (brainshot)
 1. [FBW] Improved speed dependent roll law model - @IbrahimK42 (IbrahimK42)
 1. [SOUND] Pack sounds use new APU model variables - @tracernz (Mike)
 1. [HYD] Hydraulic system updated. Multiple sections. Better regulation - @Crocket63 (crocket)

--- a/src/instruments/src/PFD/FMA.tsx
+++ b/src/instruments/src/PFD/FMA.tsx
@@ -89,6 +89,7 @@ const A1A2Cell = () => {
     const AThrMode = getSimVar('L:A32NX_AUTOTHRUST_MODE', 'enum');
 
     let text: string | undefined;
+    let autobreakText: string | undefined;
 
     switch (AThrMode) {
     case 1:
@@ -178,7 +179,23 @@ const A1A2Cell = () => {
             </g>
         );
     default:
-        return null;
+        break;
+    }
+
+    // Autobrakes displays in PFD when active and no warning from AUTOTHROTTLE
+    const autobreakMessage = getSimVar('L:A32NX_AUTOBRAKES_ARMED_MODE', 'enum');
+    switch (autobreakMessage) {
+    case 1:
+        autobreakText = 'BRK LO';
+        break;
+    case 2:
+        autobreakText = 'BRK MED';
+        break;
+    case 3:
+        autobreakText = 'BRK MAX';
+        break;
+    default:
+        break;
     }
 
     return (
@@ -187,6 +204,7 @@ const A1A2Cell = () => {
                 <path className="NormalStroke White" d="m0.70556 1.8143h30.927v6.0476h-30.927z" />
             </ShowForSeconds>
             <text className="FontMedium MiddleAlign Green" x="16.782249" y="7.1280665">{text}</text>
+            <text className="FontMedium MiddleAlign Cyan" x="16.989958" y="14.382949">{autobreakText}</text>
         </g>
     );
 };
@@ -243,24 +261,6 @@ const AB3Cell = () => {
         return (
             <text className="FontMedium MiddleAlign Cyan" x="35.434673" y="21.656223">{`SPEED SEL ${text}`}</text>
         );
-    }
-
-    // Autobrakes displays in PFD when active
-    const autobreakMessage = getSimVar('L:A32NX_AUTOBRAKES_ARMED_MODE', 'enum');
-    switch (autobreakMessage) {
-    case 1:
-        return (
-            <text className="FontMedium MiddleAlign Cyan" x="16.989958" y="21.641243">BRK LO</text>
-        );
-    case 2:
-        return (
-            <text className="FontMedium MiddleAlign Cyan" x="16.989958" y="21.641243">BRK MED</text>
-        );
-    case 3:
-        return (
-            <text className="FontMedium MiddleAlign Cyan" x="16.989958" y="21.641243">BRK MAX</text>
-        );
-    default:
     }
     return null;
 };

--- a/src/instruments/src/PFD/FMA.tsx
+++ b/src/instruments/src/PFD/FMA.tsx
@@ -186,13 +186,13 @@ const A1A2Cell = () => {
     const autobreakMessage = getSimVar('L:A32NX_AUTOBRAKES_ARMED_MODE', 'enum');
     switch (autobreakMessage) {
     case 1:
-        autobreakText = 'BRK LO';
+        autobrakeText = 'BRK LO';
         break;
     case 2:
-        autobreakText = 'BRK MED';
+        autobrakeText = 'BRK MED';
         break;
     case 3:
-        autobreakText = 'BRK MAX';
+        autobrakeText = 'BRK MAX';
         break;
     default:
         break;
@@ -204,7 +204,7 @@ const A1A2Cell = () => {
                 <path className="NormalStroke White" d="m0.70556 1.8143h30.927v6.0476h-30.927z" />
             </ShowForSeconds>
             <text className="FontMedium MiddleAlign Green" x="16.782249" y="7.1280665">{text}</text>
-            <text className="FontMedium MiddleAlign Cyan" x="16.989958" y="14.382949">{autobreakText}</text>
+            <text className="FontMedium MiddleAlign Cyan" x="16.989958" y="14.382949">{autobrakeText}</text>
         </g>
     );
 };

--- a/src/instruments/src/PFD/FMA.tsx
+++ b/src/instruments/src/PFD/FMA.tsx
@@ -183,8 +183,8 @@ const A1A2Cell = () => {
     }
 
     // Autobrakes displays in PFD when active and no warning from AUTOTHROTTLE
-    const autobreakMessage = getSimVar('L:A32NX_AUTOBRAKES_ARMED_MODE', 'enum');
-    switch (autobreakMessage) {
+    const autobrakeMessage = getSimVar('L:A32NX_AUTOBRAKES_ARMED_MODE', 'enum');
+    switch (autobrakeMessage) {
     case 1:
         autobrakeText = 'BRK LO';
         break;

--- a/src/instruments/src/PFD/FMA.tsx
+++ b/src/instruments/src/PFD/FMA.tsx
@@ -89,7 +89,7 @@ const A1A2Cell = () => {
     const AThrMode = getSimVar('L:A32NX_AUTOTHRUST_MODE', 'enum');
 
     let text: string | undefined;
-    let autobreakText: string | undefined;
+    let autobrakeText: string | undefined;
 
     switch (AThrMode) {
     case 1:

--- a/src/instruments/src/PFD/FMA.tsx
+++ b/src/instruments/src/PFD/FMA.tsx
@@ -244,6 +244,24 @@ const AB3Cell = () => {
             <text className="FontMedium MiddleAlign Cyan" x="35.434673" y="21.656223">{`SPEED SEL ${text}`}</text>
         );
     }
+
+    // Autobrakes displays in PFD when active
+    const autobreakMessage = getSimVar('L:A32NX_AUTOBRAKES_ARMED_MODE', 'enum');
+    switch (autobreakMessage) {
+    case 1:
+        return (
+            <text className="FontMedium MiddleAlign Cyan" x="16.989958" y="21.641243">BRK LO</text>
+        );
+    case 2:
+        return (
+            <text className="FontMedium MiddleAlign Cyan" x="16.989958" y="21.641243">BRK MED</text>
+        );
+    case 3:
+        return (
+            <text className="FontMedium MiddleAlign Cyan" x="16.989958" y="21.641243">BRK MAX</text>
+        );
+    default:
+    }
     return null;
 };
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
The AIRBUS had a software update that shows the AUTOBREAK status on the PFD. This small change reads from the state and presents the label on the PFD only if there are no AUTO-THROTTLE warnings.

## Screenshots (if necessary)
Real Life: 
![REAL - AutoBrakes on PFD](https://user-images.githubusercontent.com/72168990/158250274-4c89f045-59bb-4649-9f6f-4c4e16931cf8.png)


New Implementation: 
![FBW - AutoBreak PFD](https://user-images.githubusercontent.com/72168990/158250220-b41780a5-6864-446a-af98-2322f0434c47.PNG)
![Uploading FBW - AutoBreak PFD 2.PNG…]()

## References

## Additional context
Only if there is no AUTOTHROTTLE warning that uses 2 rows

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
ON GROUND: Set the engines and set the autobreak
ON AIR: Select autobreak on the air, also switch the autothrottle and set the power outside the CLB radius to make sure it dissapear the label and returns when solved the CLB issue.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
