### PR TITLE
fix(APU): APU Bleed pressure not shown with ADIRI1 off

### DIFF
--- a/src/instruments/src/SD/Pages/Apu/Apu.tsx
+++ b/src/instruments/src/SD/Pages/Apu/Apu.tsx
@@ -147,7 +147,7 @@ const ApuBleed = ({ x, y } : ComponentPositionProps) => {
     const [apuBleedPressure] = useSimVar('L:APU_BLEED_PRESSURE', 'PSI', 1000);
     const displayedBleedPressure = Math.round(apuBleedPressure / 2) * 2; // APU bleed pressure is shown in steps of two.
 
-    const [adir1ModeSelectorKnob] = useSimVar('L:A32NX_OVHD_ADIRS_IR_1_MODE_SELECTOR_KNOB', 'Enum');
+    // const [adir1ModeSelectorKnob] = useSimVar('L:A32NX_OVHD_ADIRS_IR_1_MODE_SELECTOR_KNOB', 'Enum');
 
     useEffect(() => {
         if (apuBleedPbOn) {
@@ -172,9 +172,9 @@ const ApuBleed = ({ x, y } : ComponentPositionProps) => {
                 <text
                     x={44}
                     y={48}
-                    className={`FontLarger Right ${adir1ModeSelectorKnob === 1 ? 'Green' : 'Amber'}`}
+                    className={`FontLarger Right ${apuBleedOpen && apuBleedPbOnConfirmed ? 'Green' : 'Amber'}`}
                 >
-                    {adir1ModeSelectorKnob === 1 ? displayedBleedPressure : 'XX'}
+                    {apuBleedOpen && apuBleedPbOnConfirmed ? displayedBleedPressure : 'XX'}
                 </text>
                 <text x={90} y={48} className="Cyan FontNormal Right">PSI</text>
 

--- a/src/instruments/src/SD/Pages/Apu/Apu.tsx
+++ b/src/instruments/src/SD/Pages/Apu/Apu.tsx
@@ -147,8 +147,6 @@ const ApuBleed = ({ x, y } : ComponentPositionProps) => {
     const [apuBleedPressure] = useSimVar('L:APU_BLEED_PRESSURE', 'PSI', 1000);
     const displayedBleedPressure = Math.round(apuBleedPressure / 2) * 2; // APU bleed pressure is shown in steps of two.
 
-    // const [adir1ModeSelectorKnob] = useSimVar('L:A32NX_OVHD_ADIRS_IR_1_MODE_SELECTOR_KNOB', 'Enum');
-
     useEffect(() => {
         if (apuBleedPbOn) {
             const timeout = setTimeout(() => {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
The APU page is not showing the Bleed Air PSI when the ADIRI1 is not aligned which does not follow the right procedure as explained in the APU manual.

## Screenshots (if necessary)
APU page shows no pressure
![BLEED ISSUE 2](https://user-images.githubusercontent.com/72168990/158270096-43ed4c78-d4e4-40be-91d4-1a0a46c56e71.PNG)

Pneumatic bleed is working from the APU
![BLEED ISSUE 1](https://user-images.githubusercontent.com/72168990/158270025-8ff3886e-7a9e-4ff6-b424-2c70efcf4c10.PNG)

Fixed Version with no ADIRI1:
![image](https://user-images.githubusercontent.com/72168990/158274244-0c01d65d-6c4c-49b6-8388-7b82cfb0f69e.png)




## References
Manual shows no link to ADIRI1
![image](https://user-images.githubusercontent.com/72168990/158270185-4e00dae0-58d4-4f16-a8fe-b574f6c66a0f.png)

## Additional context

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->

## Testing instructions
Current issue: Start the APU and the APU bleed without aligning the ADIRI1
Correct state: Regardless of the ADIRI1 the bleed should be displayed.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
