### PR TITLE
fix: same page tab redirection

### DIFF
--- a/src/instruments/src/EFB/Utils/routing.tsx
+++ b/src/instruments/src/EFB/Utils/routing.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Route, Redirect, useHistory } from 'react-router-dom';
 
 export interface PageLink {
@@ -31,7 +31,6 @@ type HistoryEntry = {pathname: string, search: string, hash: string, state: any,
 export const findLatestSeenPathname = (history: any, basePath: string): string | undefined => {
     // @ts-ignore
     const historyEntries: HistoryEntry[] = history.entries;
-
     const lastSeenPathname = [...historyEntries].reverse().find(({ pathname }) => pathname.includes(`${basePath}/`))?.pathname;
 
     return lastSeenPathname;
@@ -39,7 +38,14 @@ export const findLatestSeenPathname = (history: any, basePath: string): string |
 
 export const PageRedirect = ({ basePath, tabs }: PageRouteProps) => {
     const history = useHistory();
-    const redirectPathname = useRef((() => findLatestSeenPathname(history, basePath) ?? `${basePath}/${pathify(tabs[0].name)}`)());
+    const getRedirectPathname = useCallback(() => findLatestSeenPathname(history, basePath) ?? `${basePath}/${pathify(tabs[0].name)}`, [history, basePath, tabs]);
+    const redirectPathname = useRef(getRedirectPathname());
+
+    useEffect(() => {
+        history.listen(() => {
+            redirectPathname.current = getRedirectPathname();
+        });
+    }, []);
 
     return (
         <Route exact path={basePath}>

--- a/src/instruments/src/EFB/Utils/routing.tsx
+++ b/src/instruments/src/EFB/Utils/routing.tsx
@@ -42,9 +42,11 @@ export const PageRedirect = ({ basePath, tabs }: PageRouteProps) => {
     const redirectPathname = useRef(getRedirectPathname());
 
     useEffect(() => {
-        history.listen(() => {
+        const unregisterHistoryListener = history.listen(() => {
             redirectPathname.current = getRedirectPathname();
         });
+
+        return unregisterHistoryListener;
     }, []);
 
     return (


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes an issue where clicking on the sidebar button of the current page you are on redirects you to an incorrect tab. This caused a complete crash when going to pinned charts page and clicking on 'Navigation & Charts' button on sidebar.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Erick [Z-6]#6484

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Go to an EFB page with tabs and go to any other tab than the first one. Click on the same link on the sidebar that took you to your page and your tab should not change. Go to Navigation & Charts page and go to Pinned Charts. Clicking on the sidebar link should not cause a crash of the EFB.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
