### PR TITLE
fix(adirs): various IRS data fixes

### DIFF
--- a/src/instruments/src/PFD/AttitudeIndicatorHorizon.tsx
+++ b/src/instruments/src/PFD/AttitudeIndicatorHorizon.tsx
@@ -113,11 +113,11 @@ export class Horizon extends DisplayComponent<HorizonProps> {
             if (pitch.isNormalOperation()) {
                 this.pitchGroupRef.instance.style.display = 'block';
 
-                this.pitchGroupRef.instance.style.transform = `translate3d(0px, ${calculateHorizonOffsetFromPitch(-currentValueAtPrecision)}px, 0px)`;
+                this.pitchGroupRef.instance.style.transform = `translate3d(0px, ${calculateHorizonOffsetFromPitch(currentValueAtPrecision)}px, 0px)`;
             } else {
                 this.pitchGroupRef.instance.style.display = 'none';
             }
-            const yOffset = Math.max(Math.min(calculateHorizonOffsetFromPitch(-currentValueAtPrecision), 31.563), -31.563);
+            const yOffset = Math.max(Math.min(calculateHorizonOffsetFromPitch(currentValueAtPrecision), 31.563), -31.563);
             this.yOffset.set(yOffset);
         });
 
@@ -127,7 +127,7 @@ export class Horizon extends DisplayComponent<HorizonProps> {
             if (roll.isNormalOperation()) {
                 this.rollGroupRef.instance.style.display = 'block';
 
-                this.rollGroupRef.instance.setAttribute('transform', `rotate(${currentValueAtPrecision} 68.814 80.730)`);
+                this.rollGroupRef.instance.setAttribute('transform', `rotate(${-currentValueAtPrecision} 68.814 80.730)`);
             } else {
                 this.rollGroupRef.instance.style.display = 'none';
             }
@@ -544,9 +544,9 @@ class RisingGround extends DisplayComponent<{ bus: EventBus, filteredRadioAltitu
     private horizonGroundRectangle = FSComponent.createRef<SVGGElement>();
 
     private setOffset() {
-        const targetPitch = (this.radioAlt.isNoComputedData() || this.radioAlt.isFailureWarning()) ? -200 : -0.1 * this.props.filteredRadioAltitude.get();
+        const targetPitch = (this.radioAlt.isNoComputedData() || this.radioAlt.isFailureWarning()) ? 200 : 0.1 * this.props.filteredRadioAltitude.get();
 
-        const targetOffset = Math.max(Math.min(calculateHorizonOffsetFromPitch((-this.lastPitch.value) - targetPitch) - 31.563, 0), -63.093);
+        const targetOffset = Math.max(Math.min(calculateHorizonOffsetFromPitch(this.lastPitch.value + targetPitch) - 31.563, 0), -63.093);
         this.horizonGroundRectangle.instance.style.transform = `translate3d(0px, ${targetOffset.toFixed(2)}px, 0px)`;
     }
 

--- a/src/instruments/src/PFD/FlightPathDirector.tsx
+++ b/src/instruments/src/PFD/FlightPathDirector.tsx
@@ -141,9 +141,9 @@ export class FlightPathDirector extends DisplayComponent<{bus: EventBus, isAttEx
             const FDPitchOrderLim = Math.max(Math.min(FDPitchOrder, 22.5), -22.5) * 1.9;
 
             const daLimConv = Math.max(Math.min(this.data.da.value, 21), -21) * DistanceSpacing / ValueSpacing;
-            const pitchSubFpaConv = (calculateHorizonOffsetFromPitch(-this.data.pitch.value) - calculateHorizonOffsetFromPitch(this.data.fpa.value));
+            const pitchSubFpaConv = (calculateHorizonOffsetFromPitch(this.data.pitch.value) - calculateHorizonOffsetFromPitch(this.data.fpa.value));
             const rollCos = Math.cos(this.data.roll.value * Math.PI / 180);
-            const rollSin = Math.sin(this.data.roll.value * Math.PI / 180);
+            const rollSin = Math.sin(-this.data.roll.value * Math.PI / 180);
 
             const FDRollOffset = FDRollOrderLim * 0.77;
             const xOffsetFpv = daLimConv * rollCos - pitchSubFpaConv * rollSin;

--- a/src/instruments/src/PFD/FlightPathVector.tsx
+++ b/src/instruments/src/PFD/FlightPathVector.tsx
@@ -84,9 +84,9 @@ export class FlightPathVector extends DisplayComponent<{bus: EventBus}> {
 
     private moveBird() {
         const daLimConv = Math.max(Math.min(this.data.da.value, 21), -21) * DistanceSpacing / ValueSpacing;
-        const pitchSubFpaConv = (calculateHorizonOffsetFromPitch(-this.data.pitch.value) - calculateHorizonOffsetFromPitch(this.data.fpa.value));
+        const pitchSubFpaConv = (calculateHorizonOffsetFromPitch(this.data.pitch.value) - calculateHorizonOffsetFromPitch(this.data.fpa.value));
         const rollCos = Math.cos(this.data.roll.value * Math.PI / 180);
-        const rollSin = Math.sin(this.data.roll.value * Math.PI / 180);
+        const rollSin = Math.sin(-this.data.roll.value * Math.PI / 180);
 
         const xOffset = daLimConv * rollCos - pitchSubFpaConv * rollSin;
         const yOffset = pitchSubFpaConv * rollCos + daLimConv * rollSin;

--- a/src/instruments/src/PFD/PFD.tsx
+++ b/src/instruments/src/PFD/PFD.tsx
@@ -74,9 +74,9 @@ export class PFDComponent extends DisplayComponent<PFDProps> {
             this.failuresConsumer.update();
             this.displayFailed.set(this.failuresConsumer.isActive(getDisplayIndex() === 1 ? A320Failure.LeftPfdDisplay : A320Failure.RightPfdDisplay));
             if (!this.isAttExcessive.get() && ((this.pitch.isNormalOperation()
-            && (-this.pitch.value > 25 || -this.pitch.value < -13)) || (this.roll.isNormalOperation() && Math.abs(this.roll.value) > 45))) {
+            && (this.pitch.value > 25 || this.pitch.value < -13)) || (this.roll.isNormalOperation() && Math.abs(this.roll.value) > 45))) {
                 this.isAttExcessive.set(true);
-            } else if (this.isAttExcessive.get() && this.pitch.isNormalOperation() && -this.pitch.value < 22 && -this.pitch.value > -10
+            } else if (this.isAttExcessive.get() && this.pitch.isNormalOperation() && this.pitch.value < 22 && this.pitch.value > -10
             && this.roll.isNormalOperation() && Math.abs(this.roll.value) < 40) {
                 this.isAttExcessive.set(false);
             }

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -17,7 +17,7 @@ use uom::si::{
     angular_velocity::degree_per_second,
     f64::*,
     length::foot,
-    ratio::{percent, ratio},
+    ratio::ratio,
     thermodynamic_temperature::degree_celsius,
     velocity::{foot_per_minute, knot},
 };
@@ -1296,6 +1296,7 @@ mod tests {
     use uom::si::{
         angle::degree,
         length::foot,
+        ratio::percent,
         thermodynamic_temperature::degree_celsius,
         velocity::{foot_per_minute, knot},
     };


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* Output correct units for Rotation rates and Body accelerations: Previously, RPM and percentage were used, instead of the correct units of deg/s and G.
* Use correct sign for Rotation rates and Attitude to conform to Aeronautical standards, in particular, flip the signs of Pitch, Bank, q, p, theta_dot, phi_dot.
* Add the gravitational vector to the body accelerations, since the sim does not include it in the body acceleration simvars.
* Change the G LOAD indication on the SD permanent data area to use IR data (Body Normal Acceleration):
   * It is now shown if the acceleration data is valid and above 1.4G or below 0.7G for more than 2s
   * It disappears 5 seconds after the acceleration returns to normal, or the data goes invalid.
   * If it is shown while the data is invalid (only during the 5s it remains displayed), the data is replaced with 'XX'

Since the Rotation rates and accelerations are not used yet, these changes will have no effect.
The Pitch and Roll data are used, and I have corrected all the usages I could find, although it should be confirmed that I actually found all usages.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
* Make sure that the systems that use the IRS Pitch and Roll data continue to function normally, for example the PFD.
* Make sure the G LOAD indication works normally.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
