### PR TITLE
feat(efb): add scrolling to failure ComfortUI

### DIFF
--- a/src/instruments/src/EFB/Failures/Pages/Comfort/index.tsx
+++ b/src/instruments/src/EFB/Failures/Pages/Comfort/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Route } from 'react-router';
 import { Link } from 'react-router-dom';
 import { Failure } from '@flybywiresim/failures';
+import { ScrollableContainer } from '../../../UtilComponents/ScrollableContainer';
 import { t } from '../../../translation';
 import { pathify } from '../../../Utils/routing';
 import { AtaChapterPage } from './AtaChapterPage';
@@ -61,13 +62,15 @@ interface ComfortUIProps {
 export const ComfortUI = ({ filteredChapters, allChapters, failures }: ComfortUIProps) => (
     <>
         <Route exact path="/failures/comfort">
-            {filteredChapters.map((chapter) => (
-                <ATAChapterCard
-                    ataNumber={chapter}
-                    title={AtaChaptersTitle[chapter]}
-                    description={AtaChaptersDescription[chapter]}
-                />
-            ))}
+            <ScrollableContainer height={48}>
+                {filteredChapters.map((chapter) => (
+                    <ATAChapterCard
+                        ataNumber={chapter}
+                        title={AtaChaptersTitle[chapter]}
+                        description={AtaChaptersDescription[chapter]}
+                    />
+                ))}
+            </ScrollableContainer>
             {filteredChapters.length === 0 && (
                 <div className="flex justify-center items-center mt-4 rounded-md border-2 border-theme-accent" style={{ height: '48rem' }}>
                     <p>{t('Failures.NoItemsFound')}</p>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Adds scrolling to the chapter list of the failure ComfortUI, this is needed for the added chapters in #6913.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
