### PR TITLE
chore: Fire overhead structure using const generics for bigger planes

### DIFF
--- a/src/systems/a320_systems/src/hydraulic/mod.rs
+++ b/src/systems/a320_systems/src/hydraulic/mod.rs
@@ -5588,7 +5588,7 @@ mod tests {
             overhead: A320HydraulicOverheadPanel,
             autobrake_panel: AutobrakePanel,
             emergency_electrical_overhead: A320TestEmergencyElectricalOverheadPanel,
-            engine_fire_overhead: EngineFireOverheadPanel,
+            engine_fire_overhead: EngineFireOverheadPanel<2>,
             landing_gear: LandingGear,
             lgcius: LandingGearControlInterfaceUnitSet,
             adirus: A320TestAdirus,

--- a/src/systems/a320_systems/src/lib.rs
+++ b/src/systems/a320_systems/src/lib.rs
@@ -52,7 +52,7 @@ pub struct A320 {
     fuel: A320Fuel,
     engine_1: LeapEngine,
     engine_2: LeapEngine,
-    engine_fire_overhead: EngineFireOverheadPanel,
+    engine_fire_overhead: EngineFireOverheadPanel<2>,
     electrical: A320Electrical,
     power_consumption: A320PowerConsumption,
     ext_pwr: ExternalPowerSource,

--- a/src/systems/systems/src/engine/mod.rs
+++ b/src/systems/systems/src/engine/mod.rs
@@ -15,27 +15,35 @@ pub trait Engine: EngineCorrectedN2 + EngineUncorrectedN2 + EngineCorrectedN1 {
     fn is_above_minimum_idle(&self) -> bool;
 }
 
-pub struct EngineFireOverheadPanel {
-    // TODO: Once const generics are available in the dev-env rustc version, we can replace
-    // this with an array sized by the const.
-    engine_fire_push_buttons: [FirePushButton; 2],
+use std::convert::TryInto;
+pub struct EngineFireOverheadPanel<const N: usize> {
+    engine_fire_push_buttons: [FirePushButton; N],
 }
-impl EngineFireOverheadPanel {
+impl<const N: usize> EngineFireOverheadPanel<N> {
     pub fn new(context: &mut InitContext) -> Self {
+        let mut button_array = vec![];
+        for idx in 0..N {
+            button_array.push(FirePushButton::new(
+                context,
+                format!("ENG{}", idx + 1).as_str(),
+            ));
+        }
+
         Self {
-            engine_fire_push_buttons: [
-                FirePushButton::new(context, "ENG1"),
-                FirePushButton::new(context, "ENG2"),
-            ],
+            engine_fire_push_buttons: button_array.try_into().unwrap_or_else(
+                |v: Vec<FirePushButton>| {
+                    panic!("Expected a Vec of length {} but it was {}", N, v.len())
+                },
+            ),
         }
     }
 }
-impl EngineFirePushButtons for EngineFireOverheadPanel {
+impl<const N: usize> EngineFirePushButtons for EngineFireOverheadPanel<N> {
     fn is_released(&self, engine_number: usize) -> bool {
         self.engine_fire_push_buttons[engine_number - 1].is_released()
     }
 }
-impl SimulationElement for EngineFireOverheadPanel {
+impl<const N: usize> SimulationElement for EngineFireOverheadPanel<N> {
     fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
         accept_iterable!(self.engine_fire_push_buttons, visitor);
 
@@ -50,7 +58,7 @@ mod engine_fire_overhead_panel_tests {
 
     #[test]
     fn after_construction_fire_push_buttons_are_not_released() {
-        let test_bed = SimulationTestBed::from(ElementCtorFn(EngineFireOverheadPanel::new));
+        let test_bed = SimulationTestBed::from(ElementCtorFn(EngineFireOverheadPanel::<2>::new));
 
         assert!(!test_bed.query_element(|e| e.is_released(1)));
         assert!(!test_bed.query_element(|e| e.is_released(2)));
@@ -58,7 +66,8 @@ mod engine_fire_overhead_panel_tests {
 
     #[test]
     fn fire_push_button_is_released_returns_false_when_not_released() {
-        let mut test_bed = SimulationTestBed::from(ElementCtorFn(EngineFireOverheadPanel::new));
+        let mut test_bed =
+            SimulationTestBed::from(ElementCtorFn(EngineFireOverheadPanel::<2>::new));
         test_bed.write_by_name("FIRE_BUTTON_ENG1", false);
         test_bed.run();
 
@@ -67,10 +76,27 @@ mod engine_fire_overhead_panel_tests {
 
     #[test]
     fn fire_push_button_is_released_returns_true_when_released() {
-        let mut test_bed = SimulationTestBed::from(ElementCtorFn(EngineFireOverheadPanel::new));
+        let mut test_bed =
+            SimulationTestBed::from(ElementCtorFn(EngineFireOverheadPanel::<2>::new));
         test_bed.write_by_name("FIRE_BUTTON_ENG1", true);
         test_bed.run();
 
         assert!(test_bed.query_element(|e| e.is_released(1)));
+    }
+
+    #[test]
+    fn fire_push_button_variables_exist() {
+        let mut test_bed =
+            SimulationTestBed::from(ElementCtorFn(EngineFireOverheadPanel::<3>::new));
+
+        test_bed.run();
+
+        assert!(!test_bed.contains_variable_with_name("FIRE_BUTTON_ENG0"));
+
+        assert!(test_bed.contains_variable_with_name("FIRE_BUTTON_ENG1"));
+        assert!(test_bed.contains_variable_with_name("FIRE_BUTTON_ENG2"));
+        assert!(test_bed.contains_variable_with_name("FIRE_BUTTON_ENG3"));
+
+        assert!(!test_bed.contains_variable_with_name("FIRE_BUTTON_ENG4"));
     }
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Using const generics for fire overhead... to  prepare for bigger planes

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Fire handle cuts off the correct hydraulic engine pump.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
