### PR TITLE
fix(fms): fix sync of origin runway when loading from MSFS World Map

### DIFF
--- a/src/fmgc/src/flightplanning/FlightPlanManager.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanManager.ts
@@ -1209,7 +1209,7 @@ export class FlightPlanManager {
                 .departures[currentFlightPlan.procedureDetails.departureIndex]
                 .runwayTransitions[currentFlightPlan.procedureDetails.departureRunwayIndex];
             const runways = (currentFlightPlan.originAirfield.infos as AirportInfo).oneWayRunways;
-            await this.setOriginRunwayIndex(runways.findIndex(r => r.number === transition.runwayNumber && r.designator === transition.runwayDesignator));
+            await this.setOriginRunwayIndex(runways.findIndex(r => r.number === transition.runwayNumber && r.designator === transition.runwayDesignation));
         }
     }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
When loading in from the world map, origin runway is sometimes ignored and not passed to FMS. This PR restores the flight plan sync from the world map to the correct and expected behaviour.


## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

Before:

![FlightSimulator_AdCdkqs4vJ](https://user-images.githubusercontent.com/15316958/168311157-1609c2d8-677d-422e-9471-38a739eaa9a5.jpg)

After:

![FlightSimulator_AY4uwJPb3D](https://user-images.githubusercontent.com/15316958/168311194-64dc646b-e3dc-4e83-84e7-ea7a3f624853.jpg)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): 2Cas#1022

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Download and Load the following .FLT into MSFS

https://drive.google.com/file/d/1n4sBYpPC7VM9rOvrXbTdOG5JerUjrlJ7/view?usp=sharing

Check that the flight plan is loaded in correctly

Exit, Open a random route with a departure/arrival procedure from the world map (High altitude airways, etc).

Check that this is loaded in correctly.


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
