### PR TITLE
fix(hyd): Too slow leak measurement valves operation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -34,6 +34,7 @@
 1. [MCDU] Added formatter to improve text alignment and ease integration - @derl30n (Leon)
 1. [EFB] Fix default unit to match UI and other consumers - @tracernz (Mike)
 1. [MCDU] Added 4:3 aspect ratio compatibility to remote mcdu client - @tyler58546 (tyler58546)
+1. [HYD] Fixed too slow leak measurement valves operation - @Crocket63 (crocket)
 
 ## 0.8.0
 

--- a/src/systems/systems/src/hydraulic/mod.rs
+++ b/src/systems/systems/src/hydraulic/mod.rs
@@ -1546,7 +1546,7 @@ pub struct LeakMeasurementValve {
     downstream_pressure: Pressure,
 }
 impl LeakMeasurementValve {
-    const VALVE_RESPONSE_TIME_CONSTANT: Duration = Duration::from_millis(1500);
+    const VALVE_RESPONSE_TIME_CONSTANT: Duration = Duration::from_millis(500);
 
     fn new(powered_by: ElectricalBusType) -> Self {
         Self {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Two issues fixed:
- Too slow leak measurement valves allowed flight controls to move a little bit on cargo door operation start.
- Yellow valve opening as soon as yellow epump is auto shutdown was also allowing flight controls to move due to residual pressure

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

-Use cargo door.
-Check that no flight control move (including spoilers) when cargo door is used, or when yellow electric pump stops after cargo door operation.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
