### PR TITLE
fix(docs): Correct order of gear compressed bits in LGCIU bus doc

### DIFF
--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -2769,9 +2769,9 @@ In the variables below, {number} should be replaced with one item in the set: { 
     - | Bit |                                     Description                                     |
       |:---:|:-----------------------------------------------------------------------------------:|
       | 11  | LH & RH gear shock absorber compressed (Don't treat GND PWR connected as on ground) |
-      | 12  | LH gear shock absorber compressed (Don't treat GND PWR connected as on ground)      |
-      | 13  | RH gear shock absorber compressed (Don't treat GND PWR connected as on ground)      |
-      | 14  | Nose gear shock absorber compressed (Don't treat GND PWR connected as on ground)    |
+      | 12  | Nose gear shock absorber compressed (Don't treat GND PWR connected as on ground)    |
+      | 13  | LH gear shock absorber compressed (Don't treat GND PWR connected as on ground)      |
+      | 14  | RH gear shock absorber compressed (Don't treat GND PWR connected as on ground)      |
       | 15  | LH & RH gear downlocked                                                             |
 
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR fixes an error in the LGCIU bus docs: In the discrete word 2, the shock absorber compressed bits
were the wrong way around.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
