### PR TITLE
fixed 100above issue and updated changelog.MD

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -229,6 +229,7 @@
 1. [MCUD] Add LSK for vert rev at destination - @tracernz (Mike)
 1. [MODEL] Add detailed rivet mesh to allow for ALDB+COMP+NORM ribbons - @bouveng (Johan Bouveng)
 1. [SD] Rewrite Bleed page to React - @RichardPilbery (tricky_dicky#3571)
+1. [GPWS] Mute "100 above" callout during autoland - @patmack14 (Patrick Macken)
 
 ## 0.7.0
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_GPWS.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_GPWS.js
@@ -143,7 +143,7 @@ class A32NX_GPWS {
 
         this.GPWSComputeLightsAndCallouts();
 
-        if ((mda !== 0 || dh !== -1) && phase === FmgcFlightPhases.APPROACH) {
+        if ((mda !== 0 || (dh !== -1 && dh !== -2) && phase === FmgcFlightPhases.APPROACH)) {
             let minimumsDA; //MDA or DH
             let minimumsIA; //radio or baro altitude
             const baroAlt = SimVar.GetSimVarValue("INDICATED ALTITUDE", "feet");


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #6504 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Mutes the "100 above" and "MINIMUMS" callouts during an autoland when "NO" for decision height is entered in MCDU.  Because there are no minimums during a true full autoland these should not be played per the aircraft manual referenced below. 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![100 callout](https://user-images.githubusercontent.com/41206846/162490209-965be51f-a420-4fa4-b6b6-d7779e38b3f6.PNG)



<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): @Pat M

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Start an autoland approach with "NO" entered for the decision altitudes in the MDCU approach page.  The "100 ABOVE" and "MINIMUMS" callouts should not be played.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
