### PR TITLE
refactor(engine): remove static values for inner tank overflow check

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -248,6 +248,7 @@
 1. [MISC] Added custom Autobrake event for SimConnect - @aguther (Andreas Guther)
 1. [EWD] Fixed failures not re-triggering when resolved - @tricky_dicky (Richard Pilbery)
 1. [SOUND] Prevent autopilot disconnect from sounding on C+D spawn - @tricky_dicky (Richard Pilbery) and @saschl (saschl#9432)
+1. [ENGINE/FADEC] Remove static values for inner tank overflow check - @Revyn112 (Denis Freund)
 
 ## 0.7.0
 

--- a/src/fadec/src/EngineControl.h
+++ b/src/fadec/src/EngineControl.h
@@ -871,17 +871,21 @@ class EngineControl {
       fuelLeft = (fuelLeftPre - (fuelBurn1 * KGS_TO_LBS)) + xfrAuxLeft + (xfrCenter / 2);     // LBS
       fuelRight = (fuelRightPre - (fuelBurn2 * KGS_TO_LBS)) + xfrAuxRight + (xfrCenter / 2);  // LBS
 
+
+      double leftQuantity = simVars->getTankLeftQuantity() * fuelWeightGallon; // LBS
+      double rightQuantity = simVars->getTankRightQuantity() * fuelWeightGallon; // LBS
+
       // Checking for Inner Tank overflow - Will be taken off with Rust code
-      if (fuelLeft > 12167.1 && fuelRight > 12167.1) {
-        fuelCenter = centerQuantity + (fuelLeft - 12167.1) + (fuelRight - 12167.1);
-        fuelLeft = 12167.1;
-        fuelRight = 12167.1;
-      } else if (fuelRight > 12167.1) {
-        fuelCenter = centerQuantity + fuelRight - 12167.1;
-        fuelRight = 12167.1;
-      } else if (fuelLeft > 12167.1) {
-        fuelCenter = centerQuantity + fuelLeft - 12167.1;
-        fuelLeft = 12167.1;
+      if (fuelLeft > leftQuantity && fuelRight > rightQuantity) {
+        fuelCenter = centerQuantity + (fuelLeft - leftQuantity) + (fuelRight - rightQuantity);
+        fuelLeft = leftQuantity;
+        fuelRight = rightQuantity;
+      } else if (fuelRight > rightQuantity) {
+        fuelCenter = centerQuantity + fuelRight - rightQuantity;
+        fuelRight = rightQuantity;
+      } else if (fuelLeft > leftQuantity) {
+        fuelCenter = centerQuantity + fuelLeft - leftQuantity;
+        fuelLeft = leftQuantity;
       } else {
         fuelCenter = centerQuantity;
       }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
This change removes the static values for the Inner Fuel Tank check and use the MSFS SimVar values instead.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
The code is more dynamically when changes happend and so it is better for the general maintaining process. On the other hand, as the FBW A32NX gets integrated in other addons this change is very helpful for the developer to maintain they code.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Load standard appron configuration of A32NX (Cold & Dark).
2. Turn on the FlyPad (EFB).
3. Switch to the Fuel Page.
4. Refill all tanks completly.
4. Check if fuel gets transfered to center tank when inner tank limit is reached.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
