### PR TITLE
fix(lgciu): write LGCIU discrete word bits as compressed instead of extended

### DIFF
--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -810,10 +810,7 @@ impl LandingGearControlInterfaceUnit {
             Arinc429Word::new(0, SignStatus::FailureWarning)
         } else {
             let mut word = Arinc429Word::new(0, SignStatus::NormalOperation);
-            word.set_bit(
-                11,
-                self.sensor_inputs.left_and_right_gear_compressed(false),
-            );
+            word.set_bit(11, self.sensor_inputs.left_and_right_gear_compressed(false));
             word.set_bit(12, self.sensor_inputs.nose_gear_compressed(false));
             word.set_bit(13, self.sensor_inputs.left_gear_compressed(false));
             word.set_bit(14, self.sensor_inputs.right_gear_compressed(false));

--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -812,11 +812,11 @@ impl LandingGearControlInterfaceUnit {
             let mut word = Arinc429Word::new(0, SignStatus::NormalOperation);
             word.set_bit(
                 11,
-                !self.sensor_inputs.left_and_right_gear_compressed(false),
+                self.sensor_inputs.left_and_right_gear_compressed(false),
             );
-            word.set_bit(12, !self.sensor_inputs.nose_gear_compressed(false));
-            word.set_bit(13, !self.sensor_inputs.left_gear_compressed(false));
-            word.set_bit(14, !self.sensor_inputs.right_gear_compressed(false));
+            word.set_bit(12, self.sensor_inputs.nose_gear_compressed(false));
+            word.set_bit(13, self.sensor_inputs.left_gear_compressed(false));
+            word.set_bit(14, self.sensor_inputs.right_gear_compressed(false));
             word.set_bit(
                 15,
                 self.sensor_inputs.left_gear_down_and_locked


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This fixes a small error I made during #7173, in the LGCIU discrete word 2, where I accidentally negated the landing gear compressed bits 11, 12, 13 and 14, which is not correct according to the documentation.

This data is not used yet, so no testing is necessary.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
