### PR TITLE
fix: reset display on HDG push in NAV and disarm NAV when flight plan is lost

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FCU/A320_Neo_FCU.js
@@ -585,6 +585,11 @@ class A320_Neo_FCU_Heading extends A320_Neo_FCU_Component {
         clearTimeout(this._resetSelectionTimeout);
         this.isPreselectionModeActive = false;
         this.inSelection = false;
+        const lateralMode = SimVar.GetSimVarValue("L:A32NX_FMA_LATERAL_MODE", "Number");
+        const isManagedActive = this.isManagedModeActive(lateralMode);
+        if (isManagedActive) {
+            this.isSelectedValueActive = false;
+        }
         SimVar.SetSimVarValue("K:A32NX.FCU_TO_AP_HDG_PUSH", "number", 0);
         SimVar.SetSimVarValue("K:HEADING_SLOT_INDEX_SET", "number", 2);
     }

--- a/src/fbw/src/model/AutopilotStateMachine.cpp
+++ b/src/fbw/src/model/AutopilotStateMachine.cpp
@@ -3154,10 +3154,10 @@ void AutopilotStateMachineModelClass::step()
   conditionSoftAlt = !rtb_BusConversion_InsertedFor_BusAssignment_at_inport_2_BusCreator1_APPR_push;
   engageCondition = !AutopilotStateMachine_DWork.Delay1_DSTATE.armed.FINAL_DES;
   state_e_tmp_0 = !AutopilotStateMachine_DWork.DelayInput1_DSTATE_g;
-  AutopilotStateMachine_DWork.state_e = (state_e_tmp_0 && ((AutopilotStateMachine_U.in.data.H_radio_ft >= 30.0) ||
-    (!rtb_AND)) && (rtb_cLAND || AutopilotStateMachine_U.in.input.FM_rnav_appr_selected) &&
-    (!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode == lateral_mode_NAV)) &&
-    (!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode == lateral_mode_LAND)) &&
+  AutopilotStateMachine_DWork.state_e = (state_e_tmp_0 && AutopilotStateMachine_U.in.data.is_flight_plan_available &&
+    ((AutopilotStateMachine_U.in.data.H_radio_ft >= 30.0) || (!rtb_AND)) && (rtb_cLAND ||
+    AutopilotStateMachine_U.in.input.FM_rnav_appr_selected) && (!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode ==
+    lateral_mode_NAV)) && (!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode == lateral_mode_LAND)) &&
     (!(AutopilotStateMachine_DWork.Delay_DSTATE.output.mode == lateral_mode_FLARE)) && (engageCondition || state_e_tmp ||
     rtb_BusAssignment1_data_altimeter_setting_changed || conditionSoftAlt) && AutopilotStateMachine_DWork.state_e);
   AutopilotStateMachine_DWork.wasFlightPlanAvailable = AutopilotStateMachine_U.in.data.is_flight_plan_available;


### PR DESCRIPTION
Fixes #7098

## Summary of Changes
This PR fixes an issue in the FCU when in mode `NAV` and HDG is selected by rotating the knob. After `45 s` the display clears automatically (again showing `---`). When the knob was pushed it should directly clear the display and show `---`. The timeout was cleared but the HDG was still shown (without any timeout).

Additionally, this PR fixes an issue with armed NAV. When a flight plan is available and the `XTK > 10 nm` the `NAV` mode is not engaged but armed. When the flight plan was lost, it didn't disarm. This is now working.

## Testing instructions

### FCU
- enter `NAV` mode, the display on the FCU should show `---`
- select a heading by rotating the HDG knob
- push the HDG knob -> FCU should display `---`
- select a heading by rotating the HDG knob
- wait for `45 s` -> FCU should display `---`

### AP
- enter a flight plan
- fly away for more than `10 NM` (XTK displayed on the ND) using `HDG` mode
- push knob to arm NAV (NAV shown blue on the FMA)
- clear the flight plan
- NAV should disarm

ℹ️ You can also use the local variables to achieve this (in development mode and no flight plan entered):
- `A32NX_FG_AVAIL` = `1`
- `A32NX_FG_CROSS_TRACK_ERROR` = `15`

When NAV is then shown in blue and setting `A32NX_FG_AVAIL` to `0` NAV should disarm.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
