### PR TITLE
feat(hyd): add spawning gear up, and correct surface positions at init

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -18,6 +18,7 @@
 1. [ATSU] Fix cargo weight is not set on manually PAX - @Revyn112 (Revyn112#1010)
 1. [CDSS] When off no longer displays door video - @davidwalschots (David Walschots)
 1. [FMGC] Map leg course with station declination where required - @tracernz (Mike)
+1. [HYD] Gear system now supports spawning in flight gear up - @Crocket63 (crocket)
 
 ## 0.8.0
 

--- a/src/systems/a320_systems/src/hydraulic/mod.rs
+++ b/src/systems/a320_systems/src/hydraulic/mod.rs
@@ -71,12 +71,11 @@ use systems::hydraulic::PressureSwitchState;
 struct A320HydraulicReservoirFactory {}
 impl A320HydraulicReservoirFactory {
     fn new_green_reservoir(context: &mut InitContext) -> Reservoir {
-        let reservoir_offset_when_gear_up =
-            if context.is_on_ground() || context.start_state() == StartState::Final {
-                Volume::new::<gallon>(0.)
-            } else {
-                Volume::new::<gallon>(-1.3)
-            };
+        let reservoir_offset_when_gear_up = if context.start_gear_down() {
+            Volume::new::<gallon>(0.)
+        } else {
+            Volume::new::<gallon>(-1.3)
+        };
 
         Reservoir::new(
             context,
@@ -981,7 +980,7 @@ impl A320GearFactory {
 struct A320GearSystemFactory {}
 impl A320GearSystemFactory {
     fn a320_gear_system(context: &mut InitContext) -> HydraulicGearSystem {
-        let init_downlocked = context.is_on_ground() || context.start_state() == StartState::Final;
+        let init_downlocked = context.start_gear_down();
 
         HydraulicGearSystem::new(
             context,
@@ -10518,10 +10517,11 @@ mod tests {
                 .in_flight()
                 .run_one_tick();
 
-            assert!(test_bed.get_left_elevator_position().get::<ratio>() < 0.51);
-            assert!(test_bed.get_right_elevator_position().get::<ratio>() < 0.51);
-            assert!(test_bed.get_left_elevator_position().get::<ratio>() > 0.49);
-            assert!(test_bed.get_right_elevator_position().get::<ratio>() > 0.49);
+            // Elevator deflection is assymetrical so middle is below 0.5
+            assert!(test_bed.get_left_elevator_position().get::<ratio>() < 0.45);
+            assert!(test_bed.get_right_elevator_position().get::<ratio>() < 0.45);
+            assert!(test_bed.get_left_elevator_position().get::<ratio>() > 0.35);
+            assert!(test_bed.get_right_elevator_position().get::<ratio>() > 0.35);
         }
     }
 }

--- a/src/systems/a320_systems/src/hydraulic/mod.rs
+++ b/src/systems/a320_systems/src/hydraulic/mod.rs
@@ -312,12 +312,18 @@ impl A320AileronFactory {
     }
 
     /// Builds an aileron control surface body for A320 Neo
-    fn a320_aileron_body() -> LinearActuatedRigidBodyOnHingeAxis {
+    fn a320_aileron_body(init_drooped_down: bool) -> LinearActuatedRigidBodyOnHingeAxis {
         let size = Vector3::new(3.325, 0.16, 0.58);
         let cg_offset = Vector3::new(0., 0., -0.5 * size[2]);
 
         let control_arm = Vector3::new(0., -0.0525, 0.);
         let anchor = Vector3::new(0., -0.0525, 0.33);
+
+        let init_position = if init_drooped_down {
+            Angle::new::<degree>(-25.)
+        } else {
+            Angle::new::<degree>(0.)
+        };
 
         LinearActuatedRigidBodyOnHingeAxis::new(
             Mass::new::<kilogram>(24.65),
@@ -327,7 +333,7 @@ impl A320AileronFactory {
             anchor,
             Angle::new::<degree>(-25.),
             Angle::new::<degree>(50.),
-            Angle::new::<degree>(-25.),
+            init_position,
             1.,
             false,
             Vector3::new(1., 0., 0.),
@@ -336,8 +342,8 @@ impl A320AileronFactory {
 
     /// Builds an aileron assembly consisting of the aileron physical rigid body and two hydraulic actuators connected
     /// to it
-    fn a320_aileron_assembly() -> HydraulicLinearActuatorAssembly<2> {
-        let aileron_body = Self::a320_aileron_body();
+    fn a320_aileron_assembly(init_drooped_down: bool) -> HydraulicLinearActuatorAssembly<2> {
+        let aileron_body = Self::a320_aileron_body(init_drooped_down);
 
         let aileron_actuator_outward = Self::a320_aileron_actuator(&aileron_body);
         let aileron_actuator_inward = Self::a320_aileron_actuator(&aileron_body);
@@ -349,12 +355,13 @@ impl A320AileronFactory {
     }
 
     fn new_aileron(context: &mut InitContext, id: ActuatorSide) -> AileronAssembly {
-        let assembly = Self::a320_aileron_assembly();
+        let init_drooped_down = !context.is_in_flight();
+        let assembly = Self::a320_aileron_assembly(init_drooped_down);
         AileronAssembly::new(context, id, assembly, Self::new_a320_aileron_aero_model())
     }
 
     fn new_a320_aileron_aero_model() -> AerodynamicModel {
-        let body = Self::a320_aileron_body();
+        let body = Self::a320_aileron_body(true);
         AerodynamicModel::new(
             &body,
             Some(Vector3::new(0., 1., 0.)),
@@ -517,12 +524,18 @@ impl A320ElevatorFactory {
     }
 
     /// Builds an aileron control surface body for A320 Neo
-    fn a320_elevator_body() -> LinearActuatedRigidBodyOnHingeAxis {
+    fn a320_elevator_body(init_drooped_down: bool) -> LinearActuatedRigidBodyOnHingeAxis {
         let size = Vector3::new(6., 0.405, 1.125);
         let cg_offset = Vector3::new(0., 0., -0.5 * size[2]);
 
         let control_arm = Vector3::new(0., -0.091, 0.);
         let anchor = Vector3::new(0., -0.091, 0.41);
+
+        let init_position = if init_drooped_down {
+            Angle::new::<degree>(-17.)
+        } else {
+            Angle::new::<degree>(0.)
+        };
 
         LinearActuatedRigidBodyOnHingeAxis::new(
             Mass::new::<kilogram>(58.6),
@@ -532,7 +545,7 @@ impl A320ElevatorFactory {
             anchor,
             Angle::new::<degree>(-17.),
             Angle::new::<degree>(47.),
-            Angle::new::<degree>(-17.),
+            init_position,
             100.,
             false,
             Vector3::new(1., 0., 0.),
@@ -541,8 +554,8 @@ impl A320ElevatorFactory {
 
     /// Builds an aileron assembly consisting of the aileron physical rigid body and two hydraulic actuators connected
     /// to it
-    fn a320_elevator_assembly() -> HydraulicLinearActuatorAssembly<2> {
-        let elevator_body = Self::a320_elevator_body();
+    fn a320_elevator_assembly(init_drooped_down: bool) -> HydraulicLinearActuatorAssembly<2> {
+        let elevator_body = Self::a320_elevator_body(init_drooped_down);
 
         let elevator_actuator_outboard = Self::a320_elevator_actuator(&elevator_body);
         let elevator_actuator_inbord = Self::a320_elevator_actuator(&elevator_body);
@@ -554,12 +567,13 @@ impl A320ElevatorFactory {
     }
 
     fn new_elevator(context: &mut InitContext, id: ActuatorSide) -> ElevatorAssembly {
-        let assembly = Self::a320_elevator_assembly();
+        let init_drooped_down = !context.is_in_flight();
+        let assembly = Self::a320_elevator_assembly(init_drooped_down);
         ElevatorAssembly::new(context, id, assembly, Self::new_a320_elevator_aero_model())
     }
 
     fn new_a320_elevator_aero_model() -> AerodynamicModel {
-        let body = Self::a320_elevator_body();
+        let body = Self::a320_elevator_body(true);
         AerodynamicModel::new(
             &body,
             Some(Vector3::new(0., 1., 0.)),
@@ -605,14 +619,18 @@ impl A320RudderFactory {
     }
 
     /// Builds an aileron control surface body for A320 Neo
-    fn a320_rudder_body() -> LinearActuatedRigidBodyOnHingeAxis {
+    fn a320_rudder_body(init_at_center: bool) -> LinearActuatedRigidBodyOnHingeAxis {
         let size = Vector3::new(0.42, 6.65, 1.8);
         let cg_offset = Vector3::new(0., 0.5 * size[1], -0.5 * size[2]);
 
         let control_arm = Vector3::new(-0.144, 0., 0.);
         let anchor = Vector3::new(-0.144, 0., 0.50);
 
-        let randomized_init_position_angle_degree = random_from_range(-15., 15.);
+        let randomized_init_position_angle_degree = if init_at_center {
+            0.
+        } else {
+            random_from_range(-15., 15.)
+        };
 
         LinearActuatedRigidBodyOnHingeAxis::new(
             Mass::new::<kilogram>(95.),
@@ -631,8 +649,8 @@ impl A320RudderFactory {
 
     /// Builds an aileron assembly consisting of the aileron physical rigid body and two hydraulic actuators connected
     /// to it
-    fn a320_rudder_assembly() -> HydraulicLinearActuatorAssembly<3> {
-        let rudder_body = Self::a320_rudder_body();
+    fn a320_rudder_assembly(init_at_center: bool) -> HydraulicLinearActuatorAssembly<3> {
+        let rudder_body = Self::a320_rudder_body(init_at_center);
 
         let elevator_actuator_green = Self::a320_rudder_actuator(&rudder_body);
         let elevator_actuator_blue = Self::a320_rudder_actuator(&rudder_body);
@@ -649,12 +667,16 @@ impl A320RudderFactory {
     }
 
     fn new_rudder(context: &mut InitContext) -> RudderAssembly {
-        let assembly = Self::a320_rudder_assembly();
+        let init_at_center = context.start_state() == StartState::Taxi
+            || context.start_state() == StartState::Runway
+            || context.is_in_flight();
+
+        let assembly = Self::a320_rudder_assembly(init_at_center);
         RudderAssembly::new(context, assembly, Self::new_a320_rudder_aero_model())
     }
 
     fn new_a320_rudder_aero_model() -> AerodynamicModel {
-        let body = Self::a320_rudder_body();
+        let body = Self::a320_rudder_body(true);
         AerodynamicModel::new(
             &body,
             Some(Vector3::new(1., 0., 0.)),

--- a/src/systems/a320_systems/src/hydraulic/mod.rs
+++ b/src/systems/a320_systems/src/hydraulic/mod.rs
@@ -6108,6 +6108,10 @@ mod tests {
                 Ratio::new::<ratio>(self.read_by_name("HYD_ELEV_RIGHT_DEFLECTION"))
             }
 
+            fn get_rudder_position(&mut self) -> Ratio {
+                Ratio::new::<ratio>(self.read_by_name("HYD_RUD_DEFLECTION"))
+            }
+
             fn get_nose_steering_ratio(&mut self) -> Ratio {
                 Ratio::new::<ratio>(self.read_by_name("NOSE_WHEEL_POSITION_RATIO"))
             }
@@ -10471,6 +10475,53 @@ mod tests {
 
             assert!(test_bed.get_spoiler_right_mean_position().get::<ratio>() > 0.48);
             assert!(test_bed.get_spoiler_right_mean_position().get::<ratio>() < 0.52);
+        }
+
+        #[test]
+        fn gear_init_up_if_spawning_in_air() {
+            let test_bed = test_bed_in_flight_with()
+                .set_cold_dark_inputs()
+                .in_flight()
+                .run_one_tick();
+
+            assert!(test_bed.gear_system_state() == GearSystemState::AllUpLocked);
+        }
+
+        #[test]
+        fn aileron_init_centered_if_spawning_in_air() {
+            let mut test_bed = test_bed_in_flight_with()
+                .set_cold_dark_inputs()
+                .in_flight()
+                .run_one_tick();
+
+            assert!(test_bed.get_left_aileron_position().get::<ratio>() < 0.51);
+            assert!(test_bed.get_right_aileron_position().get::<ratio>() < 0.51);
+            assert!(test_bed.get_left_aileron_position().get::<ratio>() > 0.49);
+            assert!(test_bed.get_right_aileron_position().get::<ratio>() > 0.49);
+        }
+
+        #[test]
+        fn rudder_init_centered_if_spawning_in_air() {
+            let mut test_bed = test_bed_in_flight_with()
+                .set_cold_dark_inputs()
+                .in_flight()
+                .run_one_tick();
+
+            assert!(test_bed.get_rudder_position().get::<ratio>() > 0.49);
+            assert!(test_bed.get_rudder_position().get::<ratio>() < 0.51);
+        }
+
+        #[test]
+        fn elevator_init_centered_if_spawning_in_air() {
+            let mut test_bed = test_bed_in_flight_with()
+                .set_cold_dark_inputs()
+                .in_flight()
+                .run_one_tick();
+
+            assert!(test_bed.get_left_elevator_position().get::<ratio>() < 0.51);
+            assert!(test_bed.get_right_elevator_position().get::<ratio>() < 0.51);
+            assert!(test_bed.get_left_elevator_position().get::<ratio>() > 0.49);
+            assert!(test_bed.get_right_elevator_position().get::<ratio>() > 0.49);
         }
     }
 }

--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     simulation::{
         InitContext, Read, SimulationElement, SimulationElementVisitor, SimulatorReader,
-        SimulatorWriter, UpdateContext, VariableIdentifier, Write,
+        SimulatorWriter, StartState, UpdateContext, VariableIdentifier, Write,
     },
 };
 use uom::si::{
@@ -489,13 +489,15 @@ struct LandingGearHandleUnit {
 }
 impl LandingGearHandleUnit {
     fn new(context: &mut InitContext) -> Self {
+        let init_gear_down = context.is_on_ground() || context.start_state() == StartState::Final;
+
         Self {
             gear_handle_real_position_id: context.get_identifier("GEAR_HANDLE_POSITION".to_owned()),
             gear_handle_position_requested_id: context
                 .get_identifier("GEAR_LEVER_POSITION_REQUEST".to_owned()),
 
-            is_lever_down: true,
-            lever_should_lock_down: true,
+            is_lever_down: init_gear_down,
+            lever_should_lock_down: init_gear_down,
         }
     }
 

--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     simulation::{
         InitContext, Read, SimulationElement, SimulationElementVisitor, SimulatorReader,
-        SimulatorWriter, StartState, UpdateContext, VariableIdentifier, Write,
+        SimulatorWriter, UpdateContext, VariableIdentifier, Write,
     },
 };
 use uom::si::{
@@ -489,7 +489,7 @@ struct LandingGearHandleUnit {
 }
 impl LandingGearHandleUnit {
     fn new(context: &mut InitContext) -> Self {
-        let init_gear_down = context.is_on_ground() || context.start_state() == StartState::Final;
+        let init_gear_down = context.start_gear_down();
 
         Self {
             gear_handle_real_position_id: context.get_identifier("GEAR_HANDLE_POSITION".to_owned()),

--- a/src/systems/systems/src/simulation/mod.rs
+++ b/src/systems/systems/src/simulation/mod.rs
@@ -143,6 +143,10 @@ impl<'a> InitContext<'a> {
         self.start_state
     }
 
+    pub fn start_gear_down(&self) -> bool {
+        self.is_on_ground() || self.start_state == StartState::Final
+    }
+
     pub fn is_in_flight(&self) -> bool {
         matches!(
             self.start_state,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Spawning in the air was causing issues as gear always was down.

Now plane should only spawn gear down if in final or on ground.

All other flight control surfaces should init in neutral position when spawning with engines on and/or in flight

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Spawn anywhere possible. Check everything is consistent in gear system.

Spawn anywhere possible. Check aileron init drooped down only on ground when engines off

Spawn anywhere possible. Check elevator init drooped down  only on ground when engines off

Spawn anywhere possible. Check rudder init in neutral position whenever spawning engines on

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
