### PR TITLE
fix: use main gear compression for some onground detections

### DIFF
--- a/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
+++ b/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
@@ -398,7 +398,7 @@ class SidestickIndicator extends DisplayComponent<{ bus: EventBus }> {
 
     private sideStickY = 0;
 
-    private onGround = 0;
+    private onGround = true;
 
     private crossHairRef = FSComponent.createRef<SVGPathElement>();
 
@@ -411,7 +411,7 @@ class SidestickIndicator extends DisplayComponent<{ bus: EventBus }> {
     private handleSideStickIndication() {
         const oneEngineRunning = this.engOneRunning || this.engTwoRunning;
 
-        if (this.onGround === 0 || !oneEngineRunning) {
+        if (!this.onGround || !oneEngineRunning) {
             this.onGroundForVisibility.set('hidden');
         } else {
             this.onGroundForVisibility.set('visible');
@@ -424,7 +424,7 @@ class SidestickIndicator extends DisplayComponent<{ bus: EventBus }> {
 
         const sub = this.props.bus.getSubscriber<PFDSimvars>();
 
-        sub.on('onGround').whenChanged().handle((g) => {
+        sub.on('centerGearCompressed').whenChanged().handle((g) => {
             this.onGround = g;
             this.handleSideStickIndication();
         });

--- a/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
+++ b/src/instruments/src/PFD/AttitudeIndicatorFixed.tsx
@@ -424,7 +424,7 @@ class SidestickIndicator extends DisplayComponent<{ bus: EventBus }> {
 
         const sub = this.props.bus.getSubscriber<PFDSimvars>();
 
-        sub.on('centerGearCompressed').whenChanged().handle((g) => {
+        sub.on('noseGearCompressed').whenChanged().handle((g) => {
             this.onGround = g;
             this.handleSideStickIndication();
         });

--- a/src/instruments/src/PFD/AttitudeIndicatorHorizon.tsx
+++ b/src/instruments/src/PFD/AttitudeIndicatorHorizon.tsx
@@ -449,7 +449,11 @@ class SideslipIndicator extends DisplayComponent<SideslipIndicatorProps> {
 
     private slideSlip = FSComponent.createRef<SVGPathElement>();
 
-    private onGround = 1;
+    private onGround = true;
+
+    private leftMainGearCompressed = true;
+
+    private rightMainGearCompressed = true;
 
     private roll = new Arinc429Word(0);
 
@@ -466,8 +470,15 @@ class SideslipIndicator extends DisplayComponent<SideslipIndicatorProps> {
 
         const sub = this.props.bus.getSubscriber<PFDSimvars & Arinc429Values>();
 
-        sub.on('onGround').whenChanged().handle((og) => {
-            this.onGround = og;
+        sub.on('leftMainGearCompressed').whenChanged().handle((og) => {
+            this.leftMainGearCompressed = og;
+            this.onGround = this.rightMainGearCompressed || og;
+            this.determineSlideSlip();
+        });
+
+        sub.on('rightMainGearCompressed').whenChanged().handle((og) => {
+            this.rightMainGearCompressed = og;
+            this.onGround = this.leftMainGearCompressed || og;
             this.determineSlideSlip();
         });
 

--- a/src/instruments/src/PFD/instrument.tsx
+++ b/src/instruments/src/PFD/instrument.tsx
@@ -71,7 +71,9 @@ class A32NX_PFD extends BaseInstrument {
         this.simVarPublisher.subscribe('altitude');
         this.simVarPublisher.subscribe('speed');
         this.simVarPublisher.subscribe('alphaProt');
-        this.simVarPublisher.subscribe('onGround');
+        this.simVarPublisher.subscribe('centerGearCompressed');
+        this.simVarPublisher.subscribe('leftMainGearCompressed');
+        this.simVarPublisher.subscribe('rightMainGearCompressed');
         this.simVarPublisher.subscribe('activeLateralMode');
         this.simVarPublisher.subscribe('activeVerticalMode');
         this.simVarPublisher.subscribe('fmaModeReversion');

--- a/src/instruments/src/PFD/instrument.tsx
+++ b/src/instruments/src/PFD/instrument.tsx
@@ -71,7 +71,7 @@ class A32NX_PFD extends BaseInstrument {
         this.simVarPublisher.subscribe('altitude');
         this.simVarPublisher.subscribe('speed');
         this.simVarPublisher.subscribe('alphaProt');
-        this.simVarPublisher.subscribe('centerGearCompressed');
+        this.simVarPublisher.subscribe('noseGearCompressed');
         this.simVarPublisher.subscribe('leftMainGearCompressed');
         this.simVarPublisher.subscribe('rightMainGearCompressed');
         this.simVarPublisher.subscribe('activeLateralMode');

--- a/src/instruments/src/PFD/shared/PFDSimvarPublisher.tsx
+++ b/src/instruments/src/PFD/shared/PFDSimvarPublisher.tsx
@@ -12,7 +12,9 @@ export interface PFDSimvars {
     altitude: number;
     speed: number;
     alphaProt: number;
-    onGround: number;
+    centerGearCompressed: boolean;
+    leftMainGearCompressed: boolean;
+    rightMainGearCompressed: boolean;
     activeLateralMode: number;
     activeVerticalMode: number;
     fmaModeReversion: boolean;
@@ -124,7 +126,9 @@ export enum PFDVars {
     altitude = 'L:A32NX_ADIRS_ADR_1_ALTITUDE',
     speed = 'L:A32NX_ADIRS_ADR_1_COMPUTED_AIRSPEED',
     alphaProt = 'L:A32NX_SPEEDS_ALPHA_PROTECTION',
-    onGround = 'L:A32NX_LGCIU_1_NOSE_GEAR_COMPRESSED',
+    centerGearCompressed = 'L:A32NX_LGCIU_1_CENTER_GEAR_COMPRESSED',
+    leftMainGearCompressed = 'L:A32NX_LGCIU_1_LEFT_GEAR_COMPRESSED',
+    rightMainGearCompressed = 'L:A32NX_LGCIU_1_RIGHT_GEAR_COMPRESSED',
     activeLateralMode = 'L:A32NX_FMA_LATERAL_MODE',
     activeVerticalMode = 'L:A32NX_FMA_VERTICAL_MODE',
     fmaModeReversion = 'L:A32NX_FMA_MODE_REVERSION',
@@ -238,7 +242,9 @@ export class PFDSimvarPublisher extends SimVarPublisher<PFDSimvars> {
         ['altitude', { name: PFDVars.altitude, type: SimVarValueType.Number }],
         ['speed', { name: PFDVars.speed, type: SimVarValueType.Number }],
         ['alphaProt', { name: PFDVars.alphaProt, type: SimVarValueType.Number }],
-        ['onGround', { name: PFDVars.onGround, type: SimVarValueType.Number }],
+        ['centerGearCompressed', { name: PFDVars.centerGearCompressed, type: SimVarValueType.Bool }],
+        ['leftMainGearCompressed', { name: PFDVars.leftMainGearCompressed, type: SimVarValueType.Bool }],
+        ['rightMainGearCompressed', { name: PFDVars.rightMainGearCompressed, type: SimVarValueType.Bool }],
         ['activeLateralMode', { name: PFDVars.activeLateralMode, type: SimVarValueType.Number }],
         ['activeVerticalMode', { name: PFDVars.activeVerticalMode, type: SimVarValueType.Number }],
         ['fmaModeReversion', { name: PFDVars.fmaModeReversion, type: SimVarValueType.Bool }],

--- a/src/instruments/src/PFD/shared/PFDSimvarPublisher.tsx
+++ b/src/instruments/src/PFD/shared/PFDSimvarPublisher.tsx
@@ -12,7 +12,7 @@ export interface PFDSimvars {
     altitude: number;
     speed: number;
     alphaProt: number;
-    centerGearCompressed: boolean;
+    noseGearCompressed: boolean;
     leftMainGearCompressed: boolean;
     rightMainGearCompressed: boolean;
     activeLateralMode: number;
@@ -126,7 +126,7 @@ export enum PFDVars {
     altitude = 'L:A32NX_ADIRS_ADR_1_ALTITUDE',
     speed = 'L:A32NX_ADIRS_ADR_1_COMPUTED_AIRSPEED',
     alphaProt = 'L:A32NX_SPEEDS_ALPHA_PROTECTION',
-    centerGearCompressed = 'L:A32NX_LGCIU_1_CENTER_GEAR_COMPRESSED',
+    noseGearCompressed = 'L:A32NX_LGCIU_1_NOSE_GEAR_COMPRESSED',
     leftMainGearCompressed = 'L:A32NX_LGCIU_1_LEFT_GEAR_COMPRESSED',
     rightMainGearCompressed = 'L:A32NX_LGCIU_1_RIGHT_GEAR_COMPRESSED',
     activeLateralMode = 'L:A32NX_FMA_LATERAL_MODE',
@@ -242,7 +242,7 @@ export class PFDSimvarPublisher extends SimVarPublisher<PFDSimvars> {
         ['altitude', { name: PFDVars.altitude, type: SimVarValueType.Number }],
         ['speed', { name: PFDVars.speed, type: SimVarValueType.Number }],
         ['alphaProt', { name: PFDVars.alphaProt, type: SimVarValueType.Number }],
-        ['centerGearCompressed', { name: PFDVars.centerGearCompressed, type: SimVarValueType.Bool }],
+        ['noseGearCompressed', { name: PFDVars.noseGearCompressed, type: SimVarValueType.Bool }],
         ['leftMainGearCompressed', { name: PFDVars.leftMainGearCompressed, type: SimVarValueType.Bool }],
         ['rightMainGearCompressed', { name: PFDVars.rightMainGearCompressed, type: SimVarValueType.Bool }],
         ['activeLateralMode', { name: PFDVars.activeLateralMode, type: SimVarValueType.Number }],

--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -159,7 +159,7 @@ impl LandingGearControlInterfaceUnit {
             left_gear_down_and_locked: false,
             nose_gear_down_and_locked: false,
             nose_gear_compressed_id: context
-                .get_identifier(format!("LGCIU_{}_NOSE_GEAR_COMPRESSED", number)),
+                .get_identifier(format!("LGCIU_{}_CENTER_GEAR_COMPRESSED", number)),
             left_gear_compressed_id: context
                 .get_identifier(format!("LGCIU_{}_LEFT_GEAR_COMPRESSED", number)),
             right_gear_compressed_id: context

--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -159,7 +159,7 @@ impl LandingGearControlInterfaceUnit {
             left_gear_down_and_locked: false,
             nose_gear_down_and_locked: false,
             nose_gear_compressed_id: context
-                .get_identifier(format!("LGCIU_{}_CENTER_GEAR_COMPRESSED", number)),
+                .get_identifier(format!("LGCIU_{}_NOSE_GEAR_COMPRESSED", number)),
             left_gear_compressed_id: context
                 .get_identifier(format!("LGCIU_{}_LEFT_GEAR_COMPRESSED", number)),
             right_gear_compressed_id: context


### PR DESCRIPTION
Should avoid speedtape showing error state when the nose is being lifted

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #7124

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Before that change, only the center/nose gear was used to determine whether the plane was on ground. This can cause issues with the Toolbar Pushback, as the raises the nose which can decompress the gear and show faulty speedtapes on the PFD. This replaces some usages of "onGround" with the left or right maingear.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Use toolbar pushback and verify the nose is lifted.
2. Speedtape is showing correctly on the PFD during pushback.
<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
