### PR TITLE
perf: reduce fuel persistency update rate and enable clang optimizations

### DIFF
--- a/src/fadec/build.sh
+++ b/src/fadec/build.sh
@@ -36,6 +36,7 @@ clang++ \
   -fno-exceptions \
   -fms-extensions \
   -fvisibility=hidden \
+  -O3 \
   -I "${MSFS_SDK}/WASM/include" \
   -I "${MSFS_SDK}/SimConnect SDK/include" \
   -I "${DIR}/../fbw/src/inih" \

--- a/src/fbw/build.sh
+++ b/src/fbw/build.sh
@@ -34,6 +34,7 @@ clang \
   -fno-exceptions \
   -fms-extensions \
   -fvisibility=hidden \
+  -O3 \
   -I "${MSFS_SDK}/WASM/include" \
   -I "${DIR}/src/zlib" \
   "${DIR}/src/zlib/adler32.c" \
@@ -69,6 +70,7 @@ clang++ \
   -fno-exceptions \
   -fms-extensions \
   -fvisibility=hidden \
+  -O3 \
   -I "${MSFS_SDK}/WASM/include" \
   -I "${MSFS_SDK}/SimConnect SDK/include" \
   -I "${DIR}/src/inih" \


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
I noticed that the file for fuel persistency was written every update cycle while being on ground which showed quite a high runtime in the WASM debug window. I've added a timer to only update it every second which should be sufficient IMO.

Furthermore I've enabled clang optimization which also showed a slight improvement in runtime. Note that I used O3 which might be aggressive but I've done a few flights over the last week and didn't notice any erratic behaviour.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

### Before

![fadec_before](https://user-images.githubusercontent.com/19493808/170253968-903993e0-b81a-49a7-b8f3-4bb3654dd7a1.png)
![fbw_before](https://user-images.githubusercontent.com/19493808/170253976-0f80ae70-da95-43eb-ac75-77fecae08976.png)

### After
![fadec_after](https://user-images.githubusercontent.com/19493808/170254076-24b6e3f2-adb3-4bc5-a5b1-6ee59988b1a8.png)
![fbw_after](https://user-images.githubusercontent.com/19493808/170254095-0793268d-930c-4857-bb85-03655ce77988.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Spawn C&D and verify the fuel state is saved correctly every second (check the Modified timestamp of the file in the "work/AircraftStates" for the selected livery.
2. Take off and verify the fuel state is not updated (as it was before this change)
3. Observe system behaviour (FBW, AP and Engines) for any possible strange behaviour (very high or low numbers, unusual behaviour)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
