### PR TITLE
fix(dcdu,mcdu): dcdu/mcdu visualization issues

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsAtis.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsAtis.js
@@ -50,11 +50,6 @@ class CDUAocRequestsAtis {
             enrouteText = "ENROUTE[color]cyan";
         }
 
-        let sendMessage = "SEND*[color]cyan";
-        if (store.selected !== "") {
-            sendMessage = "SEND\xa0[color]cyan";
-        }
-
         let arrText = "[ ]";
         if (store.selected !== "") {
             arrText = store.selected;
@@ -65,6 +60,11 @@ class CDUAocRequestsAtis {
 
         const updateView = () => {
             if (mcdu.page.Current === mcdu.page.AOCRequestAtis) {
+                let sendMessage = "SEND*[color]cyan";
+                if (store.selected === "" || store.sendStatus === "SENDING") {
+                    sendMessage = "SEND\xa0[color]cyan";
+                }
+
                 mcdu.setTemplate([
                     ["AOC ATIS REQUEST"],
                     ["\xa0AIRPORT", "↓FORMAT FOR\xa0"],

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsWeather.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsWeather.js
@@ -43,13 +43,13 @@ class CDUAocRequestsWeather {
             }
         }
 
-        let sendMessage = "SEND\xa0[color]cyan";
-        if (data.airports.filter((n) => n).length !== 0) {
-            sendMessage = "SEND*[color]cyan";
-        }
-
         const updateView = () => {
             if (mcdu.page.Current === mcdu.page.AOCRequestWeather) {
+                let sendMessage = "SEND\xa0[color]cyan";
+                if (data.airports.filter((n) => n).length !== 0 && data.sendStatus !== "SENDING") {
+                    sendMessage = "SEND*[color]cyan";
+                }
+
                 mcdu.setTemplate([
                     ["AOC WEATHER REQUEST"],
                     ["\xa0WX TYPE", "AIRPORTS\xa0"],

--- a/src/atsu/src/com/webinterfaces/HoppieConnector.ts
+++ b/src/atsu/src/com/webinterfaces/HoppieConnector.ts
@@ -21,6 +21,11 @@ export class HoppieConnector {
     public static async activateHoppie() {
         SimVar.SetSimVarValue('L:A32NX_HOPPIE_ACTIVE', 'number', 0);
 
+        if (NXDataStore.get('CONFIG_HOPPIE_ENABLED', 'DISABLED') === 'DISABLED') {
+            console.log('Hoppie deactivated in EFB');
+            return;
+        }
+
         if (NXDataStore.get('CONFIG_HOPPIE_USERID', '') === '') {
             console.log('No Hoppie-ID set');
             return;

--- a/src/instruments/src/EFB/Settings/Settings.tsx
+++ b/src/instruments/src/EFB/Settings/Settings.tsx
@@ -557,6 +557,7 @@ const ATSUAOCPage = () => {
     const { simbriefUserId, setSimbriefUserId } = useContext(SimbriefUserIdContext);
     const [simbriefDisplay, setSimbriefDisplay] = useState(simbriefUserId);
 
+    const [hoppieEnabled, setHoppieEnabled] = usePersistentProperty('CONFIG_HOPPIE_ENABLED', 'DISABLED');
     const [hoppieUserId, setHoppieUserId] = usePersistentProperty('CONFIG_HOPPIE_USERID');
     const [hoppieError, setHoppieError] = useState(false);
 
@@ -725,6 +726,16 @@ const ATSUAOCPage = () => {
         }
     }
 
+    function handleHoppieEnabled(toggleValue: boolean) {
+        if (toggleValue) {
+            setHoppieEnabled('ENABLED');
+            HoppieConnector.activateHoppie();
+        } else {
+            setHoppieEnabled('DISABLED');
+            HoppieConnector.deactivateHoppie();
+        }
+    }
+
     return (
         <div className="bg-navy-lighter rounded-xl px-6 divide-y divide-gray-700 flex flex-col">
             <div className="py-4 flex flex-row justify-between items-center">
@@ -815,6 +826,10 @@ const ATSUAOCPage = () => {
                         onChange={(value) => setHoppieUserId(value)}
                     />
                 </div>
+            </div>
+            <div className="py-4 flex flex-row justify-between items-center">
+                <span className="text-lg text-gray-300">Hoppie enabled</span>
+                <Toggle value={hoppieEnabled === 'ENABLED'} onToggle={(toggleValue) => handleHoppieEnabled(toggleValue)} />
             </div>
         </div>
     );


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes findings in Discord

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The AOC-ATIS and AOC-Weather pages handle the SEND*- and SEND-strings in RSK6 wrong.
This PR removes the * if a request is in the send-queue of the A/C or if no airport is set.

An other finding is that the DCDU runs through the selftest if the sim is started on the runway.
A fix is provided that the selftest is only executed during a cold&dark sim-start, otherwise is the system directly active.

Additionally is a persistent global flag set that defines if Hoppie is enabled or not.
Otherwise is it currently impossible to deactivate the Hoppie connection

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Sven [de en]

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Fill out INIT A
  - Check Hoppie enabled is deactivated in EFB/Settings/AOC
  - Hoppie enabled is deactivated -> MCDU/ATC COMM/Notification -> Enter callsign -> Scratchpad should show NO HOPPIE CONNECTION
  - Enable Hoppie in EFB -> Enter available callsign in Notification -> NOTIFY* is shown and logon can be sent
  - Validate after sim-restart that the "Hoppie enabled" flag is in the same state as in the last flight
- Start sim in cold&dark
  - plug-in EXT PWR -> wait until SELFTEST pops up -> remove EXT PWR -> plug-in EXT PWR -> SELFTEST pops up again
  - plug-in EXT PWR -> wait until SELFTEST/wait data processed -> remove EXT PWR -> plug-in EXT PWR -> direct visualization of active DCDU
- Start sim on runway with running engines
  - DCDU is directly active
- MCDU/AOC/WEATHER
  - No INIT A set up -> SEND is shown
  - No INIT A set up -> Manually insertion of airports -> SEND* is shown
  - INIT A set up -> SEND* is shown
  - SEND* removed as long as SENDING is active -> returns after SENT or FAILURE is shown
- MCDU/AOC/ATIS
  - No INIT A set up -> SEND is shown
  - No INIT A set up -> Manually insertion of airports -> SEND* is shown
  - INIT A set up -> SEND* is shown
  - SEND* removed as long as SENDING is active -> returns after SENT or FAILURE is shown


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
