### PR TITLE
fix: properly check onGround variable for speedtape

### DIFF
--- a/src/instruments/src/PFD/SpeedIndicator.tsx
+++ b/src/instruments/src/PFD/SpeedIndicator.tsx
@@ -161,7 +161,7 @@ export class AirspeedIndicator extends DisplayComponent<AirspeedIndicatorProps> 
 
     private setOutline() {
         let airspeedValue: number;
-        if (this.airSpeed.isFailureWarning() || (this.airSpeed.isNoComputedData() && !this.onGround)) {
+        if (this.airSpeed.isFailureWarning() || (this.airSpeed.isNoComputedData() && !this.onGround.get())) {
             airspeedValue = NaN;
         } else if (this.airSpeed.isNoComputedData()) {
             airspeedValue = 30;
@@ -255,11 +255,13 @@ export class AirspeedIndicator extends DisplayComponent<AirspeedIndicatorProps> 
         pf.on('leftMainGearCompressed').whenChanged().handle((g) => {
             this.leftMainGearCompressed = g;
             this.onGround.set(this.rightMainGearCompressed || g);
+            this.setOutline();
         });
 
         pf.on('rightMainGearCompressed').whenChanged().handle((g) => {
             this.rightMainGearCompressed = g;
             this.onGround.set(this.leftMainGearCompressed || g);
+            this.setOutline();
         });
 
         // showBars replacement


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
I changed `"onGround" to a subscription in the Speedtape in the last PR and forgot to update the check properly. Error is not directly visible but should be fixed either way

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Not needed IMO. Non visible change.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
