### PR TITLE
fix(PFD): MACH SEL label position

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## 0.8.0
 
+1. [PFD] Fixed MATCH SEL position on the FMA - @brainshot (salvapatuel)
 1. [FBW] Improved speed dependent roll law model - @IbrahimK42 (IbrahimK42)
 1. [SOUND] Pack sounds use new APU model variables - @tracernz (Mike)
 1. [HYD] Hydraulic system updated. Multiple sections. Better regulation - @Crocket63 (crocket)

--- a/src/instruments/src/PFD/FMA.tsx
+++ b/src/instruments/src/PFD/FMA.tsx
@@ -234,14 +234,14 @@ const AB3Cell = () => {
     if (machPresel !== -1) {
         const text = machPresel.toFixed(2);
         return (
-            <text className="FontMedium MiddleAlign Cyan" x="35.434673" y="21.656223">{`MACH SEL ${text}`}</text>
+            <text className="FontMedium Cyan" x="16.234673" y="21.656223">{`MACH SEL ${text}`}</text>
         );
     }
     const spdPresel = getSimVar('L:A32NX_SpeedPreselVal', 'knots');
     if (spdPresel !== -1) {
         const text = Math.round(spdPresel);
         return (
-            <text className="FontMedium MiddleAlign Cyan" x="35.434673" y="21.656223">{`SPEED SEL ${text}`}</text>
+            <text className="FontMedium Cyan" x="12.434673" y="21.656223">{`SPEED SEL ${text}`}</text>
         );
     }
     return null;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #6774

## Summary of Changes
Fixes the issue that was using the same X position for SPEED SEL and MATCH SEL, now each label uses its own X position.

## Screenshots (if necessary)
New SPEED SEL: https://1drv.ms/u/s!Ap5-Yc_OFzrgs9oV72XFZpxWk4japg?e=qJmYtj
New MACH SEL: https://1drv.ms/u/s!Ap5-Yc_OFzrgs9oWFoQsYbSEaXG86w?e=UUes63

## References

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
As explained on the issue raised : https://github.com/flybywiresim/a32nx/issues/6774

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
Change the SPEED SELECTION or MATCH SELECTION on the CRZ page

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
