### PR TITLE
fix: SU9 issue with engine control

### DIFF
--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -1633,7 +1633,8 @@ bool FlyByWireInterface::updateAutothrust(double sampleTime) {
     idAutothrustDisabled->set(autoThrust.getExternalOutputs().out.data_computed.ATHR_disabled);
 
     // write output to sim --------------------------------------------------------------------------------------------
-    SimOutputThrottles simOutputThrottles = {autoThrustOutput.sim_throttle_lever_1_pos, autoThrustOutput.sim_throttle_lever_2_pos,
+    SimOutputThrottles simOutputThrottles = {fmin(99.9999999999999, autoThrustOutput.sim_throttle_lever_1_pos),
+                                             fmin(99.9999999999999, autoThrustOutput.sim_throttle_lever_2_pos),
                                              autoThrustOutput.sim_thrust_mode_1, autoThrustOutput.sim_thrust_mode_2};
     if (!simConnectInterface.sendData(simOutputThrottles)) {
       cout << "WASM: Write data failed!" << endl;


### PR DESCRIPTION
## Summary of Changes
Fixes a weird issue with SU9 that causes the engine control to stop working. This happens when 100% is written to the sim throttle. In many cases this is when TOGA thrust is applied and the plane starts rolling and thrust limit is further increased.

## Testing instructions
- start on the runway in SU9
- take-off with TOGA power

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
