### PR TITLE
fix(atsu): cargo weight on set of PAX without simbrief

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -13,6 +13,7 @@
 1. [HYD] Now allowing reverting gravity gear extension - @Crocket63 (crocket)
 1. [TCAS] Fixed issue when turning to STBY while RA is issued - @2hwk (2Cas#1022)
 1. [GPWS] Alt callouts now finish before altitude is reached - @2hwk (2Cas#1022)
+1. [ATSU] Fix cargo weight is not set on manually PAX - @Revyn112 (Revyn112#1010)
 
 ## 0.8.0
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_OFPData.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_OFPData.js
@@ -81,7 +81,7 @@ class CDUAocOfpData {
                 async (value) => {
                     await setDefaultWeights(0, 0);
                     await SimVar.SetSimVarValue(`L:${station.simVar}_DESIRED`, "Number", value);
-                    await setTargetCargo(value, '');
+                    await setTargetCargo(value, 0);
                     updateView();
                 }
             );
@@ -155,7 +155,7 @@ class CDUAocOfpData {
                 async (value) => {
                     await setDefaultWeights(0, 0);
                     await setTargetPax(value);
-                    await setTargetCargo(value, '');
+                    await setTargetCargo(value, 0);
                     updateView();
                 }
             );


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
This small change fixes a bug at `W/B` page where cargo weight is not loaded when entering a manually passenger count without using simbrief. Currently, when you set PAX to 174 the cargo in hold remains on 0kg.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Start up A32NX from cold & dark.
2. Navigate to W/B Page via ATSU > AOC.
3. Set the total PAX count (e.g. 174).
4. Check if Cargo in Hold is now also calculated.
5. Start boarding: PAX and Cargo should be loaded now correctly.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
