### PR TITLE
fix: fire handles can't be stowed

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1025,3 +1025,4 @@
 1. [MISC] Standby Instrument stays ON if emergency power should be available, bug fixes - @2hwk (2Cas#1022 on discord)
 1. [CDU] Full +/- button functionality - @lhoenig (Lukas Hoenig)
 1. [DCDU] Fixed MSG- and MSG+ button labels - @tyler58546 (tyler58546)
+1. [OVHD] Fixed fire push button not being able to be stowed - Julian Sebline (Julian Sebline#8476 on Discord)

--- a/src/behavior/src/A32NX_Interior_Fire.xml
+++ b/src/behavior/src/A32NX_Interior_Fire.xml
@@ -78,7 +78,7 @@
             <UseTemplate Name = "ASOBO_GT_Interaction_LeftSingle_Leave_Code">
                 <LEFT_SINGLE_CODE>
                     (L:A32NX_FIRE_GUARD_#TYPE##ID#) 1 == if{
-                    1 (&gt;#TOGGLE_VAR#) #LEFT_SINGLE_CODE#
+                        (#TOGGLE_VAR#) ! (&gt;#TOGGLE_VAR#)
                     }
                 </LEFT_SINGLE_CODE>
                 <LEFT_LEAVE_CODE />

--- a/src/systems/systems/src/overhead/mod.rs
+++ b/src/systems/systems/src/overhead/mod.rs
@@ -501,7 +501,7 @@ impl FirePushButton {
     }
 
     pub fn set_released(&mut self, released: bool) {
-        self.is_released = self.is_released || released;
+        self.is_released = released;
     }
 
     pub fn is_released(&self) -> bool {

--- a/src/systems/systems/src/overhead/mod.rs
+++ b/src/systems/systems/src/overhead/mod.rs
@@ -1086,7 +1086,7 @@ mod fire_push_button_tests {
     }
 
     #[test]
-    fn once_released_stays_released() {
+    fn can_be_stowed_after_release() {
         let mut test_bed = SimulationTestBed::from(ElementCtorFn(|context| {
             FirePushButton::new(context, "TEST")
         }));
@@ -1094,7 +1094,7 @@ mod fire_push_button_tests {
         test_bed.command_element(|e| e.set_released(true));
         test_bed.command_element(|e| e.set_released(false));
 
-        assert!(test_bed.query_element(|e| e.is_released()));
+        assert!(test_bed.query_element(|e| !e.is_released()));
     }
 
     #[test]


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

Fixes #4596

## Summary of Changes
After being pushed, the fire buttons couldn't be stowed. Now, the LVAR for a specific fire push button takes its opposite value every time there's a click on it. This couln't be done without changing a condition in Rust: at each frame it updates the LVAR with a variable but this variable was always true as soon as the button was pushed.

## Contact
Discord username (if different from GitHub): Julian Sebline#8476

## Testing instructions
1) Open the guard of a given fire push button
2) Click twice on the fire push button

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
