### PR TITLE
fix(engine): tuned FADEC Idle N1 calculation

### DIFF
--- a/src/fadec/src/EngineControl.h
+++ b/src/fadec/src/EngineControl.h
@@ -78,13 +78,13 @@ class EngineControl {
   /// <summary>
   /// Generate Idle/ Initial Engine Parameters (non-imbalanced)
   /// </summary>
-  void generateIdleParameters(double pressAltitude, double ambientTemp, double ambientPressure) {
+  void generateIdleParameters(double pressAltitude, double mach, double ambientTemp, double ambientPressure) {
     double idleCN1;
     double idleCFF;
 
-    idleCN1 = iCN1(pressAltitude, ambientTemp);
+    idleCN1 = iCN1(pressAltitude, mach, ambientTemp);
     idleN1 = idleCN1 * sqrt(ratios->theta2(0, ambientTemp));
-    idleN2 = iCN2(pressAltitude) * sqrt(ratios->theta(ambientTemp));
+    idleN2 = iCN2(pressAltitude, mach) * sqrt(ratios->theta(ambientTemp));
     idleCFF = poly->correctedFuelFlow(idleCN1, 0, pressAltitude);                                               // lbs/hr
     idleFF = idleCFF * LBS_TO_KGS * ratios->delta2(0, ambientPressure) * sqrt(ratios->theta2(0, ambientTemp));  // Kg/hr
     idleEGT = poly->correctedEGT(idleCN1, idleCFF, 0, pressAltitude) * ratios->theta2(0, ambientTemp);
@@ -1150,7 +1150,7 @@ class EngineControl {
     }
     wai = simVars->getWAI();
 
-    generateIdleParameters(pressAltitude, ambientTemp, ambientPressure);
+    generateIdleParameters(pressAltitude, mach, ambientTemp, ambientPressure);
 
     // Timer timer;
     for (engine = 1; engine <= 2; engine++) {

--- a/src/fadec/src/Tables.h
+++ b/src/fadec/src/Tables.h
@@ -10,8 +10,11 @@ EngineRatios* ratios;
 /// </summary>
 /// <returns>Returns CN2 - correctedN1 pair.</returns>
 double table1502(int i, int j) {
-  double t[13][2] = {{18.2, 0},       {22, 1.9},  {26, 2.5}, {57, 12.8}, {68.2, 19.6}, {77, 26},    {83, 31.42024},
-                     {89, 40.972041}, {92.8, 51}, {97, 65},  {100, 77},  {104, 85},    {116.5, 101}};
+  double t[13][4] = {{18.20, 0.00, 0.00, 17.00},      {22.00, 1.90, 1.90, 17.40},    {26.00, 2.50, 2.50, 18.20},
+                     {57.00, 12.80, 12.80, 27.00},    {68.20, 19.60, 19.60, 34.83},  {77.00, 26.00, 26.00, 40.84},
+                     {83.00, 31.42, 31.42, 44.77},    {89.00, 40.97, 40.97, 50.09},  {92.80, 51.00, 51.00, 55.04},
+                     {97.00, 65.00, 65.00, 65.00},    {100.00, 77.00, 77.00, 77.00}, {104.00, 85.00, 85.00, 85.50},
+                     {116.50, 101.00, 101.00, 101.00}};
 
   return t[i][j];
 }
@@ -19,10 +22,10 @@ double table1502(int i, int j) {
 /// <summary>
 /// Calculate expected CN2 at Idle
 /// </summary>
-double iCN2(double pressAltitude) {
+double iCN2(double pressAltitude, double mach) {
   double cn2 = 0;
 
-  cn2 = 68.2 / sqrt((288.15 - (1.98 * pressAltitude / 1000)) / 288.15);
+  cn2 = 68.2 / (sqrt((288.15 - (1.98 * pressAltitude / 1000)) / 288.15) * sqrt(1 + (0.2 * powFBW(mach, 2))));
 
   return cn2;
 }
@@ -30,12 +33,13 @@ double iCN2(double pressAltitude) {
 /// <summary>
 /// Calculate expected correctedN1 at Idle
 /// </summary>
-double iCN1(double pressAltitude, double ambientTemp) {
+double iCN1(double pressAltitude, double mach, double ambientTemp) {
   int i;
-  double cn1 = 0;
-  double cn2 = iCN2(pressAltitude);
+  double cn1_lo = 0, cn1_hi = 0, cn1 = 0;
+  double cn2 = iCN2(pressAltitude, mach);
   double cell = 0;
-  double cn2lo = 0, cn2hi = 0, cn1lo = 0, cn1hi = 0;
+  double cn2lo = 0, cn2hi = 0;
+  double cn1lolo = 0, cn1hilo = 0, cn1lohi = 0, cn1hihi = 0;
 
   for (i = 0; i < 13; i++) {
     cell = table1502(i, 0);
@@ -43,12 +47,23 @@ double iCN1(double pressAltitude, double ambientTemp) {
       break;
     }
   }
+
   cn2lo = table1502(i - 1, 0);
   cn2hi = table1502(i, 0);
-  cn1lo = table1502(i - 1, 1);
-  cn1hi = table1502(i, 1);
 
-  cn1 = interpolate(cn2, cn2lo, cn2hi, cn1lo, cn1hi);
+  cn1lolo = table1502(i - 1, 1);
+  cn1hilo = table1502(i, 1);
+
+  if (mach <= 0.2) {
+    cn1 = interpolate(cn2, cn2lo, cn2hi, cn1lolo, cn1hilo);
+  } else {
+    cn1lohi = table1502(i - 1, 3);
+    cn1hihi = table1502(i, 3);
+
+    cn1_lo = interpolate(cn2, cn2lo, cn2hi, cn1lolo, cn1hilo);
+    cn1_hi = interpolate(cn2, cn2lo, cn2hi, cn1lohi, cn1hihi);
+    cn1 = interpolate(mach, 0.2, 0.9, cn1_lo, cn1_hi);
+  }
 
   return cn1;
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->


## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Preliminary Idle N1 values were calculated solely as a function of altitude  by the FADEC. This worked as expected for ground operations at very low speeds (static and taxi). This PR fixes Idle N1 by making it also a function of speed (Mach). 

The FADEC calculated Idle N1 (A32NX_ENGINE_IDLE_N1) should match now actual N1 at Idle TLA.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): TazX [Z+2]#0405

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
To be assessed and determined:

**ON GROUND (Static and Taxi)**
Check that A32NX_ENGINE_IDLE_N1 = Actual EW/D N1

**CRUISE**
1. Cruise at CLB detent (leveled flight at fixed Mach)
2. Bring TLA to Idle detent
3. Watch FADEC Idle N1 go down as Mach also goes down
4. Actual N1 should be also rolling back but with a certain lag with respect to FADEC due to rapid decrease of Mach
5. NOTE: Hard to see that both Idle N1s match until you loose enough speed so that the aircraft pitches down and compensates

**DESCENT**
1. Perform a Descent at Idle
2. Try to maintain Mach (will be hard due to altitude changes)
3. Check FADEC Idle is very close to Actual N1

Disclaimer: If engine response had been instantaneous to Mach, both FADEC and Actual N1s should be synched. But since engine behaves with certain delay with respect to Mach changes, it will be hard to check if there is an exact match.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
