### PR TITLE
fix(dev): changelog and rust plugin recommendation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,9 +8,6 @@
 
 1. [MODEL] Add Wheel Chocks and GSE Safety Cones - @bouveng (Johan Bouveng)
 1. [MCDU] Allow Wind Request from Simbrief flight plan - @USA-RedDragon (Jacob McSwain)
-
-## 0.9.0
-
 1. [HYD] Fix fluid return handling of actuators - @Crocket63 (crocket)
 
 ## 0.8.0

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "matklad.rust-analyzer",
+    "rust-lang.rust-analyzer",
     "vadimcn.vscode-lldb",
     "xaver.clang-format"
   ]


### PR DESCRIPTION
## Summary of Changes
This PR fixes:
- the double entry of 0.9.0 in the changelog
- VS Code Rust plugin recommendation (the plugin unique identifier was renamed)

## Testing instructions
- no testing required

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
