### PR TITLE
fix: restore backlight bleed on pfd

### DIFF
--- a/src/instruments/src/PFD/shared/displayUnit.tsx
+++ b/src/instruments/src/PFD/shared/displayUnit.tsx
@@ -1,6 +1,7 @@
 import { ClockEvents, DisplayComponent, EventBus, FSComponent, Subscribable, VNode } from 'msfssdk';
 
 import './common.scss';
+import './pixels.scss';
 
 import { NXDataStore } from '@shared/persistence';
 import { PFDSimvars } from './PFDSimvarPublisher';

--- a/src/instruments/src/PFD/shared/pixels.scss
+++ b/src/instruments/src/PFD/shared/pixels.scss
@@ -4,7 +4,7 @@
   height: 100%;
   position: absolute;
   z-index: 998;
-  opacity: 0.75;
-  background-color: rgba(0, 0, 255, 0.025);
-  box-shadow: inset 0px 0px 30px 10px rgba(0, 75, 255, 0.04);
+  opacity: 1;
+  background-color: rgba(0, 0, 255, 0.035);
+  box-shadow: inset 0px 0px 30px 10px rgba(0, 76, 255, 0.08);
 }

--- a/src/instruments/src/PFD/style.scss
+++ b/src/instruments/src/PFD/style.scss
@@ -254,13 +254,3 @@ text.Red {
 .HiddenElement {
   display: none;
 }
-
-.BacklightBleed {
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  z-index: 998;
-  opacity: 0.75;
-  background-color: rgba(0, 0, 255, 0.025);
-  box-shadow: inset 0px 0px 30px 10px rgba(0, 75, 255, 0.04);
-}


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Adds the missing backlight bleed for the PFD.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/19493808/179423675-a00f841a-34a2-404f-b4f8-77d640a11b68.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Backlight bleed should be identical to all other screens
2. Homecockpit mode disables backlight bleed

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
