### PR TITLE
feat: use new steering axis for nosewheel

### DIFF
--- a/scripts/dev-env/run.cmd
+++ b/scripts/dev-env/run.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set image="ghcr.io/flybywiresim/dev-env@sha256:b7c1230b06425d2c3499545cef1ca831455845ec05e40d105969ae50f6074013"
+set image="ghcr.io/flybywiresim/dev-env@sha256:e991c4ec02e3b40b949ca6c2b16eff0f7ea8da34c6d26f5d9fc9e3a04b1f1d65"
 
 docker image inspect %image% 1> nul || docker system prune --filter label=flybywiresim=true -f
 docker run --rm -it -v "%cd%:/external" %image% %*

--- a/scripts/dev-env/run.cmd
+++ b/scripts/dev-env/run.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set image="ghcr.io/flybywiresim/dev-env@sha256:e991c4ec02e3b40b949ca6c2b16eff0f7ea8da34c6d26f5d9fc9e3a04b1f1d65"
+set image="ghcr.io/flybywiresim/dev-env@sha256:8974895d1d870fee5c5655ffa22e3aebff1879ca689b86c0c8f4e19c0dd4b27a"
 
 docker image inspect %image% 1> nul || docker system prune --filter label=flybywiresim=true -f
 docker run --rm -it -v "%cd%:/external" %image% %*

--- a/scripts/dev-env/run.sh
+++ b/scripts/dev-env/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE="ghcr.io/flybywiresim/dev-env@sha256:b7c1230b06425d2c3499545cef1ca831455845ec05e40d105969ae50f6074013"
+IMAGE="ghcr.io/flybywiresim/dev-env@sha256:e991c4ec02e3b40b949ca6c2b16eff0f7ea8da34c6d26f5d9fc9e3a04b1f1d65"
 
 # only set `-it` if there is a tty
 if [ -t 0 ] && [ -t 1 ];

--- a/scripts/dev-env/run.sh
+++ b/scripts/dev-env/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE="ghcr.io/flybywiresim/dev-env@sha256:e991c4ec02e3b40b949ca6c2b16eff0f7ea8da34c6d26f5d9fc9e3a04b1f1d65"
+IMAGE="ghcr.io/flybywiresim/dev-env@sha256:8974895d1d870fee5c5655ffa22e3aebff1879ca689b86c0c8f4e19c0dd4b27a"
 
 # only set `-it` if there is a tty
 if [ -t 0 ] && [ -t 1 ];

--- a/src/systems/a320_systems_wasm/src/nose_wheel_steering.rs
+++ b/src/systems/a320_systems_wasm/src/nose_wheel_steering.rs
@@ -42,7 +42,7 @@ pub(super) fn nose_wheel_steering(builder: &mut MsfsAspectBuilder) -> Result<(),
     // Lacking a better event to bind to, we've picked a mixture axis for setting the
     // tiller handle position.
     builder.event_to_variable(
-        "AXIS_MIXTURE4_SET",
+        "AXIS_STEERING_SET",
         EventToVariableMapping::EventData32kPosition,
         Variable::aspect("RAW_TILLER_HANDLE_POSITION"),
         |options| options.mask(),

--- a/src/systems/a320_systems_wasm/src/nose_wheel_steering.rs
+++ b/src/systems/a320_systems_wasm/src/nose_wheel_steering.rs
@@ -39,6 +39,14 @@ pub(super) fn nose_wheel_steering(builder: &mut MsfsAspectBuilder) -> Result<(),
     // The tiller handle should start in a centered position.
     builder.init_variable(Variable::aspect("RAW_TILLER_HANDLE_POSITION"), 0.5);
 
+    // This axis is kept for legacy reasons and was used before the steering axis was available
+    builder.event_to_variable(
+        "AXIS_MIXTURE4_SET",
+        EventToVariableMapping::EventData32kPosition,
+        Variable::aspect("RAW_TILLER_HANDLE_POSITION"),
+        |options| options.mask(),
+    )?;
+
     builder.event_to_variable(
         "AXIS_STEERING_SET",
         EventToVariableMapping::EventData32kPosition,

--- a/src/systems/a320_systems_wasm/src/nose_wheel_steering.rs
+++ b/src/systems/a320_systems_wasm/src/nose_wheel_steering.rs
@@ -39,8 +39,6 @@ pub(super) fn nose_wheel_steering(builder: &mut MsfsAspectBuilder) -> Result<(),
     // The tiller handle should start in a centered position.
     builder.init_variable(Variable::aspect("RAW_TILLER_HANDLE_POSITION"), 0.5);
 
-    // Lacking a better event to bind to, we've picked a mixture axis for setting the
-    // tiller handle position.
     builder.event_to_variable(
         "AXIS_STEERING_SET",
         EventToVariableMapping::EventData32kPosition,


### PR DESCRIPTION
## Summary of Changes
This PR switches the control of the nosewheel steering to the new axis for steering that was introduced in SU9.

**For that purpose this PR also updates the dev-env to use SDK 0.18.0.0.**

**NOT TO BE MERGED BEFORE SU9 RELEASE**

## Testing instructions
- test if airplane still works normal (FBW, AP, Systems)
- test if nosewheel steering is working with new axis

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
