### PR TITLE
feat(fms): correct hw dept/arr page scrolling

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
@@ -233,7 +233,7 @@ class CDUAvailableArrivalsPage {
             const maxPage = starSelection ? (selectedArrival ? Math.max(selectedArrival.enRouteTransitions.length - 2, matchingArrivals.length - 2) : matchingArrivals.length - 2) : (pageCurrent, airportInfo.approaches.length - 3);
             if (pageCurrent < maxPage) {
                 mcdu.onUp = () => {
-                    pageCurrent++;
+                    pageCurrent += 3;
                     if (pageCurrent < 0) {
                         pageCurrent = 0;
                     }
@@ -243,7 +243,7 @@ class CDUAvailableArrivalsPage {
             }
             if (pageCurrent > 0) {
                 mcdu.onDown = () => {
-                    pageCurrent--;
+                    pageCurrent -= 3;
                     if (pageCurrent < 0) {
                         pageCurrent = 0;
                     }
@@ -365,7 +365,7 @@ class CDUAvailableArrivalsPage {
 
             if (pageCurrent < selectedApproach.transitions.length - 3) {
                 mcdu.onUp = () => {
-                    pageCurrent += 3;
+                    pageCurrent += 4;
                     if (pageCurrent < 0) {
                         pageCurrent = 0;
                     }
@@ -375,7 +375,7 @@ class CDUAvailableArrivalsPage {
             }
             if (pageCurrent > 0) {
                 mcdu.onDown = () => {
-                    pageCurrent -= 3;
+                    pageCurrent -= 4;
                     if (pageCurrent < 0) {
                         pageCurrent = 0;
                     }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
@@ -365,7 +365,7 @@ class CDUAvailableArrivalsPage {
 
             if (pageCurrent < selectedApproach.transitions.length - 3) {
                 mcdu.onUp = () => {
-                    pageCurrent++;
+                    pageCurrent += 4;
                     if (pageCurrent < 0) {
                         pageCurrent = 0;
                     }
@@ -375,7 +375,7 @@ class CDUAvailableArrivalsPage {
             }
             if (pageCurrent > 0) {
                 mcdu.onDown = () => {
-                    pageCurrent--;
+                    pageCurrent -= 4;
                     if (pageCurrent < 0) {
                         pageCurrent = 0;
                     }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableArrivalsPage.js
@@ -365,7 +365,7 @@ class CDUAvailableArrivalsPage {
 
             if (pageCurrent < selectedApproach.transitions.length - 3) {
                 mcdu.onUp = () => {
-                    pageCurrent += 4;
+                    pageCurrent += 3;
                     if (pageCurrent < 0) {
                         pageCurrent = 0;
                     }
@@ -375,7 +375,7 @@ class CDUAvailableArrivalsPage {
             }
             if (pageCurrent > 0) {
                 mcdu.onDown = () => {
-                    pageCurrent -= 4;
+                    pageCurrent -= 3;
                     if (pageCurrent < 0) {
                         pageCurrent = 0;
                     }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableDeparturesPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableDeparturesPage.js
@@ -150,7 +150,7 @@ class CDUAvailableDeparturesPage {
             }
             if (pageCurrent < maxPage) {
                 mcdu.onUp = () => {
-                    pageCurrent += 3;
+                    pageCurrent += 4;
                     if (pageCurrent < 0) {
                         pageCurrent = 0;
                     }
@@ -160,7 +160,7 @@ class CDUAvailableDeparturesPage {
             }
             if (pageCurrent > 0) {
                 mcdu.onDown = () => {
-                    pageCurrent -= 3;
+                    pageCurrent -= 4;
                     if (pageCurrent < 0) {
                         pageCurrent = 0;
                     }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableDeparturesPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableDeparturesPage.js
@@ -150,7 +150,7 @@ class CDUAvailableDeparturesPage {
             }
             if (pageCurrent < maxPage) {
                 mcdu.onUp = () => {
-                    pageCurrent += 4;
+                    pageCurrent += (sidSelection) ? 3 : 4;
                     if (pageCurrent < 0) {
                         pageCurrent = 0;
                     }
@@ -160,7 +160,7 @@ class CDUAvailableDeparturesPage {
             }
             if (pageCurrent > 0) {
                 mcdu.onDown = () => {
-                    pageCurrent -= 4;
+                    pageCurrent -= (sidSelection) ? 3 : 4;
                     if (pageCurrent < 0) {
                         pageCurrent = 0;
                     }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableDeparturesPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_AvailableDeparturesPage.js
@@ -150,7 +150,7 @@ class CDUAvailableDeparturesPage {
             }
             if (pageCurrent < maxPage) {
                 mcdu.onUp = () => {
-                    pageCurrent++;
+                    pageCurrent += 3;
                     if (pageCurrent < 0) {
                         pageCurrent = 0;
                     }
@@ -160,7 +160,7 @@ class CDUAvailableDeparturesPage {
             }
             if (pageCurrent > 0) {
                 mcdu.onDown = () => {
-                    pageCurrent--;
+                    pageCurrent -= 3;
                     if (pageCurrent < 0) {
                         pageCurrent = 0;
                     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Fixed DEPARTURES and ARRIVAL page SID/STAR/TRANS scrolling on the MCDU to be true to life to the Honeywell H3 FMS.
- Now scrolls per page vs per item. 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

https://user-images.githubusercontent.com/15316958/169535180-4df761d5-c3ad-44ef-b2fb-ce93d73fb647.mp4

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): 2Cas#1022

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Fill out flight plan with arrival/departure airfield
- Select Departure, scroll up/down and verify that every departure runway/SID/transition can be selected and that scrolling is now per page
- Select Arrival, scroll up/down and verify that every arrival runway/STAR/VIA/transition can be selected and that scrolling is now per page

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
