### PR TITLE
fix(mcdu): radnav manual ils freq entry no crs set

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -132,10 +132,8 @@ class CDUNavRadioPage {
                 const lsCourse = SimVar.GetSimVarValue('L:A32NX_FM_LS_COURSE', 'number');
                 if (lsCourse >= 0) {
                     ilsCourseCell = `{${mcdu.ilsCourse !== undefined ? 'big' : 'small'}}F${lsCourse.toFixed(0).padStart(3, "0")}{end}`;
-                } else {
-                    if (mcdu._ilsFrequencyPilotEntered) {
-                        ilsCourseCell = "{amber}____{end}";
-                    }
+                } else if (mcdu._ilsFrequencyPilotEntered) {
+                    ilsCourseCell = "{amber}____{end}";
                 }
             }
             mcdu.onLeftInput[2] = (value, scratchpadCallback) => {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -133,7 +133,9 @@ class CDUNavRadioPage {
                 if (lsCourse >= 0) {
                     ilsCourseCell = `{${mcdu.ilsCourse !== undefined ? 'big' : 'small'}}F${lsCourse.toFixed(0).padStart(3, "0")}{end}`;
                 } else {
-                    ilsCourseCell = "{amber}____{end}";
+                    if (mcdu._ilsFrequencyPilotEntered) {
+                        ilsCourseCell = "{amber}____{end}";
+                    }
                 }
             }
             mcdu.onLeftInput[2] = (value, scratchpadCallback) => {


### PR DESCRIPTION
<!-- Signed-off-by: Leon Beeser <leon.beeser@yahoo.de> -->

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #7054

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The amber boxes should not be show without an LS frequency, and instead the field should display as follows:
```
CRS
[  ]
```
The amber boxes should only appear when the frequency is set manually. When setting an ident, the CRS is set automatically.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
| ![image](https://user-images.githubusercontent.com/1857322/163272819-f4de13b2-1e0d-47e8-aba5-af013968e61e.png) | ![image](https://user-images.githubusercontent.com/1857322/163272844-0cd38ce1-9517-49a8-85b5-15c03cbd6b53.png) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1857322/163272931-c0eebf5e-2af0-4545-87b0-2c802b12c21a.png) | ![image](https://user-images.githubusercontent.com/1857322/163273180-434a30de-4ee5-4100-af08-64b27831eef2.png) |


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): DerL30N#3751

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Ensure the above cases can be observed in the sim.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
