### PR TITLE
fix(bleed): Fix stack overflow when container contains NaNs

### DIFF
--- a/src/systems/systems/src/pneumatic/mod.rs
+++ b/src/systems/systems/src/pneumatic/mod.rs
@@ -104,7 +104,9 @@ pub trait PneumaticContainer {
         Self: Sized,
     {
         // Since the pressure change is not linear but is nearly linear we simply approximate it via linear interpolation
-        if self.pressure() <= other.pressure() {
+        if self.pressure() > other.pressure() {
+            -other.get_mass_flow_for_equilibrium(self)
+        } else {
             let pressure_diff = other.pressure() - self.pressure();
             let mut mass_aproximation = other.mass() / 2.;
             for _ in 0..3 {
@@ -130,8 +132,6 @@ pub trait PneumaticContainer {
                 mass_aproximation = -pressure_diff.get::<pascal>() / pressure_gradient;
             }
             mass_aproximation
-        } else {
-            -other.get_mass_flow_for_equilibrium(self)
         }
     }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR fixes a small issue introduced with #6810 where the systems wasm module would run into a stack overflow which leads to a sim crash. The stack overflow only occurs if there ever appears a NaN in a PneumaticContainer (which should never happen).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Really not needed because it just switches around the if condition.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
