### PR TITLE
perf: improved simulation variable hooks

### DIFF
--- a/src/instruments/src/ATC/index.tsx
+++ b/src/instruments/src/ATC/index.tsx
@@ -1,5 +1,5 @@
 import './style.scss';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useSimVar, useSplitSimVar } from '@instruments/common/simVars';
 import { useInteractionEvent, useUpdate } from '@instruments/common/hooks';
 import { TcasComputer } from '@tcas/index';
@@ -30,19 +30,21 @@ const PoweredXpdrDisplay = () => {
     const [ltsTest] = useSimVar('L:A32NX_OVHD_INTLT_ANN', 'Number', 250);
     const [tcas] = useState(() => new TcasComputer());
 
-    const [transponderCode, setTransponderCode] = useSplitSimVar('TRANSPONDER CODE:1', 'Bco16', 'K:XPNDR_SET', 'Bco16', 500);
+    const [transponderCode, setTransponderCode] = useSplitSimVar('TRANSPONDER CODE:1', 'Bco16', 'K:XPNDR_SET', 'Bco16');
     const codeInDisplay = newDigits !== null ? newDigits : getDigitsFromBco16(transponderCode);
 
     useEffect(() => {
         tcas.init();
     }, []);
 
-    useUpdate((deltaTime) => {
+    const updateCallback = useCallback((deltaTime) => {
         tcas.update(deltaTime);
         if (displayResetTimer > 0) {
             setDisplayResetTimer(Math.max(displayResetTimer - deltaTime / 1000, 0));
         }
-    });
+    }, [displayResetTimer]);
+
+    useUpdate(updateCallback);
 
     useEffect(() => {
         if (displayResetTimer === -1) {

--- a/src/instruments/src/Common/displayUnit.tsx
+++ b/src/instruments/src/Common/displayUnit.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { NXDataStore } from '@shared/persistence';
 import { useSimVar } from './simVars';
 import { useUpdate } from './hooks';
@@ -29,22 +29,22 @@ function BacklightBleed(props) {
 export const DisplayUnit: React.FC<DisplayUnitProps> = (props) => {
     const [coldDark] = useSimVar('L:A32NX_COLD_AND_DARK_SPAWN', 'Bool', 200);
     const [state, setState] = useState((coldDark) ? DisplayUnitState.Off : DisplayUnitState.Standby);
-    const [timer, setTimer] = useState<number | null>(null);
+    const timer = useRef<number | null>(null);
 
     const [potentiometer] = useSimVar(`LIGHT POTENTIOMETER:${props.potentiometerIndex}`, 'percent over 100', 200);
     const [electricityState] = useSimVar(props.electricitySimvar, 'bool', 200);
     const [homeCockpit] = useSimVar('L:A32NX_HOME_COCKPIT_ENABLED', 'bool', 200);
 
     useUpdate((deltaTime) => {
-        if (timer !== null) {
-            if (timer > 0) {
-                setTimer(timer - (deltaTime / 1000));
+        if (timer.current !== null) {
+            if (timer.current > 0) {
+                timer.current -= (deltaTime / 1000);
             } else if (state === DisplayUnitState.Standby) {
                 setState(DisplayUnitState.Off);
-                setTimer(null);
+                timer.current = null;
             } else if (state === DisplayUnitState.Selftest) {
                 setState(DisplayUnitState.On);
-                setTimer(null);
+                timer.current = null;
             }
         }
 
@@ -59,18 +59,18 @@ export const DisplayUnit: React.FC<DisplayUnitProps> = (props) => {
             setState(DisplayUnitState.Off);
         } else if (state === DisplayUnitState.On && (potentiometer === 0 || electricityState === 0)) {
             setState(DisplayUnitState.Standby);
-            setTimer(10);
+            timer.current = 10;
         } else if (state === DisplayUnitState.Standby && (potentiometer !== 0 && electricityState !== 0)) {
             setState(DisplayUnitState.On);
-            setTimer(null);
+            timer.current = null;
         } else if (state === DisplayUnitState.Off && (potentiometer !== 0 && electricityState !== 0 && !props.failed)) {
             setState(DisplayUnitState.Selftest);
-            setTimer(parseInt(NXDataStore.get('CONFIG_SELF_TEST_TIME', '15')));
+            timer.current = parseInt(NXDataStore.get('CONFIG_SELF_TEST_TIME', '15'));
         } else if (state === DisplayUnitState.Selftest && (potentiometer === 0 || electricityState === 0)) {
             setState(DisplayUnitState.Off);
-            setTimer(null);
+            timer.current = null;
         }
-    }, [state, potentiometer, electricityState]);
+    }, [timer.current, state, potentiometer, electricityState]);
 
     if (state === DisplayUnitState.Selftest) {
         return (

--- a/src/instruments/src/Common/index.tsx
+++ b/src/instruments/src/Common/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import * as Defaults from './defaults';
-import { SimVarProvider } from './simVars';
 import { FbwAircraftSentryClient } from '../../../sentry-client/src/FbwAircraftSentryClient';
 
 declare const process: any;
@@ -17,7 +16,7 @@ export const render = (Slot: React.ReactElement, enableSentryTracing = false, se
         root: sentryRootClient,
     });
 
-    ReactDOM.render(<SimVarProvider>{Slot}</SimVarProvider>, Defaults.getRenderTarget());
+    ReactDOM.render(Slot, Defaults.getRenderTarget());
 };
 
 /**

--- a/src/instruments/src/Common/simVars.tsx
+++ b/src/instruments/src/Common/simVars.tsx
@@ -1,255 +1,10 @@
-import * as React from 'react';
-import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useInteractionEvents, useUpdate } from './hooks';
-
-/**
- * If the same SimVar or GlobalVar is requested in multiple places with
- * equivalent units, we normalize them to a common name to deduplicate the
- * entries in the cache.
- */
-const normalizeUnitName = (unit: UnitName): UnitName => {
-    switch (unit) {
-    case 'bool':
-    case 'Bool':
-    case 'boolean':
-    case 'Boolean':
-        return 'bool';
-    case 'number':
-    case 'Number':
-        return 'number';
-    case 'Degrees':
-    case 'degree':
-        return 'degree';
-    case 'Percent':
-    case 'percent':
-        return 'percent';
-    case 'Feet':
-    case 'feet':
-    case 'feets':
-    case 'Feets':
-        return 'feet';
-    case 'Knots':
-    case 'knots':
-        return 'knots';
-    default:
-        return unit;
-    }
-};
 
 type SimVarSetter = <T extends SimVarValue>(oldValue: T) => T;
 
-type RetrieveSimVar = (name: string, unit: UnitName, force?: boolean, varType?: number) => SimVarValue;
-type UpdateSimVar = (name: string, unit: UnitName, newValueOrSetter: SimVarValue | SimVarSetter, proxy?: string) => void;
-type RegisterSimVar = (name: string, unit: UnitName, refreshRate: number, varType: number) => void;
-type UnregisterSimVar = (name: string, unit: UnitName, refreshRate: number, varType: number) => void;
-
-const errorCallback = () => {
-    throw Error('useSimVar was called in a React tree with no SimVarProvider');
-};
-const context = React.createContext<{
-    retrieve: RetrieveSimVar,
-    update: UpdateSimVar,
-    register: RegisterSimVar,
-    unregister: UnregisterSimVar,
-}>({
-    retrieve: errorCallback,
-    update: errorCallback,
-    register: errorCallback,
-    unregister: errorCallback,
-});
-const { Provider: InternalProvider } = context;
-
 type UnitName = string | any; // once typings is next to tsconfig.json, use those units
 type SimVarValue = number | any;
-type SimVarCache = Record<string, {
-    value: SimVarValue,
-    lastUpdatedAgo: number,
-}>;
-
-/**
- * This component provides the basic functionality for the useSimVar hooks.
- * By keeping the last known SimVar values inside this provider, we're
- * effectively caching each SimVar, so that there is no additional overhead when
- * using multiple useSimVar hooks for the same SimVar.
- * For improved performance, this component will only trigger renders when the
- * "update" custom event is emitted through an instrument.
- */
-const SimVarProvider: React.FC = ({ children }) => {
-    const listeners = useRef<Record<string, number[]>>({});
-    const [cache, setCache] = useState<SimVarCache>({});
-
-    useUpdate((deltaTime: number) => {
-        const stateUpdates: Record<string, {
-            value?: SimVarValue,
-            lastUpdatedAgo: number,
-        }> = {};
-
-        for (const [key, intervals] of Object.entries(listeners.current)) {
-            // First, let's check if there are any listeners at all
-            if (!intervals.length) {
-                continue;
-            }
-
-            // The refresh time is given by the *smallest* maximum update
-            // interval.
-            const threshold = Math.min(...intervals);
-            const lastUpdatedAgo = (cache[key] ? cache[key].lastUpdatedAgo || 0 : 0) + deltaTime;
-
-            if (lastUpdatedAgo >= threshold) {
-                // At this point, as we haven't updated this SimVar recently, we
-                // need to fetch the latest value from the simulator and store
-                // it.
-                const [name, rawUnit] = key.split('/');
-                const unit = normalizeUnitName(rawUnit as UnitName);
-                let value;
-                if (name.startsWith('_GLOBAL_')) {
-                    value = SimVar.GetGlobalVarValue(name.substr(8), unit);
-                } else if (name.startsWith('_GAME_')) {
-                    value = SimVar.GetGameVarValue(name.substr(6), unit);
-                } else {
-                    value = SimVar.GetSimVarValue(name, unit);
-                }
-                stateUpdates[key] = {
-                    value,
-                    lastUpdatedAgo: lastUpdatedAgo % threshold,
-                };
-            } else {
-                // Otherwise, just increment lastUpdatedAgo.
-                stateUpdates[key] = { lastUpdatedAgo };
-            }
-        }
-
-        setCache((oldCache) => {
-            const newCache: SimVarCache = {};
-            for (const [key, update] of Object.entries(stateUpdates)) {
-                newCache[key] = { ...oldCache[key], ...update };
-            }
-            return { ...oldCache, ...newCache };
-        });
-    });
-
-    const getKey = (name: string, unit: UnitName, varType: number) => {
-        switch (varType) {
-        default:
-            return `${name}/${normalizeUnitName(unit)}`;
-        case 1:
-            return `_GLOBAL_${name}/${normalizeUnitName(unit)}`;
-        case 2:
-            return `_GAME_${name}/${normalizeUnitName(unit)}`;
-        }
-    };
-
-    /**
-     * This function will be called by the SimVar hooks through the context and
-     * retrieves the appropriate SimVar value from the cache if it exists, and
-     * retrieve it from the simulator otherwise.
-     * @param name The SimVar to update.
-     * @param unit The unit of the SimVar to update.
-     * @param force Whether to always bypass the cache and always retrieve it
-     * from the simulator.
-     */
-    const retrieve: RetrieveSimVar = (name, unit, force, varType) => {
-        const key = getKey(name, unit, varType || 0);
-        if (cache[key] && !force) {
-            return cache[key].value;
-        }
-        let value;
-        switch (varType) {
-        default:
-            value = SimVar.GetSimVarValue(name, unit);
-            break;
-        case 1:
-            value = SimVar.GetGlobalVarValue(name, unit);
-            break;
-        case 2:
-            value = SimVar.GetGameVarValue(name, unit);
-            break;
-        }
-        setCache((oldCache) => ({
-            ...oldCache,
-            [key]: {
-                value,
-                lastUpdatedAgo: 0,
-            },
-        }));
-        return value;
-    };
-
-    /**
-     * This function will be called by the SimVar hooks through the context and
-     * updates the appropriate SimVar for the specific unit with the supplied
-     * value.
-     * @param name The SimVar to update.
-     * @param unit The unit of the SimVar to update.
-     * @param value {*|(function(*): *)} Either the new value for the
-     * SimVar, or an update function that takes the old value and returns an
-     * updated value.
-     * @param proxy If the SimVar used to set the SimVar is different from the
-     * SimVar used to retrieve it, set this parameter to the SimVar for the set
-     * operation.
-     */
-    const update: UpdateSimVar = (name, unit, value, proxy) => {
-        const key = getKey(name, unit, 0);
-        setCache((oldCache) => {
-            const newValue = typeof value === 'function' ? value(oldCache[key].value) : value;
-            SimVar.SetSimVarValue((proxy || name), unit, newValue);
-            return {
-                ...oldCache,
-                [key]: {
-                    value: newValue,
-                    lastUpdatedAgo: 0,
-                },
-            };
-        });
-    };
-
-    /**
-     * This function will be called by the useSimVar hook through the context
-     * and ensures the SimVar with the supplied name and unit will be updated
-     * every refreshRate.
-     */
-    const register: RegisterSimVar = (name, unit, refreshRate, varType) => {
-        const key = getKey(name, unit, varType);
-        if (!listeners.current[key]) {
-            listeners.current[key] = [];
-        }
-        listeners.current[key].push(refreshRate || 0);
-    };
-
-    /**
-     * This function will be called by the useSimVar hook through the context
-     * and notifies us that there is one listener less for this specific SimVar
-     * and unit combination.
-     */
-    const unregister: UnregisterSimVar = (name, unit, refreshRate, varType): void => {
-        const key = getKey(name, unit, varType);
-        const old = listeners.current[key];
-        if (!Array.isArray(old) || old.length === 0) {
-            throw new Error('Attempted to unregisterHook with no known listener');
-        }
-        if (old.length === 1) {
-            // if we're unregistering the last entry, delete the array...
-            delete listeners.current[key];
-        } else {
-            // ...otherwise, filter out the first occurence of this value
-            const index = listeners.current[key].indexOf(refreshRate || 0);
-            // splice removes in-place, so an assignment would be wrong here as the return value is the removed element
-            listeners.current[key].splice(index, 1);
-        }
-    };
-
-    return (
-        <InternalProvider value={{
-            retrieve,
-            update,
-            register,
-            unregister,
-        }}
-        >
-            { children }
-        </InternalProvider>
-    );
-};
 
 /**
  * The useSimVar hook provides an easy way to read and write SimVars from React.
@@ -266,7 +21,7 @@ const SimVarProvider: React.FC = ({ children }) => {
  *
  * @param name The name of the SimVar.
  * @param unit The unit of the SimVar.
- * @param refreshRate The time in milliseconds that needs to elapse before
+ * @param refreshInterval The time in milliseconds that needs to elapse before
  * the next render will cause a SimVar refresh from the simulator.
  *
  * @example
@@ -286,33 +41,38 @@ const SimVarProvider: React.FC = ({ children }) => {
 export const useSimVar = (
     name: string,
     unit: UnitName,
-    refreshRate = 0,
+    refreshInterval = 0,
 ): [SimVarValue, (newValueOrSetter: SimVarValue | SimVarSetter
 ) => void] => {
-    const lastUpdate = useRef(Date.now() - refreshRate - 1);
+    const lastUpdate = useRef(Date.now() - refreshInterval - 1);
 
-    const [value, setValue] = useState(() => SimVar.GetSimVarValue(name, unit));
+    const [stateValue, setStateValue] = useState(() => SimVar.GetSimVarValue(name, unit));
 
     const updateCallback = useCallback(() => {
-        const newValue = SimVar.GetSimVarValue(name, unit);
-
         const delta = Date.now() - lastUpdate.current;
 
-        if (delta > refreshRate) {
+        if (delta > refreshInterval) {
             lastUpdate.current = Date.now();
-            setValue(newValue);
+
+            const newValue = SimVar.GetSimVarValue(name, unit);
+
+            setStateValue(newValue);
         }
-    }, [name, unit, refreshRate]);
+    }, [name, unit, refreshInterval]);
 
     useUpdate(updateCallback);
 
-    const setter = useCallback((value: any | SimVarSetter) => {
-        SimVar.SetSimVarValue(name, unit, typeof value === 'function' ? value(SimVar.GetSimVarValue(name, unit)) : value);
+    const setter = useCallback((valueOrSetter: any | SimVarSetter) => {
+        const executedValue = typeof valueOrSetter === 'function' ? valueOrSetter(stateValue) : valueOrSetter;
 
-        return value;
-    }, [name, unit]);
+        SimVar.SetSimVarValue(name, unit, executedValue);
 
-    return [value, setter];
+        setStateValue(executedValue);
+
+        return stateValue;
+    }, [name, unit, stateValue]);
+
+    return [stateValue, setter];
 };
 
 /**
@@ -322,7 +82,7 @@ export const useSimVar = (
  *
  * @param name The name of the GlobalVar.
  * @param unit The unit of the GlobalVar.
- * @param refreshRate The time in milliseconds that needs to elapse before
+ * @param refreshInterval The time in milliseconds that needs to elapse before
  * the next render will cause a SimVar refresh from the simulator.
  *
  * @example
@@ -336,26 +96,27 @@ export const useSimVar = (
 export const useGlobalVar = (
     name: string,
     unit: UnitName,
-    refreshRate = 0,
+    refreshInterval = 0,
 ): SimVarValue => {
-    const lastUpdate = useRef(Date.now() - refreshRate - 1);
+    const lastUpdate = useRef(Date.now() - refreshInterval - 1);
 
-    const [value, setValue] = useState(() => SimVar.GetGlobalVarValue(name, unit));
+    const [stateValue, setStateValue] = useState(() => SimVar.GetGlobalVarValue(name, unit));
 
     const updateCallback = useCallback(() => {
-        const newValue = SimVar.GetGlobalVarValue(name, unit);
-
         const delta = Date.now() - lastUpdate.current;
 
-        if (delta > refreshRate) {
+        if (delta > refreshInterval) {
             lastUpdate.current = Date.now();
-            setValue(newValue);
+
+            const newValue = SimVar.GetGlobalVarValue(name, unit);
+
+            setStateValue(newValue);
         }
-    }, [name, unit, refreshRate]);
+    }, [name, unit, refreshInterval]);
 
     useUpdate(updateCallback);
 
-    return value;
+    return stateValue;
 };
 
 /**
@@ -365,7 +126,7 @@ export const useGlobalVar = (
  *
  * @param name The name of the useGameVar.
  * @param unit The unit of the useGameVar.
- * @param refreshRate The time in milliseconds that needs to elapse before
+ * @param refreshInterval The time in milliseconds that needs to elapse before
  * the next render will cause a SimVar refresh from the simulator.
  *
  * @example
@@ -379,26 +140,27 @@ export const useGlobalVar = (
 export const useGameVar = (
     name: string,
     unit: UnitName,
-    refreshRate = 0,
+    refreshInterval = 0,
 ): SimVarValue => {
-    const lastUpdate = useRef(Date.now() - refreshRate - 1);
+    const lastUpdate = useRef(Date.now() - refreshInterval - 1);
 
-    const [value, setValue] = useState(() => SimVar.GetGameVarValue(name, unit));
+    const [stateValue, setStateValue] = useState(() => SimVar.GetGameVarValue(name, unit));
 
     const updateCallback = useCallback(() => {
-        const newValue = SimVar.GetGameVarValue(name, unit);
-
         const delta = Date.now() - lastUpdate.current;
 
-        if (delta > refreshRate) {
+        if (delta > refreshInterval) {
             lastUpdate.current = Date.now();
-            setValue(newValue);
+
+            const newValue = SimVar.GetGameVarValue(name, unit);
+
+            setStateValue(newValue);
         }
-    }, [name, unit, refreshRate]);
+    }, [name, unit, refreshInterval]);
 
     useUpdate(updateCallback);
 
-    return value;
+    return stateValue;
 };
 
 /**
@@ -417,7 +179,7 @@ export const useGameVar = (
  * @param unit The unit of the SimVar.
  * @param interactionEvents The name of the interaction events that signals a
  * change to the SimVar.
- * @param refreshRate The time in milliseconds that needs to elapse before
+ * @param refreshInterval The time in milliseconds that needs to elapse before
  * the next render will cause a SimVar refresh from the simulator.
  *
  * @example
@@ -436,19 +198,43 @@ export const useInteractionSimVar = (
     name: string,
     unit: UnitName,
     interactionEvents: string | string[],
-    refreshRate = 500,
+    refreshInterval = 500,
 ): [SimVarValue, (newValueOrSetter: SimVarValue | SimVarSetter
 ) => void] => {
-    const contextValue = useContext(context);
-    const value = useSimVarValue(name, unit, refreshRate);
+    const lastUpdate = useRef(Date.now() - refreshInterval - 1);
+
+    const [stateValue, setStateValue] = useState(() => SimVar.GetSimVarValue(name, unit));
+
+    const updateCallback = useCallback(() => {
+        const delta = Date.now() - lastUpdate.current;
+
+        if (delta > refreshInterval) {
+            lastUpdate.current = Date.now();
+
+            const newValue = SimVar.GetSimVarValue(name, unit);
+
+            setStateValue(newValue);
+        }
+    }, [name, unit, refreshInterval]);
+
+    useUpdate(updateCallback);
 
     useInteractionEvents(
         Array.isArray(interactionEvents) ? interactionEvents : [interactionEvents],
-        () => contextValue.retrieve(name, unit, true), // force an update
+        () => setStateValue(SimVar.GetSimVarValue(name, unit)), // force an update
     );
 
-    const setter = useSimVarSetter(name, unit);
-    return [value, setter];
+    const setter = useCallback((valueOrSetter: any | SimVarSetter) => {
+        const executedValue = typeof valueOrSetter === 'function' ? valueOrSetter(stateValue) : valueOrSetter;
+
+        SimVar.SetSimVarValue(name, unit, executedValue);
+
+        setStateValue(executedValue);
+
+        return stateValue;
+    }, [name, unit]);
+
+    return [stateValue, setter];
 };
 
 /**
@@ -460,7 +246,7 @@ export const useInteractionSimVar = (
  * @param readUnit The unit of the SimVar to read from.
  * @param writeName The name of the SimVar to write to.
  * @param writeUnit The unit of the SimVar to write to.
- * @param refreshRate The time in milliseconds that needs to elapse before
+ * @param refreshInterval The time in milliseconds that needs to elapse before
  * the next render will cause a SimVar refresh from the simulator.
  *
  * @example
@@ -479,57 +265,11 @@ export const useSplitSimVar = (
     readUnit: UnitName,
     writeName: string,
     writeUnit?: UnitName,
-    refreshRate = 0,
+    refreshInterval = 0,
 ): [SimVarValue, (newValueOrSetter: SimVarValue | SimVarSetter
 ) => void] => {
-    const [value] = useSimVar(readName, readUnit, refreshRate);
+    const [value] = useSimVar(readName, readUnit, refreshInterval);
     const [, setter] = useSimVar(writeName, writeUnit || readUnit);
 
     return [value, setter];
 };
-
-/**
- * This is an internal hook that exposes the internal value for a SimVar only.
- * You will usually want to useSimVar instead. Don't use this unless you know
- * what you're doing and writing your own hook.
- */
-export const useSimVarValue = (name: string, unit: UnitName, refreshRate: number): SimVarValue => {
-    const contextValue = useContext(context);
-
-    useEffect(() => {
-        // This part of useEffect will be called whenever either:
-        // - the component has just mounted, or
-        // - one the parameters below (name, unit, refreshRate) has changed.
-        // In these cases, we want to register our current parameters with the
-        // SimVarProvider that we access through the context.
-        contextValue.register(name, unit, refreshRate, 0);
-        return () => {
-            // This part of useEffect will be called whenever either:
-            // - one of the parameters below (name, unit, refreshRate) is about
-            //   to change, or
-            // - the component is about to unmount
-            // In these cases, we want to unregister our current parameters from
-            // the SimVar provider, that we again access through the context.
-            contextValue.unregister(name, unit, refreshRate, 0);
-        };
-    }, [name, unit, refreshRate]);
-
-    return contextValue.retrieve(name, unit);
-};
-
-/**
- * This is an internal hook that exposes the internal setter for a SimVar only.
- * You will usually want to useSimVar instead. Don't use this unless you know
- * what you're doing and writing your own hook.
- */
-export const useSimVarSetter = (
-    name: string,
-    unit: UnitName,
-    proxy?: string,
-): ((newValueOrSetter: SimVarValue | SimVarSetter) => void
-) => {
-    const contextValue = useContext(context);
-    return (value) => contextValue.update(name, unit, value, proxy);
-};
-
-export { SimVarProvider };

--- a/src/instruments/src/Common/simVars.tsx
+++ b/src/instruments/src/Common/simVars.tsx
@@ -51,7 +51,7 @@ export const useSimVar = (
     const updateCallback = useCallback(() => {
         const delta = Date.now() - lastUpdate.current;
 
-        if (delta > refreshInterval) {
+        if (delta >= refreshInterval) {
             lastUpdate.current = Date.now();
 
             const newValue = SimVar.GetSimVarValue(name, unit);
@@ -105,7 +105,7 @@ export const useGlobalVar = (
     const updateCallback = useCallback(() => {
         const delta = Date.now() - lastUpdate.current;
 
-        if (delta > refreshInterval) {
+        if (delta >= refreshInterval) {
             lastUpdate.current = Date.now();
 
             const newValue = SimVar.GetGlobalVarValue(name, unit);
@@ -149,7 +149,7 @@ export const useGameVar = (
     const updateCallback = useCallback(() => {
         const delta = Date.now() - lastUpdate.current;
 
-        if (delta > refreshInterval) {
+        if (delta >= refreshInterval) {
             lastUpdate.current = Date.now();
 
             const newValue = SimVar.GetGameVarValue(name, unit);
@@ -208,7 +208,7 @@ export const useInteractionSimVar = (
     const updateCallback = useCallback(() => {
         const delta = Date.now() - lastUpdate.current;
 
-        if (delta > refreshInterval) {
+        if (delta >= refreshInterval) {
             lastUpdate.current = Date.now();
 
             const newValue = SimVar.GetSimVarValue(name, unit);

--- a/src/instruments/src/DCDU/elements/AffirmNegativeButtons.tsx
+++ b/src/instruments/src/DCDU/elements/AffirmNegativeButtons.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { AtsuMessageComStatus } from '@atsu/messages/AtsuMessage';
 import { CpdlcMessage } from '@atsu/messages/CpdlcMessage';
-import { useUpdate } from '@instruments/common/hooks.js';
 import { Button } from './Button';
 
 type AffirmNegativeButtonsProps = {
     message: CpdlcMessage,
     selectedResponse: number,
     setMessageStatus(message: number, response: number),
-    setStatus: (sender: string, message: string) => void,
+    setStatus: (sender: string, message: string, duration: number) => void,
     isStatusAvailable: (sender: string) => boolean,
     sendResponse: (message: number, response: number) => void,
     closeMessage: (message: number) => void
@@ -17,13 +16,11 @@ type AffirmNegativeButtonsProps = {
 export const AffirmNegativeButtons: React.FC<AffirmNegativeButtonsProps> = ({ message, selectedResponse, setMessageStatus, setStatus, isStatusAvailable, sendResponse, closeMessage }) => {
     const buttonsBlocked = message.Response !== undefined && message.Response.ComStatus === AtsuMessageComStatus.Sending;
 
-    useUpdate(() => {
-        if (buttonsBlocked) {
-            if (isStatusAvailable('Buttons') === true) {
-                setStatus('Buttons', 'SENDING');
-            }
+    if (buttonsBlocked) {
+        if (isStatusAvailable('Buttons')) {
+            setStatus('Buttons', 'SENDING', -1);
         }
-    });
+    }
 
     // define the rules for the visualization of the buttons
     let showAnswers = false;

--- a/src/instruments/src/DCDU/elements/AffirmNegativeButtons.tsx
+++ b/src/instruments/src/DCDU/elements/AffirmNegativeButtons.tsx
@@ -18,7 +18,7 @@ export const AffirmNegativeButtons: React.FC<AffirmNegativeButtonsProps> = ({ me
 
     if (buttonsBlocked) {
         if (isStatusAvailable('Buttons')) {
-            setStatus('Buttons', 'SENDING', -1);
+            setStatus('Buttons', 'SENDING', Infinity);
         }
     }
 

--- a/src/instruments/src/DCDU/elements/DatalinkMessage.tsx
+++ b/src/instruments/src/DCDU/elements/DatalinkMessage.tsx
@@ -6,7 +6,7 @@ import { MessageVisualization } from './MessageVisualization';
 type DatalinkMessageProps = {
     messages: CpdlcMessage[],
     isStatusAvailable: (sender: string) => boolean,
-    setStatus: (sender: string, message: string) => void,
+    setStatus: (sender: string, message: string, duration: number) => void,
     resetStatus: (sender: string) => void
 }
 

--- a/src/instruments/src/DCDU/elements/MessageVisualization.tsx
+++ b/src/instruments/src/DCDU/elements/MessageVisualization.tsx
@@ -21,7 +21,7 @@ type MessageVisualizationProps = {
     yStart: number,
     deltaY: number,
     isStatusAvailable: ((sender: string) => boolean) | undefined,
-    setStatus: ((sender: string, message: string) => void) | undefined,
+    setStatus: ((sender: string, message: string, duration: number) => void) | undefined,
     resetStatus: ((sender: string) => void) | undefined,
 }
 
@@ -206,7 +206,7 @@ export const MessageVisualization: React.FC<MessageVisualizationProps> = memo(({
             }
             setPageIndex(pageIndex - 1);
         } else if (isStatusAvailable !== undefined && setStatus !== undefined && isStatusAvailable('DatalinkMessage') === true) {
-            setStatus('DatalinkMessage', 'NO MORE PGE');
+            setStatus('DatalinkMessage', 'NO MORE PGE', 5);
         }
     });
     useInteractionEvents(['A32NX_DCDU_BTN_MPL_POEPLUS', 'A32NX_DCDU_BTN_MPR_POEPLUS'], () => {
@@ -220,7 +220,7 @@ export const MessageVisualization: React.FC<MessageVisualizationProps> = memo(({
             }
             setPageIndex(pageIndex + 1);
         } else if (isStatusAvailable !== undefined && setStatus !== undefined && isStatusAvailable('DatalinkMessage') === true) {
-            setStatus('DatalinkMessage', 'NO MORE PGE');
+            setStatus('DatalinkMessage', 'NO MORE PGE', 5);
         }
     });
 

--- a/src/instruments/src/DCDU/elements/OutputButtons.tsx
+++ b/src/instruments/src/DCDU/elements/OutputButtons.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { AtsuMessageComStatus } from '@atsu/messages/AtsuMessage';
 import { CpdlcMessage } from '@atsu/messages/CpdlcMessage';
-import { useUpdate } from '@instruments/common/hooks.js';
 import { Button } from './Button';
 
 type OutputButtonsProps = {
     message: CpdlcMessage,
-    setStatus: (sender: string, message: string) => void,
+    setStatus: (sender: string, message: string, duration: number) => void,
     isStatusAvailable: (sender: string) => boolean,
     sendMessage: (message: number) => void,
     deleteMessage: (message: number) => void,
@@ -16,13 +15,11 @@ type OutputButtonsProps = {
 export const OutputButtons: React.FC<OutputButtonsProps> = ({ message, setStatus, isStatusAvailable, sendMessage, deleteMessage, closeMessage }) => {
     const buttonsBlocked = message.ComStatus === AtsuMessageComStatus.Sending;
 
-    useUpdate(() => {
-        if (buttonsBlocked) {
-            if (isStatusAvailable('Buttons') === true) {
-                setStatus('Buttons', 'SENDING');
-            }
+    if (buttonsBlocked) {
+        if (isStatusAvailable('Buttons')) {
+            setStatus('Buttons', 'SENDING', -1);
         }
-    });
+    }
 
     // define the rules for the visualization of the buttons
     let showAnswers = false;

--- a/src/instruments/src/DCDU/elements/OutputButtons.tsx
+++ b/src/instruments/src/DCDU/elements/OutputButtons.tsx
@@ -17,7 +17,7 @@ export const OutputButtons: React.FC<OutputButtonsProps> = ({ message, setStatus
 
     if (buttonsBlocked) {
         if (isStatusAvailable('Buttons')) {
-            setStatus('Buttons', 'SENDING', -1);
+            setStatus('Buttons', 'SENDING', Infinity);
         }
     }
 

--- a/src/instruments/src/DCDU/elements/RogerButtons.tsx
+++ b/src/instruments/src/DCDU/elements/RogerButtons.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { AtsuMessageComStatus } from '@atsu/messages/AtsuMessage';
 import { CpdlcMessage } from '@atsu/messages/CpdlcMessage';
-import { useUpdate } from '@instruments/common/hooks.js';
 import { Button } from './Button';
 
 type RogerButtonsProps = {
     message: CpdlcMessage,
     selectedResponse: number,
     setMessageStatus(message: number, response: number),
-    setStatus: (sender: string, message: string) => void,
+    setStatus: (sender: string, message: string, duration: number) => void,
     isStatusAvailable: (sender: string) => boolean,
     sendResponse: (message: number, response: number) => void,
     closeMessage: (message: number) => void
@@ -17,13 +16,11 @@ type RogerButtonsProps = {
 export const RogerButtons: React.FC<RogerButtonsProps> = ({ message, selectedResponse, setMessageStatus, setStatus, isStatusAvailable, sendResponse, closeMessage }) => {
     const buttonsBlocked = message.Response !== undefined && message.Response.ComStatus === AtsuMessageComStatus.Sending;
 
-    useUpdate(() => {
-        if (buttonsBlocked) {
-            if (isStatusAvailable('Buttons')) {
-                setStatus('Buttons', 'SENDING');
-            }
+    if (buttonsBlocked) {
+        if (isStatusAvailable('Buttons')) {
+            setStatus('Buttons', 'SENDING', -1);
         }
-    });
+    }
 
     // define the rules for the visualization of the buttons
     let showAnswers = false;

--- a/src/instruments/src/DCDU/elements/RogerButtons.tsx
+++ b/src/instruments/src/DCDU/elements/RogerButtons.tsx
@@ -18,7 +18,7 @@ export const RogerButtons: React.FC<RogerButtonsProps> = ({ message, selectedRes
 
     if (buttonsBlocked) {
         if (isStatusAvailable('Buttons')) {
-            setStatus('Buttons', 'SENDING', -1);
+            setStatus('Buttons', 'SENDING', Infinity);
         }
     }
 

--- a/src/instruments/src/DCDU/elements/WilcoUnableButtons.tsx
+++ b/src/instruments/src/DCDU/elements/WilcoUnableButtons.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { AtsuMessageComStatus } from '@atsu/messages/AtsuMessage';
 import { CpdlcMessage } from '@atsu/messages/CpdlcMessage';
-import { useUpdate } from '@instruments/common/hooks.js';
 import { Button } from './Button';
 
 type WilcoUnableButtonsProps = {
     message: CpdlcMessage,
     selectedResponse: number,
     setMessageStatus(message: number, response: number),
-    setStatus: (sender: string, message: string) => void,
+    setStatus: (sender: string, message: string, duration: number) => void,
     isStatusAvailable: (sender: string) => boolean,
     sendResponse: (message: number, response: number) => void,
     closeMessage: (message: number) => void
@@ -17,13 +16,11 @@ type WilcoUnableButtonsProps = {
 export const WilcoUnableButtons: React.FC<WilcoUnableButtonsProps> = ({ message, selectedResponse, setMessageStatus, setStatus, isStatusAvailable, sendResponse, closeMessage }) => {
     const buttonsBlocked = message.Response !== undefined && message.Response.ComStatus === AtsuMessageComStatus.Sending;
 
-    useUpdate(() => {
-        if (buttonsBlocked) {
-            if (isStatusAvailable('Buttons')) {
-                setStatus('Buttons', 'SENDING');
-            }
+    if (buttonsBlocked) {
+        if (isStatusAvailable('Buttons')) {
+            setStatus('Buttons', 'SENDING', -1);
         }
-    });
+    }
 
     // define the rules for the visualization of the buttons
     let showAnswers = false;

--- a/src/instruments/src/DCDU/elements/WilcoUnableButtons.tsx
+++ b/src/instruments/src/DCDU/elements/WilcoUnableButtons.tsx
@@ -18,7 +18,7 @@ export const WilcoUnableButtons: React.FC<WilcoUnableButtonsProps> = ({ message,
 
     if (buttonsBlocked) {
         if (isStatusAvailable('Buttons')) {
-            setStatus('Buttons', 'SENDING', -1);
+            setStatus('Buttons', 'SENDING', Infinity);
         }
     }
 

--- a/src/instruments/src/DCDU/index.tsx
+++ b/src/instruments/src/DCDU/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useSimVar } from '@instruments/common/simVars';
 import { useCoherentEvent, useInteractionEvents } from '@instruments/common/hooks';
 import { AtsuMessageComStatus, AtsuMessageDirection, AtsuMessageType } from '@atsu/messages/AtsuMessage';
@@ -19,7 +19,6 @@ import { DcduLines } from './elements/DcduLines';
 import { DatalinkMessage } from './elements/DatalinkMessage';
 import { MessageStatus } from './elements/MessageStatus';
 import { AtcStatus } from './elements/AtcStatus';
-import { useUpdate } from '../util.js';
 
 import './style.scss';
 
@@ -42,11 +41,15 @@ const DCDU: React.FC = () => {
     const [isColdAndDark] = useSimVar('L:A32NX_COLD_AND_DARK_SPAWN', 'Bool', 200);
     const [state, setState] = useState((isColdAndDark) ? DcduState.Off : DcduState.On);
     const [messages, setMessages] = useState(new Map<number, [CpdlcMessage[], number, number]>());
-    const [statusMessage, setStatusMessage] = useState({ sender: '', message: '', remainingMilliseconds: 0 });
+    const [statusMessage, setStatusMessage] = useState({ sender: '', message: '' });
     const [events] = useState(RegisterViewListener('JS_LISTENER_SIMVARS', undefined, true));
     const [messageUid, setMessageUid] = useState(-1);
     const [atcMessage, setAtcMessage] = useState('');
-    const [timer, setTimer] = useState<number | null>(null);
+    const [screenTimeout, setScreenTimeout] = useState<NodeJS.Timeout | null>(null);
+    const [messageStatusTimeout, setMessageStatusTimeout] = useState<NodeJS.Timeout | null>(null);
+    const messagesRef = useRef<Map<number, [CpdlcMessage[], number, number]>>();
+
+    messagesRef.current = messages;
 
     // functions to handle the status area
     const isStatusAvailable = (sender: string) => statusMessage.sender === sender || statusMessage.message.length === 0;
@@ -56,16 +59,31 @@ const DCDU: React.FC = () => {
         if (sender.length === 0 || sender === statusMessage.sender) {
             state.sender = '';
             state.message = '';
-            state.remainingMilliseconds = 0;
             setStatusMessage(state);
+            if (messageStatusTimeout) {
+                clearTimeout(messageStatusTimeout);
+                setMessageStatusTimeout(null);
+            }
         }
     };
-    const setStatus = (sender: string, message: string) => {
+    const setStatus = (sender: string, message: string, duration: number) => {
         const state = statusMessage;
         state.sender = sender;
         state.message = message;
-        state.remainingMilliseconds = 5000;
         setStatusMessage(state);
+        if (duration > 0) {
+            if (messageStatusTimeout) {
+                clearTimeout(messageStatusTimeout);
+            }
+
+            setMessageStatusTimeout(setTimeout(() => {
+                const state = statusMessage;
+                state.sender = '';
+                state.message = '';
+                setStatusMessage(state);
+                setMessageStatusTimeout(null);
+            }, duration * 1000));
+        }
     };
 
     const setMessageStatus = (uid: number, response: number) => {
@@ -87,7 +105,11 @@ const DCDU: React.FC = () => {
 
     // functions to handle the internal queue
     const closeMessage = (uid: number) => {
-        const sortedMessages = sortedMessageArray(messages);
+        if (!messagesRef.current) {
+            return;
+        }
+
+        const sortedMessages = sortedMessageArray(messagesRef.current);
         const index = sortedMessages.findIndex((element) => element[0][0].UniqueMessageID === uid);
 
         events.triggerToAllSubscribers('A32NX_ATSU_DCDU_MESSAGE_CLOSED', uid);
@@ -105,7 +127,7 @@ const DCDU: React.FC = () => {
             }
 
             // update the map
-            const updatedMap = new Map<number, [CpdlcMessage[], number, number]>(messages);
+            const updatedMap = new Map<number, [CpdlcMessage[], number, number]>(messagesRef.current);
             updatedMap.delete(uid);
             setMessages(updatedMap);
         }
@@ -113,11 +135,11 @@ const DCDU: React.FC = () => {
 
     // the message scroll button handling
     useInteractionEvents(['A32NX_DCDU_BTN_MPL_MS0MINUS', 'A32NX_DCDU_BTN_MPR_MS0MINUS'], () => {
-        if (messages.size === 0) {
+        if (!messagesRef.current || messagesRef.current.size === 0) {
             return;
         }
 
-        const sortedMessages = sortedMessageArray(messages);
+        const sortedMessages = sortedMessageArray(messagesRef.current);
         let index = 0;
         if (messageUid !== -1) {
             index = sortedMessages.findIndex((element) => messageUid === element[0][0].UniqueMessageID);
@@ -125,7 +147,7 @@ const DCDU: React.FC = () => {
 
         if (index === 0) {
             if (isStatusAvailable('Mainpage') === true) {
-                setStatus('Mainpage', 'NO MORE MSG');
+                setStatus('Mainpage', 'NO MORE MSG', 5);
             }
         } else {
             resetStatus('');
@@ -135,11 +157,11 @@ const DCDU: React.FC = () => {
         setMessageUid(sortedMessages[index][0][0].UniqueMessageID);
     });
     useInteractionEvents(['A32NX_DCDU_BTN_MPL_MS0PLUS', 'A32NX_DCDU_BTN_MPR_MS0PLUS'], () => {
-        if (messages.size === 0) {
+        if (!messagesRef.current || messagesRef.current.size === 0) {
             return;
         }
 
-        const sortedMessages = sortedMessageArray(messages);
+        const sortedMessages = sortedMessageArray(messagesRef.current);
         let index = 0;
         if (messageUid !== -1) {
             index = sortedMessages.findIndex((element) => messageUid === element[0][0].UniqueMessageID);
@@ -147,7 +169,7 @@ const DCDU: React.FC = () => {
 
         if (index + 1 >= sortedMessages.length) {
             if (isStatusAvailable('Mainpage') === true) {
-                setStatus('Mainpage', 'NO MORE MSG');
+                setStatus('Mainpage', 'NO MORE MSG', 5);
             }
         } else {
             resetStatus('');
@@ -194,16 +216,17 @@ const DCDU: React.FC = () => {
         });
 
         if (cpdlcMessages.length !== 0) {
-            const newMessageMap = new Map(messages);
-            const dcduBlock = messages.get(cpdlcMessages[0].UniqueMessageID);
+            const newMessageMap = new Map(messagesRef.current);
+            const dcduBlock = newMessageMap.get(cpdlcMessages[0].UniqueMessageID);
+
             if (dcduBlock !== undefined) {
                 // update the status entry
                 if (dcduBlock[0][0].Direction === AtsuMessageDirection.Downlink) {
                     if (dcduBlock[0][0].ComStatus !== cpdlcMessages[0].ComStatus) {
                         if (cpdlcMessages[0].ComStatus === AtsuMessageComStatus.Failed) {
-                            setStatus('Mainpage', 'COM FAILED');
+                            setStatus('Mainpage', 'COM FAILED', 5);
                         } else if (cpdlcMessages[0].ComStatus === AtsuMessageComStatus.Sent) {
-                            setStatus('Mainpage', 'SENT');
+                            setStatus('Mainpage', 'SENT', 5);
                         }
                     }
                 } else if (cpdlcMessages[0].Response !== undefined) {
@@ -211,15 +234,15 @@ const DCDU: React.FC = () => {
                     if (dcduBlock[0][0].Response !== undefined) {
                         if (dcduBlock[0][0].Response.ComStatus !== cpdlcMessages[0].Response.ComStatus) {
                             if (cpdlcMessages[0].Response.ComStatus === AtsuMessageComStatus.Failed) {
-                                setStatus('Mainpage', 'COM FAILED');
+                                setStatus('Mainpage', 'COM FAILED', 5);
                             } else if (cpdlcMessages[0].Response.ComStatus === AtsuMessageComStatus.Sent) {
-                                setStatus('Mainpage', 'SENT');
+                                setStatus('Mainpage', 'SENT', 5);
                             }
                         }
                     } else if (cpdlcMessages[0].Response.ComStatus === AtsuMessageComStatus.Failed) {
-                        setStatus('Mainpage', 'COM FAILED');
+                        setStatus('Mainpage', 'COM FAILED', 5);
                     } else if (cpdlcMessages[0].Response.ComStatus === AtsuMessageComStatus.Sent) {
-                        setStatus('Mainpage', 'SENT');
+                        setStatus('Mainpage', 'SENT', 5);
                     }
                 }
 
@@ -252,44 +275,28 @@ const DCDU: React.FC = () => {
         setAtcMessage(message);
     });
 
-    useUpdate((deltaTime) => {
-        if (timer !== null) {
-            if (timer > 0) {
-                setTimer(timer - (deltaTime / 1000));
-            } else if (state === DcduState.Off && electricityState !== 0) {
-                setState(DcduState.Selftest);
-                setTimer(6);
-            } else if (state === DcduState.Selftest) {
-                setState(DcduState.Waiting);
-                setTimer(12);
-            } else if (state === DcduState.Waiting) {
-                setState(DcduState.On);
-                setTimer(null);
-            }
-        }
-
-        // check if the status is outdated
-        const status = statusMessage;
-        if (status.message !== '') {
-            status.remainingMilliseconds -= deltaTime;
-            if (status.remainingMilliseconds <= 0) {
-                resetStatus('');
-            }
-        }
-    });
-
     useEffect(() => {
         if (state === DcduState.On && electricityState === 0) {
             setState(DcduState.Standby);
-        } else if (state === DcduState.Off && electricityState !== 0) {
-            setState(DcduState.Selftest);
-            setTimer(6);
+            setScreenTimeout(setTimeout(() => setState(DcduState.Off), 10000));
         } else if (state === DcduState.Standby && electricityState !== 0) {
             setState(DcduState.On);
-            setTimer(null);
-        } else if (electricityState === 0) {
+            if (screenTimeout) {
+                clearTimeout(screenTimeout);
+                setScreenTimeout(null);
+            }
+        } else if (state === DcduState.Off && electricityState !== 0) {
+            setState(DcduState.Selftest);
+            setScreenTimeout(setTimeout(() => {
+                setState(DcduState.Waiting);
+                setScreenTimeout(setTimeout(() => setState(DcduState.On), 12000));
+            }, 6000));
+        } else if ((state === DcduState.Selftest || state === DcduState.Waiting) && electricityState === 0) {
             setState(DcduState.Off);
-            setTimer(null);
+            if (screenTimeout) {
+                clearTimeout(screenTimeout);
+                setScreenTimeout(null);
+            }
         }
     }, [electricityState]);
 
@@ -297,8 +304,8 @@ const DCDU: React.FC = () => {
     let messageIndex = -1;
     let visibleMessages: CpdlcMessage[] | undefined = undefined;
     let response: number = -1;
-    if (state === DcduState.On && messages.size !== 0) {
-        const arrMessages = sortedMessageArray(messages);
+    if (state === DcduState.On && messagesRef.current?.size !== 0) {
+        const arrMessages = sortedMessageArray(messagesRef.current);
 
         if (messageUid !== -1) {
             messageIndex = arrMessages.findIndex((element) => messageUid === element[0][0].UniqueMessageID);
@@ -415,7 +422,7 @@ const DCDU: React.FC = () => {
                     )}
                     <DcduLines />
                     {
-                        (messages.size > 1
+                        (messagesRef.current.size > 1
                         && (
                             <>
                                 <g>
@@ -425,7 +432,7 @@ const DCDU: React.FC = () => {
                                         {' '}
                                         /
                                         {' '}
-                                        {messages.size}
+                                        {messagesRef.current.size}
                                     </text>
                                 </g>
                             </>

--- a/src/instruments/src/DCDU/index.tsx
+++ b/src/instruments/src/DCDU/index.tsx
@@ -71,7 +71,7 @@ const DCDU: React.FC = () => {
         state.sender = sender;
         state.message = message;
         setStatusMessage(state);
-        if (duration > 0) {
+        if (Number.isFinite(duration)) {
             if (messageStatusTimeout) {
                 clearTimeout(messageStatusTimeout);
             }

--- a/src/instruments/src/DCDU/index.tsx
+++ b/src/instruments/src/DCDU/index.tsx
@@ -77,7 +77,7 @@ const DCDU: React.FC = () => {
             entry[2] = response;
             updateMap.set(uid, entry);
 
-            setMessages(updateMap)
+            setMessages(updateMap);
         }
     };
 

--- a/src/instruments/src/DCDU/index.tsx
+++ b/src/instruments/src/DCDU/index.tsx
@@ -69,16 +69,16 @@ const DCDU: React.FC = () => {
     };
 
     const setMessageStatus = (uid: number, response: number) => {
-        const updateMap = messages;
+        const updateMap = new Map<number, [CpdlcMessage[], number, number]>(messages);
 
         const entry = updateMap.get(uid);
         if (entry !== undefined) {
             events.triggerToAllSubscribers('A32NX_ATSU_DCDU_MESSAGE_READ', uid);
             entry[2] = response;
             updateMap.set(uid, entry);
-        }
 
-        setMessages(updateMap);
+            setMessages(updateMap)
+        }
     };
 
     const deleteMessage = (uid: number) => events.triggerToAllSubscribers('A32NX_ATSU_DELETE_MESSAGE', uid);
@@ -105,7 +105,7 @@ const DCDU: React.FC = () => {
             }
 
             // update the map
-            const updatedMap = messages;
+            const updatedMap = new Map<number, [CpdlcMessage[], number, number]>(messages);
             updatedMap.delete(uid);
             setMessages(updatedMap);
         }
@@ -194,6 +194,7 @@ const DCDU: React.FC = () => {
         });
 
         if (cpdlcMessages.length !== 0) {
+            const newMessageMap = new Map(messages);
             const dcduBlock = messages.get(cpdlcMessages[0].UniqueMessageID);
             if (dcduBlock !== undefined) {
                 // update the status entry
@@ -234,11 +235,10 @@ const DCDU: React.FC = () => {
                 if (cpdlcMessages[0].Response !== undefined && cpdlcMessages[0].Response.ComStatus === AtsuMessageComStatus.Sent) {
                     dcduBlock[2] = -1;
                 }
-
-                setMessages(messages.set(cpdlcMessages[0].UniqueMessageID, dcduBlock));
             } else {
-                setMessages(messages.set(cpdlcMessages[0].UniqueMessageID, [cpdlcMessages, new Date().getTime(), -1]));
+                newMessageMap.set(cpdlcMessages[0].UniqueMessageID, [cpdlcMessages, new Date().getTime(), -1]);
             }
+            setMessages(newMessageMap);
 
             if (messageUid === -1) {
                 setMessageUid(cpdlcMessages[0].UniqueMessageID);

--- a/src/instruments/src/SD/Pages/Cond/Cond.tsx
+++ b/src/instruments/src/SD/Pages/Cond/Cond.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '../../../Common';
 import { setIsEcamPage } from '../../../Common/defaults';
-import { SimVarProvider, useSimVar } from '../../../Common/simVars';
+import { useSimVar } from '../../../Common/simVars';
 
 import './Cond.scss';
 
@@ -118,4 +118,4 @@ const CondUnit = ({ title, selectedTemp, cabinTemp, trimTemp, x, offset, hotAir 
     );
 };
 
-render(<SimVarProvider><CondPage /></SimVarProvider>);
+render(<CondPage />);

--- a/src/instruments/src/SD/Pages/Crz/Crz.tsx
+++ b/src/instruments/src/SD/Pages/Crz/Crz.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { GaugeComponent, GaugeMarkerComponent, splitDecimals } from '@instruments/common/gauges';
 import { render } from '../../../Common';
 import { setIsEcamPage } from '../../../Common/defaults';
-import { SimVarProvider, useSimVar } from '../../../Common/simVars';
+import { useSimVar } from '../../../Common/simVars';
 import { usePersistentProperty } from '../../../Common/persistence';
 import { fuelForDisplay } from '../../Common/FuelFunctions';
 
@@ -232,4 +232,4 @@ export const CondComponent = () => {
     );
 };
 
-render(<SimVarProvider><CrzPage /></SimVarProvider>);
+render(<CrzPage />);

--- a/src/instruments/src/SD/Pages/Door/Door.tsx
+++ b/src/instruments/src/SD/Pages/Door/Door.tsx
@@ -2,7 +2,7 @@ import './Door.scss';
 import React from 'react';
 import { render } from '@instruments/common/index';
 import { setIsEcamPage } from '../../../Common/defaults';
-import { SimVarProvider, useSimVar } from '../../../Common/simVars';
+import { useSimVar } from '../../../Common/simVars';
 
 setIsEcamPage('door_page');
 
@@ -88,4 +88,4 @@ export const DoorPage = () => {
     );
 };
 
-render(<SimVarProvider><DoorPage /></SimVarProvider>);
+render(<DoorPage />);

--- a/src/instruments/src/SD/Pages/Elec/Elec.tsx
+++ b/src/instruments/src/SD/Pages/Elec/Elec.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { render } from '@instruments/common/index';
 import { PageTitle } from '../../Common/PageTitle';
 import { setIsEcamPage } from '../../../Common/defaults';
-import { SimVarProvider, useSimVar } from '../../../Common/simVars';
+import { useSimVar } from '../../../Common/simVars';
 import { EcamPage } from '../../Common/EcamPage';
 import { SvgGroup } from '../../Common/SvgGroup';
 
@@ -518,4 +518,4 @@ const Wire = ({ d, amber }: WireProps) => {
     return <path className={classes} d={d} />;
 };
 
-render(<SimVarProvider><ElecPage /></SimVarProvider>);
+render(<ElecPage />);

--- a/src/instruments/src/SD/Pages/Fctl/Fctl.tsx
+++ b/src/instruments/src/SD/Pages/Fctl/Fctl.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@instruments/common/index';
 import { setIsEcamPage } from '../../../Common/defaults';
-import { SimVarProvider, useSimVar } from '../../../Common/simVars';
+import { useSimVar } from '../../../Common/simVars';
 import { PageTitle } from '../../Common/PageTitle';
 import { EcamPage } from '../../Common/EcamPage';
 import { SvgGroup } from '../../Common/SvgGroup';
@@ -286,4 +286,4 @@ const Note: React.FunctionComponent<ComponentPositionProps> = ({ x, y, children 
     <text x={x} y={y} className="Note" textAnchor="middle" alignmentBaseline="central">{children}</text>
 );
 
-render(<SimVarProvider><FctlPage /></SimVarProvider>);
+render(<FctlPage />);

--- a/src/instruments/src/SD/Pages/Fuel/Fuel.tsx
+++ b/src/instruments/src/SD/Pages/Fuel/Fuel.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { render } from '@instruments/common/index';
-import { SimVarProvider, useSimVar } from '@instruments/common/simVars';
+import { useSimVar } from '@instruments/common/simVars';
 import { setIsEcamPage } from '@instruments/common/defaults';
 import { useArinc429Var } from '@instruments/common/arinc429';
 import { usePersistentProperty } from '../../../Common/persistence';
@@ -359,4 +359,4 @@ const Pump = ({ x, y, onBus = 'DC_ESS', pumpNumber, centreTank, tankQuantity }: 
     );
 };
 
-render(<SimVarProvider><FuelPage /></SimVarProvider>);
+render(<FuelPage />);

--- a/src/instruments/src/SD/Pages/Hyd/Hyd.tsx
+++ b/src/instruments/src/SD/Pages/Hyd/Hyd.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { render } from '@instruments/common/index';
-import { SimVarProvider, useSimVar } from '@instruments/common/simVars';
+import { useSimVar } from '@instruments/common/simVars';
 import { setIsEcamPage } from '@instruments/common/defaults';
 import { ptuArray, levels } from './common';
 import { Triangle } from '../../Common/Shapes';
@@ -449,4 +449,4 @@ const PTU = ({ x, y, ptuScenario } : PTUProps) => {
     );
 };
 
-render(<SimVarProvider><HydPage /></SimVarProvider>);
+render(<HydPage />);

--- a/src/instruments/src/SD/Pages/Wheel/Wheel.tsx
+++ b/src/instruments/src/SD/Pages/Wheel/Wheel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@instruments/common/index';
 import classNames from 'classnames';
-import { SimVarProvider, useSimVar } from '@instruments/common/simVars';
+import { useSimVar } from '@instruments/common/simVars';
 import { setIsEcamPage } from '@instruments/common/defaults';
 import { useArinc429Var } from '@instruments/common/arinc429';
 import { Arinc429Word } from '@shared/arinc429';
@@ -513,4 +513,4 @@ const Wheels = ({ x, y, left, right }: WheelsProps) => {
     );
 };
 
-render(<SimVarProvider><WheelPage /></SimVarProvider>);
+render(<WheelPage />);


### PR DESCRIPTION
## Background

### Old hooks

The old SimVar hooks were based on a React context object provided by a `SimVarPovider`. This would centralize get/set calls into the context component, and allow employing a global cache. The client hooks would then call into that context, employing said global cache to access values.

On `set` operations, the global cache state would be mutated in identity, causing a re-render in every component using the hook. This was a tradeoff, effectively enabling dedupe-ing `SimVar.GetSimVarValuie` calls in the context component.

### New hooks

The new hooks simply employ two core mechanisms: a `useState` containing the current value, a `useRef` containing the latest timestamp of a get operation, and a `useUpdate` callback to compare the timer and get the value if necessary.

After performance testing, it is noticed that the deduep-ing tradeoff was not worth the resullting re-render penalty. CoherentGTUIThread times on idle on runway have went from 8-10ms to about 5-7, for instance.

## Summary of Changes

* This PR introduces experimental new simvar hooks, which are simpler and do not employ global caching. The main performance improvement is avoiding frequent re-renders, at the expense of no dedupeing simvar get calls.
* This changes the `maxStaleness` argument to `refreshInterval` - code will have to be checked for correcteness

* [x] Introduce new hooks
* [x] Port `useInteractionSimVar`
* [x] Adjust documentation
* [ ] Verify correctness of time-sensitive uses
* [x] Remove old hooks and provider

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
