### PR TITLE
fix(fws): slats warning during flaps 3 takeoff

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -22,6 +22,7 @@
 1. [MCDU] Added imperial runway length - @derl30n (Leon)
 1. [MCDU] Refactor and improve input handling and conversions in MCDU W&B - @sidnov (Sid)
 1. [MCDU] Improved arrivals/departure page scrolling, more true-to-life behaviour and cosmetic apperance - @2hwk (2Cas#1022)
+1. [ECAM] Fix erroneous SLATS NOT IN T.O CONFIG warning during flaps 3 takeoff - @beheh (Benedict Etzel)
 
 ## 0.8.0
 

--- a/src/instruments/src/EWD/elements/PseudoFWC.tsx
+++ b/src/instruments/src/EWD/elements/PseudoFWC.tsx
@@ -216,8 +216,15 @@ const PseudoFWC: React.FC = () => {
     const [autoBrake] = useSimVar('L:A32NX_AUTOBRAKES_ARMED_MODE', 'enum', 500);
     const [flapsHandle] = useSimVar('L:A32NX_FLAPS_HANDLE_INDEX', 'enum', 500);
     const [flapsIndex] = useSimVar('L:A32NX_FLAPS_CONF_INDEX', 'number', 100);
+
     const [slatsAngle] = useSimVar('L:A32NX_LEFT_SLATS_ANGLE', 'degrees', 100);
+    const slatsInfD = slatsAngle <= 17;
+    const slatsSupG = slatsAngle >= 25;
+
     const [flapsAngle] = useSimVar('L:A32NX_LEFT_FLAPS_ANGLE', 'degrees', 100);
+    const flapsInfA = flapsAngle <= 2;
+    const flapsSupF = flapsAngle >= 24;
+
     const [toconfig] = useSimVar('L:A32NX_TO_CONFIG_NORMAL', 'bool', 100);
 
     const [adirsRemainingAlignTime] = useSimVar('L:A32NX_ADIRS_REMAINING_IR_ALIGNMENT_TIME', 'seconds', 1000);
@@ -639,7 +646,7 @@ const PseudoFWC: React.FC = () => {
                 && toconfigFailed
             )
             || (
-                [3, 4, 5].includes(flightPhase) && (slatsAngle < 18 || slatsAngle > 22)
+                [3, 4, 5].includes(flightPhase) && (slatsInfD || slatsSupG)
             ),
             whichCodeToReturn: [0, 1],
             codesToReturn: ['270008501', '270008502'],
@@ -657,7 +664,7 @@ const PseudoFWC: React.FC = () => {
                 && toconfigFailed
             )
             || (
-                [3, 4, 5].includes(flightPhase) && (flapsAngle < 10 || flapsAngle > 20)
+                [3, 4, 5].includes(flightPhase) && (flapsInfA || flapsSupF)
             ),
             whichCodeToReturn: [0, 1],
             codesToReturn: ['270009001', '270009002'],
@@ -1628,6 +1635,8 @@ const PseudoFWC: React.FC = () => {
         fireButton1,
         fireButton2,
         fireButtonAPU,
+        flapsInfA,
+        flapsSupF,
         flapsHandle,
         flapsIndex,
         flightPhase,
@@ -1671,6 +1680,8 @@ const PseudoFWC: React.FC = () => {
         seatBelt,
         showTakeoffInhibit,
         showLandingInhibit,
+        slatsInfD,
+        slatsSupG,
         speedBrake,
         spoilersArmed,
         strobeLightsOn,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
A minor change to the flap and slat angles that may have resulted in an erroneous SLATS NOT IN T.O CONFIG or FLAPS NOT IN T.O CONFIG or during takeoff.

This doesn't fix or change the behaviour of the T.O CONF button, it just updates the angles and ensures the warning is correctly updated.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Start a Flaps 3 takeoff roll. Ensure there is no erroneous FLAPS NOT IN T.O CONFIG or SLATS NOT IN T.O CONFIG warning.
Start a Flaps 0 & Flaps Full takeoff roll. Ensure there are both the FLAPS NOT IN T.O CONFIG or SLATS NOT IN T.O CONFIG warning.
Try intermediate settings. The warning should not appear in positions 1, 2 and 3 and vanish/appear as the flaps or slats move through these positions.

For this test, ignore the T.O CONF push button.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
