### PR TITLE
docs: prepare for documentation improvements

### DIFF
--- a/igniter.config.mjs
+++ b/igniter.config.mjs
@@ -12,7 +12,7 @@ export default new TaskOfTasks('a32nx', [
         new ExecTask('fmgc','npm run build:fmgc', ['src/fmgc', 'flybywire-aircraft-a320-neo/html_ui/JS/fmgc']),
         new ExecTask('systems', [
             'cargo build --target wasm32-wasi --release',
-            'wasm-opt -O3 -o flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/panel/systems.wasm target/wasm32-wasi/release/systems.wasm',
+            'wasm-opt -O3 -o flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/panel/systems.wasm target/wasm32-wasi/release/a320_systems_wasm.wasm',
         ], ['src/systems', 'Cargo.lock', 'Cargo.toml', 'flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/panel/systems.wasm']),
         new ExecTask('systems-autopilot', [
             'src/fbw/build.sh',

--- a/src/systems/a320_hydraulic_simulation_graphs/Cargo.toml
+++ b/src/systems/a320_hydraulic_simulation_graphs/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 authors = ["davydecorps <38904654+crocket63@users.noreply.github.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "a320_hydraulic_simulation_graphs"
+doc = false
 
 [dependencies]
 systems = { path = "../systems" }

--- a/src/systems/a320_hydraulic_simulation_graphs/src/main.rs
+++ b/src/systems/a320_hydraulic_simulation_graphs/src/main.rs
@@ -4,7 +4,7 @@ use plotlib::style::LineStyle;
 use plotlib::view::ContinuousView;
 use std::time::Duration;
 
-pub use systems::hydraulic::*;
+use systems::hydraulic::*;
 
 use systems::{
     electrical::{test::TestElectricitySource, ElectricalBus, Electricity},

--- a/src/systems/a320_systems_wasm/Cargo.toml
+++ b/src/systems/a320_systems_wasm/Cargo.toml
@@ -5,10 +5,8 @@ authors = ["FlyByWire Simulations"]
 edition = "2018"
 
 [lib]
-name = "systems"
 crate-type = ["cdylib"]
 test = false
-doc = false
 
 [dependencies]
 uom = "0.32.0"

--- a/src/systems/a320_systems_wasm/src/elevators.rs
+++ b/src/systems/a320_systems_wasm/src/elevators.rs
@@ -1,9 +1,5 @@
 use std::error::Error;
-use systems::shared::{from_bool, to_bool};
-use systems_wasm::aspects::{
-    max, EventToVariableMapping, ExecuteOn, MsfsAspectBuilder, VariableToEventMapping,
-    VariableToEventWriteOn,
-};
+use systems_wasm::aspects::{ExecuteOn, MsfsAspectBuilder};
 use systems_wasm::Variable;
 
 pub(super) fn elevators(builder: &mut MsfsAspectBuilder) -> Result<(), Box<dyn Error>> {

--- a/src/systems/a320_systems_wasm/src/lib.rs
+++ b/src/systems/a320_systems_wasm/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg(any(target_arch = "wasm32", doc))]
 mod ailerons;
 mod autobrakes;
 mod brakes;

--- a/src/systems/a320_systems_wasm/src/nose_wheel_steering.rs
+++ b/src/systems/a320_systems_wasm/src/nose_wheel_steering.rs
@@ -98,12 +98,10 @@ pub(super) fn nose_wheel_steering(builder: &mut MsfsAspectBuilder) -> Result<(),
             if realistic_tiller_enabled {
                 // Convert tiller handle position to [-1;1], -1 is left
                 tiller_handle_position * 2. - 1.
+            } else if !tiller_pedal_disconnect {
+                rudder_pedal_position
             } else {
-                if !tiller_pedal_disconnect {
-                    rudder_pedal_position
-                } else {
-                    0.
-                }
+                0.
             }
         },
         Variable::named("TILLER_HANDLE_POSITION"),

--- a/src/systems/a320_systems_wasm/src/rudder.rs
+++ b/src/systems/a320_systems_wasm/src/rudder.rs
@@ -1,9 +1,5 @@
 use std::error::Error;
-use systems::shared::{from_bool, to_bool};
-use systems_wasm::aspects::{
-    max, EventToVariableMapping, ExecuteOn, MsfsAspectBuilder, VariableToEventMapping,
-    VariableToEventWriteOn,
-};
+use systems_wasm::aspects::{ExecuteOn, MsfsAspectBuilder};
 use systems_wasm::Variable;
 
 pub(super) fn rudder(builder: &mut MsfsAspectBuilder) -> Result<(), Box<dyn Error>> {

--- a/src/systems/systems/src/shared/low_pass_filter.rs
+++ b/src/systems/systems/src/shared/low_pass_filter.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 #[derive(PartialEq, Copy, Clone)]
 /// First order low pass filter
 /// y(k) = y(k-1)  +  (1-a)*( x(k) - y(k-1) ) with a = exp (-T/tau)
-/// See https://gregstanleyandassociates.com/whitepapers/FaultDiagnosis/Filtering/Exponential-Filter/exponential-filter.htm
+/// See <https://gregstanleyandassociates.com/whitepapers/FaultDiagnosis/Filtering/Exponential-Filter/exponential-filter.htm>
 pub struct LowPassFilter<T>
 where
     T: AddAssign<T> + Sub<Output = T> + Mul<f64, Output = T> + Copy,

--- a/src/systems/systems_wasm/Cargo.toml
+++ b/src/systems/systems_wasm/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2018"
 
 [lib]
 test = false
-doctest = false
-doc = false
 
 [dependencies]
 uom = "0.30.0"

--- a/src/systems/systems_wasm/src/aspects.rs
+++ b/src/systems/systems_wasm/src/aspects.rs
@@ -56,9 +56,9 @@ pub(super) trait Aspect {
     }
 }
 
-/// Type used to configure and build an [Aspect].
+/// Type used to configure an aspect of the connectivity between MSFS and the simulation.
 ///
-/// It should be noted that the resulting [Aspect] executes its tasks in the order in which they
+/// It should be noted that the resulting aspect executes its tasks in the order in which they
 /// were declared. Declaration order is important when one action depends on another action.
 /// When e.g. a variable that is mapped should then be written to an event, be sure to
 /// declare the mapping before the event writing.

--- a/src/systems/systems_wasm/src/aspects.rs
+++ b/src/systems/systems_wasm/src/aspects.rs
@@ -3,6 +3,7 @@ use crate::{
 };
 use enum_dispatch::enum_dispatch;
 use msfs::sim_connect::{SimConnect, SimConnectRecv, SIMCONNECT_OBJECT_ID_USER};
+use msfs::sys;
 use std::error::Error;
 use std::time::{Duration, Instant};
 use systems::simulation::VariableIdentifier;
@@ -179,7 +180,7 @@ impl<'a, 'b> MsfsAspectBuilder<'a, 'b> {
         mapping: EventToVariableMapping,
         target: Variable,
         configure_options: fn(EventToVariableOptions) -> EventToVariableOptions,
-    ) -> Result<u32, Box<dyn Error>> {
+    ) -> Result<sys::DWORD, Box<dyn Error>> {
         Self::precondition_not_aircraft_variable(&target);
 
         let target = self.variables.register(&target);
@@ -225,7 +226,7 @@ impl<'a, 'b> MsfsAspectBuilder<'a, 'b> {
         input: Variable,
         mapping: VariableToEventMapping,
         write_on: VariableToEventWriteOn,
-        event_id: u32,
+        event_id: sys::DWORD,
     ) {
         let input = self.variables.register(&input);
 
@@ -694,15 +695,15 @@ pub enum EventToVariableMapping {
     /// When the event occurs, sets the variable to the given value.
     Value(f64),
 
-    /// Maps the event data from a u32 to an f64 without any further processing.
+    /// Maps the event data from a sys::DWORD to an [f64] without any further processing.
     EventDataRaw,
 
-    /// Maps the event data from a 32k position to an f64.
+    /// Maps the event data from a 32k position to an [f64].
     EventData32kPosition,
 
     /// When the event occurs, calls the function with event data and sets
     /// the variable to the returned value.
-    EventDataToValue(fn(u32) -> f64),
+    EventDataToValue(fn(sys::DWORD) -> f64),
 
     /// When the event occurs, calls the function with the current variable value and
     /// sets the variable to the returned value.
@@ -710,7 +711,7 @@ pub enum EventToVariableMapping {
 
     /// When the event occurs, calls the function with event data and the current
     /// variable value and sets the variable to the returned value.
-    EventDataAndCurrentValueToValue(fn(u32, f64) -> f64),
+    EventDataAndCurrentValueToValue(fn(sys::DWORD, f64) -> f64),
 
     /// Converts the event occurrence to a value which increases and decreases
     /// by the given factors.
@@ -730,7 +731,7 @@ trait HandleMessages {
 }
 
 struct EventToVariable {
-    event_id: u32,
+    event_id: sys::DWORD,
     event_handled_before_tick: bool,
     target: VariableIdentifier,
     mapping: EventToVariableMapping,
@@ -830,10 +831,10 @@ impl HandleMessages for EventToVariable {
 #[derive(Clone, Copy)]
 /// Declares how to map the given variable value to an event value.
 pub enum VariableToEventMapping {
-    /// Maps the variable from an f64 to a u32 without any further processing.
+    /// Maps the variable from an [f64] to a sys::DWORD without any further processing.
     EventDataRaw,
 
-    /// Maps the variable from an f64 to a 32k position.
+    /// Maps the variable from an [f64] to a 32k position.
     EventData32kPosition,
 }
 
@@ -851,7 +852,7 @@ struct ToEvent {
     input: VariableIdentifier,
     mapping: VariableToEventMapping,
     write_on: VariableToEventWriteOn,
-    event_id: u32,
+    event_id: sys::DWORD,
     last_written_value: Option<f64>,
 }
 
@@ -876,7 +877,7 @@ impl ToEvent {
         input: VariableIdentifier,
         mapping: VariableToEventMapping,
         write_on: VariableToEventWriteOn,
-        event_id: u32,
+        event_id: sys::DWORD,
     ) -> Self {
         Self {
             input,
@@ -912,7 +913,7 @@ impl ExecutableVariableAction for ToEvent {
                 SIMCONNECT_OBJECT_ID_USER,
                 self.event_id,
                 match self.mapping {
-                    VariableToEventMapping::EventDataRaw => value as u32,
+                    VariableToEventMapping::EventDataRaw => value as sys::DWORD,
                     VariableToEventMapping::EventData32kPosition => {
                         f64_to_sim_connect_32k_pos(value)
                     }

--- a/src/systems/systems_wasm/src/electrical.rs
+++ b/src/systems/systems_wasm/src/electrical.rs
@@ -1,7 +1,10 @@
-use std::error::Error;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::msfs::legacy::execute_calculator_code;
+#[cfg(target_arch = "wasm32")]
+use msfs::legacy::execute_calculator_code;
 
 use crate::{ExecuteOn, MsfsAspectBuilder, Variable};
-use msfs::legacy::execute_calculator_code;
+use std::error::Error;
 use systems::shared::{to_bool, ElectricalBusType};
 
 pub(super) fn electrical_buses<const N: usize>(

--- a/src/systems/systems_wasm/src/failures.rs
+++ b/src/systems/systems_wasm/src/failures.rs
@@ -1,5 +1,9 @@
-use fxhash::FxHashMap;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::msfs::legacy::NamedVariable;
+#[cfg(target_arch = "wasm32")]
 use msfs::legacy::NamedVariable;
+
+use fxhash::FxHashMap;
 
 use systems::failures::FailureType;
 

--- a/src/systems/systems_wasm/src/lib.rs
+++ b/src/systems/systems_wasm/src/lib.rs
@@ -1,18 +1,22 @@
-#![cfg(any(target_arch = "wasm32", doc))]
 #[macro_use]
 pub mod aspects;
 mod electrical;
 mod failures;
+mod msfs;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::msfs::legacy::{AircraftVariable, NamedVariable};
+#[cfg(target_arch = "wasm32")]
+use ::msfs::legacy::{AircraftVariable, NamedVariable};
 
 use crate::aspects::{Aspect, ExecuteOn, MsfsAspectBuilder};
 use crate::electrical::{auxiliary_power_unit, electrical_buses};
-use failures::Failures;
-use fxhash::FxHashMap;
-use msfs::{
-    legacy::{AircraftVariable, NamedVariable},
+use ::msfs::{
     sim_connect::{data_definition, Period, SimConnect, SimConnectRecv, SIMCONNECT_OBJECT_ID_USER},
     MSFSEvent,
 };
+use failures::Failures;
+use fxhash::FxHashMap;
 use std::fmt::{Display, Formatter};
 use std::{error::Error, time::Duration};
 use systems::shared::ElectricalBusType;

--- a/src/systems/systems_wasm/src/lib.rs
+++ b/src/systems/systems_wasm/src/lib.rs
@@ -13,7 +13,7 @@ use crate::aspects::{Aspect, ExecuteOn, MsfsAspectBuilder};
 use crate::electrical::{auxiliary_power_unit, electrical_buses};
 use ::msfs::{
     sim_connect::{data_definition, Period, SimConnect, SimConnectRecv, SIMCONNECT_OBJECT_ID_USER},
-    MSFSEvent,
+    sys, MSFSEvent,
 };
 use failures::Failures;
 use fxhash::FxHashMap;
@@ -535,7 +535,7 @@ struct SimulationTime {
 }
 
 impl SimulationTime {
-    const REQUEST_ID: u32 = 0;
+    const REQUEST_ID: sys::DWORD = 0;
 }
 
 struct Time {
@@ -586,7 +586,7 @@ const RANGE_32KPOS_VAL_FROM_SIMCONNECT: f64 =
     MAX_32KPOS_VAL_FROM_SIMCONNECT - MIN_32KPOS_VAL_FROM_SIMCONNECT;
 const OFFSET_32KPOS_VAL_FROM_SIMCONNECT: f64 = 16384.;
 // Takes a 32k position type from simconnect, returns a value from scaled from 0 to 1
-pub fn sim_connect_32k_pos_to_f64(sim_connect_axis_value: u32) -> f64 {
+pub fn sim_connect_32k_pos_to_f64(sim_connect_axis_value: sys::DWORD) -> f64 {
     let casted_value = (sim_connect_axis_value as i32) as f64;
     let scaled_value =
         (casted_value + OFFSET_32KPOS_VAL_FROM_SIMCONNECT) / RANGE_32KPOS_VAL_FROM_SIMCONNECT;
@@ -594,32 +594,10 @@ pub fn sim_connect_32k_pos_to_f64(sim_connect_axis_value: u32) -> f64 {
     scaled_value.min(1.).max(0.)
 }
 // Takes a [0:1] f64 and returns a simconnect 32k position type
-pub fn f64_to_sim_connect_32k_pos(scaled_axis_value: f64) -> u32 {
+pub fn f64_to_sim_connect_32k_pos(scaled_axis_value: f64) -> sys::DWORD {
     let back_to_position_format = ((scaled_axis_value) * RANGE_32KPOS_VAL_FROM_SIMCONNECT)
         - OFFSET_32KPOS_VAL_FROM_SIMCONNECT;
     let to_i32 = back_to_position_format as i32;
 
-    to_i32 as u32
-}
-
-#[cfg(test)]
-mod sim_connect_type_casts {
-    use super::*;
-    #[test]
-    fn min_simconnect_value() {
-        // We expect to get first element of YS1
-        assert!(sim_connect_32k_pos_to_f64(u32::MAX - 16384) <= 0.001);
-    }
-    #[test]
-    fn middle_simconnect_value() {
-        // We expect to get first element of YS1
-        let val = sim_connect_32k_pos_to_f64(0);
-        assert!((0.499..=0.501).contains(&val));
-    }
-
-    #[test]
-    fn max_simconnect_value() {
-        // We expect to get first element of YS1
-        assert!(sim_connect_32k_pos_to_f64(16384) >= 0.999);
-    }
+    to_i32 as sys::DWORD
 }

--- a/src/systems/systems_wasm/src/msfs.rs
+++ b/src/systems/systems_wasm/src/msfs.rs
@@ -1,0 +1,47 @@
+///! Module declared to be able to compile documentation.
+///! Does not provide any meaningful functionality.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) mod legacy {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    pub fn execute_calculator_code<T>(_code: &str) {}
+
+    #[derive(Debug)]
+    pub struct AircraftVariable {}
+
+    impl AircraftVariable {
+        pub fn from(
+            _name: &str,
+            _units: &str,
+            _index: usize,
+        ) -> Result<Self, Box<dyn std::error::Error>> {
+            Ok(Self {})
+        }
+
+        pub fn get(&self) -> f64 {
+            0.
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct NamedVariable {
+        value: Rc<Cell<f64>>,
+    }
+
+    impl NamedVariable {
+        pub fn from(_name: &str) -> Self {
+            Self {
+                value: Rc::new(Cell::new(0.)),
+            }
+        }
+
+        pub fn get_value(&self) -> f64 {
+            self.value.get()
+        }
+
+        pub fn set_value(&self, value: f64) {
+            self.value.set(value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary of Changes
In the coming period I want to reduce the barrier to entry for developers new to A320 systems programming. This PR prepares our Rust environment for providing improved developer documentation through `cargo doc`.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

## Testing instructions

No testing is necessary.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
