### PR TITLE
fix(lights): Remove infinitive emitter in ambient logo light.

### DIFF
--- a/flybywire-aircraft-a320-neo/effects/LIGHT_A32NX_LogoLightAmbient.fx
+++ b/flybywire-aircraft-a320-neo/effects/LIGHT_A32NX_LogoLightAmbient.fx
@@ -7,7 +7,7 @@ Priority=0
 [Properties]
 
 [Emitter.0]
-Lifetime=0.0, 0.0
+Lifetime=0.5, 0.5
 Delay=0.0, 0.0
 Bounce=0.0
 Light=1


### PR DESCRIPTION


## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Changes the emitter in the ambient logo light to be a temporary one instead of an infinitive.
This have caused performance issues as new particles was generated forever.


## References
https://devsupport.flightsimulator.com/questions/7606/potential-performance-issue-over-time-caused-by-li.html

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
No need to test. No harmful change, just for the better.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): @bouveng 

## Testing instructions
N/A

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
