### PR TITLE
fix(rmp): SEL indicator colour

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -243,6 +243,7 @@
 1. [FMGC] Add lat/lon waypoint ident option - @tracernz (Mike)
 1. [HYD] Reduced engine driven pumps efficiency in active regulation area - @Crocket63
 1. [FMGC] Implemented Airport Button - @patmack14 (Patrick Macken)
+1. [RMP] Fixed colour of SEL indicator - @tracernz (Mike)
 
 ## 0.7.0
 

--- a/src/model/models.json
+++ b/src/model/models.json
@@ -826,6 +826,20 @@
           [0.587402, 0.958984],
           [0.621582, 0.973633]
         ]
+      },
+      {
+        "accessors": [
+          "x0_PUSH_RADIOL_SEL_SEQ2_vertices#0_TEXCOORD_0",
+          "x0_PUSH_RADIOL_SEL_SEQ2_vertices#0_TEXCOORD_1",
+          "x0_PUSH_RADIOR_SEL_SEQ2_vertices#0_TEXCOORD_0",
+          "x0_PUSH_RADIOR_SEL_SEQ2_vertices#0_TEXCOORD_1"
+        ],
+        "data": [
+          [0.400669, 0.736029],
+          [0.382114, 0.753607],
+          [0.382358, 0.736029],
+          [0.400913, 0.753607]
+        ]
       }
     ],
     "splitAnimations": [


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Change RMP SEL indicator colour from green to amber.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
FCOM

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Select the other side's VHF channel to turn on SEL light... make sure it's amber. Check both sides.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
