### PR TITLE
fix(fmgc): don't add legs to the empty segment

### DIFF
--- a/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
+++ b/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
@@ -385,9 +385,19 @@ export class ManagedFlightPlan {
             this.reflowSegments();
             this.reflowDistances();
         } else {
-            let segment = segmentType !== undefined
-                ? this.getSegment(segmentType)
-                : this.findSegmentByWaypointIndex(index);
+            let segment;
+
+            if (segmentType !== undefined) {
+                segment = this.getSegment(segmentType);
+                if (segment === FlightPlanSegment.Empty) {
+                    segment = this.addSegment(segmentType);
+                }
+            } else {
+                segment = this.findSegmentByWaypointIndex(index);
+                if (segment === FlightPlanSegment.Empty) {
+                    throw new Error('ManagedFlightPlan::addWaypoint: no segment found!');
+                }
+            }
 
             // hitting first waypoint in segment > enroute
             if (segment.type > SegmentType.Enroute && index === segment.offset) {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

There was a bug when building departures if the second waypoint was a "duplicate" of the first (also happens if the second leg is effectively null, e.g. a CA leg with the same altitude as the first CA leg), the departure segment would be deleted and the remaining legs would be inserted into the "EmptySegment" which is effectively a black hole for legs. This would only occur for poorly coded procedures, in this case the LPMA DEGU1E departure from runway 05 when using Navigraph/Jeppesen data (MSFS/Navblue and NavDataPro/LIDO databases have a better coding for this departure).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Try loading some departures and checking they appear okay.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
