### PR TITLE
fix(isis): Brightness adjustment in home cockpit mode

### DIFF
--- a/src/instruments/src/ISIS/AutoBrightness.tsx
+++ b/src/instruments/src/ISIS/AutoBrightness.tsx
@@ -20,7 +20,6 @@ export const AutoBrightness: React.FC<AutoBrightnessProps> = ({ bugsActive, chil
 
     const [targetBrightness, setTargetBrightness] = useState(isDaytimeRef.current ? dayBrightness : nightBrightness);
     const [currentBrightness, setCurrentBrightness] = useSimVar('L:A32NX_BARO_BRIGHTNESS', 'number', 10000);
-    const [homeCockpit] = useSimVar('L:A32NX_HOME_COCKPIT_ENABLED', 'bool', 200);
 
     const isBrightnessUpPressed = useRef(false);
     const isBrightnessDownPressed = useRef(false);
@@ -89,16 +88,20 @@ export const AutoBrightness: React.FC<AutoBrightnessProps> = ({ bugsActive, chil
         { additionalDeps: [currentBrightness, targetBrightness], runOnStart: false },
     );
 
-    if (homeCockpit) {
-        return (
-            <g style={{ opacity: 1.0 }}>
-                {children}
-            </g>
-        );
-    }
-
     return (
-        <g style={{ opacity: currentBrightness }}>
+        <g>
+            <svg
+                style={{
+                    position: 'absolute',
+                    top: '0%',
+                    left: '0%',
+                    width: '100%',
+                    height: '100%',
+                    backgroundColor: `rgba(0,0,0, ${1 - currentBrightness})`,
+                    zIndex: 3,
+                }}
+                viewBox="0 0 512 512"
+            />
             {children}
         </g>
     );

--- a/src/instruments/src/ISIS/ISISDisplayUnit.tsx
+++ b/src/instruments/src/ISIS/ISISDisplayUnit.tsx
@@ -58,7 +58,7 @@ export const ISISDisplayUnit: React.FC<ISISDisplayUnitProps> = ({ indicatedAirsp
     if (state === DisplayUnitState.Selftest) {
         return (
             <>
-                <svg id="SelfTest" className="SelfTest" version="1.1" viewBox="0 0 512 512">
+                <svg id="SelfTest" style={{ backgroundColor: 'black' }} className="SelfTest" version="1.1" viewBox="0 0 512 512">
                     <g id="AttFlag">
                         <rect id="AttTest" className="FillYellow" width="84" height="40" x="214" y="174" />
                         <text id="AltTestTxt" className="TextBackground" textAnchor="middle" x="256" y="206">ATT</text>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #6950

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* Brightness should now be adjustable in home cockpit mode
* Popup display should no longer contain reflections of cockpit interior when brightness is low

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

Old:

![image](https://user-images.githubusercontent.com/15316958/164970271-4e6001cc-c5a7-4daf-b216-547a2e83e535.png)

New:

https://user-images.githubusercontent.com/15316958/164970274-6c791d15-c5e8-4028-b34b-fcd34630cc08.mp4


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): 2Cas#1022

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
* Spawn C&D
* Open EFB Settings > Realism - Turn home cockpit mode on
* Attempt to adjust brightness on ISIS
* Brightness should increase/decrease
* Popout display with RALT+Left Click on ISIS display
* No cockpit reflections/transparency should be present

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
