### PR TITLE
fix(ewd): Fixed ADIRS memo message appearing in Amber when engines off

### DIFF
--- a/src/instruments/src/EWD/elements/PseudoFWC.tsx
+++ b/src/instruments/src/EWD/elements/PseudoFWC.tsx
@@ -940,7 +940,7 @@ const PseudoFWC: React.FC = () => {
             flightPhaseInhib: [3, 4, 5, 6, 7, 8, 9, 10],
             simVarIsActive: !!(adirsRemainingAlignTime >= 240 && [adiru1State, adiru2State, adiru3State].every((a) => a === 1)),
             whichCodeToReturn: [
-                adirsMessage1(adirsRemainingAlignTime, (engine1State > 0 || engine2State > 0)),
+                adirsMessage1(adirsRemainingAlignTime, (engine1State > 0 && engine1State < 4) || (engine2State > 0 && engine2State < 4)),
             ],
             codesToReturn: ['000003001', '000003002', '000003003', '000003004', '000003005', '000003006', '000003007', '000003008'],
             memoInhibit: !!(tomemo === 1 || ldgmemo === 1),
@@ -952,7 +952,7 @@ const PseudoFWC: React.FC = () => {
             flightPhaseInhib: [3, 4, 5, 6, 7, 8, 9, 10],
             simVarIsActive: !!(adirsRemainingAlignTime > 0 && adirsRemainingAlignTime < 240 && [adiru1State, adiru2State, adiru3State].every((a) => a === 1)),
             whichCodeToReturn: [
-                adirsMessage2(adirsRemainingAlignTime, (engine1State > 0 || engine2State > 0)),
+                adirsMessage2(adirsRemainingAlignTime, (engine1State > 0 && engine1State < 4) || (engine2State > 0 && engine2State < 4)),
             ],
             codesToReturn: ['000003101', '000003102', '000003103', '000003104', '000003105', '000003106', '000003107', '000003108'],
             memoInhibit: !!(tomemo === 1 || ldgmemo === 1),


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The IR IN ALIGN message should appear in green on the EWD when engines are off and in amber when they are on. However, in the event that a flight has been completed and the engines shutdown, the IR IN ALIGN message will appear in amber if the ADIRS are re-aligned. This has been fixed by this PR.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

![image](https://user-images.githubusercontent.com/5834254/161444284-848be413-d377-4732-af02-b22506225747.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Spawn in on approach
2. Land and shutdown the aircraft (but leave it externallyt powered)
3. Turn off the ADIRS
4. Wait 5 minutes
5. Turn the ADIRS back on and confirm IR IN ALIGN messages are in green
6. Start an engine
7. Confirm that the IR IN ALIGN messages are now in amber. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
