### PR TITLE
fix: some small TCAS improvements

### DIFF
--- a/src/tcas/src/components/TcasComputer.ts
+++ b/src/tcas/src/components/TcasComputer.ts
@@ -467,7 +467,7 @@ export class TcasComputer implements TcasComponent {
             // information, we need to rely on the fallback method
             // this also leads to problems above 1750 ft (the threshold for ground detection), since the aircraft on ground are then shown again.
             // Currently just hide all above currently ground alt (of ppos) + 380, not ideal but works better than other solutions.
-            const groundAlt = this.planeAlt - this.radioAlt; // altitude of the terrain
+            const groundAlt = this.planeAlt - this.radioAlt.value; // altitude of the terrain
             const onGround = traffic.alt < (groundAlt + 360) || traffic.groundSpeed < 30;
             traffic.onGround = onGround;
             let isDisplayed = false;

--- a/src/tcas/src/components/TcasComputer.ts
+++ b/src/tcas/src/components/TcasComputer.ts
@@ -1138,6 +1138,15 @@ export class TcasComputer implements TcasComponent {
         this.updateInhibitions();
         this.updateStatusFaults();
         if (this.tcasMode.getVar() === TcasMode.STBY) {
+            this.advisoryState = TcasState.NONE;
+            this.tcasState.setVar(TcasState.NONE);
+            this.correctiveRa.setVar(false);
+            SimVar.SetSimVarValue('L:A32NX_TCAS_STATE', 'Enum', 0);
+            SimVar.SetSimVarValue('L:A32NX_TCAS_RA_CORRECTIVE', 'bool', 0);
+            SimVar.SetSimVarValue('L:A32NX_TCAS_VSPEED_RED:1', 'Number', 0);
+            SimVar.SetSimVarValue('L:A32NX_TCAS_VSPEED_RED:2', 'Number', 0);
+            SimVar.SetSimVarValue('L:A32NX_TCAS_VSPEED_GREEN:1', 'Number', 0);
+            SimVar.SetSimVarValue('L:A32NX_TCAS_VSPEED_GREEN:2', 'Number', 0);
             if (this.sendAirTraffic.length !== 0) {
                 this.sendAirTraffic.length = 0;
                 this.sendListener.triggerToAllSubscribers('A32NX_TCAS_TRAFFIC', stringify(this.sendAirTraffic));

--- a/src/tcas/src/components/TcasComputer.ts
+++ b/src/tcas/src/components/TcasComputer.ts
@@ -1141,8 +1141,6 @@ export class TcasComputer implements TcasComponent {
             this.advisoryState = TcasState.NONE;
             this.tcasState.setVar(TcasState.NONE);
             this.correctiveRa.setVar(false);
-            SimVar.SetSimVarValue('L:A32NX_TCAS_STATE', 'Enum', 0);
-            SimVar.SetSimVarValue('L:A32NX_TCAS_RA_CORRECTIVE', 'bool', 0);
             SimVar.SetSimVarValue('L:A32NX_TCAS_VSPEED_RED:1', 'Number', 0);
             SimVar.SetSimVarValue('L:A32NX_TCAS_VSPEED_RED:2', 'Number', 0);
             SimVar.SetSimVarValue('L:A32NX_TCAS_VSPEED_GREEN:1', 'Number', 0);


### PR DESCRIPTION
## Summary of Changes
- use the actual radio altitude value
- reset all variables when TCAS is turned off to ensure clean state when you have been in a TCAS RA

## Testing instructions
- fly the plane and try to get into TCAS RA
- turn TCAS off -> result should be a clean state on the PFD

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
