### PR TITLE
feat: added config parameter to change key increment for throttles

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -238,6 +238,7 @@
 1. [PFD] Reimplement PFD with msfs-avionics framework for improved performance - @saschl (saschl#9432)
 1. [GPWS] Mute "100 above" callout during autoland - @patmack14 (Patrick Macken)
 1. [MCDU] Refactored mcdu key input events - @derl30n - (Leon)
+1. [AUTOTHRUST] Added configuration option to allow change of key increment size - @aguther (Andreas Guther)
 
 ## 0.7.0
 

--- a/docs/Configuration/ThrottleConfiguration.ini
+++ b/docs/Configuration/ThrottleConfiguration.ini
@@ -6,6 +6,10 @@
 ;  true -> axis minimum -> max reverse
 ; false -> axis minimum -> idle
 reverse_on_axis = true
+; determines the increment for a key event (+/-):
+key_increment_normal = 0.05
+; determines the increment for a "small" key event (+/-):
+key_increment_small = 0.025
 
 [throttle_axis_1]
 ; start of REV FULL

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -2182,6 +2182,14 @@ In the variables below, {number} should be replaced with one item in the set: { 
     - Indicates the low or high value to latch into the given detent
     - Range is from -1 to 1
 
+- A32NX_THROTTLE_MAPPING_INCREMENT_NORMAL
+  - Number
+  - Indicates the increment being used for normal key events
+
+- A32NX_THROTTLE_MAPPING_INCREMENT_SMALL
+  - Number
+  - Indicates the increment being used for small key events
+
 ## Engine and FADEC System
 
 - A32NX_ENGINE_CYCLE_TIME

--- a/src/fbw/src/ThrottleAxisMapping.cpp
+++ b/src/fbw/src/ThrottleAxisMapping.cpp
@@ -35,6 +35,8 @@ ThrottleAxisMapping::ThrottleAxisMapping(unsigned int id) {
   idThrustLeverAngle = make_unique<LocalVariable>(LVAR_THRUST_LEVER_ANGLE.c_str());
   idUsingConfig = make_unique<LocalVariable>(LVAR_LOAD_CONFIG.c_str());
   idUseReverseOnAxis = make_unique<LocalVariable>(LVAR_USE_REVERSE_ON_AXIS.c_str());
+  idIncrementNormal = make_unique<LocalVariable>(LVAR_INCREMENT_NORMAL.c_str());
+  idIncrementSmall = make_unique<LocalVariable>(LVAR_INCREMENT_SMALL.c_str());
   idDetentReverseLow = make_unique<LocalVariable>(LVAR_DETENT_REVERSE_LOW.c_str());
   idDetentReverseHigh = make_unique<LocalVariable>(LVAR_DETENT_REVERSE_HIGH.c_str());
   idDetentReverseIdleLow = make_unique<LocalVariable>(LVAR_DETENT_REVERSEIDLE_LOW.c_str());
@@ -150,19 +152,19 @@ void ThrottleAxisMapping::onEventThrottleCut() {
 }
 
 void ThrottleAxisMapping::onEventThrottleIncrease() {
-  increaseThrottleBy(0.05);
+  increaseThrottleBy(incrementNormal);
 }
 
 void ThrottleAxisMapping::onEventThrottleIncreaseSmall() {
-  increaseThrottleBy(0.025);
+  increaseThrottleBy(incrementSmall);
 }
 
 void ThrottleAxisMapping::onEventThrottleDecrease() {
-  decreaseThrottleBy(0.05);
+  decreaseThrottleBy(incrementNormal);
 }
 
 void ThrottleAxisMapping::onEventThrottleDecreaseSmall() {
-  decreaseThrottleBy(0.025);
+  decreaseThrottleBy(incrementSmall);
 }
 
 void ThrottleAxisMapping::onEventThrottleSet_10() {
@@ -272,7 +274,9 @@ void ThrottleAxisMapping::decreaseThrottleBy(double value) {
 
 ThrottleAxisMapping::Configuration ThrottleAxisMapping::getDefaultConfiguration() {
   return {
-      true,  // use reverse on axis
+      true,   // use reverse on axis
+      0.05,   // increment normal
+      0.025,  // increment small
       -1.00,  // reverse low
       -0.95,  // reverse high
       -0.72,  // reverse idle low
@@ -290,14 +294,16 @@ ThrottleAxisMapping::Configuration ThrottleAxisMapping::getDefaultConfiguration(
 
 ThrottleAxisMapping::Configuration ThrottleAxisMapping::loadConfigurationFromLocalVariables() {
   idUsingConfig->set(true);
-  return {idUseReverseOnAxis->get() == 1, idDetentReverseLow->get(), idDetentReverseHigh->get(), idDetentReverseIdleLow->get(),
-          idDetentReverseIdleHigh->get(), idDetentIdleLow->get(),    idDetentIdleHigh->get(),    idDetentClimbLow->get(),
-          idDetentClimbHigh->get(),       idDetentFlexMctLow->get(), idDetentFlexMctHigh->get(), idDetentTogaLow->get(),
-          idDetentTogaHigh->get()};
+  return {idUseReverseOnAxis->get() == 1, idIncrementNormal->get(),      idIncrementSmall->get(),        idDetentReverseLow->get(),
+          idDetentReverseHigh->get(),     idDetentReverseIdleLow->get(), idDetentReverseIdleHigh->get(), idDetentIdleLow->get(),
+          idDetentIdleHigh->get(),        idDetentClimbLow->get(),       idDetentClimbHigh->get(),       idDetentFlexMctLow->get(),
+          idDetentFlexMctHigh->get(),     idDetentTogaLow->get(),        idDetentTogaHigh->get()};
 }
 
 void ThrottleAxisMapping::storeConfigurationInLocalVariables(const Configuration& configuration) {
   idUseReverseOnAxis->set(configuration.useReverseOnAxis);
+  idIncrementNormal->set(configuration.incrementNormal);
+  idIncrementSmall->set(configuration.incrementSmall);
   if (configuration.useReverseOnAxis) {
     idDetentReverseLow->set(configuration.reverseLow);
     idDetentReverseHigh->set(configuration.reverseHigh);
@@ -323,6 +329,8 @@ ThrottleAxisMapping::Configuration ThrottleAxisMapping::loadConfigurationFromIni
   idUsingConfig->set(true);
   return {
       INITypeConversion::getBoolean(structure, CONFIGURATION_SECTION_COMMON, "REVERSE_ON_AXIS", false),
+      INITypeConversion::getDouble(structure, CONFIGURATION_SECTION_COMMON, "KEY_INCREMENT_NORMAL", 0.05),
+      INITypeConversion::getDouble(structure, CONFIGURATION_SECTION_COMMON, "KEY_INCREMENT_SMALL", 0.025),
       INITypeConversion::getDouble(structure, CONFIGURATION_SECTION_AXIS, "REVERSE_LOW", -1.00),
       INITypeConversion::getDouble(structure, CONFIGURATION_SECTION_AXIS, "REVERSE_HIGH", -0.95),
       INITypeConversion::getDouble(structure, CONFIGURATION_SECTION_AXIS, "REVERSE_IDLE_LOW", -0.20),
@@ -340,6 +348,8 @@ ThrottleAxisMapping::Configuration ThrottleAxisMapping::loadConfigurationFromIni
 
 void ThrottleAxisMapping::storeConfigurationInIniStructure(INIStructure& structure, const Configuration& configuration) {
   structure[CONFIGURATION_SECTION_COMMON]["REVERSE_ON_AXIS"] = configuration.useReverseOnAxis ? "true" : "false";
+  structure[CONFIGURATION_SECTION_COMMON]["KEY_INCREMENT_NORMAL"] = to_string(configuration.incrementNormal);
+  structure[CONFIGURATION_SECTION_COMMON]["KEY_INCREMENT_SMALL"] = to_string(configuration.incrementSmall);
   structure[CONFIGURATION_SECTION_AXIS]["REVERSE_LOW"] = to_string(configuration.reverseLow);
   structure[CONFIGURATION_SECTION_AXIS]["REVERSE_HIGH"] = to_string(configuration.reverseHigh);
   structure[CONFIGURATION_SECTION_AXIS]["REVERSE_IDLE_LOW"] = to_string(configuration.reverseIdleLow);
@@ -357,6 +367,10 @@ void ThrottleAxisMapping::storeConfigurationInIniStructure(INIStructure& structu
 void ThrottleAxisMapping::updateMappingFromConfiguration(const Configuration& configuration) {
   // update use reverse on axis
   useReverseOnAxis = configuration.useReverseOnAxis;
+
+  // update increments
+  incrementNormal = configuration.incrementNormal;
+  incrementSmall = configuration.incrementSmall;
 
   // mapping table vector
   vector<pair<double, double>> mappingTable;

--- a/src/fbw/src/ThrottleAxisMapping.h
+++ b/src/fbw/src/ThrottleAxisMapping.h
@@ -50,6 +50,8 @@ class ThrottleAxisMapping {
  private:
   struct Configuration {
     bool useReverseOnAxis;
+    double incrementNormal;
+    double incrementSmall;
     double reverseLow;
     double reverseHigh;
     double reverseIdleLow;
@@ -83,6 +85,8 @@ class ThrottleAxisMapping {
   void decreaseThrottleBy(double value);
 
   bool useReverseOnAxis = false;
+  double incrementNormal = 0.0;
+  double incrementSmall = 0.0;
 
   bool inFlight = false;
   bool isReverseToggleActive = false;
@@ -99,6 +103,8 @@ class ThrottleAxisMapping {
 
   std::unique_ptr<LocalVariable> idUsingConfig;
   std::unique_ptr<LocalVariable> idUseReverseOnAxis;
+  std::unique_ptr<LocalVariable> idIncrementNormal;
+  std::unique_ptr<LocalVariable> idIncrementSmall;
   std::unique_ptr<LocalVariable> idDetentReverseLow;
   std::unique_ptr<LocalVariable> idDetentReverseHigh;
   std::unique_ptr<LocalVariable> idDetentReverseIdleLow;
@@ -116,6 +122,8 @@ class ThrottleAxisMapping {
   std::string LVAR_THRUST_LEVER_ANGLE = "A32NX_AUTOTHRUST_TLA:";
   std::string LVAR_LOAD_CONFIG = "A32NX_THROTTLE_MAPPING_LOADED_CONFIG:";
   std::string LVAR_USE_REVERSE_ON_AXIS = "A32NX_THROTTLE_MAPPING_USE_REVERSE_ON_AXIS:";
+  std::string LVAR_INCREMENT_NORMAL = "A32NX_THROTTLE_MAPPING_INCREMENT_NORMAL";
+  std::string LVAR_INCREMENT_SMALL = "A32NX_THROTTLE_MAPPING_INCREMENT_SMALL";
   std::string LVAR_DETENT_REVERSE_LOW = "A32NX_THROTTLE_MAPPING_REVERSE_LOW:";
   std::string LVAR_DETENT_REVERSE_HIGH = "A32NX_THROTTLE_MAPPING_REVERSE_HIGH:";
   std::string LVAR_DETENT_REVERSEIDLE_LOW = "A32NX_THROTTLE_MAPPING_REVERSE_IDLE_LOW:";


### PR DESCRIPTION
## Summary of Changes
This PR adds an option to the Throttle configuration that allows the change of the increment that is used when key events are pressed (normal and small).

The default increment is as before, and users should not see any difference. If a user wants to change that, he will be able to do so using the configuration file.

If requested, this can be added to the EFB later as an additional option in the Throttle calibration.

## Testing instructions
Test if the values can be changed in the `ThrottleConfiguration.ini` with the following entries:
```
[throttle_common]
; determines the increment for a key event (+/-):
key_increment_normal = 0.05
; determines the increment for a "small" key event (+/-):
key_increment_small = 0.025
```

Change the values in the config file and reload them (you can use the EFB button to load the settings from file for this).

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
