### PR TITLE
feat: add flight phase transition from APPROACH to CLIMB

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -190,6 +190,7 @@
 1. [AP] Corrected guidance for OP DES, CLB and DES for small flight level changes - @aguther (Andreas Guther)
 1. [AP] Improved roll law transition from flight to ground mode during Autoland - @aguther (Andreas Guther)
 1. [AP] Improved V/PATH law - lukecologne (luke)
+1. [MCDU] Added missing flight phase transition from APPR -> CLIMB - @aguther (Andreas Guther)
 
 ## 0.7.0
 

--- a/src/fmgc/src/flightphase/Phase.ts
+++ b/src/fmgc/src/flightphase/Phase.ts
@@ -123,7 +123,10 @@ export class DescentPhase extends Phase {
 export class ApproachPhase extends Phase {
     landingConfirmation = new ConfirmationNode(30 * 1000);
 
+    cruiseFl = 0;
+
     init() {
+        this.cruiseFl = SimVar.GetSimVarValue('L:AIRLINER_CRUISE_ALTITUDE', 'number') / 100;
         SimVar.SetSimVarValue('L:AIRLINER_TO_FLEX_TEMP', 'Number', 0);
         this.nextPhase = FmgcFlightPhase.Done;
     }
@@ -131,6 +134,11 @@ export class ApproachPhase extends Phase {
     shouldActivateNextPhase(_deltaTime) {
         if (SimVar.GetSimVarValue('L:A32NX_FMA_VERTICAL_MODE', 'number') === 41) {
             this.nextPhase = FmgcFlightPhase.GoAround;
+            return true;
+        }
+
+        if (SimVar.GetSimVarValue('L:AIRLINER_CRUISE_ALTITUDE', 'number') / 100 !== this.cruiseFl) {
+            this.nextPhase = FmgcFlightPhase.Climb;
             return true;
         }
 


### PR DESCRIPTION
## Summary of Changes
This PR adds a missing transition from the FMGC flight phase APPROACH to CLIMB.

When in flight phase APPROACH, the transition to flight phase CLIMB can be performed by entering a new cruise flight level in the MCDU.

## Testing instructions
- get into FMGC flight phase APPROACH
- enter a new cruise flight level into the FMGC
- FMGC flight phase should change to CLIMB

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
