### PR TITLE
fix(model): expose gnd equipment visibility simvar

### DIFF
--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -25,7 +25,11 @@
 
 - A32NX_IS_STATIONARY
   - Bool
-  - Aircraft is stationary in relation to the speed of the first surface directly underneath it. (not moving on a carrier for example)
+  - Aircraft is stationary in relation to the speed of the first surface directly underneath it. (stationary on a carrier that is moving would be considered stationary)
+
+- A32NX_GND_EQP_IS_VISIBLE
+  - Bool
+  - Indicates if any GND equipment is visible or not
 
 - A32NX_START_STATE
   - Enum

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO.xml
@@ -481,10 +481,13 @@
                 <GND_ENABLE_OVRD>(L:A32NX_MODEL_CONES_ENABLED) (L:A32NX_IS_STATIONARY, bool) and</GND_ENABLE_OVRD>
             </UseTemplate>
 
-            <!-- Utility function for creating the A32NX_IS_STATIONARY L-var. -->
+            <!-- Utility function for creating the A32NX_IS_STATIONARY and A32NX_GND_EQP_IS_VISIBLE L-vars. -->
             <UseTemplate Name="ASOBO_GT_Update">
                 <FREQUENCY>10</FREQUENCY>
-                <UPDATE_CODE>(A:SURFACE RELATIVE GROUND SPEED, feet per second) 0.1 &gt; ! (&gt;L:A32NX_IS_STATIONARY, bool)</UPDATE_CODE>
+                <UPDATE_CODE>
+                    (A:SURFACE RELATIVE GROUND SPEED, feet per second) 0.1 &gt; ! (&gt;L:A32NX_IS_STATIONARY, bool)
+                    (A:SIM ON GROUND, bool) (L:A32NX_ENGINE_N1:1, Number) 3.5 &lt; and (L:A32NX_ENGINE_N1:2, Number) 3.5 &lt; and (L:A32NX_HYD_NW_STRG_DISC_ECAM_MEMO, bool) 0 == and (A:LIGHT BEACON ON, bool) 0 == and (&gt;L:A32NX_GND_EQP_IS_VISIBLE, bool)
+                </UPDATE_CODE>
             </UseTemplate>
 
         </Component>


### PR DESCRIPTION
## Summary of Changes
This PR adds a new simvar called `A32NX_GND_EQP_IS_VISIBLE` that exposes the current visibility of ground equipment.

## Additional context
Same logic already reviewed and Q&A.
No need for test, simvar used internally in `flypadosv3`.

Discord username (if different from GitHub): @bouveng

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
