### PR TITLE
fix(fmgc): improve procedure loading perf

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -57,6 +57,7 @@
 1. [MODEL] Added new animated gear gravity extension handle- @tyler58546 (tyler58546), @MoreRightRudder (Mike), @Crocket63 (crocket), @Lantarius
 1. [MCDU] Hide stored elements on A/C Status when there are none - @tracernz (Mike)
 1. [FMGC] Fix ident for CD legs - @tracernz (Mike)
+1. [FMGC] Improve procedure loading performance - @tracernz (Mike)
 
 ## 0.8.0
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/FlightElements/A32NX_Waypoint.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/FlightElements/A32NX_Waypoint.js
@@ -234,6 +234,7 @@ class WayPointInfo {
         this.long = data.lon;
     }
     async UpdateAirway(name) {
+        await this.ensureRouteData();
         if (this.airways.findIndex(airway => airway.name === name) === -1) {
             const airways = await this.instrument.facilityLoader.getAllAirways(this, name);
             if (airways.length === 1) {
@@ -242,7 +243,11 @@ class WayPointInfo {
         }
     }
     async UpdateAirways() {
+        await this.ensureRouteData();
         this.airways = await this.instrument.facilityLoader.getAllAirways(this);
+    }
+    async ensureRouteData() {
+        // only needed for navaids
     }
 }
 class AirportInfo extends WayPointInfo {
@@ -611,7 +616,21 @@ class AirportInfo extends WayPointInfo {
         }
     }
 }
-class VORInfo extends WayPointInfo {
+
+class NavaidInfo extends WayPointInfo {
+    async ensureRouteData() {
+        if (!this.routes) {
+            const intersection = await this.instrument.facilityLoader.getIntersectionData(this.icao);
+            if (intersection) {
+                this.routes = intersection.routes;
+            } else {
+                this.routes = [];
+            }
+        }
+    }
+}
+
+class VORInfo extends NavaidInfo {
     constructor(_instrument) {
         super(_instrument);
     }
@@ -724,7 +743,7 @@ class VORInfo extends WayPointInfo {
         });
     }
 }
-class NDBInfo extends WayPointInfo {
+class NDBInfo extends NavaidInfo {
     constructor(_instrument) {
         super(_instrument);
     }

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/FlightElements/A32NX_WaypointLoader.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/FlightElements/A32NX_WaypointLoader.js
@@ -177,7 +177,7 @@ class FacilityLoader {
             case 'N':
                 const ndbPromises = [queueRawLoad('LOAD_NDB', icao, 'N')];
                 if (!skipIntersectionData) {
-                    vorPromises.push(queueRawLoad('LOAD_INTERSECTION', icao, 'W'));
+                    ndbPromises.push(queueRawLoad('LOAD_INTERSECTION', icao, 'W'));
                 }
                 return Promise.all(ndbPromises)
                     .then(facilities => {

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/FlightElements/A32NX_WaypointLoader.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/FlightElements/A32NX_WaypointLoader.js
@@ -130,7 +130,7 @@ class FacilityLoader {
      * Gets the raw facility data for a given icao.
      * @param {String} icao The ICAO to get the raw facility data for.
      */
-    getFacilityRaw(icao, timeout = 1500) {
+    getFacilityRaw(icao, timeout = 1500, skipIntersectionData = false) {
 
         const queueRawLoad = (loadCall, icao, type) => {
             return new Promise((resolve) => {
@@ -161,21 +161,31 @@ class FacilityLoader {
                     return queueRawLoad('LOAD_INTERSECTION', icao, 'W');
                 }
             case 'V':
-                return Promise.all([queueRawLoad('LOAD_VOR', icao, 'V'), queueRawLoad('LOAD_INTERSECTION', icao, 'W')])
+                const vorPromises = [queueRawLoad('LOAD_VOR', icao, 'V')];
+                if (!skipIntersectionData) {
+                    vorPromises.push(queueRawLoad('LOAD_INTERSECTION', icao, 'W'));
+                }
+                return Promise.all(vorPromises)
                     .then(facilities => {
                         if (facilities[1]) {
                             return Object.assign(facilities[0], facilities[1]);
+                        } else if (!skipIntersectionData) {
+                            console.warn('Missing insersection data', facilities[0]);
                         }
-                        console.warn('Missing insersection data', facilities[0]);
                         return facilities[0];
                     });
             case 'N':
-                return Promise.all([queueRawLoad('LOAD_NDB', icao, 'N'), queueRawLoad('LOAD_INTERSECTION', icao, 'W')])
+                const ndbPromises = [queueRawLoad('LOAD_NDB', icao, 'N')];
+                if (!skipIntersectionData) {
+                    vorPromises.push(queueRawLoad('LOAD_INTERSECTION', icao, 'W'));
+                }
+                return Promise.all(ndbPromises)
                     .then(facilities => {
                         if (facilities[1]) {
                             Object.assign(facilities[0], facilities[1]);
+                        } else if (!skipIntersectionData) {
+                            console.warn('Missing insersection data', facilities[0]);
                         }
-                        console.warn('Missing insersection data', facilities[0]);
                         return facilities[0];
                     });
         }

--- a/src/fmgc/src/flightplanning/LegsProcedure.ts
+++ b/src/fmgc/src/flightplanning/LegsProcedure.ts
@@ -80,15 +80,15 @@ export class LegsProcedure {
     ) {
       for (const leg of this._legs) {
           if (this.isIcaoValid(leg.fixIcao)) {
-              this._facilitiesToLoad.set(leg.fixIcao, this._instrument.facilityLoader.getFacilityRaw(leg.fixIcao, 2000));
+              this._facilitiesToLoad.set(leg.fixIcao, this._instrument.facilityLoader.getFacilityRaw(leg.fixIcao, 2000, true));
           }
 
           if (this.isIcaoValid(leg.originIcao)) {
-              this._facilitiesToLoad.set(leg.originIcao, this._instrument.facilityLoader.getFacilityRaw(leg.originIcao, 2000));
+              this._facilitiesToLoad.set(leg.originIcao, this._instrument.facilityLoader.getFacilityRaw(leg.originIcao, 2000, true));
           }
 
           if (this.isIcaoValid(leg.arcCenterFixIcao)) {
-              this._facilitiesToLoad.set(leg.arcCenterFixIcao, this._instrument.facilityLoader.getFacilityRaw(leg.arcCenterFixIcao, 2000));
+              this._facilitiesToLoad.set(leg.arcCenterFixIcao, this._instrument.facilityLoader.getFacilityRaw(leg.arcCenterFixIcao, 2000, true));
           }
       }
   }

--- a/typings/asobo-vcockpits-instruments/html_ui/Pages/VCockpit/Instruments/Shared/FlightElements/WaypointLoader.d.ts
+++ b/typings/asobo-vcockpits-instruments/html_ui/Pages/VCockpit/Instruments/Shared/FlightElements/WaypointLoader.d.ts
@@ -1,3 +1,3 @@
 declare class FacilityLoader {
-    getFacilityRaw(icao: string, timeout?: number): Promise<any>;
+    getFacilityRaw(icao: string, timeout?: number, skipIntersectionData?: boolean): Promise<any>;
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Substantially improve procedure loading performance with procedures containing navaids. We don't need intersection data (for airways) for stringing terminal procedures.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Check a number of SIDs, STARs and approaches. Best tested in exp for a while. Check that airways can be strung from the end of a SID.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
