### PR TITLE
feat(pfd): Improve barberpole rendering on the PFD

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -37,6 +37,7 @@
 1. [MCDU] Added 4:3 aspect ratio compatibility to remote mcdu client - @tyler58546 (tyler58546)
 1. [HYD] Fixed too slow leak measurement valves operation - @Crocket63 (crocket)
 1. [ISIS] Added temporary ISIS font with arrows - @aweissoertel (Alexibexi#7550)
+1. [PFD] Improve PFD barberpole rendering and behaviour - @lukecologne (luke)
 
 ## 0.8.0
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR changes the way the barberpole indicators (Vmax, VAlphaProt) are implemented.
Instead of building them from multiple paths, they are now one path and so only translated as a whole. This makes the code simpler, and should help performance at least a tiny bit. It also creates a little visual effect: if you get too fast (or too slow, in case of the Valphaprot bar), the barberpole bar will stop moving with the speedscale. This is verified with multiple videos from FFS (see screenshots section).
This PR is a blocker for implementing the VStallWarn bar for #6913, so it would be great if this could be merged quickly.

Quick note: I had to disable the Eslint `max-len` rule for the path string lines, if there is a way to add linebreaks to strings in jsx please let me know.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
https://user-images.githubusercontent.com/39596827/179327693-a81b5bab-a719-4cb5-9103-f044e305a559.mp4


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

Example for the effect (in this case it can be seen for the VStallWarn bar, but I have another video locally that shows the same for Vmax):
https://www.youtube.com/watch?v=rKEKwYTvuZU

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Check the correct behaviour of the barberpole indicators (for example that it appears at the correct speed, etc). You can check the numerical values of the bars for comparison by opening the Model Behaviours window in the devmode, and switch to the localvars tab, then search for Vmax/alpha_protection.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
