### PR TITLE
fix(gpws): altitude callouts now on time

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [ENGINE] Fuel persistency between each flight - @juliansebline (Julian Sebline#8476)
 1. [HYD] Now allowing reverting gravity gear extension - @Crocket63 (crocket)
 1. [TCAS] Fixed issue when turning to STBY while RA is issued - @2hwk (2Cas#1022)
+1. [GPWS] Alt callouts now finish before altitude is reached - @2hwk (2Cas#1022)
 
 ## 0.8.0
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_GPWS.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_GPWS.js
@@ -436,14 +436,14 @@ class A32NX_GPWS {
         }
         switch (this.AltCallState.value) {
             case "ground":
-                if (radioAlt > 5) {
+                if (radioAlt > 6) {
                     this.AltCallState.action("up");
                 }
                 break;
             case "over5":
-                if (radioAlt > 10) {
+                if (radioAlt > 12) {
                     this.AltCallState.action("up");
-                } else if (radioAlt <= 5) {
+                } else if (radioAlt <= 6) {
                     if (this.RetardState.value !== "retardPlaying") {
                         this.core.soundManager.tryPlaySound(soundList.alt_5);
                     }
@@ -451,9 +451,9 @@ class A32NX_GPWS {
                 }
                 break;
             case "over10":
-                if (radioAlt > 20) {
+                if (radioAlt > 22) {
                     this.AltCallState.action("up");
-                } else if (radioAlt <= 10) {
+                } else if (radioAlt <= 12) {
                     if (this.RetardState.value !== "retardPlaying") {
                         this.core.soundManager.tryPlaySound(soundList.alt_10);
                     }
@@ -461,87 +461,87 @@ class A32NX_GPWS {
                 }
                 break;
             case "over20":
-                if (radioAlt > 30) {
+                if (radioAlt > 32) {
                     this.AltCallState.action("up");
-                } else if (radioAlt <= 20) {
+                } else if (radioAlt <= 22) {
                     this.core.soundManager.tryPlaySound(soundList.alt_20);
                     this.AltCallState.action("down");
                 }
                 break;
             case "over30":
-                if (radioAlt > 40) {
+                if (radioAlt > 42) {
                     this.AltCallState.action("up");
-                } else if (radioAlt <= 30) {
+                } else if (radioAlt <= 32) {
                     this.core.soundManager.tryPlaySound(soundList.alt_30);
                     this.AltCallState.action("down");
                 }
                 break;
             case "over40":
-                if (radioAlt > 50) {
+                if (radioAlt > 53) {
                     this.AltCallState.action("up");
-                } else if (radioAlt <= 40) {
+                } else if (radioAlt <= 42) {
                     this.core.soundManager.tryPlaySound(soundList.alt_40);
                     this.AltCallState.action("down");
                 }
                 break;
             case "over50":
-                if (radioAlt > 100) {
+                if (radioAlt > 110) {
                     this.AltCallState.action("up");
-                } else if (radioAlt <= 50) {
+                } else if (radioAlt <= 53) {
                     this.core.soundManager.tryPlaySound(soundList.alt_50);
                     this.AltCallState.action("down");
                 }
                 break;
             case "over100":
-                if (radioAlt > 200) {
+                if (radioAlt > 210) {
                     this.AltCallState.action("up");
-                } else if (radioAlt <= 100) {
+                } else if (radioAlt <= 110) {
                     this.core.soundManager.tryPlaySound(soundList.alt_100);
                     this.AltCallState.action("down");
                 }
                 break;
             case "over200":
-                if (radioAlt > 300) {
+                if (radioAlt > 310) {
                     this.AltCallState.action("up");
-                } else if (radioAlt <= 200) {
+                } else if (radioAlt <= 210) {
                     this.core.soundManager.tryPlaySound(soundList.alt_200);
                     this.AltCallState.action("down");
                 }
                 break;
             case "over300":
-                if (radioAlt > 400) {
+                if (radioAlt > 410) {
                     this.AltCallState.action("up");
-                } else if (radioAlt <= 300) {
+                } else if (radioAlt <= 310) {
                     this.core.soundManager.tryPlaySound(soundList.alt_300);
                     this.AltCallState.action("down");
                 }
                 break;
             case "over400":
-                if (radioAlt > 500) {
+                if (radioAlt > 513) {
                     this.AltCallState.action("up");
-                } else if (radioAlt <= 400) {
+                } else if (radioAlt <= 410) {
                     this.core.soundManager.tryPlaySound(soundList.alt_400);
                     this.AltCallState.action("down");
                 }
                 break;
             case "over500":
-                if (radioAlt > 1000) {
+                if (radioAlt > 1020) {
                     this.AltCallState.action("up");
-                } else if (radioAlt <= 500) {
+                } else if (radioAlt <= 513) {
                     this.core.soundManager.tryPlaySound(soundList.alt_500);
                     this.AltCallState.action("down");
                 }
                 break;
             case "over1000":
-                if (radioAlt > 2500) {
+                if (radioAlt > 2530) {
                     this.AltCallState.action("up");
-                } else if (radioAlt <= 1000) {
+                } else if (radioAlt <= 1020) {
                     this.core.soundManager.tryPlaySound(soundList.alt_1000);
                     this.AltCallState.action("down");
                 }
                 break;
             case "over2500":
-                if (radioAlt <= 2500) {
+                if (radioAlt <= 2530) {
                     this.core.soundManager.tryPlaySound(soundList.alt_2500);
                     this.AltCallState.action("down");
                 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #2086

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Altitude callouts were triggered when the altitude is reached, meaning that by the time the callout audio would finish after the altitude had already been passed (too late). This modifies the alert values with corrected ones (see Beheh's comment on the linked issue).

This was planned to be solved by the rust FWC, but for now as this will take some time, the current placeholder logic will be updated by this PR.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Perform a normal landing and pay attention to the altitude callouts. They should complete just before the altitude is reached while on the G/S.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
