### PR TITLE
fix(efb): useInterval to cleanup interval properly

### DIFF
--- a/src/instruments/src/EFB/StatusBar/StatusBar.tsx
+++ b/src/instruments/src/EFB/StatusBar/StatusBar.tsx
@@ -84,7 +84,7 @@ const StatusBar = (props: StatusBarProps) => {
                 <IconPower
                     onClick={() => {
                         efbClearState();
-                        Power.setContentState(ContentState.OFF);
+                        Power.setContent(ContentState.OFF);
                     }}
                     className="ml-6"
                     size={25}

--- a/src/instruments/src/EFB/StatusBar/StatusBar.tsx
+++ b/src/instruments/src/EFB/StatusBar/StatusBar.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useContext } from 'react';
 import { IconAccessPoint, IconBattery4, IconPower } from '@tabler/icons';
 import { connect } from 'react-redux';
+import useInterval from '@instruments/common/useInterval';
 import { efbClearState } from '../Store/action-creator/efb';
 
 import { PowerContext, ContentState } from '../index';
@@ -53,17 +54,13 @@ const StatusBar = (props: StatusBarProps) => {
         return formatTime(([minutes, seconds]));
     }
 
-    useEffect(() => {
-        setInterval(() => {
-            const date = new Date();
-            const timeSinceStart = calculateTimeSinceStart(date);
-            props.updateCurrentTime(date);
-            props.updateTimeSinceStart(timeSinceStart);
-            setCurrentTime(date);
-        }, 1000);
-
-        return () => clearInterval();
-    }, []);
+    useInterval(() => {
+        const date = new Date();
+        const timeSinceStart = calculateTimeSinceStart(date);
+        props.updateCurrentTime(date);
+        props.updateTimeSinceStart(timeSinceStart);
+        setCurrentTime(date);
+    }, 1000);
 
     const { efbClearState } = props;
 
@@ -87,7 +84,7 @@ const StatusBar = (props: StatusBarProps) => {
                 <IconPower
                     onClick={() => {
                         efbClearState();
-                        Power.setContent(ContentState.OFF);
+                        Power.setContentState(ContentState.OFF);
                     }}
                     className="ml-6"
                     size={25}


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This interval is not cleaned up on unmount of the component and therefore runs when the EFB is turned and is created multiple times when it's turned back on. Switching it to make use of `useInterval` which does a proper cleanup.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Make sure the time in the EFB status bar is still being updated.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
