### PR TITLE
fix(tcas): hotfix for TCAS standby bug

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,6 +11,7 @@
 1. [HYD] Fix fluid return handling of actuators - @Crocket63 (crocket)
 1. [ENGINE] Fuel persistency between each flight - @juliansebline (Julian Sebline#8476)
 1. [HYD] Now allowing reverting gravity gear extension - @Crocket63 (crocket)
+1. [TCAS] Fixed issue when turning to STBY while RA is issued - @2hwk (2Cas#1022)
 
 ## 0.8.0
 

--- a/src/tcas/src/components/TcasComputer.ts
+++ b/src/tcas/src/components/TcasComputer.ts
@@ -329,11 +329,21 @@ export class TcasComputer implements TcasComponent {
      * Set TCAS status
      */
     private updateStatusFaults(): void {
-        // If in STBY, inhibit all, set sens to 1
+        // If in STBY, inhibit all, set sens to 1, clear all existing RAs
         if (this.tcasMode.getVar() === TcasMode.STBY) {
             this.taOnly.setVar(false);
             this.tcasFault.setVar(false);
             this.sensitivity.setVar(1);
+
+            this.activeRa.info = null;
+            this.activeRa.isReversal = false;
+            this.activeRa.secondsSinceStart = 0;
+            this.activeRa.hasBeenAnnounced = false;
+
+            this._newRa.info = null;
+            this._newRa.isReversal = false;
+            this._newRa.secondsSinceStart = 0;
+            this._newRa.hasBeenAnnounced = false;
             return;
         }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #7152

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes an issue where if TCAS was switched to standby while an RA is issued, the TCAS computer would stop functioning and issuing TAs and RAs when switched back to TA/RA.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
Note; There are other TCAS bugs which are known issues which will not be addressed in this PR, this is a hotfix. 

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): 2Cas#1022

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Intercept traffic around a busy airfield, then when a RA is issued, turn the TCAS mode to STBY (from TA/RA). Turn the TCAS mode switch back to TA/RA, and try to intercept traffic again. Appropriate TA/RA should be issued. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
