### PR TITLE
fix(notif): passthrough pause events

### DIFF
--- a/flybywire-aircraft-a320-neo/html_ui/JS/A32NX_Util.js
+++ b/flybywire-aircraft-a320-neo/html_ui/JS/A32NX_Util.js
@@ -299,10 +299,10 @@ class NXNotifManager {
 
     constructor() {
         Coherent.on("keyIntercepted", (key) => this.registerIntercepts(key));
-        Coherent.call("INTERCEPT_KEY_EVENT", "PAUSE_TOGGLE", 1);
-        Coherent.call("INTERCEPT_KEY_EVENT", "PAUSE_ON", 1);
-        Coherent.call("INTERCEPT_KEY_EVENT", "PAUSE_OFF", 1);
-        Coherent.call("INTERCEPT_KEY_EVENT", "PAUSE_SET", 1);
+        Coherent.call("INTERCEPT_KEY_EVENT", "PAUSE_TOGGLE", 0);
+        Coherent.call("INTERCEPT_KEY_EVENT", "PAUSE_ON", 0);
+        Coherent.call("INTERCEPT_KEY_EVENT", "PAUSE_OFF", 0);
+        Coherent.call("INTERCEPT_KEY_EVENT", "PAUSE_SET", 0);
         this.notifications = [];
     }
 

--- a/src/shared/src/notification.ts
+++ b/src/shared/src/notification.ts
@@ -43,10 +43,10 @@ export class NotificationManager {
     }
 
     registerIntercepts() {
-        this.manager.interceptKey('PAUSE_TOGGLE', true);
-        this.manager.interceptKey('PAUSE_ON', true);
-        this.manager.interceptKey('PAUSE_OFF', true);
-        this.manager.interceptKey('PAUSE_SET', true);
+        this.manager.interceptKey('PAUSE_TOGGLE', false);
+        this.manager.interceptKey('PAUSE_ON', false);
+        this.manager.interceptKey('PAUSE_OFF', false);
+        this.manager.interceptKey('PAUSE_SET', false);
 
         const subscriber = this.eventBus.getSubscriber<KeyEvents>();
         subscriber.on('key_intercept').handle((keyData) => {

--- a/src/shared/src/notification.ts
+++ b/src/shared/src/notification.ts
@@ -43,10 +43,10 @@ export class NotificationManager {
     }
 
     registerIntercepts() {
-        this.manager.interceptKey('PAUSE_TOGGLE', false);
-        this.manager.interceptKey('PAUSE_ON', false);
-        this.manager.interceptKey('PAUSE_OFF', false);
-        this.manager.interceptKey('PAUSE_SET', false);
+        this.manager.interceptKey('PAUSE_TOGGLE', true);
+        this.manager.interceptKey('PAUSE_ON', true);
+        this.manager.interceptKey('PAUSE_OFF', true);
+        this.manager.interceptKey('PAUSE_SET', true);
 
         const subscriber = this.eventBus.getSubscriber<KeyEvents>();
         subscriber.on('key_intercept').handle((keyData) => {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Pause events were being captured and not passed through to Simconnect, resulting in problems with 3rd party external addons. This PR fixes this to allow these events to passthrough. No visible change for users.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Spawn in any state
2. Use flight assistant menu to enable AUTO TRIM/RUDDER/etc
3. This should spawn the incompatible options alert notification 

![image](https://user-images.githubusercontent.com/15316958/170876327-5fd0da27-8dae-4bf1-a39b-f0ecffc7398e.png)

5. Press ESC to PAUSE and exit to the menu
6. Notification should now dismiss itself and disappear.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
