### PR TITLE
build: compile fadec object file in separate directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ node_modules
 /src/fdr2csv/*.exe
 /src/fbw/obj/
 /src/fdr2csv/build/
+/src/fadec/obj/
 .env
 src/instruments/buildSrc/custom/*
 /flybywire-aircraft-a320-neo/MCDU SERVER/

--- a/src/fadec/build.sh
+++ b/src/fadec/build.sh
@@ -13,6 +13,10 @@ fi
 
 set -ex
 
+# create temporary folder for o files
+mkdir -p "${DIR}/obj"
+pushd "${DIR}/obj"
+
 # compile c++ code
 clang++ \
   -c \
@@ -38,6 +42,9 @@ clang++ \
   "${DIR}/src/FadecGauge.cpp" \
   -o fadec.o
 
+# restore directory
+popd
+
 wasm-ld \
   --no-entry \
   --allow-undefined \
@@ -53,5 +60,5 @@ wasm-ld \
   --gc-sections \
   -O3 --lto-O3 \
   -lc++ -lc++abi \
-   fadec.o \
+  ${DIR}/obj/*.o \
   -o $OUTPUT


### PR DESCRIPTION
## Summary of Changes
This PR changes the target directory for the object file that is generated during compilation of the fadec wasm module.

## Testing instructions
- spawn on runway and check if engines are working normal and can be controlled

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
