### PR TITLE
feat: show warning when incompatible assistance functions are enabled

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_Core.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_Core.js
@@ -93,6 +93,7 @@ class A32NX_Core {
         const deltaTime = this.getDeltaTime();
 
         this.soundManager.update(deltaTime);
+        this.tipsManager.update(deltaTime);
 
         let updatedModules = 0;
         this.modules.forEach(moduleDefinition => {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_TipsManager.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_TipsManager.js
@@ -47,7 +47,7 @@ class A32NX_TipsManager {
         const assistenceLandingEnabled = SimVar.GetSimVarValue("ASSISTANCE LANDING ENABLED", "Bool");
         const assistenceAutotrimActive = SimVar.GetSimVarValue("AI AUTOTRIM ACTIVE", "Bool");
         if (assistenceTakeOffEnabled || assistenceLandingEnabled || assistenceAutotrimActive) {
-            this.notif.showNotification({message: "Ensure you have turned off all assistance functions:\n\n-AUTO-RUDDER\n- ASSISTED YOKE\n- ASSISTED LANDING\n- ASSISTED TAKEOFF\n-AI ANTI-STALL PROTECTION\n- AI AUTO-TRIM\nASSISTED CONTROLLER SENSITIVITY\n\nThey cause serious incompatibility!", timeout: 20000});
+            this.notif.showNotification({message: "Ensure you have turned off all assistance functions:\n\n-AUTO-RUDDER\n- ASSISTED YOKE\n- ASSISTED LANDING\n- ASSISTED TAKEOFF\n- AI ANTI-STALL PROTECTION\n- AI AUTO-TRIM\n- ASSISTED CONTROLLER SENSITIVITY\n\nThey cause serious incompatibility!", timeout: 20000});
         }
     }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_TipsManager.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_TipsManager.js
@@ -2,6 +2,13 @@ class A32NX_TipsManager {
     constructor() {
         this.notif = new NXNotif();
         this.checkThrottleCalibration();
+        this.updateThrottler = new UpdateThrottler(30000);
+    }
+
+    update(deltaTime) {
+        if (this.updateThrottler.canUpdate(deltaTime) !== -1) {
+            this.checkAssistenceConfiguration();
+        }
     }
 
     checkThrottleCalibration() {
@@ -32,6 +39,15 @@ class A32NX_TipsManager {
                     input = Math.round(SimVar.GetSimVarValue("L:A32NX_THROTTLE_MAPPING_INPUT:1", "Number") * 100) / 100;
                 }
             }, 300000);
+        }
+    }
+
+    checkAssistenceConfiguration() {
+        const assistenceTakeOffEnabled = SimVar.GetSimVarValue("ASSISTANCE TAKEOFF ENABLED", "Bool");
+        const assistenceLandingEnabled = SimVar.GetSimVarValue("ASSISTANCE LANDING ENABLED", "Bool");
+        const assistenceAutotrimActive = SimVar.GetSimVarValue("AI AUTOTRIM ACTIVE", "Bool");
+        if (assistenceTakeOffEnabled || assistenceLandingEnabled || assistenceAutotrimActive) {
+            this.notif.showNotification({message: "Ensure you have turned off the following assistance functions:\n- ASSISTET TAKEOFF\n- ASSISTET LANDING\n- AI AUTO-TRIM\n\nThey cause serious incompatibility!", timeout: 20000});
         }
     }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_TipsManager.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_TipsManager.js
@@ -47,7 +47,7 @@ class A32NX_TipsManager {
         const assistenceLandingEnabled = SimVar.GetSimVarValue("ASSISTANCE LANDING ENABLED", "Bool");
         const assistenceAutotrimActive = SimVar.GetSimVarValue("AI AUTOTRIM ACTIVE", "Bool");
         if (assistenceTakeOffEnabled || assistenceLandingEnabled || assistenceAutotrimActive) {
-            this.notif.showNotification({message: "Ensure you have turned off the following assistance functions:\n- ASSISTED TAKEOFF\n- ASSISTED LANDING\n- AI AUTO-TRIM\n\nThey cause serious incompatibility!", timeout: 20000});
+            this.notif.showNotification({message: "Ensure you have turned off all assistance functions:\n\n-AUTO-RUDDER\n- ASSISTED YOKE\n- ASSISTED LANDING\n- ASSISTED TAKEOFF\n-AI ANTI-STALL PROTECTION\n- AI AUTO-TRIM\nASSISTED CONTROLLER SENSITIVITY\n\nThey cause serious incompatibility!", timeout: 20000});
         }
     }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_TipsManager.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_TipsManager.js
@@ -47,7 +47,7 @@ class A32NX_TipsManager {
         const assistenceLandingEnabled = SimVar.GetSimVarValue("ASSISTANCE LANDING ENABLED", "Bool");
         const assistenceAutotrimActive = SimVar.GetSimVarValue("AI AUTOTRIM ACTIVE", "Bool");
         if (assistenceTakeOffEnabled || assistenceLandingEnabled || assistenceAutotrimActive) {
-            this.notif.showNotification({message: "Ensure you have turned off the following assistance functions:\n- ASSISTET TAKEOFF\n- ASSISTET LANDING\n- AI AUTO-TRIM\n\nThey cause serious incompatibility!", timeout: 20000});
+            this.notif.showNotification({message: "Ensure you have turned off the following assistance functions:\n- ASSISTED TAKEOFF\n- ASSISTED LANDING\n- AI AUTO-TRIM\n\nThey cause serious incompatibility!", timeout: 20000});
         }
     }
 


### PR DESCRIPTION
## Summary of Changes
This PR introduces a warning screen when one of the following incompatible assistance functions is active:
- ASSISTED TAKEOFF
- ASSISTED LANDING
- AI AUTO-TRIM

The very offensive re-appearing of the warning is intentional. The plane cannot be properly flown when one of the assistants is active (i.e. engine stops after take-off).

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/6629914/166122412-1a1dbd37-489c-4713-ba5f-cb58de51c8e4.png)

## Testing instructions
- enable one or more of the mentioned assistants
- spawn on runway with engines running
- warning should appear
- turn off assistant
- warning should disappear after timeout

⚠️ it turned out that the related sim variable is not always `1` when the assistant is `on`. Depending on the situation it can still be `0` but get `1` in a situation when the assistant might get active. For example, the take-off assistant seems not active with engines off. The warning might not appear in every case, but it should appear at least when one of the assistants is about to get active.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
