### PR TITLE
fix: change sentry.io sample rate to 10%

### DIFF
--- a/src/sentry-client/src/FbwAircraftSentryClient.ts
+++ b/src/sentry-client/src/FbwAircraftSentryClient.ts
@@ -213,6 +213,7 @@ export class FbwAircraftSentryClient {
             dsn: config.dsn,
             release,
             integrations,
+            sampleRate: 0.1,
         });
 
         console.log('[SentryClient] Sentry initialized');


### PR DESCRIPTION
## Summary of Changes

* Changes sentry.io sample rate to 10% to avoid exceeding our quota. Default was 100%, which is way too much.

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

* Make sure screens still work, ig

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
