### PR TITLE
fix: only show warning due to enabled assistants when in cockpit

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_TipsManager.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_TipsManager.js
@@ -43,6 +43,10 @@ class A32NX_TipsManager {
     }
 
     checkAssistenceConfiguration() {
+        // only check when actually flying, otherwise return
+        if (SimVar.GetSimVarValue("CAMERA STATE", "Number") >= 10) {
+            return;
+        }
         const assistenceTakeOffEnabled = SimVar.GetSimVarValue("ASSISTANCE TAKEOFF ENABLED", "Bool");
         const assistenceLandingEnabled = SimVar.GetSimVarValue("ASSISTANCE LANDING ENABLED", "Bool");
         const assistenceAutotrimActive = SimVar.GetSimVarValue("AI AUTOTRIM ACTIVE", "Bool");


### PR DESCRIPTION
## Summary of Changes
This PR changes to code to show a warning of enabled assistant functions so that this does not happen in main menu and only when being in the cockpit.

## Testing instructions
- Tip should not appear in main menu

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
