### PR TITLE
fix(atsu): Fixes for NXApi-Freetext and CPDLC Logon-issues

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_FreeText.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_FreeText.js
@@ -1,5 +1,5 @@
 class CDUAocFreeText {
-    static ShowPage(mcdu, store = { "msg_to": "", "reqID": 0, "msg_line1": "", "msg_line2": "", "msg_line3": "", "msg_line4": "", "sendStatus": ""}) {
+    static ShowPage(mcdu, store = { "msg_to": "", "reqID": SimVar.GetSimVarValue('L:A32NX_HOPPIE_ACTIVE', 'number') !== 0 ? 0 : 1, "msg_line1": "", "msg_line2": "", "msg_line3": "", "msg_line4": "", "sendStatus": ""}) {
         mcdu.clearDisplay();
         mcdu.page.Current = mcdu.page.AOCFreeText;
         const networkTypes = [

--- a/src/atsu/src/ATC.ts
+++ b/src/atsu/src/ATC.ts
@@ -351,7 +351,7 @@ export class Atc {
                 }
 
                 // logon rejected
-                if (response.Content?.TypeId === 'UM9996') {
+                if (response.Content?.TypeId === 'UM9996' || response.Content?.TypeId === 'UM0') {
                     response.DcduRelevantMessage = false;
                     this.dcduLink.setAtcLogonMessage('');
                     this.currentAtc = '';

--- a/src/atsu/src/com/webinterfaces/NXApiConnector.ts
+++ b/src/atsu/src/com/webinterfaces/NXApiConnector.ts
@@ -201,7 +201,7 @@ export class NXApiConnector {
             }
 
             // Fetch new messages
-            Telex.fetchMessages()
+            await Telex.fetchMessages()
                 .then((data) => {
                     for (const msg of data) {
                         const message = new FreetextMessage();

--- a/src/atsu/src/com/webinterfaces/NXApiConnector.ts
+++ b/src/atsu/src/com/webinterfaces/NXApiConnector.ts
@@ -201,19 +201,20 @@ export class NXApiConnector {
             }
 
             // Fetch new messages
-            await Telex.fetchMessages()
-                .then((data) => {
-                    for (const msg of data) {
-                        const message = new FreetextMessage();
-                        message.Network = AtsuMessageNetwork.FBW;
-                        message.Direction = AtsuMessageDirection.Uplink;
-                        message.Station = msg.from.flight;
-                        message.Message = msg.message.replace(/;/i, ' ');
+            try {
+                const data = await Telex.fetchMessages();
+                for (const msg of data) {
+                    const message = new FreetextMessage();
+                    message.Network = AtsuMessageNetwork.FBW;
+                    message.Direction = AtsuMessageDirection.Uplink;
+                    message.Station = msg.from.flight;
+                    message.Message = msg.message.replace(/;/i, ' ');
 
-                        retval.push(message);
-                    }
-                })
-                .catch(() => [AtsuStatusCodes.ComFailed, retval]);
+                    retval.push(message);
+                }
+            } catch (_e) {
+                return [AtsuStatusCodes.ComFailed, retval];
+            }
         }
 
         return [AtsuStatusCodes.Ok, retval];


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR fixes the freetext-issues based on the NXApi-telex protocol.
Additionally is NXApi marked as default freetext-protocol if Hoppie is disabled.

A last fix handles UNABLE responses much better on "REQUEST LOGON" message.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Select FBW as freetext system and send yourself a telex-message -> check discord if message is sent -> wait for COMPANY MSG on upper ECAM -> read message in AOC/RECEIVED MESSAGES -> COMPANY MSG on upper ECAM removed
- Disable Hoppie on EFB -> Open Freetext in AOC menu -> expect FBW preselected -> Enable Hoppie -> Fill out INIT A -> Open Freetext in AOC menu -> Expect HOPPIES preselected
- Send REQUEST LOGON to ATC station -> NEXT STATION: XXXX on DCDU -> respond with UNABLE -> NEXT STATION: XXXX removed and Connection Notification is cleaned up after a reload

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
