### PR TITLE
fix(ewd): Landing memo no smoking sign logic

### DIFF
--- a/src/instruments/src/EWD/elements/PseudoFWC.tsx
+++ b/src/instruments/src/EWD/elements/PseudoFWC.tsx
@@ -202,6 +202,7 @@ const PseudoFWC: React.FC = () => {
     const [spoilersArmed] = useSimVar('L:A32NX_SPOILERS_ARMED', 'bool', 500);
     const [seatBelt] = useSimVar('A:CABIN SEATBELTS ALERT SWITCH', 'bool', 500);
     const [noSmoking] = useSimVar('L:A32NX_NO_SMOKING_MEMO', 'bool', 500);
+    const [noSmokingSwitchPosition] = useSimVar('L:XMLVAR_SWITCH_OVHD_INTLT_NOSMOKING_Position', 'enum', 500);
 
     const [strobeLightsOn] = useSimVar('L:LIGHTING_STROBE_0', 'bool', 500);
 
@@ -912,7 +913,7 @@ const PseudoFWC: React.FC = () => {
             simVarIsActive: !!ldgmemo,
             whichCodeToReturn: [
                 landingGearDown === 1 ? 1 : 0,
-                noSmoking === 1 && seatBelt === 1 ? 3 : 2,
+                noSmokingSwitchPosition !== 2 && seatBelt === 1 ? 3 : 2,
                 cabinReady ? 5 : 4,
                 spoilersArmed ? 7 : 6,
                 !gpwsFlaps3 && flapsHandle !== 4 ? 8 : null,
@@ -1613,6 +1614,7 @@ const PseudoFWC: React.FC = () => {
         manLandingElevation,
         ndXfrKnob,
         noSmoking,
+        noSmokingSwitchPosition,
         nwSteeringDisc,
         packOffBleedIsAvailable1,
         packOffBleedIsAvailable1,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #6962

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The signs ecam landing memo logic should be satisified when the no smoking switch is in either auto or on. Currently, this only works in auto if the landing gear is more than 50% down.  This reflects the previous logic. 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Spawn in on approach.
2. Once the landing memo appears, confirm that SIGNS.......ON is replaced by SIGNS ON when the seatbelt sign switch is set to ON and the no smoking switch is set to AUTO and ON (check both)


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
