### PR TITLE
perf: reduce variable access time

### DIFF
--- a/src/systems/systems/src/simulation/mod.rs
+++ b/src/systems/systems/src/simulation/mod.rs
@@ -38,17 +38,17 @@ pub trait VariableRegistry {
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
-pub struct VariableIdentifier(u8, usize);
+pub struct VariableIdentifier(usize, usize);
 
 impl VariableIdentifier {
-    pub fn new<T: Into<u8>>(variable_type: T) -> Self {
+    pub fn new<T: Into<usize>>(variable_type: T) -> Self {
         Self {
             0: variable_type.into(),
             1: 0,
         }
     }
 
-    pub fn identifier_type(&self) -> u8 {
+    pub fn identifier_type(&self) -> usize {
         self.0
     }
 

--- a/src/systems/systems_wasm/src/aspects.rs
+++ b/src/systems/systems_wasm/src/aspects.rs
@@ -245,12 +245,7 @@ impl<'a, 'b> MsfsAspectBuilder<'a, 'b> {
         func: Box<dyn Fn(&[f64], &[f64])>,
     ) {
         let observed = self.variables.register_many(&observed);
-        let starting_values = self
-            .variables
-            .read_many(&observed)
-            .iter_mut()
-            .map(|v| v.unwrap_or(0.))
-            .collect();
+        let starting_values = self.variables.read_many(&observed);
 
         self.actions.push((
             OnChange::new(observed, starting_values, func).into(),
@@ -392,11 +387,7 @@ impl ExecutableVariableAction for Map {
         _: &mut SimConnect,
         variables: &mut MsfsVariableRegistry,
     ) -> Result<(), Box<dyn Error>> {
-        let value = match variables.read(&self.input_variable_identifier) {
-            Some(value) => value,
-            None => panic!("Attempted to map a variable which is unavailable."),
-        };
-
+        let value = variables.read(&self.input_variable_identifier);
         variables.write(&self.output_variable_identifier, (self.func)(value));
 
         Ok(())
@@ -446,11 +437,8 @@ impl ExecutableVariableAction for MapMany {
         _: &mut SimConnect,
         variables: &mut MsfsVariableRegistry,
     ) -> Result<(), Box<dyn Error>> {
-        let values: Vec<f64> = variables
-            .read_many(&self.input_variable_identifiers)
-            .iter()
-            .map(|&x| x.unwrap())
-            .collect();
+        let values: Vec<f64> = variables.read_many(&self.input_variable_identifiers);
+
         let result = (self.func)(&values);
         variables.write(&self.output_variable_identifier, result);
 
@@ -491,8 +479,6 @@ impl ExecutableVariableAction for Reduce {
     ) -> Result<(), Box<dyn Error>> {
         let result = variables
             .read_many(&self.input_variable_identifiers)
-            .iter()
-            .map(|&x| x.unwrap())
             .into_iter()
             .fold(self.init, self.func);
 
@@ -539,14 +525,7 @@ impl ExecutableVariableAction for ToObject {
         let values: Vec<f64> = self
             .variables
             .iter()
-            .map(
-                |variable_identifier| match variables.read(variable_identifier) {
-                    Some(value) => value,
-                    None => {
-                        panic!("Attempted to access variables which are unavailable.")
-                    }
-                },
-            )
+            .map(|variable_identifier| variables.read(variable_identifier))
             .collect();
 
         self.target_object.write(values);
@@ -779,13 +758,11 @@ impl EventToVariable {
                 sim_connect_32k_pos_inv_to_f64(e.data())
             }
             EventToVariableMapping::EventDataToValue(func) => func(e.data()),
-            EventToVariableMapping::CurrentValueToValue(func) => {
-                func(variables.read(&self.target).unwrap_or(0.))
-            }
+            EventToVariableMapping::CurrentValueToValue(func) => func(variables.read(&self.target)),
             EventToVariableMapping::EventDataAndCurrentValueToValue(func) => {
-                func(e.data(), variables.read(&self.target).unwrap_or(0.))
+                func(e.data(), variables.read(&self.target))
             }
-            EventToVariableMapping::SmoothPress(..) => variables.read(&self.target).unwrap_or(0.),
+            EventToVariableMapping::SmoothPress(..) => variables.read(&self.target),
         }
     }
 
@@ -795,7 +772,7 @@ impl EventToVariable {
         variables: &mut MsfsVariableRegistry,
     ) {
         if let EventToVariableMapping::SmoothPress(press_factor, release_factor) = self.mapping {
-            let mut value = variables.read(&self.target).unwrap_or(0.);
+            let mut value = variables.read(&self.target);
             if self.event_handled_before_tick {
                 value += delta.as_secs_f64() * press_factor;
             } else {
@@ -902,7 +879,7 @@ impl ExecutableVariableAction for ToEvent {
         sim_connect: &mut SimConnect,
         variables: &mut MsfsVariableRegistry,
     ) -> Result<(), Box<dyn Error>> {
-        let value = variables.read(&self.input).unwrap_or(0.);
+        let value = variables.read(&self.input);
         let should_write = match self.write_on {
             VariableToEventWriteOn::EveryTick => true,
             VariableToEventWriteOn::Change => match self.last_written_value {
@@ -959,11 +936,7 @@ impl ExecutableVariableAction for OnChange {
         _: &mut SimConnect,
         variables: &mut MsfsVariableRegistry,
     ) -> Result<(), Box<dyn Error>> {
-        let current_values: Vec<f64> = variables
-            .read_many(&self.observed_variables)
-            .iter_mut()
-            .map(|v| v.unwrap_or(0.))
-            .collect();
+        let current_values: Vec<f64> = variables.read_many(&self.observed_variables);
 
         // Allow floating point equality comparison, because we really care about the
         // value being exactly equal and assume that the code that changes this value

--- a/src/systems/systems_wasm/src/lib.rs
+++ b/src/systems/systems_wasm/src/lib.rs
@@ -259,7 +259,7 @@ impl SimulatorReaderWriter for MsfsHandler {
             .unwrap_or_else(|| {
                 self.variables
                     .as_ref()
-                    .map(|registry| registry.read(identifier).unwrap_or(0.))
+                    .map(|registry| registry.read(identifier))
                     .unwrap_or(0.)
             })
     }
@@ -382,14 +382,14 @@ pub enum VariableType {
     Aspect = 2,
 }
 
-impl From<VariableType> for u8 {
+impl From<VariableType> for usize {
     fn from(value: VariableType) -> Self {
-        value as u8
+        value as usize
     }
 }
 
-impl From<u8> for VariableType {
-    fn from(value: u8) -> Self {
+impl From<usize> for VariableType {
+    fn from(value: usize) -> Self {
         match value {
             0 => Self::Aircraft,
             1 => Self::Named,
@@ -433,7 +433,7 @@ pub struct MsfsVariableRegistry {
     named_variable_prefix: String,
     name_to_identifier: FxHashMap<String, VariableIdentifier>,
     next_variable_identifier: FxHashMap<VariableType, VariableIdentifier>,
-    variables: FxHashMap<VariableIdentifier, VariableValue>,
+    variables: [Vec<VariableValue>; 3],
 }
 
 impl MsfsVariableRegistry {
@@ -442,7 +442,7 @@ impl MsfsVariableRegistry {
             named_variable_prefix,
             name_to_identifier: FxHashMap::default(),
             next_variable_identifier: FxHashMap::default(),
-            variables: FxHashMap::default(),
+            variables: [vec![], vec![], vec![]],
         }
     }
 
@@ -489,20 +489,19 @@ impl MsfsVariableRegistry {
                 }
 
                 let value: VariableValue = (&variable).into();
-                self.variables.insert(identifier, value);
+                self.variables[identifier.identifier_type()]
+                    .insert(identifier.identifier_index(), value);
 
                 identifier
             }
         }
     }
 
-    fn read(&self, identifier: &VariableIdentifier) -> Option<f64> {
-        self.variables
-            .get(identifier)
-            .map(|variable_value| variable_value.read())
+    fn read(&self, identifier: &VariableIdentifier) -> f64 {
+        self.variables[identifier.identifier_type()][identifier.identifier_index()].read()
     }
 
-    fn read_many(&self, identifiers: &[VariableIdentifier]) -> Vec<Option<f64>> {
+    fn read_many(&self, identifiers: &[VariableIdentifier]) -> Vec<f64> {
         identifiers
             .iter()
             .map(|identifier| self.read(identifier))
@@ -510,9 +509,7 @@ impl MsfsVariableRegistry {
     }
 
     fn write(&mut self, identifier: &VariableIdentifier, value: f64) {
-        if let Some(variable_value) = self.variables.get_mut(identifier) {
-            variable_value.write(value);
-        }
+        self.variables[identifier.identifier_type()][identifier.identifier_index()].write(value);
     }
 }
 


### PR DESCRIPTION
## Summary of Changes
Improves variable access performance by replacing `FxHashMap<VariableIdentifier, VariableValue>` with `[Vec<VariableValue>; 3]`. Achieves a 6.74% reduction on time spent per frame in `systems` on my machine.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SjotgunSjonnie#9623

## Testing instructions

Do some basic flying and fiddling with some systems. Things should keep working as they were before.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
