### PR TITLE
fix(fmgc): allow flight phase transition from APPR to CLB

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -3233,13 +3233,7 @@ class FMCMainDisplay extends BaseAirliners {
         this.cruiseTemperature = undefined;
         this.updateConstraints();
 
-        const acFl = Math.floor(Simplane.getAltitude() / 100);
-
-        if (acFl > fl && (phase === FmgcFlightPhases.CLIMB || phase === FmgcFlightPhases.DESCENT || phase === FmgcFlightPhases.APPROACH)) {
-            this.flightPhaseManager.changeFlightPhase(FmgcFlightPhases.CRUISE);
-        } else if (acFl < fl && (phase === FmgcFlightPhases.DESCENT || phase === FmgcFlightPhases.APPROACH)) {
-            this.flightPhaseManager.changeFlightPhase(FmgcFlightPhases.CLIMB);
-        }
+        this.flightPhaseManager.handleNewCruiseAltitudeEntered(fl);
 
         return true;
     }

--- a/src/fmgc/src/flightphase/FlightPhaseManager.ts
+++ b/src/fmgc/src/flightphase/FlightPhaseManager.ts
@@ -96,6 +96,20 @@ export class FlightPhaseManager {
         }
     }
 
+    handleNewCruiseAltitudeEntered(newCruiseFlightLevel: number): void {
+        const currentFlightLevel = Math.round(SimVar.GetSimVarValue('INDICATED ALTITUDE:3', 'feet') / 100);
+        if (this.activePhase === FmgcFlightPhase.Approach) {
+            this.changePhase(FmgcFlightPhase.Climb);
+        } else if (currentFlightLevel < newCruiseFlightLevel
+            && this.activePhase === FmgcFlightPhase.Descent) {
+            this.changePhase(FmgcFlightPhase.Climb);
+        } else if (currentFlightLevel > newCruiseFlightLevel
+            && (this.activePhase === FmgcFlightPhase.Climb
+                || this.activePhase === FmgcFlightPhase.Descent)) {
+            this.changePhase(FmgcFlightPhase.Cruise);
+        }
+    }
+
     changePhase(newPhase: FmgcFlightPhase): void {
         const prevPhase = this.phase;
         console.log(`FMGC Flight Phase: ${prevPhase} => ${newPhase}`);

--- a/src/fmgc/src/flightphase/Phase.ts
+++ b/src/fmgc/src/flightphase/Phase.ts
@@ -123,14 +123,26 @@ export class DescentPhase extends Phase {
 export class ApproachPhase extends Phase {
     landingConfirmation = new ConfirmationNode(30 * 1000);
 
+    initialCruiseFl = 0;
+
     init() {
         SimVar.SetSimVarValue('L:AIRLINER_TO_FLEX_TEMP', 'Number', 0);
+        this.initialCruiseFl = SimVar.GetSimVarValue('L:AIRLINER_CRUISE_ALTITUDE', 'number') / 100;
         this.nextPhase = FmgcFlightPhase.Done;
     }
 
     shouldActivateNextPhase(_deltaTime) {
+        const currentCruiseFl = SimVar.GetSimVarValue('L:AIRLINER_CRUISE_ALTITUDE', 'number') / 100;
+
         if (SimVar.GetSimVarValue('L:A32NX_FMA_VERTICAL_MODE', 'number') === 41) {
             this.nextPhase = FmgcFlightPhase.GoAround;
+            return true;
+        }
+
+        // this for now only covers the case when a different cruise altitude is
+        // entered and not when the same is entered again
+        if (currentCruiseFl !== this.initialCruiseFl) {
+            this.nextPhase = FmgcFlightPhase.Climb;
             return true;
         }
 

--- a/src/fmgc/src/flightphase/Phase.ts
+++ b/src/fmgc/src/flightphase/Phase.ts
@@ -83,7 +83,7 @@ export class ClimbPhase extends Phase {
             return true;
         }
 
-        return Math.round(Simplane.getAltitude() / 100) >= cruiseFl;
+        return Math.round(SimVar.GetSimVarValue('INDICATED ALTITUDE:3', 'feet') / 100) >= cruiseFl;
     }
 }
 
@@ -101,7 +101,7 @@ export class DescentPhase extends Phase {
     }
 
     shouldActivateNextPhase(_deltaTime) {
-        const fl = Math.round(Simplane.getAltitude() / 100);
+        const fl = Math.round(SimVar.GetSimVarValue('INDICATED ALTITUDE:3', 'feet') / 100);
         const fcuSelFl = Simplane.getAutoPilotDisplayedAltitudeLockValue('feet') / 100;
         const cruiseFl = SimVar.GetSimVarValue('L:AIRLINER_CRUISE_ALTITUDE', 'number') / 100;
 
@@ -123,26 +123,14 @@ export class DescentPhase extends Phase {
 export class ApproachPhase extends Phase {
     landingConfirmation = new ConfirmationNode(30 * 1000);
 
-    initialCruiseFl = 0;
-
     init() {
         SimVar.SetSimVarValue('L:AIRLINER_TO_FLEX_TEMP', 'Number', 0);
-        this.initialCruiseFl = SimVar.GetSimVarValue('L:AIRLINER_CRUISE_ALTITUDE', 'number') / 100;
         this.nextPhase = FmgcFlightPhase.Done;
     }
 
     shouldActivateNextPhase(_deltaTime) {
-        const currentCruiseFl = SimVar.GetSimVarValue('L:AIRLINER_CRUISE_ALTITUDE', 'number') / 100;
-
         if (SimVar.GetSimVarValue('L:A32NX_FMA_VERTICAL_MODE', 'number') === 41) {
             this.nextPhase = FmgcFlightPhase.GoAround;
-            return true;
-        }
-
-        // this for now only covers the case when a different cruise altitude is
-        // entered and not when the same is entered again
-        if (currentCruiseFl !== this.initialCruiseFl) {
-            this.nextPhase = FmgcFlightPhase.Climb;
             return true;
         }
 


### PR DESCRIPTION
## Summary of Changes
This PR allows to transition from APPR flight phase to CLB by entering a new and different CRZ altitude as documented in the FCOM.

## Additional context
Related to #6905 but does not completely resolve it.

## Testing instructions
- enter an origin and destination airport
- enter a cruise altitude of say FL120
- get into APPR flight phase on the FMGC
- enter a new cruise altitude of say FL130
- FMGC should move to CLB phase

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
