### PR TITLE
feat: rnp at or below 0.3 step 1

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -26,6 +26,7 @@
 1. [ECAM] Fix erroneous SLATS NOT IN T.O CONFIG warning during flaps 3 takeoff - @beheh (Benedict Etzel)
 1. [MODEL] Improved rivet mesh with more variation and detail - @Grinde (Grinde#4017)
 1. [ELEC] Make battery voltmeters update one digit at a time - @beheh (Benedict Etzel)
+1. [FMGC] Basic RNP at or below 0.3 support - @tracernz (Mike)
 
 ## 0.8.0
 

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -1710,6 +1710,20 @@ In the variables below, {number} should be replaced with one item in the set: { 
     - Indicates whether the FMS should switch to APPROACH phase.
     - **WARNING:** This is temporary and internal. Do not use.
 
+- A32NX_FMGC_{side}_LDEV_REQUEST
+    - Bool
+    - Indicates whether the FMGC is requesting L/DEV to be displayed on the PFD
+    - {side}
+        - L
+        - R
+
+- A32NX_FMGC_L_RNP
+    - Number (nautical miles)
+    - The active Required Navigation Performance
+    - {side}
+        - L
+        - R
+
 ## Autopilot System
 
 - A32NX_FMA_LATERAL_MODE

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_ProgressPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_ProgressPage.js
@@ -101,6 +101,51 @@ class CDUProgressPage {
                 }
             });
         };
+
+        let rnpCell = '-.-';
+        const rnpSize = mcdu.navigation.requiredPerformance.manualRnp ? 'big' : 'small';
+        const rnp = mcdu.navigation.requiredPerformance.activeRnp;
+        // TODO check 2 decimal cut-off
+        if (rnp > 1) {
+            rnpCell = rnp.toFixed(1).padStart(4);
+        } else if (rnp !== undefined) {
+            rnpCell = rnp.toFixed(2);
+        }
+
+        /** @type  */
+        mcdu.onLeftInput[5] = (input, scratchpadCallback) => {
+            if (input === FMCMainDisplay.clrValue) {
+                mcdu.navigation.requiredPerformance.clearPilotRnp();
+                return CDUProgressPage.ShowPage(mcdu);
+            }
+
+            const match = input.match(/^\d{1,2}(\.\d{1,2})?$/);
+            if (match === null) {
+                mcdu.setScratchpadMessage(NXSystemMessages.formatError);
+                scratchpadCallback(input);
+                return;
+            }
+
+            const rnp = parseFloat(input);
+            if (rnp < 0.01 || rnp > 20) {
+                mcdu.setScratchpadMessage(NXSystemMessages.entryOutOfRange);
+                scratchpadCallback(input);
+                return;
+            }
+
+            mcdu.navigation.requiredPerformance.setPilotRnp(rnp);
+            CDUProgressPage.ShowPage(mcdu);
+        };
+
+        let anpCell = '-.-';
+        const anp = mcdu.navigation.currentPerformance;
+        // TODO check 2 decimal cut-off
+        if (anp > 1) {
+            anpCell = anp.toFixed(1).padStart(4);
+        } else if (anp !== undefined) {
+            anpCell = anp.toFixed(2);
+        }
+
         mcdu.setTemplate([
             ["{green}" + flightPhase.padStart(15, "\xa0") + "{end}\xa0" + flightNo.padEnd(11, "\xa0")],
             ["\xa0" + "CRZ\xa0", "OPT\xa0\xa0\xa0\xa0REC MAX"],
@@ -114,7 +159,7 @@ class CDUProgressPage {
             ["\xa0PREDICTIVE"],
             ["<GPS", gpsPrimaryStatus],
             ["REQUIRED", "ESTIMATED", "ACCUR{sp}"],
-            ["{small}3.4NM{end}[color]cyan", "{small}0.07NM{end}[color]green", "HIGH[color]green"]
+            [`{cyan}{${rnpSize}}${rnpCell}NM{end}{end}`, `{green}{small}${anpCell}NM{end}{end}`, `{green}${mcdu.navigation.accuracyHigh ? 'HIGH' : 'LOW'}{end}`]
         ]);
 
         // regular update due to showing dynamic data on this page

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_ProgressPage.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_ProgressPage.js
@@ -112,7 +112,6 @@ class CDUProgressPage {
             rnpCell = rnp.toFixed(2);
         }
 
-        /** @type  */
         mcdu.onLeftInput[5] = (input, scratchpadCallback) => {
             if (input === FMCMainDisplay.clrValue) {
                 mcdu.navigation.requiredPerformance.clearPilotRnp();

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -206,11 +206,13 @@ class FMCMainDisplay extends BaseAirliners {
         this.guidanceController = new Fmgc.GuidanceController(this.flightPlanManager, this.guidanceManager, this);
         this.navRadioManager = new Fmgc.NavRadioManager(this);
         this.efisSymbols = new Fmgc.EfisSymbols(this.flightPlanManager, this.guidanceController);
+        this.navigation = new Fmgc.Navigation(this.flightPlanManager);
 
         Fmgc.initFmgcLoop(this, this.flightPlanManager);
 
         this.guidanceController.init();
         this.efisSymbols.init();
+        this.navigation.init();
 
         this.tempCurve = new Avionics.Curve();
         this.tempCurve.interpolationFunction = Avionics.CurveTool.NumberInterpolation;
@@ -515,6 +517,10 @@ class FMCMainDisplay extends BaseAirliners {
         this.groundTempPilot = undefined;
         this.onAirport = () => { };
 
+        if (this.navigation) {
+            this.navigation.requiredPerformance.clearPilotRnp();
+        }
+
         // FMGC Message Queue
         this._messageQueue.resetQueue();
 
@@ -579,6 +585,7 @@ class FMCMainDisplay extends BaseAirliners {
         if (this.fmsUpdateThrottler.canUpdate(_deltaTime) !== -1) {
             this.updateRadioNavState();
             this.checkSpeedLimit();
+            this.navigation.update();
         }
 
         this.A32NXCore.update();

--- a/src/fmgc/src/flightplanning/FlightPlanManager.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanManager.ts
@@ -32,6 +32,7 @@ import { FlightPlanAsoboSync } from './FlightPlanAsoboSync';
 import { FixInfo } from './FixInfo';
 import { LnavConfig } from '@fmgc/guidance/LnavConfig';
 import { ApproachStats, HoldData } from '@fmgc/flightplanning/data/flightplan';
+import { SegmentType } from '@fmgc/wtsdk';
 
 export enum WaypointConstraintType {
     CLB = 1,
@@ -41,6 +42,17 @@ export enum WaypointConstraintType {
 export enum FlightPlans {
     Active,
     Temporary,
+}
+
+export enum FlightArea {
+    Terminal,
+    Takeoff,
+    Enroute,
+    Oceanic,
+    VorApproach,
+    GpsApproach,
+    PrecisionApproach,
+    NonPrecisionApproach,
 }
 
 /**
@@ -64,6 +76,8 @@ export class FlightPlanManager {
     public static FlightPlanCompressedKey = 'A32NX.FlightPlan.Compressed';
 
     public static FlightPlanVersionKey = 'L:A32NX.FlightPlan.Version';
+
+    public activeArea: FlightArea = FlightArea.Terminal;
 
     /**
      * The current stored flight plan data.
@@ -123,6 +137,8 @@ export class FlightPlanManager {
                 }
             }
         }
+
+        this.updateActiveArea();
     }
 
     public onCurrentGameFlightLoaded(_callback: () => any) {
@@ -1904,5 +1920,54 @@ export class FlightPlanManager {
     getGlideslopeIntercept(flightPlanIndex = this._currentFlightPlanIndex): number | undefined {
         const fp = this._flightPlans[flightPlanIndex];
         return fp?.glideslopeIntercept ?? undefined;
+    }
+
+    private updateActiveArea(): void {
+        const activeFp = this._flightPlans[FlightPlans.Active];
+        if (!activeFp) {
+            this.activeArea = FlightArea.Terminal;
+            return;
+        }
+
+        this.activeArea = this.calculateActiveArea(activeFp);
+    }
+
+    private calculateActiveArea(activeFp: ManagedFlightPlan): FlightArea {
+        const activeIndex = activeFp.activeWaypointIndex;
+
+        const appr = activeFp.getSegment(SegmentType.Approach);
+        const arrival = activeFp.getSegment(SegmentType.Arrival);
+        const departure = activeFp.getSegment(SegmentType.Departure);
+
+        if (departure !== FlightPlanSegment.Empty && activeIndex < (departure.offset + departure.waypoints.length)) {
+            return FlightArea.Terminal;
+        }
+
+        if (arrival !== FlightPlanSegment.Empty
+            && activeIndex >= arrival.offset
+            && activeIndex < (arrival.offset + arrival.waypoints.length)) {
+            return FlightArea.Terminal;
+        }
+
+        if (appr !== FlightPlanSegment.Empty
+            && activeIndex >= appr.offset
+            && activeIndex < (appr.offset + appr.waypoints.length)
+            && activeFp.finalApproachActive) {
+            const apprType = activeFp.procedureDetails.approachType;
+            switch (apprType) {
+            case ApproachType.APPROACH_TYPE_ILS:
+                return FlightArea.PrecisionApproach;
+            case ApproachType.APPROACH_TYPE_GPS:
+            case ApproachType.APPROACH_TYPE_RNAV:
+                return FlightArea.GpsApproach;
+            case ApproachType.APPROACH_TYPE_VOR:
+            case ApproachType.APPROACH_TYPE_VORDME:
+                return FlightArea.VorApproach;
+            default:
+                return FlightArea.NonPrecisionApproach;
+            }
+        }
+
+        return FlightArea.Enroute;
     }
 }

--- a/src/fmgc/src/flightplanning/FlightPlanManager.ts
+++ b/src/fmgc/src/flightplanning/FlightPlanManager.ts
@@ -44,6 +44,9 @@ export enum FlightPlans {
     Temporary,
 }
 
+/**
+ * Navigation flight areas defined in the OPC database
+ */
 export enum FlightArea {
     Terminal,
     Takeoff,

--- a/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
+++ b/src/fmgc/src/flightplanning/ManagedFlightPlan.ts
@@ -1590,4 +1590,22 @@ export class ManagedFlightPlan {
         }
         return -1;
     }
+
+    get finalApproachActive(): boolean {
+        const appr = this.getSegment(SegmentType.Approach);
+        if (appr === FlightPlanSegment.Empty) {
+            return false;
+        }
+
+        const offset = this.activeWaypointIndex - appr.offset;
+        if (offset >= 0 && offset < appr.waypoints.length) {
+            for (const [index, wp] of appr.waypoints.entries()) {
+                if (wp.additionalData.fixTypeFlags & FixTypeFlags.FAF) {
+                    return offset >= index;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/fmgc/src/index.ts
+++ b/src/fmgc/src/index.ts
@@ -12,6 +12,7 @@ import { DecelPathBuilder } from './guidance/vnav/descent/DecelPathBuilder';
 import { VerticalFlightPlanBuilder } from './guidance/vnav/verticalFlightPlan/VerticalFlightPlanBuilder';
 import { initComponents, updateComponents, recallMessageById } from './components';
 import { WaypointBuilder } from './flightplanning/WaypointBuilder';
+import { Navigation } from './navigation/Navigation';
 
 function initFmgcLoop(baseInstrument: BaseInstrument, flightPlanManager: FlightPlanManager): void {
     initComponents(baseInstrument, flightPlanManager);
@@ -38,4 +39,5 @@ export {
     VerticalFlightPlanBuilder,
     WaypointBuilder,
     normaliseApproachName,
+    Navigation,
 };

--- a/src/fmgc/src/navigation/Navigation.ts
+++ b/src/fmgc/src/navigation/Navigation.ts
@@ -15,6 +15,7 @@ export class Navigation {
         this.requiredPerformance = new RequiredPerformance(this.flightPlanManager);
     }
 
+    // eslint-disable-next-line no-empty-function
     init(): void {}
 
     update(deltaTime: number): void {
@@ -24,9 +25,9 @@ export class Navigation {
     }
 
     private updateCurrentPerformance(): void {
-        const gs = SimVar.GetSimVarValue("GPS GROUND SPEED", "knots");
+        const gs = SimVar.GetSimVarValue('GPS GROUND SPEED', 'knots');
 
-        // fake it until we make it :D
+        // FIXME fake it until we make it :D
         const estimate = 0.03 + Math.random() * 0.02 + gs * 0.00015;
         // basic IIR filter
         this.currentPerformance = this.currentPerformance === undefined ? estimate : this.currentPerformance * 0.9 + estimate * 0.1;

--- a/src/fmgc/src/navigation/Navigation.ts
+++ b/src/fmgc/src/navigation/Navigation.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 FlyByWire Simulations
+// SPDX-License-Identifier: GPL-3.0
+
+import { FlightPlanManager } from '@fmgc/index';
+import { RequiredPerformance } from '@fmgc/navigation/RequiredPerformance';
+
+export class Navigation {
+    requiredPerformance: RequiredPerformance;
+
+    currentPerformance: number | undefined;
+
+    accuracyHigh: boolean = false;
+
+    constructor(private flightPlanManager: FlightPlanManager) {
+        this.requiredPerformance = new RequiredPerformance(this.flightPlanManager);
+    }
+
+    init(): void {}
+
+    update(deltaTime: number): void {
+        this.requiredPerformance.update(deltaTime);
+
+        this.updateCurrentPerformance();
+    }
+
+    private updateCurrentPerformance(): void {
+        const gs = SimVar.GetSimVarValue("GPS GROUND SPEED", "knots");
+
+        // fake it until we make it :D
+        const estimate = 0.03 + Math.random() * 0.02 + gs * 0.00015;
+        // basic IIR filter
+        this.currentPerformance = this.currentPerformance === undefined ? estimate : this.currentPerformance * 0.9 + estimate * 0.1;
+
+        const accuracyHigh = this.currentPerformance <= this.requiredPerformance.activeRnp;
+        if (accuracyHigh !== this.accuracyHigh) {
+            this.accuracyHigh = accuracyHigh;
+            SimVar.SetSimVarValue('L:A32NX_FMGC_L_NAV_ACCURACY_HIGH', 'bool', this.accuracyHigh);
+            SimVar.SetSimVarValue('L:A32NX_FMGC_R_NAV_ACCURACY_HIGH', 'bool', this.accuracyHigh);
+        }
+    }
+}

--- a/src/fmgc/src/navigation/RequiredPerformance.ts
+++ b/src/fmgc/src/navigation/RequiredPerformance.ts
@@ -24,7 +24,7 @@ export class RequiredPerformance {
 
     constructor(private flightPlanManager: FlightPlanManager) {}
 
-    update(deltaTime: number): void {
+    update(_deltaTime: number): void {
         this.updateAutoRnp();
 
         this.updateLDev();

--- a/src/fmgc/src/navigation/RequiredPerformance.ts
+++ b/src/fmgc/src/navigation/RequiredPerformance.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2022 FlyByWire Simulations
+// SPDX-License-Identifier: GPL-3.0
+
+import { FlightArea } from '@fmgc/flightplanning/FlightPlanManager';
+import { FlightPlanManager } from '@fmgc/index';
+
+const rnpDefaults: Record<FlightArea, number> = {
+    [FlightArea.Takeoff]: 1,
+    [FlightArea.Terminal]: 1,
+    [FlightArea.Enroute]: 2,
+    [FlightArea.Oceanic]: 2,
+    [FlightArea.VorApproach]: 0.5,
+    [FlightArea.GpsApproach]: 0.3,
+    [FlightArea.PrecisionApproach]: 0.5,
+    [FlightArea.NonPrecisionApproach]: 0.5,
+};
+
+export class RequiredPerformance {
+    activeRnp: number | undefined;
+
+    requestLDev = false;
+
+    manualRnp = false;
+
+    constructor(private flightPlanManager: FlightPlanManager) {}
+
+    update(deltaTime: number): void {
+        this.updateAutoRnp();
+
+        this.updateLDev();
+    }
+
+    setPilotRnp(rnp): void {
+        this.manualRnp = true;
+        this.setActiveRnp(rnp);
+    }
+
+    clearPilotRnp(): void {
+        this.manualRnp = false;
+        this.updateAutoRnp();
+    }
+
+    private updateAutoRnp(): void {
+        if (this.manualRnp) {
+            return;
+        }
+
+        const area = this.flightPlanManager.activeArea;
+        const rnp = rnpDefaults[area];
+
+        if (rnp !== this.activeRnp) {
+            this.setActiveRnp(rnp);
+        }
+    }
+
+    private setActiveRnp(rnp: number): void {
+        this.activeRnp = rnp;
+        SimVar.SetSimVarValue('L:A32NX_FMGC_L_RNP', 'number', rnp ?? 0);
+        SimVar.SetSimVarValue('L:A32NX_FMGC_R_RNP', 'number', rnp ?? 0);
+    }
+
+    private updateLDev(): void {
+        const area = this.flightPlanManager.activeArea;
+        const ldev = area !== FlightArea.Enroute
+            && area !== FlightArea.Oceanic
+            && this.activeRnp <= (0.3 + Number.EPSILON);
+        if (ldev !== this.requestLDev) {
+            this.requestLDev = ldev;
+            SimVar.SetSimVarValue('L:A32NX_FMGC_L_LDEV_REQUEST', 'bool', this.requestLDev);
+            SimVar.SetSimVarValue('L:A32NX_FMGC_R_LDEV_REQUEST', 'bool', this.requestLDev);
+        }
+    }
+}

--- a/src/instruments/src/ND/elements/CrossTrack.tsx
+++ b/src/instruments/src/ND/elements/CrossTrack.tsx
@@ -1,22 +1,30 @@
 import { useSimVar } from '@instruments/common/simVars';
-import React, { memo } from 'react';
+import { EfisSide } from '@shared/NavigationDisplay';
+import React from 'react';
 
 interface CrossTrackProps {
     x: number,
     y: number,
-    isPlanMode?: boolean;
+    isPlanMode?: boolean,
+    side: EfisSide,
 }
 
-export const CrossTrack: React.FC<CrossTrackProps> = memo(({ x, y, isPlanMode }) => {
+export const CrossTrack: React.FC<CrossTrackProps> = ({ x, y, isPlanMode, side }) => {
     const [crossTrackError] = useSimVar('L:A32NX_FG_CROSS_TRACK_ERROR', 'nautical miles', 250);
+    const [rnp] = useSimVar(`L:A32NX_FMGC_${side}_RNP`, 'number');
 
     let crossTrackText = '';
     let crossTrackAnchor = 'start';
     let crossTrackX = x;
     const crossTrackAbs = Math.min(99.9, Math.abs(crossTrackError));
 
-    if (crossTrackAbs >= 0.1) {
+    if (rnp > 0 && rnp <= (0.3 + Number.EPSILON) && crossTrackAbs >= (0.02 - Number.EPSILON) && crossTrackAbs < (0.3 + Number.EPSILON)) {
+        crossTrackText = crossTrackAbs.toFixed(2);
+    } else if (crossTrackAbs >= 0.1) {
         crossTrackText = crossTrackAbs.toFixed(1);
+    }
+
+    if (crossTrackText.length > 0) {
         if (crossTrackError < 0) {
             crossTrackText += 'R';
             crossTrackAnchor = 'start';
@@ -33,4 +41,4 @@ export const CrossTrack: React.FC<CrossTrackProps> = memo(({ x, y, isPlanMode })
             {crossTrackText}
         </text>
     );
-});
+};

--- a/src/instruments/src/ND/pages/ArcMode.tsx
+++ b/src/instruments/src/ND/pages/ArcMode.tsx
@@ -94,7 +94,7 @@ export const ArcMode: React.FC<ArcModeProps> = ({ symbols, adirsAlign, rangeSett
                 { lsDisplayed && <LsCourseBug heading={heading} lsCourse={lsCourse} /> }
                 <SelectedHeadingBug heading={heading} selected={selectedHeading} />
                 <Plane />
-                <CrossTrack x={390} y={646} />
+                <CrossTrack x={390} y={646} side={side} />
                 <g clipPath="url(#arc-mode-tcas-clip)">
                     <Traffic mode={Mode.ARC} mapParams={mapParams} />
                 </g>

--- a/src/instruments/src/ND/pages/PlanMode.tsx
+++ b/src/instruments/src/ND/pages/PlanMode.tsx
@@ -51,7 +51,7 @@ export const PlanMode: FC<PlanModeProps> = ({ side, symbols, adirsAlign, rangeSe
 
             <ToWaypointIndicator side={side} />
 
-            <CrossTrack x={44} y={690} isPlanMode />
+            <CrossTrack x={44} y={690} side={side} isPlanMode />
         </>
     );
 };

--- a/src/instruments/src/ND/pages/RoseMode.tsx
+++ b/src/instruments/src/ND/pages/RoseMode.tsx
@@ -101,7 +101,7 @@ export const RoseMode: FC<RoseModeProps> = ({ symbols, adirsAlign, rangeSetting,
                 <SelectedHeadingBug heading={heading} selected={selectedHeading} />
                 { mode === Mode.ROSE_ILS && <GlideSlope /> }
                 <Plane />
-                {mode === Mode.ROSE_NAV && <CrossTrack x={390} y={407} />}
+                {mode === Mode.ROSE_NAV && <CrossTrack x={390} y={407} side={side} />}
                 <g clipPath="url(#rose-mode-tcas-clip)">
                     <Traffic mode={mode} mapParams={mapParams} />
                 </g>

--- a/src/instruments/src/PFD/LandingSystemIndicator.tsx
+++ b/src/instruments/src/PFD/LandingSystemIndicator.tsx
@@ -8,11 +8,19 @@ import { LagFilter } from './PFDUtils';
 export class LandingSystem extends DisplayComponent<{ bus: EventBus, instrument: BaseInstrument }> {
     private lsButtonPressedVisibility = false;
 
+    private xtkValid = false;
+
+    private ldevRequest = false;
+
     private lsGroupRef = FSComponent.createRef<SVGGElement>();
 
     private gsReferenceLine = FSComponent.createRef<SVGPathElement>();
 
     private deviationGroup = FSComponent.createRef<SVGGElement>();
+
+    private ldevRef = FSComponent.createRef<SVGGElement>();
+
+    private vdevRef = FSComponent.createRef<SVGGElement>();
 
     private altitude = Arinc429Word.empty();
 
@@ -42,6 +50,7 @@ export class LandingSystem extends DisplayComponent<{ bus: EventBus, instrument:
         sub.on(getDisplayIndex() === 1 ? 'ls1Button' : 'ls2Button').whenChanged().handle((lsButton) => {
             this.lsButtonPressedVisibility = lsButton;
             this.lsGroupRef.instance.style.display = this.lsButtonPressedVisibility ? 'inline' : 'none';
+            this.deviationGroup.instance.style.display = this.lsButtonPressedVisibility ? 'none' : 'inline';
             this.handleGsReferenceLine();
         });
 
@@ -49,12 +58,29 @@ export class LandingSystem extends DisplayComponent<{ bus: EventBus, instrument:
             this.altitude = altitude;
             this.handleGsReferenceLine();
         });
+
+        sub.on(getDisplayIndex() === 1 ? 'ldevRequestLeft' : 'ldevRequestRight').whenChanged().handle((ldevRequest) => {
+            this.ldevRequest = ldevRequest;
+            this.updateLdevVisibility();
+        });
+
+        sub.on('xtk').whenChanged().handle((xtk) => {
+            const xtkValid = Math.abs(xtk) > 0;
+            if (xtkValid !== this.xtkValid) {
+                this.xtkValid = xtkValid;
+                this.updateLdevVisibility();
+            }
+        });
+    }
+
+    updateLdevVisibility() {
+        this.ldevRef.instance.style.display = this.ldevRequest && this.xtkValid ? 'inline' : 'none';
     }
 
     render(): VNode {
         return (
             <>
-                <g id="LSAndDeviationGroup" ref={this.lsGroupRef} style="display: none">
+                <g id="LSGroup" ref={this.lsGroupRef} style="display: none">
                     <LandingSystemInfo bus={this.props.bus} />
 
                     <g id="LSGroup">
@@ -63,9 +89,14 @@ export class LandingSystem extends DisplayComponent<{ bus: EventBus, instrument:
                         <MarkerBeaconIndicator bus={this.props.bus} />
                     </g>
 
-                    <g id="DeviationGroup" ref={this.deviationGroup} style="display: none">
+                    <path ref={this.gsReferenceLine} class="Yellow Fill" d="m115.52 80.067v1.5119h-8.9706v-1.5119z" />
+                </g>
+                <g id="DeviationGroup" ref={this.deviationGroup} style="display: none">
+                    <g id="LateralDeviationGroup" ref={this.ldevRef} style="display: none">
+                        <LDevIndicator bus={this.props.bus} />
+                    </g>
+                    <g id="VerticalDeviationGroup" ref={this.vdevRef} style="display: none">
                         <VDevIndicator bus={this.props.bus} />
-                        <LDevIndicator />
                     </g>
                 </g>
                 <path ref={this.gsReferenceLine} class="Yellow Fill" d="m115.52 80.067v1.5119h-8.9706v-1.5119z" />
@@ -370,19 +401,50 @@ class VDevIndicator extends DisplayComponent<{bus: EventBus}> {
     }
 }
 
-// Not implemented on the FMS side, so this is just static and hidden for now
-class LDevIndicator extends DisplayComponent<any> {
+class LDevIndicator extends DisplayComponent<{bus: EventBus}> {
+    private LDevSymbolLeft = FSComponent.createRef<SVGPathElement>();
+
+    private LDevSymbolRight = FSComponent.createRef<SVGPathElement>();
+
+    private LDevSymbol = FSComponent.createRef<SVGPathElement>();
+
+    onAfterRender(node: VNode): void {
+        super.onAfterRender(node);
+
+        const sub = this.props.bus.getSubscriber<PFDSimvars>();
+
+        sub.on('xtk').whenChanged().handle((xtk) => {
+            const dots = xtk / 0.1;
+
+            if (dots > 2) {
+                this.LDevSymbolRight.instance.style.visibility = 'visible';
+                this.LDevSymbolLeft.instance.style.visibility = 'hidden';
+                this.LDevSymbol.instance.style.visibility = 'hidden';
+            } else if (dots < -2) {
+                this.LDevSymbolRight.instance.style.visibility = 'hidden';
+                this.LDevSymbolLeft.instance.style.visibility = 'visible';
+                this.LDevSymbol.instance.style.visibility = 'hidden';
+            } else {
+                this.LDevSymbolRight.instance.style.visibility = 'hidden';
+                this.LDevSymbolLeft.instance.style.visibility = 'hidden';
+                this.LDevSymbol.instance.style.visibility = 'visible';
+                this.LDevSymbol.instance.style.transform = `translate3d(${dots * 30.238 / 2}px, 0px, 0px)`;
+            }
+        });
+    }
+
     render(): VNode {
         return (
-            <g id="LatDeviationSymbolsGroup" style="display: none">
-                <text className="FontSmall AlignRight Green" x="30.888" y="122.639">L/DEV</text>
-                <path className="NormalStroke White" d="m38.686 129.51v2.0158" />
-                <path className="NormalStroke White" d="m53.796 129.51v2.0158" />
-                <path className="NormalStroke White" d="m84.017 129.51v2.0158" />
-                <path className="NormalStroke White" d="m99.127 129.51v2.0158" />
-                <path id="LDevSymbolLeft" className="NormalStroke Green" d="m38.686 127.99h-2.0147v5.0397h2.0147" />
-                <path id="LDevSymbolRight" className="NormalStroke Green" d="m99.127 127.99h2.0147v5.0397h-2.0147" />
-                <path id="LDevSymbol" className="NormalStroke Green" d="m66.892 127.99v5.0397h4.0294v-5.0397h-2.0147z" />
+            <g id="LatDeviationSymbolsGroup">
+                <text class="FontSmall AlignRight Green" x="30.888" y="122.639">L/DEV</text>
+                <path class="NormalStroke White" d="m38.686 129.51v2.0158" />
+                <path class="NormalStroke White" d="m53.796 129.51v2.0158" />
+                <path class="NormalStroke White" d="m84.017 129.51v2.0158" />
+                <path class="NormalStroke White" d="m99.127 129.51v2.0158" />
+                <path id="LDevSymbolLeft" ref={this.LDevSymbolLeft} class="NormalStroke Green" d="m38.686 127.99h-2.0147v5.0397h2.0147" />
+                <path id="LDevSymbolRight" ref={this.LDevSymbolRight} class="NormalStroke Green" d="m99.127 127.99h2.0147v5.0397h-2.0147" />
+                <path id="LDevSymbol" ref={this.LDevSymbol} class="NormalStroke Green" d="m66.892 127.99v5.0397h4.0294v-5.0397h-2.0147z" />
+                <path id="LDevNeutralLine" class="Yellow Fill" d="m68.098 134.5v-8.0635h1.5119v8.0635z" />
             </g>
         );
     }

--- a/src/instruments/src/PFD/LandingSystemIndicator.tsx
+++ b/src/instruments/src/PFD/LandingSystemIndicator.tsx
@@ -8,7 +8,7 @@ import { LagFilter } from './PFDUtils';
 export class LandingSystem extends DisplayComponent<{ bus: EventBus, instrument: BaseInstrument }> {
     private lsButtonPressedVisibility = false;
 
-    private xtkValid = false;
+    private xtkValid = Subject.create(false);
 
     private ldevRequest = false;
 
@@ -65,11 +65,11 @@ export class LandingSystem extends DisplayComponent<{ bus: EventBus, instrument:
         });
 
         sub.on('xtk').whenChanged().handle((xtk) => {
-            const xtkValid = Math.abs(xtk) > 0;
-            if (xtkValid !== this.xtkValid) {
-                this.xtkValid = xtkValid;
-                this.updateLdevVisibility();
-            }
+            this.xtkValid.set(Math.abs(xtk) > 0);
+        });
+
+        this.xtkValid.sub(() => {
+            this.updateLdevVisibility();
         });
     }
 
@@ -413,7 +413,7 @@ class LDevIndicator extends DisplayComponent<{bus: EventBus}> {
 
         const sub = this.props.bus.getSubscriber<PFDSimvars>();
 
-        sub.on('xtk').whenChanged().handle((xtk) => {
+        sub.on('xtk').whenChanged().withPrecision(3).handle((xtk) => {
             const dots = xtk / 0.1;
 
             if (dots > 2) {

--- a/src/instruments/src/PFD/instrument.tsx
+++ b/src/instruments/src/PFD/instrument.tsx
@@ -182,6 +182,9 @@ class A32NX_PFD extends BaseInstrument {
         this.simVarPublisher.subscribe('daRaw');
         this.simVarPublisher.subscribe('ls1Button');
         this.simVarPublisher.subscribe('ls2Button');
+        this.simVarPublisher.subscribe('xtk');
+        this.simVarPublisher.subscribe('ldevRequestLeft');
+        this.simVarPublisher.subscribe('ldevRequestRight');
 
         FSComponent.render(<PFDComponent bus={this.bus} instrument={this} />, document.getElementById('PFD_CONTENT'));
     }

--- a/src/instruments/src/PFD/shared/PFDSimvarPublisher.tsx
+++ b/src/instruments/src/PFD/shared/PFDSimvarPublisher.tsx
@@ -112,6 +112,9 @@ export interface PFDSimvars {
     daRaw: number;
     ls1Button: boolean;
     ls2Button: boolean;
+    xtk: number;
+    ldevRequestLeft: boolean;
+    ldevRequestRight: boolean;
   }
 
 export enum PFDVars {
@@ -226,6 +229,9 @@ export enum PFDVars {
     daRaw = 'L:A32NX_ADIRS_IR_1_DRIFT_ANGLE',
     ls1Button = 'L:BTN_LS_1_FILTER_ACTIVE',
     ls2Button = 'L:BTN_LS_2_FILTER_ACTIVE',
+    xtk = 'L:A32NX_FG_CROSS_TRACK_ERROR',
+    ldevLeft = 'L:A32NX_FMGC_L_LDEV_REQUEST',
+    ldevRight = 'L:A32NX_FMGC_R_LDEV_REQUEST',
   }
 
 /** A publisher to poll and publish nav/com simvars. */
@@ -342,6 +348,9 @@ export class PFDSimvarPublisher extends SimVarPublisher<PFDSimvars> {
         ['daRaw', { name: PFDVars.daRaw, type: SimVarValueType.Number }],
         ['ls1Button', { name: PFDVars.ls1Button, type: SimVarValueType.Bool }],
         ['ls2Button', { name: PFDVars.ls2Button, type: SimVarValueType.Bool }],
+        ['xtk', { name: PFDVars.xtk, type: SimVarValueType.NM }],
+        ['ldevRequestLeft', { name: PFDVars.ldevLeft, type: SimVarValueType.Bool }],
+        ['ldevRequestRight', { name: PFDVars.ldevRight, type: SimVarValueType.Bool }],
     ])
 
     public constructor(bus: EventBus) {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Add support for RNP at or below 0.3 NM. No leg RNP values are available from the MSFS nav database so only flight area default RNPs are automatically set... and the pilot can enter a specific RNP on the PROG page.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
Various documents.

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Enter various RNP values on the PROG page. Anything between 0.01 and 20 should be possible.
- Check that clearing the pilot RNP value reverts to the flight area default.
- Check that L/DEV is displayed and showing proper cross-track error when an RNP of 0.3 or less is entered on the PROG page and in the terminal area (SID/STAR/APPR), and otherwise not.
- Check that xtk is shown on the ND with 2 decimals when RNP at or below 0.3 is entred on the PROG page, and XTK is between 0.02 and 0.3 NM, and otherwise 1 DP or not shown.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
