### PR TITLE
fix(fmgc): map unimplemented VA legs to CA

### DIFF
--- a/src/fmgc/src/efis/EfisSymbols.ts
+++ b/src/fmgc/src/efis/EfisSymbols.ts
@@ -302,8 +302,13 @@ export class EfisSymbols {
                     const wp = activeFp.getWaypoint(i);
 
                     // Managed by legs
+                    // FIXME these should integrate with the normal algorithms to pick up contraints, not be drawn in enroute ranges, etc.
                     const legType = wp.additionalData.legType;
-                    if (legType === LegType.CA || legType === LegType.CR || legType === LegType.CI || legType === LegType.FM || legType === LegType.VI || legType === LegType.VM) {
+                    if (
+                        legType === LegType.CA || legType === LegType.CR || legType === LegType.CI
+                        || legType === LegType.FM
+                        || legType === LegType.VA || legType === LegType.VI || legType === LegType.VM
+                    ) {
                         continue;
                     }
 

--- a/src/fmgc/src/guidance/GuidanceManager.ts
+++ b/src/fmgc/src/guidance/GuidanceManager.ts
@@ -95,7 +95,8 @@ export class GuidanceManager {
                 return new RFLeg(from, to, to.additionalData.center, metadata, segment);
             }
 
-            if (to.additionalData.legType === LegType.CA) {
+            // FIXME VALeg should be implemented to give proper heading guidance
+            if (to.additionalData.legType === LegType.CA || to.additionalData.legType === LegType.VA) {
                 const course = to.additionalData.vectorsCourse;
                 const altitude = to.additionalData.vectorsAltitude;
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
VA legs are not implemented yet. Map them to CALeg for now to pick up some of the improved logic there when they're the first leg of a SID... Fixes KDEN25 BAYLR6 for example. Further improvements also in #6850.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Try some SIDs beggining with a VA leg.

A random selection to help you (no criteria like runway length applied sorry):
airport_identifier | procedure_identifier | transition_identifier
-- | -- | --
LPAZ | RODI4N | RW36
LIMZ | ENOB8Q | RW03
VTCC | KEDO1B | RW36
ROTM | TIT8 | RW06
CYYC | YYC7 | RW29
WIII | CA2K | RW24
KCXO | KARRR6 | RW14
KYIP | CLVIN2 | RW05B
KLAX | MUELR4 | RW25R
CYKF | CYKF3 | RW26
KCVG | ROCKT1 | RW36R
KARR | OBENE3 | RW33
LIRM | SOR1P | RW24L
KDEN | EPKEE7 | RW34B
VOBL | AKTI7C | RW09R
KBWI | CONLE4 | RW10
KEFD | STRYA8 | RW22
KDAL | SWABR1 | RW31B
PHOG | PUHEE1 | RW20
KSTL | NATCA5 | RW11
KHOU | RETYR7 | RW13B
PAFA | PUYVO4 | RW02L
KMEM | BINKY6 | RW09
RJTT | RITL2B | RW16R
LEBL | LOBA1J | RW20
LPAZ | XUVA2S | RW18
KCXO | WYLSN8 | RW01
K39N | PRINC1 | RW28
KDPA | DARCY6 | RW15
KHOU | BLTWY7 | RW13B
RJTT | RUTAS2 | RW05
KJFK | JFK5 | RW13B
KCXO | STRYA8 | RW14
WAHQ | JOG1B | RW26
RJTT | VAMOS3 | RW05
KABQ | RDRNR3 | RW03
KFLV | RACER7 | RW16
SBCR | FATA2A | RW09
CYHZ | CYHZ4 | RW05
CYTA | AGNEX3 | RW17
RJOI | MYESE3 | RW20
PAKX | MARVN1 | RW24L
KDEN | EPKEE7 | RW25
KMKC | CHIEF7 | RW21
EDDE | ERSI1C | RW09
KDET | CLVIN2 | RW33
KSUU | REJOY1 | RW21B
VVDN | TAHU1D | RW17B
FACT | KODE1A | RW01
KHPY | STRYA8 | RW14

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
