### PR TITLE
feat(hyd): unlock ability to reset gravity gear extension

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 1. [MODEL] Add Wheel Chocks and GSE Safety Cones - @bouveng (Johan Bouveng)
 1. [MCDU] Allow Wind Request from Simbrief flight plan - @USA-RedDragon (Jacob McSwain)
+1. [HYD] Now allowing reverting gravity gear extension - @Crocket63 (crocket)
 
 ## 0.8.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,11 +8,8 @@
 
 1. [MODEL] Add Wheel Chocks and GSE Safety Cones - @bouveng (Johan Bouveng)
 1. [MCDU] Allow Wind Request from Simbrief flight plan - @USA-RedDragon (Jacob McSwain)
-1. [HYD] Now allowing reverting gravity gear extension - @Crocket63 (crocket)
-
-## 0.9.0
-
 1. [HYD] Fix fluid return handling of actuators - @Crocket63 (crocket)
+1. [HYD] Now allowing reverting gravity gear extension - @Crocket63 (crocket)
 
 ## 0.8.0
 

--- a/src/systems/a320_systems/src/hydraulic/mod.rs
+++ b/src/systems/a320_systems/src/hydraulic/mod.rs
@@ -10354,8 +10354,6 @@ mod tests {
             );
         }
 
-        // TODO un-ignore when emergency gear extension is allowed to be reset
-        #[ignore]
         #[test]
         fn reverting_emergency_extension_do_not_change_fluid_volume() {
             let mut test_bed = test_bed_with()

--- a/src/systems/a320_systems/src/hydraulic/mod.rs
+++ b/src/systems/a320_systems/src/hydraulic/mod.rs
@@ -5314,9 +5314,6 @@ impl A320GravityExtension {
     const MIN_CRANK_HANDLE_ANGLE_DEGREE: f64 = 0.;
     const CRANK_HANDLE_ANGLE_MARGIN_AT_MAX_ROTATION_DEGREE: f64 = 0.1;
 
-    // Can be allowed when handle animation is available
-    const ALLOW_RETURNING_TO_STOWED_HANDLE_POSITION: bool = true;
-
     fn new(context: &mut InitContext) -> Self {
         Self {
             gear_gravity_extension_active_id: context
@@ -5354,8 +5351,7 @@ impl A320GravityExtension {
                     - Self::CRANK_HANDLE_ANGLE_MARGIN_AT_MAX_ROTATION_DEGREE,
             ));
 
-        if Self::ALLOW_RETURNING_TO_STOWED_HANDLE_POSITION
-            && self.handle_angle.get::<degree>() > Self::MAX_CRANK_HANDLE_ANGLE_DEGREE
+        if self.handle_angle.get::<degree>() > Self::MAX_CRANK_HANDLE_ANGLE_DEGREE
             && !self.is_turned
             && self.is_extending_gear
         {

--- a/src/systems/a320_systems/src/hydraulic/mod.rs
+++ b/src/systems/a320_systems/src/hydraulic/mod.rs
@@ -10258,6 +10258,7 @@ mod tests {
             let mut test_bed = test_bed_with()
                 .set_cold_dark_inputs()
                 .in_flight()
+                .with_worst_case_ptu()
                 .set_gear_lever_down()
                 .set_green_ed_pump(false)
                 .set_yellow_ed_pump(false)
@@ -10268,7 +10269,7 @@ mod tests {
             assert!(test_bed.gear_system_state() == GearSystemState::AllDownLocked);
 
             test_bed = test_bed.set_gear_lever_up();
-            test_bed = test_bed.run_waiting_for(Duration::from_secs_f64(60.));
+            test_bed = test_bed.run_waiting_for(Duration::from_secs_f64(80.));
 
             assert!(test_bed.gear_system_state() == GearSystemState::AllUpLocked);
         }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
It is now possible to revert gravity gear extension.

Still need to hold key binding or hold and click the crank handle to use it. 
When fully turned, once key or mouse is released , next click and hold will revert the crank handle 3 turns back to stowed position.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Use gravity gear extension on ground and in flight. If clicked and hold it should:
- release doors on ground
- release doors and gears in flight.

After use even with green system available, gear should be inoperative.

If clicked and held again, and if green system available it should:
- close doors on ground
- close doors and gears in flight. (Might need to recycle gear lever if LGCIU error)

In all conditions check that reservoir level is consistent.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
