### PR TITLE
build: flyPadOS 3 localization update GitHub action

### DIFF
--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -1,0 +1,39 @@
+name: 'FlyPad Localazy Download'
+on:
+  schedule:
+    # https://crontab.guru/
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  localization-update:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'flybywiresim'
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Install Localazy CLI
+        run: npm install -g @localazy/cli
+      - name: Download Translations
+        run: cd src/instruments/src/EFB/Localization && node build-translation.js
+      - name: Print git status
+        run: git status
+      - name: Create PR
+        uses: gr2m/create-or-update-pull-request-action@v1.x  # Generate a PR or updates an existing PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: src/instruments/src/EFB/Localization/*.json
+          branch: efb-localazy-update # Specify branch that this action uses.
+          commit-message: 'automatically updated flyPadOS 3 localization'
+          title: 'build: update flyPadOS 3 localization'
+          body: >
+            This PR automatically downloads and updates the approved changes from Localazy translations for 
+            the flyPadOS3 for persisting these changes in the repo. 
+            Changes will be collected in this PR and this PR needs to be manually merged to master eventually.
+            Ask on Discord #efb if you have questions about this.
+          labels: |
+            EFB,
+            i18n


### PR DESCRIPTION
## Summary of Changes
This PR introduces a GitHub action that downloads the latest approved translations from Localazy to make sure they are regularly persisted into the repository. 

It uses an action that either creates or updates a PR with the changes. This PR will then need to be merged to master regularly. Every few weeks or after larger changes to translations should be sufficient. 

Uses: https://github.com/gr2m/create-or-update-pull-request-action

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/16833201/170891472-f2592fbe-a989-4f16-a39c-4ca6f7d5710f.png)

## Additional context
I had this workflow running on a test branch for a while now:
https://github.com/frankkopp/flybywire-a32nx-test/pull/9

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Does not influence the aircraft or code at all - just creates/updates a PR. 
Can't be tested by QA.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
