### PR TITLE
fix: ctd when using gravity gear handle in lock mode

### DIFF
--- a/src/behavior/src/A32NX_Interior_Handling.xml
+++ b/src/behavior/src/A32NX_Interior_Handling.xml
@@ -747,30 +747,15 @@
                     <VISIBILITY_CODE>(L:A32NX_GRAVITYGEAR_TURNED, bool)</VISIBILITY_CODE>
                 </UseTemplate>
                 <UseTemplate Name="ASOBO_GT_Knob_Infinite">
-                    <ANTICLOCKWISE_CONDITION type="rnp" return="boolean">
-                        alias turned = (L:A32NX_GRAVITYGEAR_TURNED, number);
-                        alias rotations = (L:A32NX_GRAVITYGEAR_ROTATIONS, number);
-                        alias rotatePct = (L:A32NX_GRAVITYGEAR_ROTATE_PCT, number);
-                        let maxRotatePct = rotations * 100;
-                        let canTurn = turned == 1 and rotatePct == maxRotatePct;
-                        canTurn
-                    </ANTICLOCKWISE_CONDITION>
-                    <ANTICLOCKWISE_CODE type="rnp">
-                        alias rotations = (L:A32NX_GRAVITYGEAR_ROTATIONS, number);
-                        rotations = (rotations - 1).max(0);
+                    <ANTICLOCKWISE_CODE>
+                        (L:A32NX_GRAVITYGEAR_TURNED, number) 1 == (L:A32NX_GRAVITYGEAR_ROTATE_PCT, number) (L:A32NX_GRAVITYGEAR_ROTATIONS, number) 100 * == and if{
+                            (L:A32NX_GRAVITYGEAR_ROTATIONS, number) 1 - 0 max (&gt;L:A32NX_GRAVITYGEAR_ROTATIONS, number)
+                        }
                     </ANTICLOCKWISE_CODE>
-
-                    <CLOCKWISE_CONDITION type="rnp" return="boolean">
-                        alias turned = (L:A32NX_GRAVITYGEAR_TURNED, number);
-                        alias rotations = (L:A32NX_GRAVITYGEAR_ROTATIONS, number);
-                        alias rotatePct = (L:A32NX_GRAVITYGEAR_ROTATE_PCT, number);
-                        let maxRotatePct = rotations * 100;
-                        let canTurn = turned == 1 and rotatePct == maxRotatePct;
-                        canTurn
-                    </CLOCKWISE_CONDITION>
-                    <CLOCKWISE_CODE type="rnp">
-                        alias rotations = (L:A32NX_GRAVITYGEAR_ROTATIONS, number);
-                        rotations = (rotations + 1).min(3);
+                    <CLOCKWISE_CODE>
+                        (L:A32NX_GRAVITYGEAR_TURNED, number) 1 == (L:A32NX_GRAVITYGEAR_ROTATE_PCT, number) (L:A32NX_GRAVITYGEAR_ROTATIONS, number) 100 * == and if{
+                            (L:A32NX_GRAVITYGEAR_ROTATIONS, number) 1 + 3 min (&gt;L:A32NX_GRAVITYGEAR_ROTATIONS, number)
+                        }
                     </CLOCKWISE_CODE>
                 </UseTemplate>
             </Component>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->


## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixed CTD when using gravity gear extension handle in the lock interaction mode

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Control scheme in legacy mode, release gear by using gravity gear handle
Restart
Switch control scheme to lock mode, then release gravity gear

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
