### PR TITLE
fix(ui): Ensure notifications are dismissed on exit to main menu

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/JS/A32NX_Util.js
+++ b/flybywire-aircraft-a320-neo/html_ui/JS/A32NX_Util.js
@@ -269,14 +269,14 @@ class NXPopUp {
             this.params.style = style;
         }
         if (callbackYes) {
-            const yes = (typeof callbackYes === 'function') ? callbackYes : () => callbackYes;
+            const yes = (typeof callbackYes === "function") ? callbackYes : () => callbackYes;
             Coherent.on(`A32NX_POP_${this.params.id}_YES`, () => {
                 Coherent.off(`A32NX_POP_${this.params.id}_YES`, null, null);
                 yes();
             });
         }
         if (callbackNo) {
-            const no = (typeof callbackNo === 'function') ? callbackNo : () => callbackNo;
+            const no = (typeof callbackNo === "function") ? callbackNo : () => callbackNo;
             Coherent.on(`A32NX_POP_${this.params.id}_NO`, () => {
                 Coherent.off(`A32NX_POP_${this.params.id}_NO`, null, null);
                 no();
@@ -298,20 +298,20 @@ class NXPopUp {
 class NXNotifManager {
 
     constructor() {
-        Coherent.on('keyIntercepted', (key) => this.registerIntercepts(key));
-        Coherent.call('INTERCEPT_KEY_EVENT', 'PAUSE_TOGGLE', 1);
-        Coherent.call('INTERCEPT_KEY_EVENT', 'PAUSE_ON', 1);
-        Coherent.call('INTERCEPT_KEY_EVENT', 'PAUSE_OFF', 1);
-        Coherent.call('INTERCEPT_KEY_EVENT', 'PAUSE_SET', 1);
+        Coherent.on("keyIntercepted", (key) => this.registerIntercepts(key));
+        Coherent.call("INTERCEPT_KEY_EVENT", "PAUSE_TOGGLE", 1);
+        Coherent.call("INTERCEPT_KEY_EVENT", "PAUSE_ON", 1);
+        Coherent.call("INTERCEPT_KEY_EVENT", "PAUSE_OFF", 1);
+        Coherent.call("INTERCEPT_KEY_EVENT", "PAUSE_SET", 1);
         this.notifications = [];
     }
 
     registerIntercepts(key) {
         switch (key) {
-            case 'PAUSE_TOGGLE':
-            case 'PAUSE_ON':
-            case 'PAUSE_OFF':
-            case 'PAUSE_SET':
+            case "PAUSE_TOGGLE":
+            case "PAUSE_ON":
+            case "PAUSE_OFF":
+            case "PAUSE_SET":
                 this.notifications.forEach((notif) => {
                     notif.hideNotification();
                 });
@@ -331,15 +331,15 @@ class NXNotifManager {
 
 class NXNotif {
     constructor() {
-        const title = 'A32NX ALERT';
+        const title = "A32NX ALERT";
         this.time = new Date().getTime();
         this.params = {
             id: `${title}_${this.time}`,
             title,
-            type: 'MESSAGE',
-            theme: 'GAMEPLAY',
-            image: 'IMAGE_NOTIFICATION',
-            description: 'Default Message',
+            type: "MESSAGE",
+            theme: "GAMEPLAY",
+            image: "IMAGE_NOTIFICATION",
+            description: "Default Message",
             timeout: 10000,
             time: this.time,
         };
@@ -380,9 +380,9 @@ class NXNotif {
         this.setData(params);
 
         if (!nxNotificationsListener) {
-            nxNotificationsListener = RegisterViewListener('JS_LISTENER_NOTIFICATIONS');
+            nxNotificationsListener = RegisterViewListener("JS_LISTENER_NOTIFICATIONS");
         }
-        nxNotificationsListener.triggerToAllSubscribers('SendNewNotification', this.params);
+        nxNotificationsListener.triggerToAllSubscribers("SendNewNotification", this.params);
         setTimeout(() => {
             this.hideNotification();
         }, this.params.timeout);
@@ -390,7 +390,7 @@ class NXNotif {
 
     // TODO FIXME: May break in the future, check every update
     hideNotification() {
-        nxNotificationsListener.triggerToAllSubscribers('HideNotification', this.params.type, null, this.params.id);
+        nxNotificationsListener.triggerToAllSubscribers("HideNotification", this.params.type, null, this.params.id);
     }
 }
 

--- a/flybywire-aircraft-a320-neo/html_ui/JS/A32NX_Util.js
+++ b/flybywire-aircraft-a320-neo/html_ui/JS/A32NX_Util.js
@@ -270,11 +270,17 @@ class NXPopUp {
         }
         if (callbackYes) {
             const yes = (typeof callbackYes === 'function') ? callbackYes : () => callbackYes;
-            Coherent.on("A32NX_POP_" + this.params.id + "_YES", yes);
+            Coherent.on(`A32NX_POP_${this.params.id}_YES`, () => {
+                Coherent.off(`A32NX_POP_${this.params.id}_YES`, null, null);
+                yes();
+            });
         }
         if (callbackNo) {
             const no = (typeof callbackNo === 'function') ? callbackNo : () => callbackNo;
-            Coherent.on("A32NX_POP_" + this.params.id + "_NO", no);
+            Coherent.on(`A32NX_POP_${this.params.id}_NO`, () => {
+                Coherent.off(`A32NX_POP_${this.params.id}_NO`, null, null);
+                no();
+            });
         }
 
         if (!this.popupListener) {
@@ -298,13 +304,6 @@ class NXNotifManager {
         Coherent.call('INTERCEPT_KEY_EVENT', 'PAUSE_OFF', 1);
         Coherent.call('INTERCEPT_KEY_EVENT', 'PAUSE_SET', 1);
         this.notifications = [];
-        /*
-        this.eventBus = new NXEvents();
-        KeyInterceptManager.getManager(this.eventBus).then((man) => {
-            this.manager = man;
-            this.registerIntercepts();
-        });
-        */
     }
 
     registerIntercepts(key) {

--- a/flybywire-aircraft-a320-neo/html_ui/JS/A32NX_Util.js
+++ b/flybywire-aircraft-a320-neo/html_ui/JS/A32NX_Util.js
@@ -288,6 +288,48 @@ class NXPopUp {
 /**
  * NXNotif utility class to create a notification event and element
  */
+
+class NXNotifManager {
+
+    constructor() {
+        Coherent.on('keyIntercepted', (key) => this.registerIntercepts(key));
+        Coherent.call('INTERCEPT_KEY_EVENT', 'PAUSE_TOGGLE', 1);
+        Coherent.call('INTERCEPT_KEY_EVENT', 'PAUSE_ON', 1);
+        Coherent.call('INTERCEPT_KEY_EVENT', 'PAUSE_OFF', 1);
+        Coherent.call('INTERCEPT_KEY_EVENT', 'PAUSE_SET', 1);
+        this.notifications = [];
+        /*
+        this.eventBus = new NXEvents();
+        KeyInterceptManager.getManager(this.eventBus).then((man) => {
+            this.manager = man;
+            this.registerIntercepts();
+        });
+        */
+    }
+
+    registerIntercepts(key) {
+        switch (key) {
+            case 'PAUSE_TOGGLE':
+            case 'PAUSE_ON':
+            case 'PAUSE_OFF':
+            case 'PAUSE_SET':
+                this.notifications.forEach((notif) => {
+                    notif.hideNotification();
+                });
+                this.notifications.length = 0;
+                break;
+            default:
+                break;
+        }
+    }
+
+    showNotification(params = {}) {
+        const notif = new NXNotif();
+        notif.showNotification(params);
+        this.notifications.push(notif);
+    }
+}
+
 class NXNotif {
     constructor() {
         const title = 'A32NX ALERT';
@@ -343,9 +385,13 @@ class NXNotif {
         }
         nxNotificationsListener.triggerToAllSubscribers('SendNewNotification', this.params);
         setTimeout(() => {
-            // TODO FIXME: May break in the future, check every update
-            nxNotificationsListener.triggerToAllSubscribers('HideNotification', this.params.type, null, this.params.id);
+            this.hideNotification();
         }, this.params.timeout);
+    }
+
+    // TODO FIXME: May break in the future, check every update
+    hideNotification() {
+        nxNotificationsListener.triggerToAllSubscribers('HideNotification', this.params.type, null, this.params.id);
     }
 }
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_TipsManager.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_TipsManager.js
@@ -1,6 +1,6 @@
 class A32NX_TipsManager {
     constructor() {
-        this.notif = new NXNotif();
+        this.notif = new NXNotifManager();
         this.checkThrottleCalibration();
         this.updateThrottler = new UpdateThrottler(15000);
         this.wasAnyAssistanceActive = false;

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -1217,7 +1217,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
 
         this.socket.onopen = () => {
             console.log(`Websocket connection to MCDU Server established. (${url})`);
-            (new NXNotif).showNotification({title: "MCDU CONNECTED", message: "Successfully connected to MCDU server.", timeout: 5000});
+            (new NXNotifManager).showNotification({title: "MCDU CONNECTED", message: "Successfully connected to MCDU server.", timeout: 5000});
             this.sendToSocket("mcduConnected");
             this.sendUpdate();
             this.socketConnectionAttempts = 0;

--- a/src/shared/src/popup.ts
+++ b/src/shared/src/popup.ts
@@ -23,7 +23,8 @@ export type NotiticationParams = {
  * import { PopUp } from '@shared/popup';
  * ...
  * const popup = new PopUp();
- * popup.showPopUp({ title: "CRITICAL SETTING CHANGED", message: "Your message here", style: "small"}, yesFunc, noFunc);
+ * popup.showPopUp("CRITICAL SETTING CHANGED", "Your message here", "small", yesFunc, noFunc);
+ * popup.showInformation("CRITICAL MESSAGE", "Your message here", "small", yesFunc);
  */
 export class PopUp {
     params: NotiticationParams;
@@ -80,11 +81,17 @@ export class PopUp {
         }
         if (callbackYes) {
             const yes = (typeof callbackYes === 'function') ? callbackYes : () => callbackYes;
-            Coherent.on(`A32NX_POP_${this.params.id}_YES`, yes);
+            Coherent.on(`A32NX_POP_${this.params.id}_YES`, () => {
+                Coherent.off(`A32NX_POP_${this.params.id}_YES`, null, null);
+                yes();
+            });
         }
         if (callbackNo) {
             const no = (typeof callbackNo === 'function') ? callbackNo : () => callbackNo;
-            Coherent.on(`A32NX_POP_${this.params.id}_NO`, no);
+            Coherent.on(`A32NX_POP_${this.params.id}_NO`, () => {
+                Coherent.off(`A32NX_POP_${this.params.id}_NO`, null, null);
+                no();
+            });
         }
 
         if (!this.popupListener) {
@@ -113,7 +120,10 @@ export class PopUp {
         }
         if (callback) {
             const yes = (typeof callback === 'function') ? callback : () => callback;
-            Coherent.on(`A32NX_POP_${this.params.id}_YES`, yes);
+            Coherent.on(`A32NX_POP_${this.params.id}_YES`, () => {
+                Coherent.off(`A32NX_POP_${this.params.id}_YES`, null, null);
+                yes();
+            });
         }
         this.params.buttons = [new NotificationButton('TT:MENU.OK', `A32NX_POP_${this.params.id}_YES`)];
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes an issue where notifications would persist on the main menu if a notification was active when the pause screen was triggered. Achieved by dismissing any active A32NX notifications when the pause menu is entered.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Open Flight Assistants menu and enable AI Auto-Trim, AI Anti-Stall Protection, etc.
- Wait for the notification to popup
- Pause and return to main menu (note: notification will still be stuck on the pause menu, sim limitation at this time)
- Notification should dismiss after exiting to main menu and not be displayed on screen. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
