### PR TITLE
feat: autopilot improvements

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -189,6 +189,7 @@
 1. [MCDU] Improved resilience of FMGC main loop - @aguther (Andreas Guther)
 1. [AP] Corrected guidance for OP DES, CLB and DES for small flight level changes - @aguther (Andreas Guther)
 1. [AP] Improved roll law transition from flight to ground mode during Autoland - @aguther (Andreas Guther)
+1. [AP] Improved V/PATH law - lukecologne (luke)
 
 ## 0.7.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -187,6 +187,8 @@
 1. [HYD] Removed blue reservoir absolute air sensor (removed on new neo) - @Crocket63
 1. [MODEL] Split master caution and warning lamps - @tracernz (Mike)
 1. [MCDU] Improved resilience of FMGC main loop - @aguther (Andreas Guther)
+1. [AP] Corrected guidance for OP DES, CLB and DES for small flight level changes - @aguther (Andreas Guther)
+1. [AP] Improved roll law transition from flight to ground mode during Autoland - @aguther (Andreas Guther)
 
 ## 0.7.0
 

--- a/src/fbw/src/model/AutopilotLaws.h
+++ b/src/fbw/src/model/AutopilotLaws.h
@@ -877,7 +877,6 @@ class AutopilotLawsModelClass
     real_T Saturation_UpperSat_jt;
     real_T Saturation_LowerSat_ih;
     real_T Gain_Gain_o1;
-    real_T Gain_Gain_pe;
     real_T Gain2_Gain_hq;
     real_T Saturation_UpperSat_f3;
     real_T Saturation_LowerSat_b;

--- a/src/fbw/src/model/AutopilotLaws_data.cpp
+++ b/src/fbw/src/model/AutopilotLaws_data.cpp
@@ -1585,8 +1585,6 @@ AutopilotLawsModelClass::Parameters_AutopilotLaws_T AutopilotLawsModelClass::Aut
 
   57.295779513082323,
 
-  0.5,
-
   8.0,
 
   1500.0,

--- a/src/fbw/src/model/AutopilotStateMachine.cpp
+++ b/src/fbw/src/model/AutopilotStateMachine.cpp
@@ -720,32 +720,31 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_OFF_entry_p(void)
 
 void AutopilotStateMachineModelClass::AutopilotStateMachine_DES_entry(void)
 {
-  real_T targetAltitude;
   AutopilotStateMachine_B.out.mode = vertical_mode_DES;
   AutopilotStateMachine_B.out.V_c_kn = AutopilotStateMachine_B.BusAssignment_g.input.V_fcu_kn;
-  if (AutopilotStateMachine_B.BusAssignment_g.data_computed.H_constraint_valid) {
-    targetAltitude = AutopilotStateMachine_B.BusAssignment_g.input.H_constraint_ft;
-  } else {
-    targetAltitude = AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft;
-  }
-
   switch (AutopilotStateMachine_B.BusAssignment_g.input.FM_requested_vertical_mode) {
    case fm_requested_vertical_mode_NONE:
-    AutopilotStateMachine_B.out.H_c_ft = targetAltitude;
-    if (std::abs(AutopilotStateMachine_B.BusAssignment_g.data.H_ind_ft - targetAltitude) <= 1200.0) {
-      AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_SPEED;
-      AutopilotStateMachine_B.out.law = vertical_law_VS;
-      AutopilotStateMachine_B.out.H_dot_c_fpm = -1000.0;
+    if (AutopilotStateMachine_B.BusAssignment_g.data_computed.H_constraint_valid) {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_constraint_ft;
     } else {
-      AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_IDLE;
-      AutopilotStateMachine_B.out.law = vertical_law_SPD_MACH;
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft;
     }
+
+    AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_IDLE;
+    AutopilotStateMachine_B.out.law = vertical_law_SPD_MACH;
+    AutopilotStateMachine_B.out.H_dot_c_fpm = 0.0;
     break;
 
    case fm_requested_vertical_mode_SPEED_THRUST:
-    AutopilotStateMachine_B.out.H_c_ft = targetAltitude;
+    if (AutopilotStateMachine_B.BusAssignment_g.data_computed.H_constraint_valid) {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_constraint_ft;
+    } else {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft;
+    }
+
     AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_IDLE;
     AutopilotStateMachine_B.out.law = vertical_law_SPD_MACH;
+    AutopilotStateMachine_B.out.H_dot_c_fpm = 0.0;
     break;
 
    case fm_requested_vertical_mode_VPATH_SPEED:
@@ -756,14 +755,24 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_DES_entry(void)
     break;
 
    case fm_requested_vertical_mode_FPA_SPEED:
-    AutopilotStateMachine_B.out.H_c_ft = targetAltitude;
+    if (AutopilotStateMachine_B.BusAssignment_g.data_computed.H_constraint_valid) {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_constraint_ft;
+    } else {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft;
+    }
+
     AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_SPEED;
     AutopilotStateMachine_B.out.law = vertical_law_FPA;
     AutopilotStateMachine_B.out.FPA_c_deg = AutopilotStateMachine_B.BusAssignment_g.input.FM_H_dot_c_fpm;
     break;
 
    case fm_requested_vertical_mode_VS_SPEED:
-    AutopilotStateMachine_B.out.H_c_ft = targetAltitude;
+    if (AutopilotStateMachine_B.BusAssignment_g.data_computed.H_constraint_valid) {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_constraint_ft;
+    } else {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft;
+    }
+
     AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_SPEED;
     AutopilotStateMachine_B.out.law = vertical_law_VS;
     AutopilotStateMachine_B.out.H_dot_c_fpm = AutopilotStateMachine_B.BusAssignment_g.input.FM_H_dot_c_fpm;
@@ -780,23 +789,11 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_DES_entry(void)
 
 void AutopilotStateMachineModelClass::AutopilotStateMachine_CLB_entry(void)
 {
-  real_T tmp;
   AutopilotStateMachine_B.out.mode = vertical_mode_CLB;
   AutopilotStateMachine_B.out.V_c_kn = AutopilotStateMachine_B.BusAssignment_g.input.V_fcu_kn;
-  if (AutopilotStateMachine_B.BusAssignment_g.data_computed.H_constraint_valid) {
-    tmp = AutopilotStateMachine_B.BusAssignment_g.input.H_constraint_ft;
-  } else {
-    tmp = AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft;
-  }
-
-  if (std::abs(AutopilotStateMachine_B.BusAssignment_g.data.H_ind_ft - tmp) <= 1200.0) {
-    AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_SPEED;
-    AutopilotStateMachine_B.out.law = vertical_law_VS;
-    AutopilotStateMachine_B.out.H_dot_c_fpm = 1000.0;
-  } else {
-    AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_CLB;
-    AutopilotStateMachine_B.out.law = vertical_law_SPD_MACH;
-  }
+  AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_CLB;
+  AutopilotStateMachine_B.out.law = vertical_law_SPD_MACH;
+  AutopilotStateMachine_B.out.H_dot_c_fpm = 0.0;
 }
 
 void AutopilotStateMachineModelClass::AutopilotStateMachine_OP_CLB_entry(void)
@@ -811,6 +808,7 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_OP_CLB_entry(void)
   } else {
     AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_CLB;
     AutopilotStateMachine_B.out.law = vertical_law_SPD_MACH;
+    AutopilotStateMachine_B.out.H_dot_c_fpm = 0.0;
   }
 
   AutopilotStateMachine_B.out.EXPED_mode_active = AutopilotStateMachine_B.BusAssignment_g.input.EXPED_push;
@@ -820,16 +818,9 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_OP_DES_entry(void)
 {
   AutopilotStateMachine_B.out.mode = vertical_mode_OP_DES;
   AutopilotStateMachine_B.out.V_c_kn = AutopilotStateMachine_B.BusAssignment_g.input.V_fcu_kn;
-  if (std::abs(AutopilotStateMachine_B.BusAssignment_g.data.H_ind_ft -
-               AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft) <= 1200.0) {
-    AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_SPEED;
-    AutopilotStateMachine_B.out.law = vertical_law_VS;
-    AutopilotStateMachine_B.out.H_dot_c_fpm = -1000.0;
-  } else {
-    AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_IDLE;
-    AutopilotStateMachine_B.out.law = vertical_law_SPD_MACH;
-  }
-
+  AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_IDLE;
+  AutopilotStateMachine_B.out.law = vertical_law_SPD_MACH;
+  AutopilotStateMachine_B.out.H_dot_c_fpm = 0.0;
   AutopilotStateMachine_B.out.EXPED_mode_active = AutopilotStateMachine_B.BusAssignment_g.input.EXPED_push;
 }
 
@@ -1586,20 +1577,11 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_ALT_CST_CPT(void)
 
 void AutopilotStateMachineModelClass::AutopilotStateMachine_CLB_during(void)
 {
-  real_T targetAltitude;
   AutopilotStateMachine_B.out.V_c_kn = AutopilotStateMachine_B.BusAssignment_g.input.V_fcu_kn;
   if (AutopilotStateMachine_B.BusAssignment_g.data_computed.H_constraint_valid) {
-    targetAltitude = AutopilotStateMachine_B.BusAssignment_g.input.H_constraint_ft;
     AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_constraint_ft;
   } else {
-    targetAltitude = AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft;
     AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft;
-  }
-
-  if (std::abs(AutopilotStateMachine_B.BusAssignment_g.data.H_ind_ft - targetAltitude) > 1200.0) {
-    AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_CLB;
-    AutopilotStateMachine_B.out.law = vertical_law_SPD_MACH;
-    AutopilotStateMachine_B.out.H_dot_c_fpm = 0.0;
   }
 }
 
@@ -1613,28 +1595,30 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_ALT_CST_CPT_entry(vo
 
 void AutopilotStateMachineModelClass::AutopilotStateMachine_DES_during(void)
 {
-  real_T targetAltitude;
   AutopilotStateMachine_B.out.V_c_kn = AutopilotStateMachine_B.BusAssignment_g.input.V_fcu_kn;
-  if (AutopilotStateMachine_B.BusAssignment_g.data_computed.H_constraint_valid) {
-    targetAltitude = AutopilotStateMachine_B.BusAssignment_g.input.H_constraint_ft;
-  } else {
-    targetAltitude = AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft;
-  }
-
   switch (AutopilotStateMachine_B.BusAssignment_g.input.FM_requested_vertical_mode) {
    case fm_requested_vertical_mode_NONE:
-    AutopilotStateMachine_B.out.H_c_ft = targetAltitude;
-    if (std::abs(AutopilotStateMachine_B.BusAssignment_g.data.H_ind_ft - targetAltitude) > 1200.0) {
-      AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_IDLE;
-      AutopilotStateMachine_B.out.law = vertical_law_SPD_MACH;
-      AutopilotStateMachine_B.out.H_dot_c_fpm = 0.0;
+    if (AutopilotStateMachine_B.BusAssignment_g.data_computed.H_constraint_valid) {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_constraint_ft;
+    } else {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft;
     }
+
+    AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_IDLE;
+    AutopilotStateMachine_B.out.law = vertical_law_SPD_MACH;
+    AutopilotStateMachine_B.out.H_dot_c_fpm = 0.0;
     break;
 
    case fm_requested_vertical_mode_SPEED_THRUST:
-    AutopilotStateMachine_B.out.H_c_ft = targetAltitude;
+    if (AutopilotStateMachine_B.BusAssignment_g.data_computed.H_constraint_valid) {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_constraint_ft;
+    } else {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft;
+    }
+
     AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_IDLE;
     AutopilotStateMachine_B.out.law = vertical_law_SPD_MACH;
+    AutopilotStateMachine_B.out.H_dot_c_fpm = 0.0;
     break;
 
    case fm_requested_vertical_mode_VPATH_SPEED:
@@ -1645,14 +1629,24 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_DES_during(void)
     break;
 
    case fm_requested_vertical_mode_FPA_SPEED:
-    AutopilotStateMachine_B.out.H_c_ft = targetAltitude;
+    if (AutopilotStateMachine_B.BusAssignment_g.data_computed.H_constraint_valid) {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_constraint_ft;
+    } else {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft;
+    }
+
     AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_SPEED;
     AutopilotStateMachine_B.out.law = vertical_law_FPA;
     AutopilotStateMachine_B.out.FPA_c_deg = AutopilotStateMachine_B.BusAssignment_g.input.FM_H_dot_c_fpm;
     break;
 
    case fm_requested_vertical_mode_VS_SPEED:
-    AutopilotStateMachine_B.out.H_c_ft = targetAltitude;
+    if (AutopilotStateMachine_B.BusAssignment_g.data_computed.H_constraint_valid) {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_constraint_ft;
+    } else {
+      AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft;
+    }
+
     AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_SPEED;
     AutopilotStateMachine_B.out.law = vertical_law_VS;
     AutopilotStateMachine_B.out.H_dot_c_fpm = AutopilotStateMachine_B.BusAssignment_g.input.FM_H_dot_c_fpm;
@@ -2081,13 +2075,6 @@ void AutopilotStateMachineModelClass::AutopilotStateMachine_OP_DES_during(void)
 {
   AutopilotStateMachine_B.out.H_c_ft = AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft;
   AutopilotStateMachine_B.out.V_c_kn = AutopilotStateMachine_B.BusAssignment_g.input.V_fcu_kn;
-  if (std::abs(AutopilotStateMachine_B.BusAssignment_g.data.H_ind_ft -
-               AutopilotStateMachine_B.BusAssignment_g.input.H_fcu_ft) > 1200.0) {
-    AutopilotStateMachine_B.out.mode_autothrust = athr_requested_mode_THRUST_IDLE;
-    AutopilotStateMachine_B.out.law = vertical_law_SPD_MACH;
-    AutopilotStateMachine_B.out.H_dot_c_fpm = 0.0;
-  }
-
   if (AutopilotStateMachine_B.BusAssignment_g.input.EXPED_push) {
     AutopilotStateMachine_B.out.EXPED_mode_active =
       !AutopilotStateMachine_B.BusAssignment_g.vertical_previous.output.EXPED_mode_active;

--- a/src/fbw/src/model/FlyByWire.cpp
+++ b/src/fbw/src/model/FlyByWire.cpp
@@ -249,11 +249,11 @@ void FlyByWireModelClass::step()
   real_T rtb_Y_c;
   real_T rtb_Y_cu;
   real_T rtb_Y_d;
-  real_T rtb_Y_ee;
   real_T rtb_Y_f;
   real_T rtb_Y_fp;
   real_T rtb_Y_g;
   real_T rtb_Y_h;
+  real_T rtb_Y_jv;
   real_T rtb_Y_jz;
   real_T rtb_Y_k1;
   real_T rtb_Y_lc;
@@ -294,7 +294,7 @@ void FlyByWireModelClass::step()
   rtb_Gainqk = FlyByWire_P.Gain_Gain_n * FlyByWire_U.in.data.q_rad_s * FlyByWire_P.Gainqk_Gain;
   rtb_Gain = FlyByWire_P.Gain_Gain_l * FlyByWire_U.in.data.r_rad_s;
   rtb_Gainpk = FlyByWire_P.Gain_Gain_a * FlyByWire_U.in.data.p_rad_s * FlyByWire_P.Gainpk_Gain;
-  FlyByWire_ConvertToEuler(rtb_GainTheta, rtb_GainPhi, rtb_Gainqk, rtb_Gain, rtb_Gainpk, &rtb_Y_ee,
+  FlyByWire_ConvertToEuler(rtb_GainTheta, rtb_GainPhi, rtb_Gainqk, rtb_Gain, rtb_Gainpk, &rtb_Y_jv,
     &FlyByWire_Y.out.sim.data.rk_deg_s, &rtb_pk);
   FlyByWire_ConvertToEuler(rtb_GainTheta, rtb_GainPhi, FlyByWire_P.Gainqk1_Gain * (FlyByWire_P.Gain_Gain_e *
     FlyByWire_U.in.data.q_dot_rad_s2), FlyByWire_P.Gain_Gain_aw * FlyByWire_U.in.data.r_dot_rad_s2,
@@ -318,10 +318,10 @@ void FlyByWireModelClass::step()
 
   rtb_uDLookupTable_g = FlyByWire_P.Gaineta_Gain * FlyByWire_U.in.input.delta_eta_pos;
   rtb_Limiterxi = FlyByWire_P.Gainxi_Gain * FlyByWire_U.in.input.delta_xi_pos;
-  rtb_BusAssignment_sim_data_qk_deg_s = rtb_Y_ee;
+  rtb_BusAssignment_sim_data_qk_deg_s = rtb_Y_jv;
   rtb_BusAssignment_sim_input_delta_eta_pos = rtb_uDLookupTable_g;
   rtb_BusAssignment_sim_input_delta_xi_pos = rtb_Limiterxi;
-  FlyByWire_LagFilter(FlyByWire_U.in.data.alpha_deg, FlyByWire_P.LagFilter_C1, FlyByWire_U.in.time.dt, &rtb_Y_ee,
+  FlyByWire_LagFilter(FlyByWire_U.in.data.alpha_deg, FlyByWire_P.LagFilter_C1, FlyByWire_U.in.time.dt, &rtb_Y_jv,
                       &FlyByWire_DWork.sf_LagFilter_n);
   FlyByWire_RateLimiter(look2_binlxpw(FlyByWire_U.in.data.V_mach, FlyByWire_U.in.data.flaps_handle_index,
     FlyByWire_P.alphamax_bp01Data, FlyByWire_P.alphamax_bp02Data, FlyByWire_P.alphamax_tableData,
@@ -332,7 +332,7 @@ void FlyByWireModelClass::step()
     FlyByWire_P.alpha0_tableData, 5U), FlyByWire_P.RateLimiterVariableTs3_up, FlyByWire_P.RateLimiterVariableTs3_lo,
                         FlyByWire_U.in.time.dt, FlyByWire_P.RateLimiterVariableTs3_InitialCondition, &rtb_Y,
                         &FlyByWire_DWork.sf_RateLimiter_b5);
-  FlyByWire_CalculateV_alpha_max(FlyByWire_U.in.data.V_ias_kn, rtb_Y_ee, rtb_Y, rtb_Y_k1, &rtb_Limiterxi);
+  FlyByWire_CalculateV_alpha_max(FlyByWire_U.in.data.V_ias_kn, rtb_Y_jv, rtb_Y, rtb_Y_k1, &rtb_Limiterxi);
   if (!FlyByWire_DWork.eventTime_not_empty) {
     FlyByWire_DWork.eventTime = FlyByWire_U.in.time.simulation_time;
     FlyByWire_DWork.eventTime_not_empty = true;
@@ -351,7 +351,7 @@ void FlyByWireModelClass::step()
     rtb_Y_c = rtb_Y_k1;
   }
 
-  FlyByWire_CalculateV_alpha_max(FlyByWire_U.in.data.V_ias_kn, rtb_Y_ee, rtb_Y, rtb_Y_c, &rtb_uDLookupTable_g);
+  FlyByWire_CalculateV_alpha_max(FlyByWire_U.in.data.V_ias_kn, rtb_Y_jv, rtb_Y, rtb_Y_c, &rtb_uDLookupTable_g);
   FlyByWire_RateLimiter(look2_binlxpw(FlyByWire_U.in.data.V_mach, FlyByWire_U.in.data.flaps_handle_index,
     FlyByWire_P.alphafloor_bp01Data, FlyByWire_P.alphafloor_bp02Data, FlyByWire_P.alphafloor_tableData,
     FlyByWire_P.alphafloor_maxIndex, 4U), FlyByWire_P.RateLimiterVariableTs1_up, FlyByWire_P.RateLimiterVariableTs1_lo,
@@ -384,19 +384,19 @@ void FlyByWireModelClass::step()
     FlyByWire_DWork.resetEventTime_not_empty = true;
   }
 
-  if ((rtb_BusAssignment_sim_input_delta_eta_pos >= -0.03125) || (rtb_Y_ee >= rtb_Y_k1) ||
+  if ((rtb_BusAssignment_sim_input_delta_eta_pos >= -0.03125) || (rtb_Y_jv >= rtb_Y_k1) ||
       (FlyByWire_DWork.resetEventTime == 0.0)) {
     FlyByWire_DWork.resetEventTime = FlyByWire_U.in.time.simulation_time;
   }
 
-  if ((rtb_on_ground == 0) && (FlyByWire_U.in.data.autopilot_custom_on == 0.0) && (rtb_Y_ee > rtb_Y_c) &&
+  if ((rtb_on_ground == 0) && (FlyByWire_U.in.data.autopilot_custom_on == 0.0) && (rtb_Y_jv > rtb_Y_c) &&
       (FlyByWire_DWork.Delay_DSTATE > 10.0)) {
     FlyByWire_DWork.sProtActive_c = 1.0;
   }
 
   if ((FlyByWire_U.in.time.simulation_time - FlyByWire_DWork.resetEventTime > 0.5) ||
       (rtb_BusAssignment_sim_input_delta_eta_pos < -0.5) || ((FlyByWire_U.in.data.H_radio_ft < 200.0) &&
-       (rtb_BusAssignment_sim_input_delta_eta_pos < 0.5) && (rtb_Y_ee < rtb_Y_c - 2.0)) || (rtb_on_ground != 0)) {
+       (rtb_BusAssignment_sim_input_delta_eta_pos < 0.5) && (rtb_Y_jv < rtb_Y_c - 2.0)) || (rtb_on_ground != 0)) {
     FlyByWire_DWork.sProtActive_c = 0.0;
   }
 
@@ -476,7 +476,7 @@ void FlyByWireModelClass::step()
       rtb_nz_limit_lo_g = 0;
     }
 
-    if ((rtb_Y_ee > rtb_Y_h + std::fmin(std::fmax(rtb_Y_p, static_cast<real_T>(rtb_nz_limit_lo_g)), 0.0)) &&
+    if ((rtb_Y_jv > rtb_Y_h + std::fmin(std::fmax(rtb_Y_p, static_cast<real_T>(rtb_nz_limit_lo_g)), 0.0)) &&
         (FlyByWire_DWork.Delay_DSTATE > 10.0)) {
       FlyByWire_DWork.sAlphaFloor = 1.0;
     } else {
@@ -527,12 +527,12 @@ void FlyByWireModelClass::step()
   FlyByWire_Y.out.sim.data.eta_deg = rtb_Minup;
   FlyByWire_Y.out.sim.data.eta_trim_deg = rtb_Delay_jj;
   rtb_BusAssignment_a_sim_data_zeta_trim_deg = FlyByWire_P.Gainpk3_Gain * FlyByWire_U.in.data.zeta_trim_pos;
-  FlyByWire_Y.out.sim.data_speeds_aoa.alpha_filtered_deg = rtb_Y_ee;
+  FlyByWire_Y.out.sim.data_speeds_aoa.alpha_filtered_deg = rtb_Y_jv;
   rtb_BusAssignment_a_sim_input_delta_zeta_pos = FlyByWire_P.Gainxi1_Gain * FlyByWire_U.in.input.delta_zeta_pos;
   rtb_alpha_floor_inhib = ((FlyByWire_U.in.data.autopilot_master_on != 0.0) || (FlyByWire_U.in.data.slew_on != 0.0) ||
     (FlyByWire_U.in.data.pause_on != 0.0) || (FlyByWire_U.in.data.tracking_mode_on_override != 0.0));
   FlyByWire_Y.out.sim.data_computed.protection_ap_disc = (((rtb_on_ground == 0) && (((rtb_ap_special_disc != 0) &&
-    (rtb_Y_ee > rtb_Y_k1)) || (rtb_Y_ee > rtb_Y_c + 0.25))) || (FlyByWire_U.in.time.simulation_time -
+    (rtb_Y_jv > rtb_Y_k1)) || (rtb_Y_jv > rtb_Y_c + 0.25))) || (FlyByWire_U.in.time.simulation_time -
     FlyByWire_DWork.eventTime_b > 3.0) || (FlyByWire_DWork.sProtActive != 0.0) || (FlyByWire_DWork.sProtActive_c != 0.0));
   FlyByWire_eta_trim_limit_lofreeze(rtb_Delay_jj, FlyByWire_DWork.sProtActive_c, &rtb_Y_p,
     &FlyByWire_DWork.sf_eta_trim_limit_lofreeze);
@@ -589,14 +589,14 @@ void FlyByWireModelClass::step()
   }
 
   if (FlyByWire_B.in_flight > FlyByWire_P.Saturation_UpperSat_er) {
-    rtb_Y_ee = FlyByWire_P.Saturation_UpperSat_er;
+    rtb_Y_jv = FlyByWire_P.Saturation_UpperSat_er;
   } else if (FlyByWire_B.in_flight < FlyByWire_P.Saturation_LowerSat_a) {
-    rtb_Y_ee = FlyByWire_P.Saturation_LowerSat_a;
+    rtb_Y_jv = FlyByWire_P.Saturation_LowerSat_a;
   } else {
-    rtb_Y_ee = FlyByWire_B.in_flight;
+    rtb_Y_jv = FlyByWire_B.in_flight;
   }
 
-  FlyByWire_RateLimiter(rtb_Y_ee, FlyByWire_P.RateLimiterVariableTs_up_d, FlyByWire_P.RateLimiterVariableTs_lo_c,
+  FlyByWire_RateLimiter(rtb_Y_jv, FlyByWire_P.RateLimiterVariableTs_up_d, FlyByWire_P.RateLimiterVariableTs_lo_c,
                         FlyByWire_U.in.time.dt, FlyByWire_P.RateLimiterVariableTs_InitialCondition_d, &rtb_Y_f,
                         &FlyByWire_DWork.sf_RateLimiter_b);
   if (FlyByWire_DWork.is_active_c6_FlyByWire == 0U) {
@@ -654,12 +654,12 @@ void FlyByWireModelClass::step()
 
      case FlyByWire_IN_Flare_Set_Rate:
       if (FlyByWire_P.ManualSwitch1_CurrentSetting == 1) {
-        rtb_Y_ee = FlyByWire_P.Constant1_Value_f;
+        rtb_Y_jv = FlyByWire_P.Constant1_Value_f;
       } else {
-        rtb_Y_ee = FlyByWire_P.Constant_Value_jz;
+        rtb_Y_jv = FlyByWire_P.Constant_Value_jz;
       }
 
-      if ((FlyByWire_U.in.data.H_radio_ft <= 30.0) || (rtb_Y_ee == 1.0)) {
+      if ((FlyByWire_U.in.data.H_radio_ft <= 30.0) || (rtb_Y_jv == 1.0)) {
         FlyByWire_DWork.is_c2_FlyByWire = FlyByWire_IN_Flare_Reduce_Theta_c;
         rtb_in_flare = 1;
         FlyByWire_B.flare_Theta_c_deg = -2.0;
@@ -1075,11 +1075,11 @@ void FlyByWireModelClass::step()
   rtb_Loaddemand2 = FlyByWire_P.Gain1_Gain_d * rtb_GainTheta;
   omega_0 = FlyByWire_P.Gain2_Gain_g * rtb_Y_g - rtb_Loaddemand2;
   if (FlyByWire_U.in.data.V_tas_kn > FlyByWire_P.Saturation3_UpperSat_k) {
-    rtb_Y_ee = FlyByWire_P.Saturation3_UpperSat_k;
+    rtb_Y_jv = FlyByWire_P.Saturation3_UpperSat_k;
   } else if (FlyByWire_U.in.data.V_tas_kn < FlyByWire_P.Saturation3_LowerSat_l) {
-    rtb_Y_ee = FlyByWire_P.Saturation3_LowerSat_l;
+    rtb_Y_jv = FlyByWire_P.Saturation3_LowerSat_l;
   } else {
-    rtb_Y_ee = FlyByWire_U.in.data.V_tas_kn;
+    rtb_Y_jv = FlyByWire_U.in.data.V_tas_kn;
   }
 
   if (omega_0 > FlyByWire_P.Saturation1_UpperSat_h) {
@@ -1091,7 +1091,7 @@ void FlyByWireModelClass::step()
   rtb_Saturation3 = (FlyByWire_P.Gain1_Gain_c4 * rtb_BusAssignment_sim_data_qk_deg_s * (FlyByWire_P.Gain_Gain_i4 *
     FlyByWire_P.Vm_currentms_Value_l) + rtb_Gain_i0) - (look1_binlxpw(FlyByWire_U.in.data.V_tas_kn,
     FlyByWire_P.uDLookupTable_bp01Data_f, FlyByWire_P.uDLookupTable_tableData_c, 6U) / (FlyByWire_P.Gain5_Gain_k *
-    rtb_Y_ee) + FlyByWire_P.Bias_Bias) * ((rtb_Limiterxi + look1_binlxpw(omega_0, FlyByWire_P.Loaddemand1_bp01Data,
+    rtb_Y_jv) + FlyByWire_P.Bias_Bias) * ((rtb_Limiterxi + look1_binlxpw(omega_0, FlyByWire_P.Loaddemand1_bp01Data,
     FlyByWire_P.Loaddemand1_tableData, 2U)) - rtb_Limiterxi);
   rtb_Y_g = rtb_Saturation3 * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.DLUT_bp01Data,
     FlyByWire_P.DLUT_tableData, 1U) * FlyByWire_P.DiscreteDerivativeVariableTs_Gain_l;
@@ -1120,17 +1120,17 @@ void FlyByWireModelClass::step()
 
   rtb_Saturation_kd = FlyByWire_P.DiscreteDerivativeVariableTs1_Gain_k * rtb_BusAssignment_sim_data_qk_deg_s;
   if (FlyByWire_U.in.data.V_tas_kn > FlyByWire_P.Saturation3_UpperSat_l) {
-    rtb_Y_ee = FlyByWire_P.Saturation3_UpperSat_l;
+    rtb_Y_jv = FlyByWire_P.Saturation3_UpperSat_l;
   } else if (FlyByWire_U.in.data.V_tas_kn < FlyByWire_P.Saturation3_LowerSat_n) {
-    rtb_Y_ee = FlyByWire_P.Saturation3_LowerSat_n;
+    rtb_Y_jv = FlyByWire_P.Saturation3_LowerSat_n;
   } else {
-    rtb_Y_ee = FlyByWire_U.in.data.V_tas_kn;
+    rtb_Y_jv = FlyByWire_U.in.data.V_tas_kn;
   }
 
   rtb_Saturation3 = (FlyByWire_P.Gain1_Gain_g * rtb_BusAssignment_sim_data_qk_deg_s * (FlyByWire_P.Gain_Gain_g *
     FlyByWire_P.Vm_currentms_Value_e) + rtb_Gain_i0) - (look1_binlxpw(FlyByWire_U.in.data.V_tas_kn,
     FlyByWire_P.uDLookupTable_bp01Data_d, FlyByWire_P.uDLookupTable_tableData_e, 6U) / (FlyByWire_P.Gain5_Gain_i *
-    rtb_Y_ee) + FlyByWire_P.Bias_Bias_b) * (rtb_Y_jz - rtb_Limiterxi);
+    rtb_Y_jv) + FlyByWire_P.Bias_Bias_b) * (rtb_Y_jz - rtb_Limiterxi);
   rtb_Gain_ok = rtb_Saturation3 * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.DLUT_bp01Data_p,
     FlyByWire_P.DLUT_tableData_p, 1U) * FlyByWire_P.DiscreteDerivativeVariableTs_Gain_f;
   rtb_Gain_gh = FlyByWire_P.DiscreteDerivativeVariableTs2_Gain_g * FlyByWire_U.in.data.V_tas_kn;
@@ -1184,11 +1184,11 @@ void FlyByWireModelClass::step()
     FlyByWire_P.RateLimiterVariableTs5_up * FlyByWire_U.in.time.dt), FlyByWire_U.in.time.dt *
     FlyByWire_P.RateLimiterVariableTs5_lo);
   if (FlyByWire_DWork.Delay_DSTATE_k > FlyByWire_P.Saturation_UpperSat_a) {
-    rtb_Y_ee = FlyByWire_P.Saturation_UpperSat_a;
+    rtb_Y_jv = FlyByWire_P.Saturation_UpperSat_a;
   } else if (FlyByWire_DWork.Delay_DSTATE_k < FlyByWire_P.Saturation_LowerSat_ps) {
-    rtb_Y_ee = FlyByWire_P.Saturation_LowerSat_ps;
+    rtb_Y_jv = FlyByWire_P.Saturation_LowerSat_ps;
   } else {
-    rtb_Y_ee = FlyByWire_DWork.Delay_DSTATE_k;
+    rtb_Y_jv = FlyByWire_DWork.Delay_DSTATE_k;
   }
 
   omega_0 = (((FlyByWire_P.precontrol_gain_Gain * FlyByWire_DWork.Delay1_DSTATE_o + rtb_alpha_err_gain) +
@@ -1200,15 +1200,15 @@ void FlyByWireModelClass::step()
     omega_0 = FlyByWire_P.Saturation3_LowerSat_h;
   }
 
-  rtb_Y_fp = omega_0 * rtb_Y_ee;
-  rtb_Y_nl = FlyByWire_P.Constant_Value_p - rtb_Y_ee;
+  rtb_Y_fp = omega_0 * rtb_Y_jv;
+  rtb_Y_nl = FlyByWire_P.Constant_Value_p - rtb_Y_jv;
   rtb_Delay_jj = FlyByWire_P.DiscreteDerivativeVariableTs1_Gain_b * rtb_BusAssignment_sim_data_qk_deg_s;
   if (FlyByWire_U.in.data.V_tas_kn > FlyByWire_P.Saturation3_UpperSat_p) {
-    rtb_Y_ee = FlyByWire_P.Saturation3_UpperSat_p;
+    rtb_Y_jv = FlyByWire_P.Saturation3_UpperSat_p;
   } else if (FlyByWire_U.in.data.V_tas_kn < FlyByWire_P.Saturation3_LowerSat_i) {
-    rtb_Y_ee = FlyByWire_P.Saturation3_LowerSat_i;
+    rtb_Y_jv = FlyByWire_P.Saturation3_LowerSat_i;
   } else {
-    rtb_Y_ee = FlyByWire_U.in.data.V_tas_kn;
+    rtb_Y_jv = FlyByWire_U.in.data.V_tas_kn;
   }
 
   if (rtb_GainPhi > FlyByWire_P.Saturation_UpperSat_d) {
@@ -1219,10 +1219,10 @@ void FlyByWireModelClass::step()
     rtb_Saturation3 = rtb_GainPhi;
   }
 
-  rtb_Y_ee = rtb_Limiterxi1 - ((rtb_uDLookupTable_g / std::cos(FlyByWire_P.Gain1_Gain_b * rtb_Saturation3) +
+  rtb_Y_jv = rtb_Limiterxi1 - ((rtb_uDLookupTable_g / std::cos(FlyByWire_P.Gain1_Gain_b * rtb_Saturation3) +
     rtb_Limiterxi2) - rtb_Limiterxi) * (look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.uDLookupTable_bp01Data_j,
-    FlyByWire_P.uDLookupTable_tableData_l, 6U) / (FlyByWire_P.Gain5_Gain_g * rtb_Y_ee) + FlyByWire_P.Bias_Bias_d);
-  rtb_Saturation3 = rtb_Y_ee * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.DLUT_bp01Data_a,
+    FlyByWire_P.uDLookupTable_tableData_l, 6U) / (FlyByWire_P.Gain5_Gain_g * rtb_Y_jv) + FlyByWire_P.Bias_Bias_d);
+  rtb_Saturation3 = rtb_Y_jv * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.DLUT_bp01Data_a,
     FlyByWire_P.DLUT_tableData_m, 1U) * FlyByWire_P.DiscreteDerivativeVariableTs_Gain_e;
   rtb_alpha_err_gain = FlyByWire_P.DiscreteDerivativeVariableTs2_Gain_a * FlyByWire_U.in.data.V_tas_kn;
   FlyByWire_LagFilter((rtb_alpha_err_gain - FlyByWire_DWork.Delay_DSTATE_fi) / FlyByWire_U.in.time.dt,
@@ -1244,24 +1244,24 @@ void FlyByWireModelClass::step()
   }
 
   omega_0 = ((((rtb_Delay_jj - FlyByWire_DWork.Delay_DSTATE_ca) / FlyByWire_U.in.time.dt * FlyByWire_P.Gain3_Gain_l +
-               rtb_Y_ee * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.PLUT_bp01Data_h,
+               rtb_Y_jv * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.PLUT_bp01Data_h,
     FlyByWire_P.PLUT_tableData_e, 1U)) + (rtb_Saturation3 - FlyByWire_DWork.Delay_DSTATE_jv) / FlyByWire_U.in.time.dt) +
              FlyByWire_P.Gain_Gain_o * rtb_uDLookupTable_g) + rtb_Y_p * look1_binlxpw(FlyByWire_U.in.data.H_radio_ft,
     FlyByWire_P.ScheduledGain_BreakpointsForDimension1_d, FlyByWire_P.ScheduledGain_Table_b, 3U);
   rtb_Gain_ei = FlyByWire_P.DiscreteDerivativeVariableTs1_Gain_p * rtb_BusAssignment_sim_data_qk_deg_s;
   if (FlyByWire_U.in.data.V_tas_kn > FlyByWire_P.Saturation3_UpperSat_b) {
-    rtb_Y_ee = FlyByWire_P.Saturation3_UpperSat_b;
+    rtb_Y_jv = FlyByWire_P.Saturation3_UpperSat_b;
   } else if (FlyByWire_U.in.data.V_tas_kn < FlyByWire_P.Saturation3_LowerSat_c) {
-    rtb_Y_ee = FlyByWire_P.Saturation3_LowerSat_c;
+    rtb_Y_jv = FlyByWire_P.Saturation3_LowerSat_c;
   } else {
-    rtb_Y_ee = FlyByWire_U.in.data.V_tas_kn;
+    rtb_Y_jv = FlyByWire_U.in.data.V_tas_kn;
   }
 
-  rtb_Y_ee = (FlyByWire_P.Gain1_Gain_gs * rtb_BusAssignment_sim_data_qk_deg_s * (FlyByWire_P.Gain_Gain_hy *
+  rtb_Y_jv = (FlyByWire_P.Gain1_Gain_gs * rtb_BusAssignment_sim_data_qk_deg_s * (FlyByWire_P.Gain_Gain_hy *
     FlyByWire_P.Vm_currentms_Value_c) + rtb_Gain_i0) - (look1_binlxpw(FlyByWire_U.in.data.V_tas_kn,
     FlyByWire_P.uDLookupTable_bp01Data_lk, FlyByWire_P.uDLookupTable_tableData_p, 6U) / (FlyByWire_P.Gain5_Gain_e *
-    rtb_Y_ee) + FlyByWire_P.Bias_Bias_dw) * (rtb_Y_lc - rtb_Limiterxi);
-  rtb_Gain_f2y = rtb_Y_ee * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.DLUT_bp01Data_f,
+    rtb_Y_jv) + FlyByWire_P.Bias_Bias_dw) * (rtb_Y_lc - rtb_Limiterxi);
+  rtb_Gain_f2y = rtb_Y_jv * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.DLUT_bp01Data_f,
     FlyByWire_P.DLUT_tableData_a, 1U) * FlyByWire_P.DiscreteDerivativeVariableTs_Gain_bf;
   rtb_Gain_ce = FlyByWire_P.DiscreteDerivativeVariableTs2_Gain_j * FlyByWire_U.in.data.V_tas_kn;
   FlyByWire_LagFilter((rtb_Gain_ce - FlyByWire_DWork.Delay_DSTATE_ez) / FlyByWire_U.in.time.dt,
@@ -1283,7 +1283,7 @@ void FlyByWireModelClass::step()
   }
 
   rtb_Limitereta = ((((rtb_Gain_ei - FlyByWire_DWork.Delay_DSTATE_ds) / FlyByWire_U.in.time.dt *
-                      FlyByWire_P.Gain3_Gain_c + rtb_Y_ee * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn,
+                      FlyByWire_P.Gain3_Gain_c + rtb_Y_jv * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn,
     FlyByWire_P.PLUT_bp01Data_i, FlyByWire_P.PLUT_tableData_l, 1U)) + (rtb_Gain_f2y - FlyByWire_DWork.Delay_DSTATE_jw) /
                      FlyByWire_U.in.time.dt) + FlyByWire_P.Gain_Gain_f0 * rtb_uDLookupTable_g) + rtb_Y_p * look1_binlxpw
     (FlyByWire_U.in.data.H_radio_ft, FlyByWire_P.ScheduledGain_BreakpointsForDimension1_n,
@@ -1312,11 +1312,11 @@ void FlyByWireModelClass::step()
   rtb_Sum1_h = FlyByWire_P.DiscreteDerivativeVariableTs1_Gain_kf * rtb_BusAssignment_sim_data_qk_deg_s;
   omega_0 = FlyByWire_P.Gain3_Gain_m * FlyByWire_P.Theta_max3_Value - rtb_Loaddemand2;
   if (FlyByWire_U.in.data.V_tas_kn > FlyByWire_P.Saturation3_UpperSat_d) {
-    rtb_Y_ee = FlyByWire_P.Saturation3_UpperSat_d;
+    rtb_Y_jv = FlyByWire_P.Saturation3_UpperSat_d;
   } else if (FlyByWire_U.in.data.V_tas_kn < FlyByWire_P.Saturation3_LowerSat_a) {
-    rtb_Y_ee = FlyByWire_P.Saturation3_LowerSat_a;
+    rtb_Y_jv = FlyByWire_P.Saturation3_LowerSat_a;
   } else {
-    rtb_Y_ee = FlyByWire_U.in.data.V_tas_kn;
+    rtb_Y_jv = FlyByWire_U.in.data.V_tas_kn;
   }
 
   if (omega_0 > FlyByWire_P.Saturation2_UpperSat_g) {
@@ -1325,12 +1325,12 @@ void FlyByWireModelClass::step()
     omega_0 = FlyByWire_P.Saturation2_LowerSat_i;
   }
 
-  rtb_Y_ee = (FlyByWire_P.Gain1_Gain_gh * rtb_BusAssignment_sim_data_qk_deg_s * (FlyByWire_P.Gain_Gain_et *
+  rtb_Y_jv = (FlyByWire_P.Gain1_Gain_gh * rtb_BusAssignment_sim_data_qk_deg_s * (FlyByWire_P.Gain_Gain_et *
     FlyByWire_P.Vm_currentms_Value_h) + rtb_Gain_i0) - (look1_binlxpw(FlyByWire_U.in.data.V_tas_kn,
     FlyByWire_P.uDLookupTable_bp01Data_le, FlyByWire_P.uDLookupTable_tableData_j, 6U) / (FlyByWire_P.Gain5_Gain_p *
-    rtb_Y_ee) + FlyByWire_P.Bias_Bias_n) * ((rtb_Limiterxi + look1_binlxpw(omega_0, FlyByWire_P.Loaddemand2_bp01Data,
+    rtb_Y_jv) + FlyByWire_P.Bias_Bias_n) * ((rtb_Limiterxi + look1_binlxpw(omega_0, FlyByWire_P.Loaddemand2_bp01Data,
     FlyByWire_P.Loaddemand2_tableData, 2U)) - rtb_Limiterxi);
-  rtb_Gain_i0 = rtb_Y_ee * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.DLUT_bp01Data_ai,
+  rtb_Gain_i0 = rtb_Y_jv * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.DLUT_bp01Data_ai,
     FlyByWire_P.DLUT_tableData_ah, 1U) * FlyByWire_P.DiscreteDerivativeVariableTs_Gain_ea;
   rtb_Loaddemand2 = FlyByWire_P.DiscreteDerivativeVariableTs2_Gain_b * FlyByWire_U.in.data.V_tas_kn;
   FlyByWire_LagFilter((rtb_Loaddemand2 - FlyByWire_DWork.Delay_DSTATE_es) / FlyByWire_U.in.time.dt,
@@ -1354,7 +1354,7 @@ void FlyByWireModelClass::step()
   }
 
   rtb_uDLookupTable_g = ((((rtb_Sum1_h - FlyByWire_DWork.Delay_DSTATE_gk) / FlyByWire_U.in.time.dt *
-    FlyByWire_P.Gain3_Gain_n + rtb_Y_ee * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.PLUT_bp01Data_b,
+    FlyByWire_P.Gain3_Gain_n + rtb_Y_jv * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn, FlyByWire_P.PLUT_bp01Data_b,
     FlyByWire_P.PLUT_tableData_j5, 1U)) + (rtb_Gain_i0 - FlyByWire_DWork.Delay_DSTATE_py) / FlyByWire_U.in.time.dt) +
     FlyByWire_P.Gain_Gain_fw * y) + rtb_Y_nl * look1_binlxpw(FlyByWire_U.in.data.H_radio_ft,
     FlyByWire_P.ScheduledGain_BreakpointsForDimension1_h, FlyByWire_P.ScheduledGain_Table_ga, 3U);
@@ -1373,17 +1373,17 @@ void FlyByWireModelClass::step()
   FlyByWire_VoterAttitudeProtection(omega_0, rtb_Y_p, rtb_uDLookupTable_g, &rtb_Y_p);
   rtb_Limitereta = rtb_Y_p * look1_binlxpw(FlyByWire_U.in.time.dt, FlyByWire_P.ScheduledGain_BreakpointsForDimension1_c,
     FlyByWire_P.ScheduledGain_Table_p, 4U);
-  rtb_Y_ee = FlyByWire_P.DiscreteTimeIntegratorVariableTs_Gain_k * rtb_Limitereta * FlyByWire_U.in.time.dt;
+  rtb_Y_jv = FlyByWire_P.DiscreteTimeIntegratorVariableTs_Gain_k * rtb_Limitereta * FlyByWire_U.in.time.dt;
   FlyByWire_DWork.icLoad_e = ((rtb_Y_f == 0.0) || (rtb_alpha_floor_inhib != 0) || FlyByWire_DWork.icLoad_e);
   if (FlyByWire_DWork.icLoad_e) {
     if (FlyByWire_B.in_flight <= FlyByWire_P.Switch_Threshold_d) {
       rtb_LimiteriH_n = rtb_BusAssignment_cs_pitch_data_computed_delta_eta_deg;
     }
 
-    FlyByWire_DWork.Delay_DSTATE_f1 = rtb_LimiteriH_n - rtb_Y_ee;
+    FlyByWire_DWork.Delay_DSTATE_f1 = rtb_LimiteriH_n - rtb_Y_jv;
   }
 
-  FlyByWire_DWork.Delay_DSTATE_f1 += rtb_Y_ee;
+  FlyByWire_DWork.Delay_DSTATE_f1 += rtb_Y_jv;
   if (FlyByWire_DWork.Delay_DSTATE_f1 > FlyByWire_P.DiscreteTimeIntegratorVariableTs_UpperLimit_c) {
     FlyByWire_DWork.Delay_DSTATE_f1 = FlyByWire_P.DiscreteTimeIntegratorVariableTs_UpperLimit_c;
   } else if (FlyByWire_DWork.Delay_DSTATE_f1 < FlyByWire_P.DiscreteTimeIntegratorVariableTs_LowerLimit_b) {
@@ -1391,39 +1391,39 @@ void FlyByWireModelClass::step()
   }
 
   if (rtb_Y_f > FlyByWire_P.Saturation_UpperSat_g4) {
-    rtb_Y_ee = FlyByWire_P.Saturation_UpperSat_g4;
+    rtb_Y_jv = FlyByWire_P.Saturation_UpperSat_g4;
   } else if (rtb_Y_f < FlyByWire_P.Saturation_LowerSat_la) {
-    rtb_Y_ee = FlyByWire_P.Saturation_LowerSat_la;
+    rtb_Y_jv = FlyByWire_P.Saturation_LowerSat_la;
   } else {
-    rtb_Y_ee = rtb_Y_f;
+    rtb_Y_jv = rtb_Y_f;
   }
 
-  rtb_uDLookupTable_g = FlyByWire_DWork.Delay_DSTATE_f1 * rtb_Y_ee;
-  rtb_Limiterxi = FlyByWire_P.Constant_Value_o - rtb_Y_ee;
+  rtb_uDLookupTable_g = FlyByWire_DWork.Delay_DSTATE_f1 * rtb_Y_jv;
+  rtb_Limiterxi = FlyByWire_P.Constant_Value_o - rtb_Y_jv;
   if (rtb_ManualSwitch > FlyByWire_P.Saturation_UpperSat_c) {
-    rtb_Y_ee = FlyByWire_P.Saturation_UpperSat_c;
+    rtb_Y_jv = FlyByWire_P.Saturation_UpperSat_c;
   } else if (rtb_ManualSwitch < FlyByWire_P.Saturation_LowerSat_m) {
-    rtb_Y_ee = FlyByWire_P.Saturation_LowerSat_m;
+    rtb_Y_jv = FlyByWire_P.Saturation_LowerSat_m;
   } else {
-    rtb_Y_ee = rtb_ManualSwitch;
+    rtb_Y_jv = rtb_ManualSwitch;
   }
 
-  rtb_LimiteriH_n = ((FlyByWire_P.Constant_Value_ju - rtb_Y_ee) * rtb_BusAssignment_cs_pitch_data_computed_delta_eta_deg
-                     + rtb_LimiteriH * rtb_Y_ee) * rtb_Limiterxi + rtb_uDLookupTable_g;
+  rtb_LimiteriH_n = ((FlyByWire_P.Constant_Value_ju - rtb_Y_jv) * rtb_BusAssignment_cs_pitch_data_computed_delta_eta_deg
+                     + rtb_LimiteriH * rtb_Y_jv) * rtb_Limiterxi + rtb_uDLookupTable_g;
   if (rtb_eta_trim_deg_should_freeze == FlyByWire_P.CompareToConstant_const_h) {
     rtb_uDLookupTable_g = FlyByWire_P.Constant_Value;
   } else {
     rtb_uDLookupTable_g = FlyByWire_DWork.Delay_DSTATE_f1;
   }
 
-  rtb_Y_ee = FlyByWire_P.Gain_Gain_ip * rtb_uDLookupTable_g * FlyByWire_P.DiscreteTimeIntegratorVariableTsLimit_Gain *
+  rtb_Y_jv = FlyByWire_P.Gain_Gain_ip * rtb_uDLookupTable_g * FlyByWire_P.DiscreteTimeIntegratorVariableTsLimit_Gain *
     FlyByWire_U.in.time.dt;
   FlyByWire_DWork.icLoad_i = (rtb_eta_trim_deg_reset || FlyByWire_DWork.icLoad_i);
   if (FlyByWire_DWork.icLoad_i) {
-    FlyByWire_DWork.Delay_DSTATE_hh = rtb_eta_trim_deg_reset_deg - rtb_Y_ee;
+    FlyByWire_DWork.Delay_DSTATE_hh = rtb_eta_trim_deg_reset_deg - rtb_Y_jv;
   }
 
-  FlyByWire_DWork.Delay_DSTATE_hh += rtb_Y_ee;
+  FlyByWire_DWork.Delay_DSTATE_hh += rtb_Y_jv;
   if (FlyByWire_DWork.Delay_DSTATE_hh > rtb_BusAssignment_cs_pitch_data_computed_eta_trim_deg_limit_up) {
     FlyByWire_DWork.Delay_DSTATE_hh = rtb_BusAssignment_cs_pitch_data_computed_eta_trim_deg_limit_up;
   } else if (FlyByWire_DWork.Delay_DSTATE_hh < rtb_BusAssignment_cs_pitch_data_computed_eta_trim_deg_limit_lo) {
@@ -1480,14 +1480,14 @@ void FlyByWireModelClass::step()
   FlyByWire_LagFilter(FlyByWire_U.in.data.engine_2_thrust_lbf - FlyByWire_U.in.data.engine_1_thrust_lbf,
                       FlyByWire_P.LagFilter1_C1_j, FlyByWire_U.in.time.dt, &rtb_Y_fp, &FlyByWire_DWork.sf_LagFilter_fr);
   if (FlyByWire_U.in.data.alpha_deg > FlyByWire_P.Saturation_UpperSat_l) {
-    rtb_Y_ee = FlyByWire_P.Saturation_UpperSat_l;
+    rtb_Y_jv = FlyByWire_P.Saturation_UpperSat_l;
   } else if (FlyByWire_U.in.data.alpha_deg < FlyByWire_P.Saturation_LowerSat_cj) {
-    rtb_Y_ee = FlyByWire_P.Saturation_LowerSat_cj;
+    rtb_Y_jv = FlyByWire_P.Saturation_LowerSat_cj;
   } else {
-    rtb_Y_ee = FlyByWire_U.in.data.alpha_deg;
+    rtb_Y_jv = FlyByWire_U.in.data.alpha_deg;
   }
 
-  FlyByWire_LagFilter(rtb_Y_ee, FlyByWire_P.LagFilter2_C1, FlyByWire_U.in.time.dt, &rtb_Y_nl,
+  FlyByWire_LagFilter(rtb_Y_jv, FlyByWire_P.LagFilter2_C1, FlyByWire_U.in.time.dt, &rtb_Y_nl,
                       &FlyByWire_DWork.sf_LagFilter_pc);
   FlyByWire_LagFilter(FlyByWire_U.in.data.engine_1_thrust_lbf - FlyByWire_U.in.data.engine_2_thrust_lbf,
                       FlyByWire_P.LagFilter3_C1, FlyByWire_U.in.time.dt, &rtb_Y_p, &FlyByWire_DWork.sf_LagFilter_at);
@@ -1513,11 +1513,11 @@ void FlyByWireModelClass::step()
       FlyByWire_P.BankAngleProtection1_tableData, 8U);
   }
 
-  rtb_Y_ee = FlyByWire_P.Gain1_Gain_bq * rtb_BusAssignment_sim_input_delta_xi_pos + rtb_uDLookupTable_g;
-  if (rtb_Y_ee > FlyByWire_P.Saturation_UpperSat_as) {
-    rtb_Y_ee = FlyByWire_P.Saturation_UpperSat_as;
-  } else if (rtb_Y_ee < FlyByWire_P.Saturation_LowerSat_o) {
-    rtb_Y_ee = FlyByWire_P.Saturation_LowerSat_o;
+  rtb_Y_jv = FlyByWire_P.Gain1_Gain_bq * rtb_BusAssignment_sim_input_delta_xi_pos + rtb_uDLookupTable_g;
+  if (rtb_Y_jv > FlyByWire_P.Saturation_UpperSat_as) {
+    rtb_Y_jv = FlyByWire_P.Saturation_UpperSat_as;
+  } else if (rtb_Y_jv < FlyByWire_P.Saturation_LowerSat_o) {
+    rtb_Y_jv = FlyByWire_P.Saturation_LowerSat_o;
   }
 
   rtb_uDLookupTable_g = 15.0;
@@ -1528,7 +1528,7 @@ void FlyByWireModelClass::step()
     rtb_uDLookupTable_g = rtb_pk;
   }
 
-  rtb_uDLookupTable_g = std::fmin(rtb_uDLookupTable_g, std::fmax(rtb_Limiterxi, rtb_Y_ee * rtb_Y_n0)) *
+  rtb_uDLookupTable_g = std::fmin(rtb_uDLookupTable_g, std::fmax(rtb_Limiterxi, rtb_Y_jv * rtb_Y_n0)) *
     FlyByWire_P.DiscreteTimeIntegratorVariableTs_Gain_m * FlyByWire_U.in.time.dt;
   FlyByWire_DWork.icLoad_l = ((rtb_Y_n0 == 0.0) || (rtb_alpha_floor_inhib != 0) ||
     (FlyByWire_U.in.data.autopilot_custom_on != 0.0) || FlyByWire_DWork.icLoad_l);
@@ -1618,18 +1618,18 @@ void FlyByWireModelClass::step()
     rtb_Limiterxi1 = FlyByWire_DWork.pY;
   }
 
-  FlyByWire_Y.out.roll.law_normal.pk_c_deg_s = rtb_Y_ee;
+  FlyByWire_Y.out.roll.law_normal.pk_c_deg_s = rtb_Y_jv;
   y = rtb_uDLookupTable_g;
   if (FlyByWire_U.in.data.V_tas_kn > FlyByWire_P.Saturation_UpperSat_ek) {
-    rtb_Y_ee = FlyByWire_P.Saturation_UpperSat_ek;
+    rtb_Y_jv = FlyByWire_P.Saturation_UpperSat_ek;
   } else if (FlyByWire_U.in.data.V_tas_kn < FlyByWire_P.Saturation_LowerSat_j) {
-    rtb_Y_ee = FlyByWire_P.Saturation_LowerSat_j;
+    rtb_Y_jv = FlyByWire_P.Saturation_LowerSat_j;
   } else {
-    rtb_Y_ee = FlyByWire_U.in.data.V_tas_kn;
+    rtb_Y_jv = FlyByWire_U.in.data.V_tas_kn;
   }
 
   omega_0 = (rtb_Gain - std::sin(FlyByWire_P.Gain1_Gain_f * rtb_uDLookupTable_g) * FlyByWire_P.Constant2_Value_p * std::
-             cos(FlyByWire_P.Gain1_Gain_l * rtb_GainTheta) / (FlyByWire_P.Gain6_Gain_k * rtb_Y_ee) *
+             cos(FlyByWire_P.Gain1_Gain_l * rtb_GainTheta) / (FlyByWire_P.Gain6_Gain_k * rtb_Y_jv) *
              FlyByWire_P.Gain_Gain_i3) * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn,
     FlyByWire_P.ScheduledGain_BreakpointsForDimension1_a, FlyByWire_P.ScheduledGain_Table_eg, 6U);
   rtb_uDLookupTable_g = rtb_Gain * look1_binlxpw(FlyByWire_U.in.data.V_tas_kn,
@@ -1649,20 +1649,20 @@ void FlyByWireModelClass::step()
   rtb_Limiterxi1 = (FlyByWire_P.Constant_Value_ku - rtb_Limiterxi1) * rtb_uDLookupTable_g + omega_0 * rtb_Limiterxi1;
   FlyByWire_RateLimiter(static_cast<real_T>(rtb_on_ground), FlyByWire_P.RateLimiterVariableTs_up_f1,
                         FlyByWire_P.RateLimiterVariableTs_lo_e, FlyByWire_U.in.time.dt,
-                        FlyByWire_P.RateLimiterVariableTs_InitialCondition_fa, &rtb_Y_ee,
+                        FlyByWire_P.RateLimiterVariableTs_InitialCondition_fa, &rtb_Y_jv,
                         &FlyByWire_DWork.sf_RateLimiter_f);
-  if (rtb_Y_ee > FlyByWire_P.Saturation_UpperSat_cr) {
-    rtb_Y_ee = FlyByWire_P.Saturation_UpperSat_cr;
-  } else if (rtb_Y_ee < FlyByWire_P.Saturation_LowerSat_o4) {
-    rtb_Y_ee = FlyByWire_P.Saturation_LowerSat_o4;
+  if (rtb_Y_jv > FlyByWire_P.Saturation_UpperSat_cr) {
+    rtb_Y_jv = FlyByWire_P.Saturation_UpperSat_cr;
+  } else if (rtb_Y_jv < FlyByWire_P.Saturation_LowerSat_o4) {
+    rtb_Y_jv = FlyByWire_P.Saturation_LowerSat_o4;
   }
 
-  rtb_uDLookupTable_g = FlyByWire_U.in.data.autopilot_custom_Beta_c_deg * rtb_Y_ee;
-  rtb_Limiterxi = FlyByWire_P.Constant_Value_i - rtb_Y_ee;
+  rtb_uDLookupTable_g = FlyByWire_U.in.data.autopilot_custom_Beta_c_deg * rtb_Y_jv;
+  rtb_Limiterxi = FlyByWire_P.Constant_Value_i - rtb_Y_jv;
   if (FlyByWire_U.in.data.autopilot_custom_on > FlyByWire_P.Switch2_Threshold_n) {
-    rtb_Y_ee = FlyByWire_U.in.data.autopilot_custom_Beta_c_deg + rtb_Y_fp;
+    rtb_Y_jv = FlyByWire_U.in.data.autopilot_custom_Beta_c_deg + rtb_Y_fp;
   } else {
-    rtb_Y_ee = rtb_BusAssignment_a_sim_input_delta_zeta_pos * look1_binlxpw(FlyByWire_U.in.data.V_ias_kn,
+    rtb_Y_jv = rtb_BusAssignment_a_sim_input_delta_zeta_pos * look1_binlxpw(FlyByWire_U.in.data.V_ias_kn,
       FlyByWire_P.ScheduledGain_BreakpointsForDimension1_jh, FlyByWire_P.ScheduledGain_Table_c, 3U);
   }
 
@@ -1680,10 +1680,10 @@ void FlyByWireModelClass::step()
     Vtas = 0.0;
   }
 
-  FlyByWire_LagFilter((rtb_Y_ee - omega_0) * look1_binlxpw(FlyByWire_U.in.data.V_ias_kn,
+  FlyByWire_LagFilter((rtb_Y_jv - omega_0) * look1_binlxpw(FlyByWire_U.in.data.V_ias_kn,
     FlyByWire_P.ScheduledGain1_BreakpointsForDimension1_a, FlyByWire_P.ScheduledGain1_Table_o, 4U) - Vtas,
                       FlyByWire_P.LagFilter_C1_em, FlyByWire_U.in.time.dt, &rtb_Y_p, &FlyByWire_DWork.sf_LagFilter_e);
-  omega_0 = rtb_Y_ee * look1_binlxpw(FlyByWire_U.in.data.V_ias_kn, FlyByWire_P.ScheduledGain_BreakpointsForDimension1_cf,
+  omega_0 = rtb_Y_jv * look1_binlxpw(FlyByWire_U.in.data.V_ias_kn, FlyByWire_P.ScheduledGain_BreakpointsForDimension1_cf,
     FlyByWire_P.ScheduledGain_Table_d, 8U) + rtb_Y_p;
   if (omega_0 > FlyByWire_P.Saturation_UpperSat_p4) {
     omega_0 = FlyByWire_P.Saturation_UpperSat_p4;
@@ -1691,53 +1691,67 @@ void FlyByWireModelClass::step()
     omega_0 = FlyByWire_P.Saturation_LowerSat_he;
   }
 
-  rtb_uDLookupTable_g = (rtb_Limiterxi * omega_0 + rtb_uDLookupTable_g) + rtb_Limiterxi1;
-  rtb_Limiterxi = rtb_Y_n0 + FlyByWire_U.in.data.autopilot_custom_on;
-  if (rtb_Limiterxi > FlyByWire_P.Saturation1_UpperSat_e) {
-    rtb_Y_ee = FlyByWire_P.Saturation1_UpperSat_e;
-  } else if (rtb_Limiterxi < FlyByWire_P.Saturation1_LowerSat_l) {
-    rtb_Y_ee = FlyByWire_P.Saturation1_LowerSat_l;
+  rtb_Y_p = (rtb_Limiterxi * omega_0 + rtb_uDLookupTable_g) + rtb_Limiterxi1;
+  FlyByWire_RateLimiter(static_cast<real_T>(rtb_nz_limit_lo_g), FlyByWire_P.RateLimiterVariableTs_up_l,
+                        FlyByWire_P.RateLimiterVariableTs_lo_m, FlyByWire_U.in.time.dt,
+                        FlyByWire_P.RateLimiterVariableTs_InitialCondition_n3, &rtb_Y_jv,
+                        &FlyByWire_DWork.sf_RateLimiter_a5);
+  if (FlyByWire_U.in.data.autopilot_custom_on <= FlyByWire_P.Switch_Threshold_p) {
+    rtb_Y_jv = FlyByWire_P.Constant_Value_l;
+  }
+
+  if (rtb_Y_jv > FlyByWire_P.Saturation_UpperSat_lt) {
+    rtb_Y_jv = FlyByWire_P.Saturation_UpperSat_lt;
+  } else if (rtb_Y_jv < FlyByWire_P.Saturation_LowerSat_ol) {
+    rtb_Y_jv = FlyByWire_P.Saturation_LowerSat_ol;
+  }
+
+  rtb_Limiterxi = (FlyByWire_P.Constant_Value_d - rtb_Y_jv) * FlyByWire_U.in.data.autopilot_custom_Phi_c_deg +
+    FlyByWire_DWork.Delay_DSTATE_eu * rtb_Y_jv;
+  rtb_uDLookupTable_g = rtb_Y_n0 + FlyByWire_U.in.data.autopilot_custom_on;
+  if (rtb_uDLookupTable_g > FlyByWire_P.Saturation1_UpperSat_e) {
+    rtb_Y_jv = FlyByWire_P.Saturation1_UpperSat_e;
+  } else if (rtb_uDLookupTable_g < FlyByWire_P.Saturation1_LowerSat_l) {
+    rtb_Y_jv = FlyByWire_P.Saturation1_LowerSat_l;
   } else {
-    rtb_Y_ee = rtb_Limiterxi;
+    rtb_Y_jv = rtb_uDLookupTable_g;
   }
 
-  if (rtb_Y_ee > FlyByWire_P.Saturation_UpperSat_ll) {
-    rtb_Y_ee = FlyByWire_P.Saturation_UpperSat_ll;
-  } else if (rtb_Y_ee < FlyByWire_P.Saturation_LowerSat_og) {
-    rtb_Y_ee = FlyByWire_P.Saturation_LowerSat_og;
+  if (rtb_Y_jv > FlyByWire_P.Saturation_UpperSat_ll) {
+    rtb_Y_jv = FlyByWire_P.Saturation_UpperSat_ll;
+  } else if (rtb_Y_jv < FlyByWire_P.Saturation_LowerSat_og) {
+    rtb_Y_jv = FlyByWire_P.Saturation_LowerSat_og;
   }
 
-  rtb_Y_p = (FlyByWire_P.Constant_Value_l - rtb_Y_ee) * rtb_Y_nl + FlyByWire_DWork.Delay_DSTATE_eu * rtb_Y_ee;
-  if (rtb_Limiterxi > FlyByWire_P.Saturation_UpperSat_eq) {
-    rtb_Limiterxi = FlyByWire_P.Saturation_UpperSat_eq;
-  } else if (rtb_Limiterxi < FlyByWire_P.Saturation_LowerSat_n) {
-    rtb_Limiterxi = FlyByWire_P.Saturation_LowerSat_n;
+  Vtas = (FlyByWire_P.Constant_Value_l1 - rtb_Y_jv) * rtb_Y_nl + rtb_Limiterxi * rtb_Y_jv;
+  if (rtb_uDLookupTable_g > FlyByWire_P.Saturation_UpperSat_eq) {
+    rtb_uDLookupTable_g = FlyByWire_P.Saturation_UpperSat_eq;
+  } else if (rtb_uDLookupTable_g < FlyByWire_P.Saturation_LowerSat_n) {
+    rtb_uDLookupTable_g = FlyByWire_P.Saturation_LowerSat_n;
   }
 
-  if (rtb_Limiterxi > FlyByWire_P.Saturation_UpperSat_il) {
-    rtb_Y_ee = FlyByWire_P.Saturation_UpperSat_il;
-  } else if (rtb_Limiterxi < FlyByWire_P.Saturation_LowerSat_fr) {
-    rtb_Y_ee = FlyByWire_P.Saturation_LowerSat_fr;
-  } else {
-    rtb_Y_ee = rtb_Limiterxi;
+  if (rtb_uDLookupTable_g > FlyByWire_P.Saturation_UpperSat_il) {
+    rtb_uDLookupTable_g = FlyByWire_P.Saturation_UpperSat_il;
+  } else if (rtb_uDLookupTable_g < FlyByWire_P.Saturation_LowerSat_fr) {
+    rtb_uDLookupTable_g = FlyByWire_P.Saturation_LowerSat_fr;
   }
 
-  rtb_Limiterxi = (FlyByWire_P.Constant_Value_f - rtb_Y_ee) * rtb_Sum1_jv + rtb_uDLookupTable_g * rtb_Y_ee;
+  rtb_Limiterxi = (FlyByWire_P.Constant_Value_f - rtb_uDLookupTable_g) * rtb_Sum1_jv + rtb_Y_p * rtb_uDLookupTable_g;
   if (FlyByWire_U.in.data.H_radio_ft <= FlyByWire_P.CompareToConstant_const_o) {
-    rtb_Y_ee = FlyByWire_P.Constant2_Value_d;
+    rtb_Y_jv = FlyByWire_P.Constant2_Value_d;
   } else {
-    rtb_Y_ee = rtb_uDLookupTable_g - rtb_Limiterxi1;
+    rtb_Y_jv = rtb_Y_p - rtb_Limiterxi1;
   }
 
-  rtb_Y_ee = FlyByWire_P.Gain4_Gain_e * rtb_Y_ee * FlyByWire_P.DiscreteTimeIntegratorVariableTs1_Gain *
+  rtb_Y_jv = FlyByWire_P.Gain4_Gain_e * rtb_Y_jv * FlyByWire_P.DiscreteTimeIntegratorVariableTs1_Gain *
     FlyByWire_U.in.time.dt;
   FlyByWire_DWork.icLoad_d = ((FlyByWire_U.in.data.autopilot_custom_on == 0.0) || (rtb_alpha_floor_inhib != 0) ||
     FlyByWire_DWork.icLoad_d);
   if (FlyByWire_DWork.icLoad_d) {
-    FlyByWire_DWork.Delay_DSTATE_f3 = rtb_BusAssignment_a_sim_data_zeta_trim_deg - rtb_Y_ee;
+    FlyByWire_DWork.Delay_DSTATE_f3 = rtb_BusAssignment_a_sim_data_zeta_trim_deg - rtb_Y_jv;
   }
 
-  FlyByWire_DWork.Delay_DSTATE_f3 += rtb_Y_ee;
+  FlyByWire_DWork.Delay_DSTATE_f3 += rtb_Y_jv;
   if (FlyByWire_DWork.Delay_DSTATE_f3 > FlyByWire_P.DiscreteTimeIntegratorVariableTs1_UpperLimit) {
     FlyByWire_DWork.Delay_DSTATE_f3 = FlyByWire_P.DiscreteTimeIntegratorVariableTs1_UpperLimit;
   } else if (FlyByWire_DWork.Delay_DSTATE_f3 < FlyByWire_P.DiscreteTimeIntegratorVariableTs1_LowerLimit) {
@@ -1748,10 +1762,10 @@ void FlyByWireModelClass::step()
     FlyByWire_DWork.Delay_DSTATE_mp, FlyByWire_P.Constant_Value_li * FlyByWire_U.in.time.dt), FlyByWire_U.in.time.dt *
     FlyByWire_P.Constant1_Value_h);
   FlyByWire_RateLimiter(rtb_LimiteriH_n, FlyByWire_P.RateLimitereta_up, FlyByWire_P.RateLimitereta_lo,
-                        FlyByWire_U.in.time.dt, FlyByWire_P.RateLimitereta_InitialCondition, &rtb_Y_ee,
+                        FlyByWire_U.in.time.dt, FlyByWire_P.RateLimitereta_InitialCondition, &rtb_uDLookupTable_g,
                         &FlyByWire_DWork.sf_RateLimiter_mi);
-  FlyByWire_RateLimiter(rtb_Y_p, FlyByWire_P.RateLimiterxi_up, FlyByWire_P.RateLimiterxi_lo, FlyByWire_U.in.time.dt,
-                        FlyByWire_P.RateLimiterxi_InitialCondition, &Vtas, &FlyByWire_DWork.sf_RateLimiter_h);
+  FlyByWire_RateLimiter(Vtas, FlyByWire_P.RateLimiterxi_up, FlyByWire_P.RateLimiterxi_lo, FlyByWire_U.in.time.dt,
+                        FlyByWire_P.RateLimiterxi_InitialCondition, &rtb_Y_jv, &FlyByWire_DWork.sf_RateLimiter_h);
   FlyByWire_RateLimiter(rtb_Limiterxi, FlyByWire_P.RateLimiterzeta_up, FlyByWire_P.RateLimiterzeta_lo,
                         FlyByWire_U.in.time.dt, FlyByWire_P.RateLimiterzeta_InitialCondition, &rtb_Y_d,
                         &FlyByWire_DWork.sf_RateLimiter_d0);
@@ -1875,12 +1889,12 @@ void FlyByWireModelClass::step()
   FlyByWire_Y.out.roll.data_computed.beta_target_deg = rtb_Y_fp;
   FlyByWire_Y.out.roll.law_normal.Phi_c_deg = y;
   FlyByWire_Y.out.roll.law_normal.xi_deg = FlyByWire_DWork.Delay_DSTATE_eu;
-  FlyByWire_Y.out.roll.law_normal.zeta_deg = rtb_uDLookupTable_g;
+  FlyByWire_Y.out.roll.law_normal.zeta_deg = rtb_Y_p;
   FlyByWire_Y.out.roll.law_normal.zeta_tc_yd_deg = rtb_Limiterxi1;
-  FlyByWire_Y.out.roll.output.xi_deg = rtb_Y_p;
+  FlyByWire_Y.out.roll.output.xi_deg = Vtas;
   FlyByWire_Y.out.roll.output.zeta_deg = rtb_Limiterxi;
   FlyByWire_Y.out.roll.output.zeta_trim_deg = FlyByWire_DWork.Delay_DSTATE_mp;
-  u0 = FlyByWire_P.Gaineta_Gain_d * rtb_Y_ee;
+  u0 = FlyByWire_P.Gaineta_Gain_d * rtb_uDLookupTable_g;
   if (u0 > FlyByWire_P.Limitereta_UpperSat) {
     FlyByWire_Y.out.output.eta_pos = FlyByWire_P.Limitereta_UpperSat;
   } else if (u0 < FlyByWire_P.Limitereta_LowerSat) {
@@ -1899,7 +1913,7 @@ void FlyByWireModelClass::step()
   }
 
   FlyByWire_Y.out.output.eta_trim_deg_should_write = rtb_eta_trim_deg_should_write;
-  u0 = FlyByWire_P.Gainxi_Gain_n * Vtas;
+  u0 = FlyByWire_P.Gainxi_Gain_n * rtb_Y_jv;
   if (u0 > FlyByWire_P.Limiterxi_UpperSat) {
     FlyByWire_Y.out.output.xi_pos = FlyByWire_P.Limiterxi_UpperSat;
   } else if (u0 < FlyByWire_P.Limiterxi_LowerSat) {

--- a/src/fbw/src/model/FlyByWire.h
+++ b/src/fbw/src/model/FlyByWire.h
@@ -126,6 +126,7 @@ class FlyByWireModelClass
     rtDW_RateLimiter_FlyByWire_T sf_RateLimiter_mi;
     rtDW_LagFilter_FlyByWire_T sf_LagFilter_e;
     rtDW_RateLimiter_FlyByWire_T sf_RateLimiter_f;
+    rtDW_RateLimiter_FlyByWire_T sf_RateLimiter_a5;
     rtDW_RateLimiter_FlyByWire_T sf_RateLimiter_d;
     rtDW_RateLimiter_FlyByWire_T sf_RateLimiter_ny;
     rtDW_RateLimiter_FlyByWire_T sf_RateLimiter_np;
@@ -282,6 +283,7 @@ class FlyByWireModelClass
     real_T RateLimiterVariableTs_InitialCondition_j;
     real_T RateLimiterVariableTs1_InitialCondition_m;
     real_T RateLimiterVariableTs_InitialCondition_fa;
+    real_T RateLimiterVariableTs_InitialCondition_n3;
     real_T RateLimiterDynamicVariableTs_InitialCondition_b;
     real_T RateLimitereta_InitialCondition;
     real_T RateLimiterxi_InitialCondition;
@@ -332,6 +334,7 @@ class FlyByWireModelClass
     real_T RateLimiterVariableTs_lo_g;
     real_T RateLimiterVariableTs1_lo_n;
     real_T RateLimiterVariableTs_lo_e;
+    real_T RateLimiterVariableTs_lo_m;
     real_T RateLimitereta_lo;
     real_T RateLimiterxi_lo;
     real_T RateLimiterzeta_lo;
@@ -358,6 +361,7 @@ class FlyByWireModelClass
     real_T RateLimiterVariableTs_up_i;
     real_T RateLimiterVariableTs1_up_j;
     real_T RateLimiterVariableTs_up_f1;
+    real_T RateLimiterVariableTs_up_l;
     real_T RateLimitereta_up;
     real_T RateLimiterxi_up;
     real_T RateLimiterzeta_up;
@@ -402,6 +406,7 @@ class FlyByWireModelClass
     real_T BankAngleProtection1_bp01Data[9];
     real_T Switch2_Threshold_i;
     real_T Switch1_Threshold;
+    real_T Constant_Value_l;
     real_T Constant2_Value_d;
     real_T Constant_Value_j;
     real_T Delay_InitialCondition;
@@ -681,11 +686,15 @@ class FlyByWireModelClass
     real_T Switch2_Threshold_n;
     real_T Saturation_UpperSat_p4;
     real_T Saturation_LowerSat_he;
+    real_T Switch_Threshold_p;
+    real_T Saturation_UpperSat_lt;
+    real_T Saturation_LowerSat_ol;
+    real_T Constant_Value_d;
     real_T Saturation1_UpperSat_e;
     real_T Saturation1_LowerSat_l;
     real_T Saturation_UpperSat_ll;
     real_T Saturation_LowerSat_og;
-    real_T Constant_Value_l;
+    real_T Constant_Value_l1;
     real_T Saturation_UpperSat_eq;
     real_T Saturation_LowerSat_n;
     real_T Saturation_UpperSat_il;

--- a/src/fbw/src/model/FlyByWire_data.cpp
+++ b/src/fbw/src/model/FlyByWire_data.cpp
@@ -436,6 +436,8 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P{
 
   0.0,
 
+  0.0,
+
   -30.0,
 
   -30.0,
@@ -539,6 +541,8 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P{
 
   -1000.0,
 
+  -0.25,
+
   -45.0,
 
   -50.0,
@@ -590,6 +594,8 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P{
   2.0,
 
   0.33333333333333331,
+
+  2.0,
 
   45.0,
 
@@ -686,6 +692,8 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P{
   0.0,
 
   0.0,
+
+  1.0,
 
   0.0,
 
@@ -1306,6 +1314,14 @@ FlyByWireModelClass::Parameters_FlyByWire_T FlyByWireModelClass::FlyByWire_P{
   25.0,
 
   -25.0,
+
+  0.0,
+
+  1.0,
+
+  0.0,
+
+  1.0,
 
   1.0,
 


### PR DESCRIPTION
Fixes #6890

## Summary of Changes
This PR introduces the following changes:
- fix for #6890, V/S target of +1000 fpm in case of altitude change < 1200 ft is only applicable for OP CLB, not for OP DES, CLB or DES
- improves transition between flight an ground in case of Autoland, it basically removes the flickering of ailerons/spoilers on ground during ROLLOUT

## Testing instructions
- test ALT -> FCU + 1100 ft -> OP CLB -> SPEED | OP CLB -> ALT
- test ALT -> FCU + 1200 ft -> OP CLB -> THR CLB | OP CLB -> ALT
- test ALT -> FCU + 1000 ft -> CLB -> THR CLB | CLB -> ALT
- test ALT -> FCU - 1000 ft -> OP DES -> THR IDLE | OP DES -> ALT
- test ALT -> FCU - 1200 ft -> OP DES -> THR IDLE | OP DES -> ALT
- test ALT -> FCU - 1000 ft -> DES -> THR IDLE | DES -> ALT
- test ALT -> FCU - 1200 ft -> DES -> THR IDLE | DES -> ALT
- perform Autoland in a few conditions, including heavy crosswind within limits (up to 20 kn) -> expected result is satisfying and no degraded performance

Remark:
do not use VNAV branch for testing, because in that branch DES might be some other sub-mode that is not using the SPD/MACH law of the AP.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
