### PR TITLE
feat(cdu): Wind Requests v1

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -248,6 +248,7 @@
 1. [MISC] Added custom Autobrake event for SimConnect - @aguther (Andreas Guther)
 1. [EWD] Fixed failures not re-triggering when resolved - @tricky_dicky (Richard Pilbery)
 1. [SOUND] Prevent autopilot disconnect from sounding on C+D spawn - @tricky_dicky (Richard Pilbery) and @saschl (saschl#9432)
+1. [MCDU] Allow Wind Request from Simbrief flight plan - @USA-RedDragon (Jacob McSwain)
 
 ## 0.7.0
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_WindPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_WindPage.js
@@ -202,7 +202,7 @@ class CDUWindPage {
         }
 
         const altitude = parseInt(elements[2]);
-        if (!isFinite(altitude) || altitude < 0 || altitude > 390) {
+        if (!isFinite(altitude) || altitude < 0 || altitude > 450) {
             return null;
         }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_WindPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_WindPage.js
@@ -290,16 +290,13 @@ class CDUWindPage {
 
     static WindRequest(mcdu, stage, _showPage) {
         getSimBriefOfp(mcdu, () => {}, () => {
+            const windData = [];
+            let lastAltitude = 0;
             switch (stage) {
                 case "CLB":
                     const clbWpts = mcdu.simbrief.navlog.filter((val) => val.stage === stage);
-                    if (clbWpts[clbWpts.length - 1].ident == "TOC") {
-                        clbWpts.pop(); // Remove TOC from CLB list
-                    }
 
                     // iterate through each clbWpt grabbing the wind data
-                    const windData = [];
-                    let lastAltitude = 0;
                     clbWpts.forEach((clbWpt, wptIdx) => {
                         if (wptIdx == 0) {
                             let altIdx = 0;
@@ -331,7 +328,7 @@ class CDUWindPage {
                             }
 
                             // Check that altitude isn't backtracking
-                            if (altitude > lastAltitude) {
+                            if (altitude > lastAltitude && lastAltitude <= clbWpt.altitude_feet) {
                                 const idx = (deltaPrevLevel > deltaThisLevel) ? levelIdx : levelIdx - 1;
 
                                 const idxAltitude = parseInt(clbWpt.wind_data.level[idx].altitude);
@@ -364,6 +361,7 @@ class CDUWindPage {
                             speed,
                             altitude,
                         });
+                        lastAltitude = altitude;
                     });
                     break;
                 case "DSC":


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Relates #7061

I'm tired of spending so much pre-start time entering wind manually 😢 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Two changes are in this PR:
1. Making the maximum MCDU wind profile maximum flight level higher than FL390. Specifically up to FL450.
2. This adds a workable wind requests system to the Wind/Temp MCDU screens. It uses the Simbrief data obtained with the flight plan. This should be workable to avoid a lot of manual data entry by pilots until further per-waypoint wind profile work can be completed. 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Mostly just coloring Wind Request, removing the inop, and adding a * on all 3 wind pages. Screenshots:

Old:
![image](https://user-images.githubusercontent.com/13051767/166904249-46c5d7a3-0a98-4d8b-9eb7-1104a8757147.png)
![image](https://user-images.githubusercontent.com/13051767/166904322-481f6fcc-1135-4269-aafc-a71689d9ed98.png)
![image](https://user-images.githubusercontent.com/13051767/166904413-879bca1f-a520-48c9-ab46-48707e8c05b7.png)


New:
![image](https://user-images.githubusercontent.com/13051767/166903228-10a02165-8276-424c-a2f0-f3514b6bdcec.png)
![image](https://user-images.githubusercontent.com/13051767/166903286-22d0456b-3390-4245-9654-16380b87a09f.png)
![image](https://user-images.githubusercontent.com/13051767/166903332-83531780-cd1a-4bdb-af25-4b88e76425d3.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

Honeywell 2009 Manual, from Table B-1, MCDU Data Format for changes to max FL entered from FL390->FL450:

![image](https://user-images.githubusercontent.com/13051767/167035548-e1e8edfd-92fd-4307-bdc3-1e1bb54249f4.png)
![image](https://user-images.githubusercontent.com/13051767/167035614-0368306a-1a7c-4660-b374-71e1399cd039.png)
![image](https://user-images.githubusercontent.com/13051767/167035617-5086e96b-22b1-4e1f-9b09-3cde90ff0712.png)


For the wind request color and star:
![image](https://user-images.githubusercontent.com/13051767/167035863-7b6baf61-7055-44e8-b4ad-67f1fa790cfb.png)

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
The most difficult part of this was constructing the correct altitudes for climb from Simbrief based on the closest flight plan waypoint altitudes. I'm down to help with per-waypoint work, I just don't know how that data should be stored in `mcdu.winds.cruise` and how affecting that structure might impact the FMS code. I'm happy to make any changes necessary. It's possible we want to extend the logic of closest altitude to descent across the STAR waypoints if we find it works well. This could be done as a part of per-waypoint work.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): USA-RedDragon#1776

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Flight levels >390 and <=450 should be able to be entered into the Wind/Temp screens.
2. Wind Request should grab TOC and TOD from Simbrief, as well as calculate out Climb from waypoint and wind profile altitudes.
3. There might be more testing required on really short flights or flights without SIDs to ensure that wind profiles for cruise are sane. I tested a few local airports such as KOKC/KTIK
4. The simbrief flight plan should be checked against the requested wind to ensure that it makes sense. Climb wind is calculated, Cruise wind is data from TOC, and Descent wind is from TOD. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
