### PR TITLE
feat: inverted nose wheel steering axis

### DIFF
--- a/src/systems/a320_systems_wasm/src/nose_wheel_steering.rs
+++ b/src/systems/a320_systems_wasm/src/nose_wheel_steering.rs
@@ -49,7 +49,7 @@ pub(super) fn nose_wheel_steering(builder: &mut MsfsAspectBuilder) -> Result<(),
 
     builder.event_to_variable(
         "AXIS_STEERING_SET",
-        EventToVariableMapping::EventData32kPosition,
+        EventToVariableMapping::EventData32kPositionInverted,
         Variable::aspect("RAW_TILLER_HANDLE_POSITION"),
         |options| options.mask(),
     )?;
@@ -100,6 +100,8 @@ pub(super) fn nose_wheel_steering(builder: &mut MsfsAspectBuilder) -> Result<(),
             let rudder_pedal_position = values[1];
             let tiller_handle_position = values[2];
             let tiller_pedal_disconnect = to_bool(values[3]);
+
+            println!("WASM: raw tiller position: {:.2}", values[2]);
 
             if realistic_tiller_enabled {
                 // Convert tiller handle position to [-1;1], -1 is left

--- a/src/systems/a320_systems_wasm/src/nose_wheel_steering.rs
+++ b/src/systems/a320_systems_wasm/src/nose_wheel_steering.rs
@@ -101,8 +101,6 @@ pub(super) fn nose_wheel_steering(builder: &mut MsfsAspectBuilder) -> Result<(),
             let tiller_handle_position = values[2];
             let tiller_pedal_disconnect = to_bool(values[3]);
 
-            println!("WASM: raw tiller position: {:.2}", values[2]);
-
             if realistic_tiller_enabled {
                 // Convert tiller handle position to [-1;1], -1 is left
                 tiller_handle_position * 2. - 1.

--- a/src/systems/systems_wasm/src/aspects.rs
+++ b/src/systems/systems_wasm/src/aspects.rs
@@ -1,5 +1,6 @@
 use crate::{
-    f64_to_sim_connect_32k_pos, sim_connect_32k_pos_to_f64, MsfsVariableRegistry, Variable,
+    f64_to_sim_connect_32k_pos, sim_connect_32k_pos_inv_to_f64, sim_connect_32k_pos_to_f64,
+    MsfsVariableRegistry, Variable,
 };
 use enum_dispatch::enum_dispatch;
 use msfs::sim_connect::{SimConnect, SimConnectRecv, SIMCONNECT_OBJECT_ID_USER};
@@ -701,6 +702,9 @@ pub enum EventToVariableMapping {
     /// Maps the event data from a 32k position to an [f64].
     EventData32kPosition,
 
+    /// Maps the event data from a 32k position to an [f64] and inverts it.
+    EventData32kPositionInverted,
+
     /// When the event occurs, calls the function with event data and sets
     /// the variable to the returned value.
     EventDataToValue(fn(sys::DWORD) -> f64),
@@ -771,6 +775,9 @@ impl EventToVariable {
             EventToVariableMapping::Value(value) => value,
             EventToVariableMapping::EventDataRaw => e.data() as f64,
             EventToVariableMapping::EventData32kPosition => sim_connect_32k_pos_to_f64(e.data()),
+            EventToVariableMapping::EventData32kPositionInverted => {
+                sim_connect_32k_pos_inv_to_f64(e.data())
+            }
             EventToVariableMapping::EventDataToValue(func) => func(e.data()),
             EventToVariableMapping::CurrentValueToValue(func) => {
                 func(variables.read(&self.target).unwrap_or(0.))

--- a/src/systems/systems_wasm/src/lib.rs
+++ b/src/systems/systems_wasm/src/lib.rs
@@ -594,7 +594,13 @@ pub fn sim_connect_32k_pos_to_f64(sim_connect_axis_value: sys::DWORD) -> f64 {
     let casted_value = (sim_connect_axis_value as i32) as f64;
     let scaled_value =
         (casted_value + OFFSET_32KPOS_VAL_FROM_SIMCONNECT) / RANGE_32KPOS_VAL_FROM_SIMCONNECT;
-
+    scaled_value.min(1.).max(0.)
+}
+// Takes a 32k position type from simconnect, returns a value from scaled from 0 to 1 (inverted)
+pub fn sim_connect_32k_pos_inv_to_f64(sim_connect_axis_value: sys::DWORD) -> f64 {
+    let casted_value = -1. * (sim_connect_axis_value as i32) as f64;
+    let scaled_value =
+        (casted_value + OFFSET_32KPOS_VAL_FROM_SIMCONNECT) / RANGE_32KPOS_VAL_FROM_SIMCONNECT;
     scaled_value.min(1.).max(0.)
 }
 // Takes a [0:1] f64 and returns a simconnect 32k position type


### PR DESCRIPTION
## Summary of Changes
This PR inverts the nosewheel steering axis. The implementation right now is as described in the sim dialog, but as several users have reported it, other planes including the default ones implement it in the opposite direction.

## Testing instructions
- test if the nose wheel steering is still working, in the inverted way
- axis mixture 4 is not changed

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
