### PR TITLE
fix(fbw): rudder stuck on one side

### DIFF
--- a/src/fbw/src/model/FlyByWire.cpp
+++ b/src/fbw/src/model/FlyByWire.cpp
@@ -1666,7 +1666,7 @@ void FlyByWireModelClass::step()
       FlyByWire_P.ScheduledGain_BreakpointsForDimension1_jh, FlyByWire_P.ScheduledGain_Table_c, 3U);
   }
 
-  Vtas = FlyByWire_U.in.data.V_tas_kn * 0.5144;
+  Vtas = std::fmax(1.0, FlyByWire_U.in.data.V_tas_kn * 0.5144);
   rtb_Y_p = FlyByWire_U.in.data.V_ias_kn * 0.5144;
   if (FlyByWire_U.in.data.V_ias_kn >= 60.0) {
     omega_0 = FlyByWire_U.in.data.beta_deg;


### PR DESCRIPTION
## Summary of Changes
This PR fixes the occasional stuck of the rudder on one side.

## Testing instructions
- play heavy with the wind and get TAS (true airspeed) to `0`

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
