### PR TITLE
fix(fmgc): robust comparison of legs

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -209,7 +209,7 @@ class CDUFlightPlanPage {
                     // ARINC Leg Types - R1A 610
                     switch (wp.additionalData.legType) {
                         case 1: // AF
-                            fixAnnotation = `${Math.round(wp.additionalData.rho).toString().substring(0, 2).padStart(2, '0')} ${wp.additionalData.navaidIdent.substring(0, 3)}`;
+                            fixAnnotation = `${Math.round(wp.additionalData.rho).toString().substring(0, 2).padStart(2, '0')} ${WayPoint.formatIdentFromIcao(wp.additionalData.recommendedIcao).substring(0, 3)}`;
                             break;
                         case 2: // CA
                         case 3: // CD

--- a/src/fmgc/src/guidance/GuidanceManager.ts
+++ b/src/fmgc/src/guidance/GuidanceManager.ts
@@ -139,7 +139,7 @@ export class GuidanceManager {
         }
 
         if (to.isVectors) {
-            return new VMLeg(to.additionalData.vectorsHeading, to.additionalData.vectorsCourse, metadata, segment);
+            return new VMLeg(to.additionalData.course, metadata, segment);
         }
 
         return new TFLeg(from, to, metadata, segment);

--- a/src/fmgc/src/guidance/GuidanceManager.ts
+++ b/src/fmgc/src/guidance/GuidanceManager.ts
@@ -80,7 +80,7 @@ export class GuidanceManager {
 
         if (to.additionalData) {
             if (to.additionalData.legType === LegType.AF) {
-                return new AFLeg(to, to.additionalData.navaid, to.additionalData.rho, to.additionalData.theta, to.additionalData.vectorsCourse, metadata, segment);
+                return new AFLeg(to, to.additionalData.recommendedLocation, to.additionalData.rho, to.additionalData.theta, to.additionalData.course, metadata, segment);
             }
 
             if (to.additionalData.legType === LegType.CF) {
@@ -97,7 +97,7 @@ export class GuidanceManager {
 
             // FIXME VALeg should be implemented to give proper heading guidance
             if (to.additionalData.legType === LegType.CA || to.additionalData.legType === LegType.VA) {
-                const course = to.additionalData.vectorsCourse;
+                const course = to.additionalData.course;
                 const altitude = to.additionalData.vectorsAltitude;
                 const extraLength = (from.additionalData.runwayLength ?? 0) / (2 * 1852);
 
@@ -109,18 +109,19 @@ export class GuidanceManager {
                     return null;
                 }
 
-                const course = to.additionalData.vectorsCourse;
+                const course = to.additionalData.course;
 
                 return new CILeg(course, nextLeg, metadata, segment);
             }
 
             if (to.additionalData.legType === LegType.CR) {
-                const course = to.additionalData.vectorsCourse;
-                const origin = to.additionalData.origin as RawFacility;
+                // TODO clean this whole thing up
+                const course = to.additionalData.course;
                 const radial = to.additionalData.radial;
                 const theta = to.additionalData.theta;
+                const ident = WayPoint.formatIdentFromIcao(to.additionalData.recommendedIcao);
 
-                const originObj = { coordinates: { lat: origin.lat, long: origin.lon }, ident: origin.icao.substring(7, 12).trim(), theta };
+                const originObj = { coordinates: to.additionalData.recommendedLocation, ident, theta };
 
                 return new CRLeg(course, originObj, radial, metadata, segment);
             }

--- a/src/fmgc/src/guidance/lnav/LnavDriver.ts
+++ b/src/fmgc/src/guidance/lnav/LnavDriver.ts
@@ -243,7 +243,7 @@ export class LnavDriver implements GuidanceComponent {
                     }
 
                     // Track Angle Error
-                    const currentHeading = SimVar.GetSimVarValue('PLANE HEADING DEGREES MAGNETIC', 'Degrees');
+                    const currentHeading = SimVar.GetSimVarValue('PLANE HEADING DEGREES TRUE', 'Degrees');
                     const deltaHeading = MathUtils.diffAngle(currentHeading, heading);
 
                     // Update and take into account turn state; only guide using phi during a forced turn

--- a/src/fmgc/src/guidance/lnav/legs/CA.ts
+++ b/src/fmgc/src/guidance/lnav/legs/CA.ts
@@ -180,6 +180,6 @@ export class CALeg extends Leg {
     }
 
     get repr(): string {
-        return `CA(${this.course.toFixed(1)}°) TO ${Math.round(this.altitude)} FT`;
+        return `CA(${this.course.toFixed(1)}T) TO ${Math.round(this.altitude)} FT`;
     }
 }

--- a/src/fmgc/src/guidance/lnav/legs/CF.ts
+++ b/src/fmgc/src/guidance/lnav/legs/CF.ts
@@ -152,6 +152,6 @@ export class CFLeg extends XFLeg {
     }
 
     get repr(): string {
-        return `CF(${this.course.toFixed(1)}°) TO ${this.fix.ident}`;
+        return `CF(${this.course.toFixed(1)}T) TO ${this.fix.ident}`;
     }
 }

--- a/src/fmgc/src/guidance/lnav/legs/CI.ts
+++ b/src/fmgc/src/guidance/lnav/legs/CI.ts
@@ -162,6 +162,6 @@ export class CILeg extends Leg {
     }
 
     get repr(): string {
-        return `CI(${Math.trunc(this.course)}°)`;
+        return `CI(${Math.trunc(this.course)}T)`;
     }
 }

--- a/src/fmgc/src/guidance/lnav/legs/CR.ts
+++ b/src/fmgc/src/guidance/lnav/legs/CR.ts
@@ -154,6 +154,6 @@ export class CRLeg extends Leg {
     }
 
     get repr(): string {
-        return 'CR';
+        return `CR ${this.course}T to ${this.origin.ident}${this.origin.theta}`;
     }
 }

--- a/src/fmgc/src/guidance/lnav/legs/RF.ts
+++ b/src/fmgc/src/guidance/lnav/legs/RF.ts
@@ -49,7 +49,7 @@ export class RFLeg extends XFLeg {
         const bearingFrom = Avionics.Utils.computeGreatCircleHeading(this.center, this.from.infos.coordinates); // -90?
         const bearingTo = Avionics.Utils.computeGreatCircleHeading(this.center, this.to.infos.coordinates); // -90?
 
-        switch (to.additionalData.turnDirection) {
+        switch (to.turnDirection) {
         case 1: // left
             this.clockwise = false;
             this.angle = Avionics.Utils.clampAngle(bearingFrom - bearingTo);

--- a/src/fmgc/src/guidance/lnav/legs/VM.ts
+++ b/src/fmgc/src/guidance/lnav/legs/VM.ts
@@ -20,8 +20,7 @@ export class VMLeg extends Leg {
     predictedPath: PathVector[] = [];
 
     constructor(
-        public heading: DegreesMagnetic,
-        public course: DegreesTrue,
+        public heading: DegreesTrue,
         public readonly metadata: Readonly<LegMetadata>,
         segment: SegmentType,
     ) {
@@ -45,7 +44,7 @@ export class VMLeg extends Leg {
 
     getPathEndPoint(): Coordinates | undefined {
         return Avionics.Utils.bearingDistanceToCoordinates(
-            this.course,
+            this.heading,
             VM_LEG_SIZE,
             this.getPathStartPoint().lat,
             this.getPathStartPoint().long,
@@ -53,6 +52,8 @@ export class VMLeg extends Leg {
     }
 
     recomputeWithParameters(_isActive: boolean, _tas: Knots, _gs: Knots, _ppos: Coordinates, _trueTrack: DegreesTrue) {
+        // FIXME course based on predicted wind
+
         this.predictedPath.length = 0;
         this.predictedPath.push(
             {
@@ -112,6 +113,6 @@ export class VMLeg extends Leg {
     }
 
     get repr(): string {
-        return `VM(${this.heading.toFixed(1)}°)`;
+        return `VM(${this.heading.toFixed(1)}T)`;
     }
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Related to https://github.com/flybywiresim/a32nx/issues/7060

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Add a much more robust comparison to determine duplicate legs. This prevents legs from being incorrectly removed from some procedures.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before (Navigraph data):
![image](https://user-images.githubusercontent.com/9995998/166141009-6267d30a-b226-49cb-8138-498e5c3c5fd9.png)
![image](https://user-images.githubusercontent.com/9995998/166140996-d776cf57-cb9b-4652-bd5a-b3b32e16da1f.png)

After (Navigraph data):
![image](https://user-images.githubusercontent.com/9995998/166140862-b14bbed1-aaf6-47a4-887a-f4521db1763b.png)
![image](https://user-images.githubusercontent.com/9995998/166140914-9d8fa4a6-e5db-44c2-bc51-0ec7cb84573e.png)

Comparison (MSFS/Navblue):
![image](https://user-images.githubusercontent.com/9995998/166141296-5a3c0636-b7dd-46f4-98b1-da538e8b9348.png)
![image](https://user-images.githubusercontent.com/9995998/166141323-541c9352-37ec-455f-b079-9abd5ecbe68f.png)



## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Testing a selection of SIDs, STARs, and approaches (viewing in plan mode and an MCDU F-PLN should be sufficient). LPMA05 GOSG1E with Navigraph/Jeppesen data was the original problematic one, but please test other procedures to ensure they're still correct too.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
