### PR TITLE
fix: reverse thrust toggle/hold

### DIFF
--- a/src/fbw/src/ThrottleAxisMapping.cpp
+++ b/src/fbw/src/ThrottleAxisMapping.cpp
@@ -212,13 +212,15 @@ void ThrottleAxisMapping::onEventThrottleSet_90() {
 void ThrottleAxisMapping::onEventReverseToggle() {
   isReverseToggleActive = !isReverseToggleActive;
   isReverseToggleKeyActive = isReverseToggleActive;
-  setCurrentValue(idleValue);
-}
+  setCurrentValue(TLA_REVERSE);
+  }
 
 void ThrottleAxisMapping::onEventReverseHold(bool isButtonHold) {
   isReverseToggleActive = isButtonHold;
   isReverseToggleKeyActive = isReverseToggleActive;
-  if (!isReverseToggleActive) {
+  if (isButtonHold){
+    setCurrentValue(TLA_REVERSE);
+  } else {
     setCurrentValue(idleValue);
   }
 }
@@ -231,7 +233,7 @@ void ThrottleAxisMapping::setCurrentValue(double value) {
   // calculate new TLA
   double newTLA = 0;
   if (!useReverseOnAxis && (isReverseToggleActive || isReverseToggleKeyActive)) {
-    newTLA = (TLA_REVERSE / 2.0) * (value + 1.0);
+    newTLA = TLA_REVERSE;
   } else {
     newTLA = thrustLeverAngleMapping.get(value);
   }


### PR DESCRIPTION


<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #7382

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This small fix changes the behaviour of the reverse thrust toggle.
When a the reverse thrust signal is received (either hold or toggle), the reverse thrust lever goes all
the way down (-20). This fix support controllers that uses this action with a
toggle button or holding it, instead of flipping the thrust axis (current behaviour).
This change is for support throttle quadrants that have a toggle/hold button at the end of the throttles axis travel like the Logitech/Saitek Pro Flight Yoke and Honeycombs (I'll update as I investigate more quadrants). This work as well with any other controller/joystick that triggers this action with a button and/or the keyboard (Not bound to axis and/or axis detents).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
ecardona#9232

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1.- Disable "Reverser on axis" on throttle calibration page
2.- Set Throttle to idle
3.- Toggle or Hold Reverse thrust with a button.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
