### PR TITLE
feat: add true heading and track

### DIFF
--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -1535,7 +1535,15 @@ In the variables below, {number} should be replaced with one item in the set: { 
     - Arinc429Word<Degrees>
     - The inertial heading of the aircraft.
 
+- A32NX_ADIRS_IR_{number}_TRUE_HEADING
+    - Arinc429Word<Degrees>
+    - The inertial heading of the aircraft.
+
 - A32NX_ADIRS_IR_{number}_TRACK
+    - Arinc429Word<Degrees>
+    - The inertial track of the aircraft.
+
+- A32NX_ADIRS_IR_{number}_TRUE_TRACK
     - Arinc429Word<Degrees>
     - The inertial track of the aircraft.
 

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -1537,7 +1537,7 @@ In the variables below, {number} should be replaced with one item in the set: { 
 
 - A32NX_ADIRS_IR_{number}_TRUE_HEADING
     - Arinc429Word<Degrees>
-    - The inertial heading of the aircraft.
+    - The true inertial heading of the aircraft.
 
 - A32NX_ADIRS_IR_{number}_TRACK
     - Arinc429Word<Degrees>
@@ -1545,7 +1545,7 @@ In the variables below, {number} should be replaced with one item in the set: { 
 
 - A32NX_ADIRS_IR_{number}_TRUE_TRACK
     - Arinc429Word<Degrees>
-    - The inertial track of the aircraft.
+    - The true inertial track of the aircraft.
 
 - A32NX_ADIRS_IR_{number}_VERTICAL_SPEED
     - Arinc429Word<Feet per minute>

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -1053,7 +1053,8 @@ impl InertialReference {
             SignStatus::NoComputedData
         };
 
-        self.true_heading.set_value(simulator_data.true_heading, ssm);
+        self.true_heading
+            .set_value(simulator_data.true_heading, ssm);
         self.heading.set_value(simulator_data.heading, ssm);
     }
 
@@ -2826,7 +2827,10 @@ mod tests {
                 ));
             test_bed.run();
 
-            assert_eq!(test_bed.true_track(adiru_number).normal_value().unwrap(), angle);
+            assert_eq!(
+                test_bed.true_track(adiru_number).normal_value().unwrap(),
+                angle
+            );
         }
 
         #[rstest]
@@ -2850,7 +2854,9 @@ mod tests {
         #[case(1)]
         #[case(2)]
         #[case(3)]
-        fn true_track_is_true_heading_when_ground_speed_less_than_50_knots(#[case] adiru_number: usize) {
+        fn true_track_is_true_heading_when_ground_speed_less_than_50_knots(
+            #[case] adiru_number: usize,
+        ) {
             let angle = Angle::new::<degree>(160.);
             let mut test_bed = all_adirus_aligned_test_bed_with()
                 .true_heading_of(angle)
@@ -2860,7 +2866,10 @@ mod tests {
                 ));
             test_bed.run();
 
-            assert_eq!(test_bed.true_track(adiru_number).normal_value().unwrap(), angle);
+            assert_eq!(
+                test_bed.true_track(adiru_number).normal_value().unwrap(),
+                angle
+            );
         }
 
         #[rstest]

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -10,7 +10,7 @@ use crate::{
         SimulatorWriter, UpdateContext, Write, Writer,
     },
 };
-use std::{fmt::Debug, fmt::Display, time::Duration};
+use std::{fmt::Display, time::Duration};
 use uom::si::acceleration::meter_per_second_squared;
 use uom::si::{
     angle::degree,
@@ -100,7 +100,7 @@ impl SimulationElement for AirDataInertialReferenceSystemOverheadPanel {
     }
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 enum InertialReferenceMode {
     Off = 0,
     Navigation = 1,
@@ -108,16 +108,6 @@ enum InertialReferenceMode {
 }
 
 read_write_enum!(InertialReferenceMode);
-
-impl Debug for InertialReferenceMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            InertialReferenceMode::Off => write!(f, "Off"),
-            InertialReferenceMode::Navigation => write!(f, "Navigation"),
-            InertialReferenceMode::Attitude => write!(f, "Attitude"),
-        }
-    }
-}
 
 impl From<f64> for InertialReferenceMode {
     fn from(value: f64) -> Self {

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -2839,10 +2839,7 @@ mod tests {
                 test_bed.run();
             }
 
-            assert_eq!(
-                test_bed.true_heading(adiru_number).is_normal_operation(),
-                true
-            );
+            assert!(test_bed.true_heading(adiru_number).is_normal_operation());
         }
 
         #[rstest]

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -562,6 +562,10 @@ impl<T: Copy + Default + PartialOrd> AdirsData<T> {
         self.ssm = ssm;
     }
 
+    fn set_from(&mut self, other: &AdirsData<T>) {
+        self.set_value(other.value, other.ssm);
+    }
+
     /// Sets failure warning with the default (0.0) value.
     fn set_failure_warning(&mut self) {
         self.value = Default::default();
@@ -1093,18 +1097,11 @@ impl InertialReference {
             ssm,
         );
 
-        self.true_track.set_value(
-            if ground_speed_above_minimum_threshold {
-                simulator_data.true_track
-            } else {
-                simulator_data.true_heading
-            },
-            if ground_speed_above_minimum_threshold {
-                ssm
-            } else {
-                self.true_heading.ssm
-            },
-        );
+        if ground_speed_above_minimum_threshold {
+            self.true_track.set_value(simulator_data.true_track, ssm);
+        } else {
+            self.true_track.set_from(&self.true_heading);
+        }
 
         self.drift_angle.set_value(
             if ground_speed_above_minimum_threshold {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR adds true heading and true track into the current ADIRS data.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
FBW-34-01

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Erick [Z-6]#6484

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Make sure that the ND still accurately represents the heading and track on the display.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
