### PR TITLE
feat(lgciu/sd): add LGCIU bus output, modify WHEEL page for LGCIUs

### DIFF
--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -2593,10 +2593,24 @@ In the variables below, {number} should be replaced with one item in the set: { 
       23    | LH gear downlocked
       24    | RH gear downlocked
       25    | Nose gear downlocked
-      26    | LH gear shock absorber not extended
-      27    | RH gear shock absorber not extended
-      28    | Nose gear shock absorber not extended
+      26    | LH gear shock absorber not extended (Treat GND PWR connected as on ground)
+      27    | RH gear shock absorber not extended (Treat GND PWR connected as on ground)
+      28    | Nose gear shock absorber not extended (Treat GND PWR connected as on ground)
       29    | Gear selected down (Lever Position)
+
+- A32NX_LGCIU_{number}_DISCRETE_WORD_2
+    - Discrete Data word 2 of the LGCIU bus output
+    - Arinc429<Discrete>
+    - {number}
+        - 1
+        - 2
+    - Bit   | Description
+      11    | LH & RH gear shock absorber compressed (Don't treat GND PWR connected as on ground)
+      12    | LH gear shock absorber compressed (Don't treat GND PWR connected as on ground)
+      13    | RH gear shock absorber compressed (Don't treat GND PWR connected as on ground)
+      14    | Nose gear shock absorber compressed (Don't treat GND PWR connected as on ground)
+      15    | LH & RH gear downlocked
+
 
 - A32NX_LGCIU_{number}_DISCRETE_WORD_3
     - Discrete Data word 3 of the LGCIU bus output

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -2571,6 +2571,49 @@ In the variables below, {number} should be replaced with one item in the set: { 
 
 ## Landing Gear (ATA 32)
 
+- A32NX_LGCIU_{number}_DISCRETE_WORD_1
+    - Discrete Data word 1 of the LGCIU bus output
+    - Arinc429<Discrete>
+    - {number}
+        - 1
+        - 2
+    - Bit   | Description
+      11    | LH gear not locked up and not selected down
+      12    | RH gear not locked up and not selected down
+      13    | Nose gear not locked up and not selected down
+      14    | LH gear not locked down and selected down
+      15    | RH gear not locked down and selected down
+      16    | Nose gear not locked down and selected down
+      17    | LH gear door not uplocked
+      18    | RH gear door not uplocked
+      19    | Nose gear door not uplocked
+      20    | LH gear uplock locked and gear locked down
+      21    | RH gear uplock locked and gear locked down
+      22    | Nose gear uplock locked and gear locked down
+      23    | LH gear downlocked
+      24    | RH gear downlocked
+      25    | Nose gear downlocked
+      26    | LH gear shock absorber not extended
+      27    | RH gear shock absorber not extended
+      28    | Nose gear shock absorber not extended
+      29    | Gear selected down (Lever Position)
+
+- A32NX_LGCIU_{number}_DISCRETE_WORD_3
+    - Discrete Data word 3 of the LGCIU bus output
+    - Arinc429<Discrete>
+    - {number}
+        - 1
+        - 2
+    - Bit   | Description
+      11    | LH gear not locked up
+      12    | RH gear not locked up
+      13    | Nose gear not locked up
+      14    | Gear selected up (Lever Position)
+      25    | LH gear door fully open
+      26    | RH gear door fully open
+      27    | LH Nose gear door fully open
+      28    | RH Nose gear door fully open
+
 - A32NX_LGCIU_{number}_{gear}_GEAR_COMPRESSED
     - Indicates if the shock absorber is compressed (not fully extended)
     - Bool

--- a/src/instruments/src/SD/Pages/Wheel/Wheel.tsx
+++ b/src/instruments/src/SD/Pages/Wheel/Wheel.tsx
@@ -1,8 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { render } from '@instruments/common/index';
 import classNames from 'classnames';
 import { SimVarProvider, useSimVar } from '@instruments/common/simVars';
 import { setIsEcamPage } from '@instruments/common/defaults';
+import { useArinc429Var } from '@instruments/common/arinc429';
+import { Arinc429Word } from '@shared/arinc429';
 import { PageTitle } from '../../Common/PageTitle';
 import './Wheel.scss';
 import { HydraulicsProvider, useHydraulics } from '../../Common/HydraulicsProvider';
@@ -25,6 +27,11 @@ export const WheelPage = () => {
 
     const maxTemperatureIndex = temperatures.reduce((maxIndex, element, index, array) => (element > array[maxIndex] ? index : maxIndex), 0);
 
+    const lgciu1DiscreteWord1 = useArinc429Var('L:A32NX_LGCIU_1_DISCRETE_WORD_1');
+    const lgciu2DiscreteWord1 = useArinc429Var('L:A32NX_LGCIU_2_DISCRETE_WORD_1');
+    const lgciu1DiscreteWord3 = useArinc429Var('L:A32NX_LGCIU_1_DISCRETE_WORD_3');
+    const lgciu2DiscreteWord3 = useArinc429Var('L:A32NX_LGCIU_2_DISCRETE_WORD_3');
+
     return (
         <EcamPage name="main-wheel">
             <PageTitle x={6} y={115} text="WHEEL" />
@@ -33,7 +40,14 @@ export const WheelPage = () => {
                 <Spoilers x={103} y={64} />
 
                 <NoseWheelSteering x={205} y={200} />
-                <LandingGearCtl x={255} y={263} />
+                <LandingGearCtl
+                    x={255}
+                    y={263}
+                    lgciu1DiscreteWord1={lgciu1DiscreteWord1}
+                    lgciu2DiscreteWord1={lgciu2DiscreteWord1}
+                    lgciu1DiscreteWord3={lgciu1DiscreteWord3}
+                    lgciu2DiscreteWord3={lgciu2DiscreteWord3}
+                />
                 <AntiSkid x={300} y={312} />
 
                 <NormalBraking x={220} y={333} />
@@ -42,7 +56,15 @@ export const WheelPage = () => {
 
             <AutoBrake x={300} y={460} />
 
-            <Gear x={18} y={210} location="left" />
+            <Gear
+                x={18}
+                y={210}
+                location="left"
+                lgciu1DiscreteWord1={lgciu1DiscreteWord1}
+                lgciu2DiscreteWord1={lgciu2DiscreteWord1}
+                lgciu1DiscreteWord3={lgciu1DiscreteWord3}
+                lgciu2DiscreteWord3={lgciu2DiscreteWord3}
+            />
             <Wheels
                 x={12}
                 y={318}
@@ -50,11 +72,27 @@ export const WheelPage = () => {
                 right={{ number: 2, temperature: temperatures[1], hottest: maxTemperatureIndex === 1 }}
             />
 
-            <Gear x={210} y={107} location="center" />
+            <Gear
+                x={210}
+                y={107}
+                location="center"
+                lgciu1DiscreteWord1={lgciu1DiscreteWord1}
+                lgciu2DiscreteWord1={lgciu2DiscreteWord1}
+                lgciu1DiscreteWord3={lgciu1DiscreteWord3}
+                lgciu2DiscreteWord3={lgciu2DiscreteWord3}
+            />
             <WheelArch x={298} y={370} type="bottom" />
             <WheelArch x={406} y={370} type="bottom" />
 
-            <Gear x={401} y={210} location="right" />
+            <Gear
+                x={401}
+                y={210}
+                location="right"
+                lgciu1DiscreteWord1={lgciu1DiscreteWord1}
+                lgciu2DiscreteWord1={lgciu2DiscreteWord1}
+                lgciu1DiscreteWord3={lgciu1DiscreteWord3}
+                lgciu2DiscreteWord3={lgciu2DiscreteWord3}
+            />
             <Wheels
                 x={436}
                 y={318}
@@ -95,13 +133,29 @@ const AntiSkid = ({ x, y }: ComponentPositionProps) => {
     ) : null;
 };
 
-const LandingGearCtl = ({ x, y }: ComponentPositionProps) => {
-    const [landingGearLeft] = useSimVar('GEAR LEFT POSITION', 'Percent Over 100', maxStaleness);
-    const [landingGearCenter] = useSimVar('GEAR CENTER POSITION', 'Percent Over 100', maxStaleness);
-    const [landingGearRight] = useSimVar('GEAR RIGHT POSITION', 'Percent Over 100', maxStaleness);
+interface LandingGearCtlProps extends ComponentPositionProps {
+    lgciu1DiscreteWord1: Arinc429Word,
+    lgciu2DiscreteWord1: Arinc429Word,
+    lgciu1DiscreteWord3: Arinc429Word,
+    lgciu2DiscreteWord3: Arinc429Word,
+}
 
-    const landingGearInTransit = landingGearLeft > 0 && landingGearLeft < 1
-        || landingGearCenter > 0 && landingGearCenter < 1 || landingGearRight > 0 && landingGearRight < 1;
+const LandingGearCtl = ({ x, y, lgciu1DiscreteWord1, lgciu2DiscreteWord1, lgciu1DiscreteWord3, lgciu2DiscreteWord3 }: LandingGearCtlProps) => {
+    const anyLgciuValid = lgciu1DiscreteWord1.isNormalOperation() || lgciu2DiscreteWord1.isNormalOperation();
+
+    const gearLeverUp = lgciu1DiscreteWord3.getBitValue(14) || lgciu2DiscreteWord3.getBitValue(14);
+    const gearLeverDown = lgciu1DiscreteWord1.getBitValue(29) || lgciu2DiscreteWord1.getBitValue(29);
+
+    const leftMainGearDownlocked = lgciu1DiscreteWord1.getBitValue(23) || lgciu2DiscreteWord1.getBitValue(23);
+    const rightMainGearDownlocked = lgciu1DiscreteWord1.getBitValue(24) || lgciu2DiscreteWord1.getBitValue(24);
+    const noseGearDownlocked = lgciu1DiscreteWord1.getBitValue(25) || lgciu2DiscreteWord1.getBitValue(25);
+
+    const leftMainGearNotUplocked = lgciu1DiscreteWord3.getBitValue(11) || lgciu2DiscreteWord3.getBitValue(11);
+    const rightMainGearNotUplocked = lgciu1DiscreteWord3.getBitValue(12) || lgciu2DiscreteWord3.getBitValue(12);
+    const noseGearNotUplocked = lgciu1DiscreteWord3.getBitValue(13) || lgciu2DiscreteWord3.getBitValue(13);
+
+    const landingGearInTransit = anyLgciuValid && ((gearLeverDown && (!leftMainGearDownlocked || !rightMainGearDownlocked || !noseGearDownlocked))
+                                || (gearLeverUp && (leftMainGearNotUplocked || rightMainGearNotUplocked || noseGearNotUplocked)));
 
     return landingGearInTransit ? (
         <text id="center-lg-ctl" x={x} y={y} className="big-text align-left color-amber">L/G CTL</text>
@@ -178,43 +232,109 @@ type GearLocation = 'left' | 'center' | 'right';
 
 interface GearDoorProps extends ComponentPositionProps {
     location: GearLocation,
-    inTransit: boolean,
+    lgciu1DiscreteWord1: Arinc429Word,
+    lgciu2DiscreteWord1: Arinc429Word,
+    lgciu1DiscreteWord3: Arinc429Word,
+    lgciu2DiscreteWord3: Arinc429Word,
 }
 
-const GearDoor = ({ x, y, location, inTransit }: GearDoorProps) => {
+const GearDoor = ({ x, y, location, lgciu1DiscreteWord1, lgciu2DiscreteWord1, lgciu1DiscreteWord3, lgciu2DiscreteWord3 }: GearDoorProps) => {
+    const anyLgciuValid = lgciu1DiscreteWord1.isNormalOperation() || lgciu2DiscreteWord1.isNormalOperation();
+
     if (location === 'center') {
+        const leftDoorFullyOpen = lgciu1DiscreteWord3.getBitValue(27) || lgciu2DiscreteWord3.getBitValue(27);
+        const rightDoorFullyOpen = lgciu1DiscreteWord3.getBitValue(28) || lgciu2DiscreteWord3.getBitValue(28);
+        const doorNotLockedUp = lgciu1DiscreteWord1.getBitValue(19) || lgciu2DiscreteWord1.getBitValue(19);
+
+        let leftGearDoorSymbol: JSX.Element | null;
+        let rightGearDoorSymbol: JSX.Element | null;
+        if (anyLgciuValid && !doorNotLockedUp && !leftDoorFullyOpen) {
+            leftGearDoorSymbol = <line className="gear-door-line" x1={19.48} x2={48.12} y1={0} y2={0} />;
+        } else if (anyLgciuValid && doorNotLockedUp && leftDoorFullyOpen) {
+            leftGearDoorSymbol = <line className="gear-door-in-transit-line" x1={15.73} x2={9.73} y1={3} y2={27.16} />;
+        } else if (anyLgciuValid && doorNotLockedUp && !leftDoorFullyOpen) {
+            leftGearDoorSymbol = (
+                <line
+                    className="gear-door-in-transit-line"
+                    transform={`rotate(${-45},${15.73},3)`}
+                    x1={15.73}
+                    x2={9.73}
+                    y1={3}
+                    y2={27.16}
+                />
+            );
+        } else {
+            leftGearDoorSymbol = <text x={24} y={3} className="color-amber" fontSize={17}>XX</text>;
+        }
+
+        if (anyLgciuValid && !doorNotLockedUp && !rightDoorFullyOpen) {
+            rightGearDoorSymbol = <line className="gear-door-line" x1={73.58} x2={104.22} y1={0} y2={0} />;
+        } else if (anyLgciuValid && doorNotLockedUp && rightDoorFullyOpen) {
+            rightGearDoorSymbol = <line className="gear-door-in-transit-line" x1={108.04} x2={114.04} y1={3} y2={27.16} />;
+        } else if (anyLgciuValid && doorNotLockedUp && !rightDoorFullyOpen) {
+            rightGearDoorSymbol = (
+                <line
+                    className="gear-door-in-transit-line"
+                    transform={`rotate(${45},${108.04},3)`}
+                    x1={108.04}
+                    x2={114.04}
+                    y1={3}
+                    y2={27.16}
+                />
+            );
+        } else {
+            rightGearDoorSymbol = <text x={79} y={3} className="color-amber" fontSize={17}>XX</text>;
+        }
+
         return (
             <SvgGroup x={x} y={y}>
                 <path className="gear-door-side-line" d="m 0 0 h 13.41" />
                 <path className="gear-door-side-line" d="m 111.31 0 h 13.41" />
 
-                {inTransit
-                    ? (
-                        <>
-                            <line className="gear-door-in-transit-line" x1={15.73} x2={9.73} y1={3} y2={27.16} />
-                            <line className="gear-door-in-transit-line" x1={108.04} x2={114.04} y1={3} y2={27.16} />
-                        </>
-                    )
-                    : (
-                        <>
-                            <line className="gear-door-line" x1={19.48} x2={48.12} y1={0} y2={0} />
-                            <line className="gear-door-line" x1={73.58} x2={104.22} y1={0} y2={0} />
-                        </>
-                    )}
+                {leftGearDoorSymbol}
+                {rightGearDoorSymbol}
 
                 <GearDoorJoint x={15.73} y={0} />
                 <GearDoorJoint x={108.04} y={0} />
             </SvgGroup>
         );
     }
+    let doorFullyOpen: boolean;
+    let doorNotLockedUp: boolean;
+    if (location === 'left') {
+        doorFullyOpen = lgciu1DiscreteWord3.getBitValue(25) || lgciu2DiscreteWord3.getBitValue(25);
+        doorNotLockedUp = lgciu1DiscreteWord1.getBitValue(17) || lgciu2DiscreteWord1.getBitValue(17);
+    } else {
+        doorFullyOpen = lgciu1DiscreteWord3.getBitValue(26) || lgciu2DiscreteWord3.getBitValue(26);
+        doorNotLockedUp = lgciu1DiscreteWord1.getBitValue(18) || lgciu2DiscreteWord1.getBitValue(18);
+    }
+
+    let gearDoorSymbol: JSX.Element | null;
+    if (anyLgciuValid && !doorNotLockedUp && !doorFullyOpen) {
+        gearDoorSymbol = <line className="gear-door-line" x1={23.35} x2={100.5} y1={0} y2={0} />;
+    } else if (anyLgciuValid && doorNotLockedUp && doorFullyOpen) {
+        gearDoorSymbol = <line className="gear-door-in-transit-line" x1={location === 'left' ? 103.01 : 21.69} x2={location === 'left' ? 112.33 : 12.37} y1={3} y2={70} />;
+    } else if (anyLgciuValid && doorNotLockedUp && !doorFullyOpen) {
+        gearDoorSymbol = (
+            <line
+                className="gear-door-in-transit-line"
+                transform={`rotate(${location === 'left' ? 45 : -45},${location === 'left' ? 103.01 : 21.69},3)`}
+                x1={location === 'left' ? 103.01 : 21.69}
+                x2={location === 'left' ? 112.33 : 12.37}
+                y1={3}
+                y2={70}
+            />
+        );
+    } else {
+        gearDoorSymbol = <text x={51} y={5} className="color-amber" fontSize={17}>XX</text>;
+    }
+
     return (
         <SvgGroup x={x} y={y}>
             <path className="gear-door-side-line" d="m0 0 h17.91" />
             <path className="gear-door-side-line" d="m106.43 0 h17.91" />
 
-            {inTransit
-                ? <line className="gear-door-in-transit-line" x1={location === 'left' ? 103.01 : 21.69} x2={location === 'left' ? 112.33 : 12.37} y1={3} y2={70} />
-                : <line className="gear-door-line" x1={23.35} x2={100.5} y1={0} y2={0} />}
+            {gearDoorSymbol}
 
             <GearDoorJoint x={location === 'left' ? 103.01 : 21.13} y={0} />
         </SvgGroup>
@@ -222,69 +342,130 @@ const GearDoor = ({ x, y, location, inTransit }: GearDoorProps) => {
 };
 
 interface LandingGearPositionIndicatorsProps extends ComponentPositionProps {
-    inTransit: boolean,
+    location: GearLocation,
+    lgciu1DiscreteWord1: Arinc429Word,
+    lgciu2DiscreteWord1: Arinc429Word,
+    lgciu1DiscreteWord3: Arinc429Word,
+    lgciu2DiscreteWord3: Arinc429Word,
 }
 
-const LandingGearPositionIndicators = ({ x, y, inTransit }: LandingGearPositionIndicatorsProps) => (
-    <SvgGroup x={x} y={y} className="gear-lgcius">
-        <g className={`shape gear-lgciu-1 color-${!inTransit ? 'green' : 'red'}`}>
-            <polygon points="0,0 22,0 22,29" />
-            <path d="m 6 0 v 8" />
-            <path d="m 11 0 v 14" />
-            <path d="m 16.5 0 v 22" />
-        </g>
+const LandingGearPositionIndicators = ({ x, y, location, lgciu1DiscreteWord1, lgciu2DiscreteWord1, lgciu1DiscreteWord3, lgciu2DiscreteWord3 }: LandingGearPositionIndicatorsProps) => {
+    const lgciu1DataValid = lgciu1DiscreteWord1.isNormalOperation();
+    const lgciu2DataValid = lgciu2DiscreteWord1.isNormalOperation();
 
-        <g className={`shape gear-lgciu-2 color-${!inTransit ? 'green' : 'red'}`}>
-            <polygon points="30,0 52,0 30,29" />
-            <path d="m 36 0 v 22" />
-            <path d="m 41 0 v 14" />
-            <path d="m 46 0 v 8" />
-        </g>
-        <g className="shape gear-failed-lgicu-1">
-            <path d="m 0 0 h 22" />
+    let lgciu1GearNotUplocked: boolean;
+    let lgciu2GearNotUplocked: boolean;
+    let lgciu1GearDownlocked: boolean;
+    let lgciu2GearDownlocked: boolean;
+    let upLockFlagShown = lgciu1DataValid && lgciu2DataValid;
+    if (location === 'left') {
+        lgciu1GearNotUplocked = lgciu1DiscreteWord3.getBitValue(11);
+        lgciu2GearNotUplocked = lgciu2DiscreteWord3.getBitValue(11);
+        lgciu1GearDownlocked = lgciu1DiscreteWord1.getBitValue(23);
+        lgciu2GearDownlocked = lgciu2DiscreteWord1.getBitValue(23);
+        upLockFlagShown = upLockFlagShown && lgciu1DiscreteWord1.getBitValue(20) && lgciu1DiscreteWord1.getBitValue(20);
+    } else if (location === 'right') {
+        lgciu1GearNotUplocked = lgciu1DiscreteWord3.getBitValue(12);
+        lgciu2GearNotUplocked = lgciu2DiscreteWord3.getBitValue(12);
+        lgciu1GearDownlocked = lgciu1DiscreteWord1.getBitValue(24);
+        lgciu2GearDownlocked = lgciu2DiscreteWord1.getBitValue(24);
+        upLockFlagShown = upLockFlagShown && lgciu1DiscreteWord1.getBitValue(21) && lgciu1DiscreteWord1.getBitValue(21);
+    } else {
+        lgciu1GearNotUplocked = lgciu1DiscreteWord3.getBitValue(13);
+        lgciu2GearNotUplocked = lgciu2DiscreteWord3.getBitValue(13);
+        lgciu1GearDownlocked = lgciu1DiscreteWord1.getBitValue(25);
+        lgciu2GearDownlocked = lgciu2DiscreteWord1.getBitValue(25);
+        upLockFlagShown = upLockFlagShown && lgciu1DiscreteWord1.getBitValue(22) && lgciu1DiscreteWord1.getBitValue(22);
+    }
 
-            <text className="gear-failed-lgciu-xx" x={13} y={16} fontSize={17}>XX</text>
-        </g>
-
-        <g className="shape gear-failed-lgicu-2">
-            <path d="m 30 0 h 22" />
-
-            <text className="gear-failed-lgciu-xx" x={39} y={16} fontSize={17}>XX</text>
-        </g>
-    </SvgGroup>
-);
-
-interface GearProps extends ComponentPositionProps {
-    location: GearLocation
-}
-
-const Gear = ({ x, y, location }: GearProps) => {
-    const [landingGearPosition] = useSimVar(`GEAR ${location.toUpperCase()} POSITION`, 'Percent Over 100', maxStaleness);
-
-    const [status, setStatus] = useState({
-        inTransit: false,
-        positionIndicatorVisible: false,
-    });
-
-    useEffect(() => {
-        const isUp = landingGearPosition === 0;
-        const isDown = landingGearPosition === 1;
-
-        setStatus({
-            inTransit: !isDown && !isUp && ((landingGearPosition >= 0.1 && landingGearPosition <= 0.9) || status.inTransit),
-            positionIndicatorVisible: !isUp && (landingGearPosition >= 0.1 || status.positionIndicatorVisible),
-        });
-    }, [landingGearPosition]);
+    let lgciu1Color = '';
+    let lgciu2Color = '';
+    if (lgciu1GearDownlocked && lgciu1GearNotUplocked) {
+        lgciu1Color = 'green';
+    } else if (!lgciu1GearDownlocked && lgciu1GearNotUplocked) {
+        lgciu1Color = 'red';
+    }
+    if (lgciu2GearDownlocked && lgciu2GearNotUplocked) {
+        lgciu2Color = 'green';
+    } else if (!lgciu2GearDownlocked && lgciu2GearNotUplocked) {
+        lgciu2Color = 'red';
+    }
 
     return (
-        <g transform="scale(1.1)">
-            <SvgGroup x={x} y={y}>
-                <GearDoor x={0} y={0} location={location} inTransit={status.inTransit} />
-                { status.positionIndicatorVisible ? <LandingGearPositionIndicators x={35} y={7} inTransit={status.inTransit} /> : null }
-            </SvgGroup>
-        </g>
+        <SvgGroup x={x} y={y} className="gear-lgcius">
+            {(lgciu1DataValid && lgciu1GearNotUplocked) && (
+                <g className={`shape gear-lgciu-1 color-${lgciu1Color}`}>
+                    <polygon points="0,0 22,0 22,29" />
+                    <path d="m 6 0 v 8" />
+                    <path d="m 11 0 v 14" />
+                    <path d="m 16.5 0 v 22" />
+                </g>
+            )}
+
+            {(lgciu2DataValid && lgciu2GearNotUplocked) && (
+                <g className={`shape gear-lgciu-2 color-${lgciu2Color}`}>
+                    <polygon points="30,0 52,0 30,29" />
+                    <path d="m 36 0 v 22" />
+                    <path d="m 41 0 v 14" />
+                    <path d="m 46 0 v 8" />
+                </g>
+            )}
+
+            {!lgciu1DataValid && (
+                <g className="color-amber">
+                    <path d="m 0 0 h 22" className="shape" />
+
+                    <text x={1} y={16} fontSize={17}>XX</text>
+                </g>
+            )}
+
+            {!lgciu2DataValid && (
+                <g className="color-amber">
+                    <path d="m 30 0 h 22" className="shape" />
+
+                    <text x={31} y={16} fontSize={17}>XX</text>
+                </g>
+            )}
+
+            {upLockFlagShown && (
+                <text className="color-amber" x={-10} y={-18} fontSize={17}>UP LOCK</text>
+            )}
+        </SvgGroup>
     );
 };
+
+interface GearProps extends ComponentPositionProps {
+    location: GearLocation,
+    lgciu1DiscreteWord1: Arinc429Word,
+    lgciu2DiscreteWord1: Arinc429Word,
+    lgciu1DiscreteWord3: Arinc429Word,
+    lgciu2DiscreteWord3: Arinc429Word,
+}
+
+const Gear = ({ x, y, location, lgciu1DiscreteWord1, lgciu2DiscreteWord1, lgciu1DiscreteWord3, lgciu2DiscreteWord3 }: GearProps) => (
+    <g transform="scale(1.1)">
+        <SvgGroup x={x} y={y}>
+            <GearDoor
+                x={0}
+                y={0}
+                location={location}
+                lgciu1DiscreteWord1={lgciu1DiscreteWord1}
+                lgciu2DiscreteWord1={lgciu2DiscreteWord1}
+                lgciu1DiscreteWord3={lgciu1DiscreteWord3}
+                lgciu2DiscreteWord3={lgciu2DiscreteWord3}
+            />
+            <LandingGearPositionIndicators
+                x={35}
+                y={7}
+                location={location}
+                lgciu1DiscreteWord1={lgciu1DiscreteWord1}
+                lgciu2DiscreteWord1={lgciu2DiscreteWord1}
+                lgciu1DiscreteWord3={lgciu1DiscreteWord3}
+                lgciu2DiscreteWord3={lgciu2DiscreteWord3}
+            />
+        </SvgGroup>
+    </g>
+);
 
 interface WheelArchProps extends ComponentPositionProps {
     type: 'top' | 'bottom',

--- a/src/instruments/src/SD/Pages/Wheel/Wheel.tsx
+++ b/src/instruments/src/SD/Pages/Wheel/Wheel.tsx
@@ -357,19 +357,19 @@ const LandingGearPositionIndicators = ({ x, y, location, lgciu1DiscreteWord1, lg
         lgciu2GearNotUplocked = lgciu2DiscreteWord3.getBitValue(11);
         lgciu1GearDownlocked = lgciu1DiscreteWord1.getBitValue(23);
         lgciu2GearDownlocked = lgciu2DiscreteWord1.getBitValue(23);
-        upLockFlagShown = upLockFlagShown && lgciu1DiscreteWord1.getBitValue(20) && lgciu1DiscreteWord1.getBitValue(20);
+        upLockFlagShown = upLockFlagShown && lgciu1DiscreteWord1.getBitValue(20) && lgciu2DiscreteWord1.getBitValue(20);
     } else if (location === 'right') {
         lgciu1GearNotUplocked = lgciu1DiscreteWord3.getBitValue(12);
         lgciu2GearNotUplocked = lgciu2DiscreteWord3.getBitValue(12);
         lgciu1GearDownlocked = lgciu1DiscreteWord1.getBitValue(24);
         lgciu2GearDownlocked = lgciu2DiscreteWord1.getBitValue(24);
-        upLockFlagShown = upLockFlagShown && lgciu1DiscreteWord1.getBitValue(21) && lgciu1DiscreteWord1.getBitValue(21);
+        upLockFlagShown = upLockFlagShown && lgciu1DiscreteWord1.getBitValue(21) && lgciu2DiscreteWord1.getBitValue(21);
     } else {
         lgciu1GearNotUplocked = lgciu1DiscreteWord3.getBitValue(13);
         lgciu2GearNotUplocked = lgciu2DiscreteWord3.getBitValue(13);
         lgciu1GearDownlocked = lgciu1DiscreteWord1.getBitValue(25);
         lgciu2GearDownlocked = lgciu2DiscreteWord1.getBitValue(25);
-        upLockFlagShown = upLockFlagShown && lgciu1DiscreteWord1.getBitValue(22) && lgciu1DiscreteWord1.getBitValue(22);
+        upLockFlagShown = upLockFlagShown && lgciu1DiscreteWord1.getBitValue(22) && lgciu2DiscreteWord1.getBitValue(22);
     }
 
     let lgciu1Color = '';

--- a/src/instruments/src/SD/Pages/Wheel/Wheel.tsx
+++ b/src/instruments/src/SD/Pages/Wheel/Wheel.tsx
@@ -45,8 +45,6 @@ export const WheelPage = () => {
                     y={263}
                     lgciu1DiscreteWord1={lgciu1DiscreteWord1}
                     lgciu2DiscreteWord1={lgciu2DiscreteWord1}
-                    lgciu1DiscreteWord3={lgciu1DiscreteWord3}
-                    lgciu2DiscreteWord3={lgciu2DiscreteWord3}
                 />
                 <AntiSkid x={300} y={312} />
 
@@ -136,26 +134,22 @@ const AntiSkid = ({ x, y }: ComponentPositionProps) => {
 interface LandingGearCtlProps extends ComponentPositionProps {
     lgciu1DiscreteWord1: Arinc429Word,
     lgciu2DiscreteWord1: Arinc429Word,
-    lgciu1DiscreteWord3: Arinc429Word,
-    lgciu2DiscreteWord3: Arinc429Word,
 }
 
-const LandingGearCtl = ({ x, y, lgciu1DiscreteWord1, lgciu2DiscreteWord1, lgciu1DiscreteWord3, lgciu2DiscreteWord3 }: LandingGearCtlProps) => {
+const LandingGearCtl = ({ x, y, lgciu1DiscreteWord1, lgciu2DiscreteWord1 }: LandingGearCtlProps) => {
     const anyLgciuValid = lgciu1DiscreteWord1.isNormalOperation() || lgciu2DiscreteWord1.isNormalOperation();
 
-    const gearLeverUp = lgciu1DiscreteWord3.getBitValue(14) || lgciu2DiscreteWord3.getBitValue(14);
-    const gearLeverDown = lgciu1DiscreteWord1.getBitValue(29) || lgciu2DiscreteWord1.getBitValue(29);
+    const leftMainGearNotDownlockedAndSelectedDown = lgciu1DiscreteWord1.getBitValue(14) || lgciu2DiscreteWord1.getBitValue(14);
+    const rightMainGearNotDownlockedAndSelectedDown = lgciu1DiscreteWord1.getBitValue(15) || lgciu2DiscreteWord1.getBitValue(15);
+    const noseGearNotDownlockedAndSelectedDown = lgciu1DiscreteWord1.getBitValue(16) || lgciu2DiscreteWord1.getBitValue(16);
 
-    const leftMainGearDownlocked = lgciu1DiscreteWord1.getBitValue(23) || lgciu2DiscreteWord1.getBitValue(23);
-    const rightMainGearDownlocked = lgciu1DiscreteWord1.getBitValue(24) || lgciu2DiscreteWord1.getBitValue(24);
-    const noseGearDownlocked = lgciu1DiscreteWord1.getBitValue(25) || lgciu2DiscreteWord1.getBitValue(25);
+    const leftMainGearNotUplockedAndNotSelectedDown = lgciu1DiscreteWord1.getBitValue(11) || lgciu2DiscreteWord1.getBitValue(11);
+    const rightMainGearNotUplockedAndNotSelectedDown = lgciu1DiscreteWord1.getBitValue(12) || lgciu2DiscreteWord1.getBitValue(12);
+    const noseGearNotUplockedAndNotSelectedDown = lgciu1DiscreteWord1.getBitValue(13) || lgciu2DiscreteWord1.getBitValue(13);
 
-    const leftMainGearNotUplocked = lgciu1DiscreteWord3.getBitValue(11) || lgciu2DiscreteWord3.getBitValue(11);
-    const rightMainGearNotUplocked = lgciu1DiscreteWord3.getBitValue(12) || lgciu2DiscreteWord3.getBitValue(12);
-    const noseGearNotUplocked = lgciu1DiscreteWord3.getBitValue(13) || lgciu2DiscreteWord3.getBitValue(13);
-
-    const landingGearInTransit = anyLgciuValid && ((gearLeverDown && (!leftMainGearDownlocked || !rightMainGearDownlocked || !noseGearDownlocked))
-                                || (gearLeverUp && (leftMainGearNotUplocked || rightMainGearNotUplocked || noseGearNotUplocked)));
+    const landingGearInTransit = anyLgciuValid && (leftMainGearNotDownlockedAndSelectedDown || rightMainGearNotDownlockedAndSelectedDown
+                                                    || noseGearNotDownlockedAndSelectedDown || leftMainGearNotUplockedAndNotSelectedDown
+                                                    || rightMainGearNotUplockedAndNotSelectedDown || noseGearNotUplockedAndNotSelectedDown);
 
     return landingGearInTransit ? (
         <text id="center-lg-ctl" x={x} y={y} className="big-text align-left color-amber">L/G CTL</text>

--- a/src/shared/src/arinc429.ts
+++ b/src/shared/src/arinc429.ts
@@ -67,4 +67,12 @@ export class Arinc429Word {
     valueOr(defaultValue: number) {
         return this.isNormalOperation() ? this.value : defaultValue;
     }
+
+    getBitValue(bit: number): boolean {
+        return ((this.value >> (bit - 1)) & 1) !== 0;
+    }
+
+    getBitValueOr(bit: number, defaultValue: boolean): boolean {
+        return this.isNormalOperation() ? ((this.value >> (bit - 1)) & 1) !== 0 : defaultValue;
+    }
 }

--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use crate::{
     failures::{Failure, FailureType},
-    shared::arinc429::{arinc429_to_f64, set_arinc429_bit, Arinc429Word, SignStatus},
+    shared::arinc429::{Arinc429Word, SignStatus},
     shared::{
         ElectricalBusType, ElectricalBuses, GearWheel, LandingGearHandle, LgciuDoorPosition,
         LgciuGearControl, LgciuGearExtension, LgciuId, LgciuInterface, LgciuWeightOnWheels,
@@ -762,66 +762,44 @@ impl LandingGearControlInterfaceUnit {
             Arinc429Word::new(0., SignStatus::FailureWarning)
         } else {
             let mut word = Arinc429Word::new(0., SignStatus::NormalOperation);
-            set_arinc429_bit(
-                &mut word,
+            word.set_bit(
                 11,
                 !self.sensor_inputs.left_gear_up_and_locked && !self.gear_handle_is_down(),
             );
-            set_arinc429_bit(
-                &mut word,
+            word.set_bit(
                 12,
                 !self.sensor_inputs.right_gear_up_and_locked && !self.gear_handle_is_down(),
             );
-            set_arinc429_bit(
-                &mut word,
+            word.set_bit(
                 13,
                 !self.sensor_inputs.nose_gear_up_and_locked && !self.gear_handle_is_down(),
             );
-            set_arinc429_bit(
-                &mut word,
+            word.set_bit(
                 14,
                 !self.sensor_inputs.left_gear_down_and_locked && self.gear_handle_is_down(),
             );
-            set_arinc429_bit(
-                &mut word,
+            word.set_bit(
                 15,
                 !self.sensor_inputs.right_gear_down_and_locked && self.gear_handle_is_down(),
             );
-            set_arinc429_bit(
-                &mut word,
+            word.set_bit(
                 16,
                 !self.sensor_inputs.nose_gear_down_and_locked && self.gear_handle_is_down(),
             );
-            set_arinc429_bit(&mut word, 17, !self.sensor_inputs.left_door_up_and_locked);
-            set_arinc429_bit(&mut word, 18, !self.sensor_inputs.right_door_up_and_locked);
-            set_arinc429_bit(&mut word, 19, !self.sensor_inputs.nose_door_up_and_locked);
+            word.set_bit(17, !self.sensor_inputs.left_door_up_and_locked);
+            word.set_bit(18, !self.sensor_inputs.right_door_up_and_locked);
+            word.set_bit(19, !self.sensor_inputs.nose_door_up_and_locked);
             // The conditions for bits 20, 21 and 22 are not implemented, so they are set to false for now.
-            set_arinc429_bit(&mut word, 20, false);
-            set_arinc429_bit(&mut word, 21, false);
-            set_arinc429_bit(&mut word, 22, false);
-            set_arinc429_bit(
-                &mut word,
-                23,
-                self.sensor_inputs.downlock_state(GearWheel::LEFT),
-            );
-            set_arinc429_bit(
-                &mut word,
-                24,
-                self.sensor_inputs.downlock_state(GearWheel::RIGHT),
-            );
-            set_arinc429_bit(
-                &mut word,
-                25,
-                self.sensor_inputs.downlock_state(GearWheel::NOSE),
-            );
-            set_arinc429_bit(&mut word, 26, self.sensor_inputs.left_gear_compressed(true));
-            set_arinc429_bit(
-                &mut word,
-                27,
-                self.sensor_inputs.right_gear_compressed(true),
-            );
-            set_arinc429_bit(&mut word, 28, self.sensor_inputs.nose_gear_compressed(true));
-            set_arinc429_bit(&mut word, 29, self.gear_handle_is_down());
+            word.set_bit(20, false);
+            word.set_bit(21, false);
+            word.set_bit(22, false);
+            word.set_bit(23, self.sensor_inputs.downlock_state(GearWheel::LEFT));
+            word.set_bit(24, self.sensor_inputs.downlock_state(GearWheel::RIGHT));
+            word.set_bit(25, self.sensor_inputs.downlock_state(GearWheel::NOSE));
+            word.set_bit(26, self.sensor_inputs.left_gear_compressed(true));
+            word.set_bit(27, self.sensor_inputs.right_gear_compressed(true));
+            word.set_bit(28, self.sensor_inputs.nose_gear_compressed(true));
+            word.set_bit(29, self.gear_handle_is_down());
 
             word
         }
@@ -832,28 +810,14 @@ impl LandingGearControlInterfaceUnit {
             Arinc429Word::new(0., SignStatus::FailureWarning)
         } else {
             let mut word = Arinc429Word::new(0., SignStatus::NormalOperation);
-            set_arinc429_bit(
-                &mut word,
+            word.set_bit(
                 11,
                 !self.sensor_inputs.left_and_right_gear_compressed(false),
             );
-            set_arinc429_bit(
-                &mut word,
-                12,
-                !self.sensor_inputs.nose_gear_compressed(false),
-            );
-            set_arinc429_bit(
-                &mut word,
-                13,
-                !self.sensor_inputs.left_gear_compressed(false),
-            );
-            set_arinc429_bit(
-                &mut word,
-                14,
-                !self.sensor_inputs.right_gear_compressed(false),
-            );
-            set_arinc429_bit(
-                &mut word,
+            word.set_bit(12, !self.sensor_inputs.nose_gear_compressed(false));
+            word.set_bit(13, !self.sensor_inputs.left_gear_compressed(false));
+            word.set_bit(14, !self.sensor_inputs.right_gear_compressed(false));
+            word.set_bit(
                 15,
                 self.sensor_inputs.left_gear_down_and_locked
                     && self.sensor_inputs.right_gear_down_and_locked,
@@ -868,15 +832,15 @@ impl LandingGearControlInterfaceUnit {
             Arinc429Word::new(0., SignStatus::FailureWarning)
         } else {
             let mut word = Arinc429Word::new(0., SignStatus::NormalOperation);
-            set_arinc429_bit(&mut word, 11, !self.sensor_inputs.left_gear_up_and_locked);
-            set_arinc429_bit(&mut word, 12, !self.sensor_inputs.right_gear_up_and_locked);
-            set_arinc429_bit(&mut word, 13, !self.sensor_inputs.nose_gear_up_and_locked);
-            set_arinc429_bit(&mut word, 14, !self.gear_handle_is_down());
-            set_arinc429_bit(&mut word, 25, self.sensor_inputs.left_door_fully_opened);
-            set_arinc429_bit(&mut word, 26, self.sensor_inputs.right_door_fully_opened);
-            set_arinc429_bit(&mut word, 27, self.sensor_inputs.nose_door_fully_opened);
+            word.set_bit(11, !self.sensor_inputs.left_gear_up_and_locked);
+            word.set_bit(12, !self.sensor_inputs.right_gear_up_and_locked);
+            word.set_bit(13, !self.sensor_inputs.nose_gear_up_and_locked);
+            word.set_bit(14, !self.gear_handle_is_down());
+            word.set_bit(25, self.sensor_inputs.left_door_fully_opened);
+            word.set_bit(26, self.sensor_inputs.right_door_fully_opened);
+            word.set_bit(27, self.sensor_inputs.nose_door_fully_opened);
             // Nose gear door should be seperated into left/right doors. For now, just copy the data.
-            set_arinc429_bit(&mut word, 28, self.sensor_inputs.nose_door_fully_opened);
+            word.set_bit(28, self.sensor_inputs.nose_door_fully_opened);
 
             word
         }
@@ -937,15 +901,15 @@ impl SimulationElement for LandingGearControlInterfaceUnit {
 
         writer.write(
             &self.discrete_word_1_id,
-            arinc429_to_f64(self.discrete_word_1()),
+            self.discrete_word_1().to_f64(),
         );
         writer.write(
             &self.discrete_word_2_id,
-            arinc429_to_f64(self.discrete_word_2()),
+            self.discrete_word_2().to_f64(),
         );
         writer.write(
             &self.discrete_word_3_id,
-            arinc429_to_f64(self.discrete_word_3()),
+            self.discrete_word_3().to_f64(),
         );
     }
 }

--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -757,11 +757,11 @@ impl LandingGearControlInterfaceUnit {
         self.status
     }
 
-    fn discrete_word_1(&self) -> Arinc429Word<f32> {
+    fn discrete_word_1(&self) -> Arinc429Word<u32> {
         if !self.is_powered {
-            Arinc429Word::new(0., SignStatus::FailureWarning)
+            Arinc429Word::new(0, SignStatus::FailureWarning)
         } else {
-            let mut word = Arinc429Word::new(0., SignStatus::NormalOperation);
+            let mut word = Arinc429Word::new(0, SignStatus::NormalOperation);
             word.set_bit(
                 11,
                 !self.sensor_inputs.left_gear_up_and_locked && !self.gear_handle_is_down(),
@@ -805,11 +805,11 @@ impl LandingGearControlInterfaceUnit {
         }
     }
 
-    fn discrete_word_2(&self) -> Arinc429Word<f32> {
+    fn discrete_word_2(&self) -> Arinc429Word<u32> {
         if !self.is_powered {
-            Arinc429Word::new(0., SignStatus::FailureWarning)
+            Arinc429Word::new(0, SignStatus::FailureWarning)
         } else {
-            let mut word = Arinc429Word::new(0., SignStatus::NormalOperation);
+            let mut word = Arinc429Word::new(0, SignStatus::NormalOperation);
             word.set_bit(
                 11,
                 !self.sensor_inputs.left_and_right_gear_compressed(false),
@@ -827,11 +827,11 @@ impl LandingGearControlInterfaceUnit {
         }
     }
 
-    fn discrete_word_3(&self) -> Arinc429Word<f32> {
+    fn discrete_word_3(&self) -> Arinc429Word<u32> {
         if !self.is_powered {
-            Arinc429Word::new(0., SignStatus::FailureWarning)
+            Arinc429Word::new(0, SignStatus::FailureWarning)
         } else {
-            let mut word = Arinc429Word::new(0., SignStatus::NormalOperation);
+            let mut word = Arinc429Word::new(0, SignStatus::NormalOperation);
             word.set_bit(11, !self.sensor_inputs.left_gear_up_and_locked);
             word.set_bit(12, !self.sensor_inputs.right_gear_up_and_locked);
             word.set_bit(13, !self.sensor_inputs.nose_gear_up_and_locked);
@@ -899,9 +899,9 @@ impl SimulationElement for LandingGearControlInterfaceUnit {
 
         writer.write(&self.fault_ecam_id, self.status() != LgciuStatus::Ok);
 
-        writer.write(&self.discrete_word_1_id, f64::from(self.discrete_word_1()));
-        writer.write(&self.discrete_word_2_id, f64::from(self.discrete_word_2()));
-        writer.write(&self.discrete_word_3_id, f64::from(self.discrete_word_3()));
+        writer.write(&self.discrete_word_1_id, self.discrete_word_1());
+        writer.write(&self.discrete_word_2_id, self.discrete_word_2());
+        writer.write(&self.discrete_word_3_id, self.discrete_word_3());
     }
 }
 

--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -899,18 +899,9 @@ impl SimulationElement for LandingGearControlInterfaceUnit {
 
         writer.write(&self.fault_ecam_id, self.status() != LgciuStatus::Ok);
 
-        writer.write(
-            &self.discrete_word_1_id,
-            self.discrete_word_1().to_f64(),
-        );
-        writer.write(
-            &self.discrete_word_2_id,
-            self.discrete_word_2().to_f64(),
-        );
-        writer.write(
-            &self.discrete_word_3_id,
-            self.discrete_word_3().to_f64(),
-        );
+        writer.write(&self.discrete_word_1_id, f64::from(self.discrete_word_1()));
+        writer.write(&self.discrete_word_2_id, f64::from(self.discrete_word_2()));
+        writer.write(&self.discrete_word_3_id, f64::from(self.discrete_word_3()));
     }
 }
 

--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -759,12 +759,36 @@ impl LandingGearControlInterfaceUnit {
             Arinc429Word::new(0., SignStatus::FailureWarning)
         } else {
             let mut word = Arinc429Word::new(0., SignStatus::NormalOperation);
-            set_arinc429_bit(&mut word, 11, !self.sensor_inputs.left_gear_up_and_locked && !self.gear_handle_is_down());
-            set_arinc429_bit(&mut word, 12, !self.sensor_inputs.right_gear_up_and_locked && !self.gear_handle_is_down());
-            set_arinc429_bit(&mut word, 13, !self.sensor_inputs.nose_gear_up_and_locked && !self.gear_handle_is_down());
-            set_arinc429_bit(&mut word, 14, !self.sensor_inputs.left_gear_down_and_locked && self.gear_handle_is_down());
-            set_arinc429_bit(&mut word, 15, !self.sensor_inputs.right_gear_down_and_locked && self.gear_handle_is_down());
-            set_arinc429_bit(&mut word, 16, !self.sensor_inputs.nose_gear_down_and_locked && self.gear_handle_is_down());
+            set_arinc429_bit(
+                &mut word,
+                11,
+                !self.sensor_inputs.left_gear_up_and_locked && !self.gear_handle_is_down(),
+            );
+            set_arinc429_bit(
+                &mut word,
+                12,
+                !self.sensor_inputs.right_gear_up_and_locked && !self.gear_handle_is_down(),
+            );
+            set_arinc429_bit(
+                &mut word,
+                13,
+                !self.sensor_inputs.nose_gear_up_and_locked && !self.gear_handle_is_down(),
+            );
+            set_arinc429_bit(
+                &mut word,
+                14,
+                !self.sensor_inputs.left_gear_down_and_locked && self.gear_handle_is_down(),
+            );
+            set_arinc429_bit(
+                &mut word,
+                15,
+                !self.sensor_inputs.right_gear_down_and_locked && self.gear_handle_is_down(),
+            );
+            set_arinc429_bit(
+                &mut word,
+                16,
+                !self.sensor_inputs.nose_gear_down_and_locked && self.gear_handle_is_down(),
+            );
             set_arinc429_bit(&mut word, 17, !self.sensor_inputs.left_door_up_and_locked);
             set_arinc429_bit(&mut word, 18, !self.sensor_inputs.right_door_up_and_locked);
             set_arinc429_bit(&mut word, 19, !self.sensor_inputs.nose_door_up_and_locked);

--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -757,7 +757,7 @@ impl LandingGearControlInterfaceUnit {
         self.status
     }
 
-    fn discrete_word_1(&self) -> Arinc429Word<u32> {
+    pub fn discrete_word_1(&self) -> Arinc429Word<u32> {
         if !self.is_powered {
             Arinc429Word::new(0, SignStatus::FailureWarning)
         } else {
@@ -805,7 +805,7 @@ impl LandingGearControlInterfaceUnit {
         }
     }
 
-    fn discrete_word_2(&self) -> Arinc429Word<u32> {
+    pub fn discrete_word_2(&self) -> Arinc429Word<u32> {
         if !self.is_powered {
             Arinc429Word::new(0, SignStatus::FailureWarning)
         } else {
@@ -827,7 +827,7 @@ impl LandingGearControlInterfaceUnit {
         }
     }
 
-    fn discrete_word_3(&self) -> Arinc429Word<u32> {
+    pub fn discrete_word_3(&self) -> Arinc429Word<u32> {
         if !self.is_powered {
             Arinc429Word::new(0, SignStatus::FailureWarning)
         } else {

--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -823,7 +823,7 @@ impl LandingGearControlInterfaceUnit {
             set_arinc429_bit(&mut word, 28, self.sensor_inputs.nose_gear_compressed(true));
             set_arinc429_bit(&mut word, 29, self.gear_handle_is_down());
 
-            return word;
+            word
         }
     }
 
@@ -859,7 +859,7 @@ impl LandingGearControlInterfaceUnit {
                     && self.sensor_inputs.right_gear_down_and_locked,
             );
 
-            return word;
+            word
         }
     }
 
@@ -878,7 +878,7 @@ impl LandingGearControlInterfaceUnit {
             // Nose gear door should be seperated into left/right doors. For now, just copy the data.
             set_arinc429_bit(&mut word, 28, self.sensor_inputs.nose_door_fully_opened);
 
-            return word;
+            word
         }
     }
 }

--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -759,9 +759,19 @@ impl LandingGearControlInterfaceUnit {
             Arinc429Word::new(0., SignStatus::FailureWarning)
         } else {
             let mut word = Arinc429Word::new(0., SignStatus::NormalOperation);
+            set_arinc429_bit(&mut word, 11, !self.sensor_inputs.left_gear_up_and_locked && !self.gear_handle_is_down());
+            set_arinc429_bit(&mut word, 12, !self.sensor_inputs.right_gear_up_and_locked && !self.gear_handle_is_down());
+            set_arinc429_bit(&mut word, 13, !self.sensor_inputs.nose_gear_up_and_locked && !self.gear_handle_is_down());
+            set_arinc429_bit(&mut word, 14, !self.sensor_inputs.left_gear_down_and_locked && self.gear_handle_is_down());
+            set_arinc429_bit(&mut word, 15, !self.sensor_inputs.right_gear_down_and_locked && self.gear_handle_is_down());
+            set_arinc429_bit(&mut word, 16, !self.sensor_inputs.nose_gear_down_and_locked && self.gear_handle_is_down());
             set_arinc429_bit(&mut word, 17, !self.sensor_inputs.left_door_up_and_locked);
             set_arinc429_bit(&mut word, 18, !self.sensor_inputs.right_door_up_and_locked);
             set_arinc429_bit(&mut word, 19, !self.sensor_inputs.nose_door_up_and_locked);
+            // The conditions for bits 20, 21 and 22 are not implemented, so they are set to false for now.
+            set_arinc429_bit(&mut word, 20, false);
+            set_arinc429_bit(&mut word, 21, false);
+            set_arinc429_bit(&mut word, 22, false);
             set_arinc429_bit(
                 &mut word,
                 23,

--- a/src/systems/systems/src/shared/arinc429.rs
+++ b/src/systems/systems/src/shared/arinc429.rs
@@ -90,6 +90,19 @@ pub(crate) fn to_arinc429(value: f64, ssm: SignStatus) -> f64 {
     f64::from_bits(bits)
 }
 
+pub(crate) fn arinc429_to_f64(word: Arinc429Word<f32>) -> f64 {
+    let value = word.value as f32;
+    let status: u64 = word.ssm.into();
+
+    let bits = (value.to_bits() as u64) << 32 | status;
+
+    f64::from_bits(bits)
+}
+
+pub(crate) fn set_arinc429_bit(word: &mut Arinc429Word<f32>, bit: u32, value: bool) {
+    word.value = (((word.value as u32) & !(1 << (bit - 1))) | ((value as u32) << (bit - 1))) as f32;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/systems/systems/src/shared/arinc429.rs
+++ b/src/systems/systems/src/shared/arinc429.rs
@@ -1,3 +1,4 @@
+#[derive(Clone, Copy)]
 pub struct Arinc429Word<T: Copy> {
     value: T,
     ssm: SignStatus,
@@ -40,31 +41,30 @@ impl<T: Copy> Arinc429Word<T> {
         self.ssm == SignStatus::NormalOperation
     }
 }
-impl Arinc429Word<f32> {
-    pub fn set_bit(&mut self, bit: u32, value: bool) {
-        self.value =
-            (((self.value as u32) & !(1 << (bit - 1))) | ((value as u32) << (bit - 1))) as f32;
+impl Arinc429Word<u32> {
+    pub fn set_bit(&mut self, bit: u8, value: bool) {
+        self.value = ((self.value) & !(1 << (bit - 1))) | ((value as u32) << (bit - 1));
     }
 
-    pub fn get_bit(&self, bit: u32) -> bool {
-        ((self.value as u32 >> (bit - 1)) & 1) != 0
+    pub fn get_bit(&self, bit: u8) -> bool {
+        ((self.value >> (bit - 1)) & 1) != 0
     }
 }
-impl From<f64> for Arinc429Word<f32> {
-    fn from(value: f64) -> Arinc429Word<f32> {
+impl From<f64> for Arinc429Word<u32> {
+    fn from(value: f64) -> Arinc429Word<u32> {
         let bits = value.to_bits();
 
         let value = (bits >> 32) as u32;
         let status = bits as u32;
 
-        Arinc429Word::new(f32::from_bits(value), status.into())
+        Arinc429Word::new(value, status.into())
     }
 }
-impl From<Arinc429Word<f32>> for f64 {
-    fn from(value: Arinc429Word<f32>) -> f64 {
+impl From<Arinc429Word<u32>> for f64 {
+    fn from(value: Arinc429Word<u32>) -> f64 {
         let status: u64 = value.ssm.into();
 
-        let bits = (value.value.to_bits() as u64) << 32 | status;
+        let bits = (value.value as u64) << 32 | status;
 
         f64::from_bits(bits)
     }
@@ -153,19 +153,19 @@ mod tests {
     fn bit_conversion_is_symmetric(#[case] expected_ssm: SignStatus) {
         let mut rng = rand::thread_rng();
 
-        let mut word = Arinc429Word::new(0., expected_ssm);
+        let mut word = Arinc429Word::new(0, expected_ssm);
 
         let mut expected_values: [bool; 30] = [false; 30];
 
         for (i, item) in expected_values.iter_mut().enumerate().take(29).skip(11) {
             *item = rng.gen();
-            word.set_bit(i as u32, *item);
+            word.set_bit(i as u8, *item);
         }
 
         let result = Arinc429Word::from(f64::from(word));
 
         for (i, item) in expected_values.iter_mut().enumerate().take(29).skip(11) {
-            let result_bit = result.get_bit(i as u32);
+            let result_bit = result.get_bit(i as u8);
             assert!(
                 result_bit == *item,
                 "Expected Bit {} to be {}, got {}",

--- a/src/systems/systems/src/shared/arinc429.rs
+++ b/src/systems/systems/src/shared/arinc429.rs
@@ -99,6 +99,7 @@ pub(crate) fn arinc429_to_f64(word: Arinc429Word<f32>) -> f64 {
     f64::from_bits(bits)
 }
 
+#[allow(dead_code)]
 pub(crate) fn arinc429_from_f64(value: f64) -> Arinc429Word<f32> {
     let bits = value.to_bits();
 
@@ -112,6 +113,7 @@ pub(crate) fn set_arinc429_bit(word: &mut Arinc429Word<f32>, bit: u32, value: bo
     word.value = (((word.value as u32) & !(1 << (bit - 1))) | ((value as u32) << (bit - 1))) as f32;
 }
 
+#[allow(dead_code)]
 pub(crate) fn get_arinc429_bit(word: &mut Arinc429Word<f32>, bit: u32) -> bool {
     ((word.value as u32 >> (bit - 1)) & 1) != 0
 }
@@ -154,20 +156,20 @@ mod tests {
 
         let mut expected_values: [bool; 30] = [false; 30];
 
-        for i in 11..29 {
-            expected_values[i] = rng.gen();
-            set_arinc429_bit(&mut word, i as u32, expected_values[i]);
+        for (i, item) in expected_values.iter_mut().enumerate().take(29).skip(11) {
+            *item = rng.gen();
+            set_arinc429_bit(&mut word, i as u32, *item);
         }
 
         let mut result = arinc429_from_f64(arinc429_to_f64(word));
 
-        for i in 11..29 {
+        for (i, item) in expected_values.iter_mut().enumerate().take(29).skip(11) {
             let result_bit = get_arinc429_bit(&mut result, i as u32);
             assert!(
-                result_bit == expected_values[i],
+                result_bit == *item,
                 "Expected Bit {} to be {}, got {}",
                 i,
-                expected_values[i],
+                *item,
                 result_bit
             );
         }

--- a/src/systems/systems/src/shared/arinc429.rs
+++ b/src/systems/systems/src/shared/arinc429.rs
@@ -90,7 +90,7 @@ pub(crate) fn to_arinc429(value: f64, ssm: SignStatus) -> f64 {
     f64::from_bits(bits)
 }
 
-pub(crate) fn arinc429_to_f64(word: Arinc429Word<f32>) -> f64 {
+pub fn arinc429_to_f64(word: Arinc429Word<f32>) -> f64 {
     let value = word.value as f32;
     let status: u64 = word.ssm.into();
 
@@ -99,8 +99,7 @@ pub(crate) fn arinc429_to_f64(word: Arinc429Word<f32>) -> f64 {
     f64::from_bits(bits)
 }
 
-#[allow(dead_code)]
-pub(crate) fn arinc429_from_f64(value: f64) -> Arinc429Word<f32> {
+pub fn arinc429_from_f64(value: f64) -> Arinc429Word<f32> {
     let bits = value.to_bits();
 
     let value = (bits >> 32) as u32;
@@ -109,12 +108,11 @@ pub(crate) fn arinc429_from_f64(value: f64) -> Arinc429Word<f32> {
     Arinc429Word::new(f32::from_bits(value), status.into())
 }
 
-pub(crate) fn set_arinc429_bit(word: &mut Arinc429Word<f32>, bit: u32, value: bool) {
+pub fn set_arinc429_bit(word: &mut Arinc429Word<f32>, bit: u32, value: bool) {
     word.value = (((word.value as u32) & !(1 << (bit - 1))) | ((value as u32) << (bit - 1))) as f32;
 }
 
-#[allow(dead_code)]
-pub(crate) fn get_arinc429_bit(word: &mut Arinc429Word<f32>, bit: u32) -> bool {
+pub fn get_arinc429_bit(word: &mut Arinc429Word<f32>, bit: u32) -> bool {
     ((word.value as u32 >> (bit - 1)) & 1) != 0
 }
 

--- a/src/systems/systems/src/shared/arinc429.rs
+++ b/src/systems/systems/src/shared/arinc429.rs
@@ -43,10 +43,12 @@ impl<T: Copy> Arinc429Word<T> {
 }
 impl Arinc429Word<u32> {
     pub fn set_bit(&mut self, bit: u8, value: bool) {
+        debug_assert!((11..=29).contains(&bit));
         self.value = ((self.value) & !(1 << (bit - 1))) | ((value as u32) << (bit - 1));
     }
 
     pub fn get_bit(&self, bit: u8) -> bool {
+        debug_assert!((11..=29).contains(&bit));
         ((self.value >> (bit - 1)) & 1) != 0
     }
 }

--- a/src/systems/systems/src/shared/arinc429.rs
+++ b/src/systems/systems/src/shared/arinc429.rs
@@ -59,14 +59,14 @@ impl From<f64> for Arinc429Word<u32> {
         let value = (bits >> 32) as u32;
         let status = bits as u32;
 
-        Arinc429Word::new(value, status.into())
+        Arinc429Word::new(f32::from_bits(value) as u32, status.into())
     }
 }
 impl From<Arinc429Word<u32>> for f64 {
     fn from(value: Arinc429Word<u32>) -> f64 {
         let status: u64 = value.ssm.into();
 
-        let bits = (value.value as u64) << 32 | status;
+        let bits = ((value.value as f32).to_bits() as u64) << 32 | status;
 
         f64::from_bits(bits)
     }

--- a/src/systems/systems/src/shared/arinc429.rs
+++ b/src/systems/systems/src/shared/arinc429.rs
@@ -41,23 +41,6 @@ impl<T: Copy> Arinc429Word<T> {
     }
 }
 impl Arinc429Word<f32> {
-    pub fn from_f64(value: f64) -> Self {
-        let bits = value.to_bits();
-
-        let value = (bits >> 32) as u32;
-        let status = bits as u32;
-
-        Arinc429Word::new(f32::from_bits(value), status.into())
-    }
-
-    pub fn to_f64(&self) -> f64 {
-        let status: u64 = self.ssm.into();
-
-        let bits = (self.value.to_bits() as u64) << 32 | status;
-
-        f64::from_bits(bits)
-    }
-
     pub fn set_bit(&mut self, bit: u32, value: bool) {
         self.value =
             (((self.value as u32) & !(1 << (bit - 1))) | ((value as u32) << (bit - 1))) as f32;
@@ -65,6 +48,25 @@ impl Arinc429Word<f32> {
 
     pub fn get_bit(&self, bit: u32) -> bool {
         ((self.value as u32 >> (bit - 1)) & 1) != 0
+    }
+}
+impl From<f64> for Arinc429Word<f32> {
+    fn from(value: f64) -> Arinc429Word<f32> {
+        let bits = value.to_bits();
+
+        let value = (bits >> 32) as u32;
+        let status = bits as u32;
+
+        Arinc429Word::new(f32::from_bits(value), status.into())
+    }
+}
+impl From<Arinc429Word<f32>> for f64 {
+    fn from(value: Arinc429Word<f32>) -> f64 {
+        let status: u64 = value.ssm.into();
+
+        let bits = (value.value.to_bits() as u64) << 32 | status;
+
+        f64::from_bits(bits)
     }
 }
 
@@ -160,7 +162,7 @@ mod tests {
             word.set_bit(i as u32, *item);
         }
 
-        let result = Arinc429Word::from_f64(word.to_f64());
+        let result = Arinc429Word::from(f64::from(word));
 
         for (i, item) in expected_values.iter_mut().enumerate().take(29).skip(11) {
             let result_bit = result.get_bit(i as u32);

--- a/src/systems/systems/src/simulation/mod.rs
+++ b/src/systems/systems/src/simulation/mod.rs
@@ -776,6 +776,18 @@ read_write_uom!(MassDensity, slug_per_cubic_foot);
 read_write_into!(MachNumber);
 read_write_into!(StartState);
 
+impl<T: Reader> Read<Arinc429Word<u32>> for T {
+    fn convert(&mut self, value: f64) -> Arinc429Word<u32> {
+        value.into()
+    }
+}
+
+impl<T: Writer> Write<Arinc429Word<u32>> for T {
+    fn convert(&mut self, value: Arinc429Word<u32>) -> f64 {
+        value.into()
+    }
+}
+
 impl<T: Reader> Read<f64> for T {
     fn convert(&mut self, value: f64) -> f64 {
         value


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR:
* Adds (part of) the LGCIU output bus, for a list of bits in the discrete words and their description, see the Lvar docs.
   * Discrete words 2 and 4 and some bits in discrete word 3 have not been added, since the functionality for them is not currently implemented in the LGCIU.
* Modifies the WHEEL SD page to use the LGCIU output bus, and improve the indications.
   * LGCIU failures should now be properly handled, and the "door partially opened" case has been added to the door indications. 
  
   

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Check that the WHEEL page works correctly in all situations, including failures

Testing suggestion from Davy:
```
Use gravity gear extension on ground and in flight. If clicked and hold it should:

release doors on ground
release doors and gears in flight.
After use even with green system available, gear should be inoperative.

If clicked and held again, and if green system available it should:

close doors on ground
close doors and gears in flight. (Might need to recycle gear lever if LGCIU error)
```

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
