### PR TITLE
fix: initialize throttle position to IDLE

### DIFF
--- a/src/fbw/src/ThrottleAxisMapping.cpp
+++ b/src/fbw/src/ThrottleAxisMapping.cpp
@@ -114,6 +114,9 @@ bool ThrottleAxisMapping::loadFromFile() {
   // update configuration
   updateMappingFromConfiguration(configuration);
 
+  // set current value to idle
+  setCurrentValue(idleValue);
+
   // success
   return true;
 }
@@ -128,6 +131,9 @@ bool ThrottleAxisMapping::saveToFile() {
 
   // set data on structure
   storeConfigurationInIniStructure(iniStructure, loadConfigurationFromLocalVariables());
+
+  // set current value to idle
+  setCurrentValue(idleValue);
 
   // write to file
   return iniFile.write(iniStructure, true);


### PR DESCRIPTION
Fixes #7183

## Summary of Changes
This PR adds initialization of the current throttle position on IDLE when the configuration is saved or loaded from file. This improves the initial position of the throttle when overall but especially when only using keyboard.

Before this PR the initial position of `0` and the resulting position was depending on the calibration.

## Testing instructions
- test if throttle is initialized with IDLE low value when loading the plane, pressing "load from file" or "save" on the EFB calibration page
- it should work as usual for the rest

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
