### PR TITLE
fix(ND): Plan Mode waypoint jumping

### DIFF
--- a/src/instruments/src/ND/elements/FlightPlan.tsx
+++ b/src/instruments/src/ND/elements/FlightPlan.tsx
@@ -59,7 +59,6 @@ export const FlightPlan: FC<FlightPathProps> = memo(({ x = 0, y = 0, side, range
                     x={0}
                     y={0}
                     mapParams={mapParams}
-                    mapParamsVersion={mapParams.version}
                     side={side}
                     group={parseInt(group) as EfisVectorsGroup}
                 />

--- a/src/instruments/src/ND/pages/ArcMode.tsx
+++ b/src/instruments/src/ND/pages/ArcMode.tsx
@@ -44,7 +44,7 @@ export const ArcMode: React.FC<ArcModeProps> = ({ symbols, adirsAlign, rangeSett
         track = Number(MathUtils.fastToFixed(track, 2));
     }
 
-    const [mapParams] = useState(() => {
+    const [mapParams, setMapParams] = useState(() => {
         const params = new MapParameters();
         params.compute(ppos, rangeSetting, 492, trueHeading);
 
@@ -52,7 +52,9 @@ export const ArcMode: React.FC<ArcModeProps> = ({ symbols, adirsAlign, rangeSett
     });
 
     useEffect(() => {
-        mapParams.compute(ppos, rangeSetting, 492, trueHeading);
+        const newMapParams = new MapParameters();
+        newMapParams.compute(ppos, rangeSetting, 492, trueHeading);
+        setMapParams(newMapParams);
     }, [ppos.lat, ppos.long, trueHeading, rangeSetting].map((n) => MathUtils.fastToFixed(n, 6)));
 
     if (adirsAlign) {
@@ -72,7 +74,6 @@ export const ArcMode: React.FC<ArcModeProps> = ({ symbols, adirsAlign, rangeSett
                             range={rangeSetting}
                             symbols={symbols}
                             mapParams={mapParams}
-                            mapParamsVersion={mapParams.version}
                             debug={false}
                         />
 

--- a/src/instruments/src/ND/pages/ArcMode.tsx
+++ b/src/instruments/src/ND/pages/ArcMode.tsx
@@ -44,17 +44,12 @@ export const ArcMode: React.FC<ArcModeProps> = ({ symbols, adirsAlign, rangeSett
         track = Number(MathUtils.fastToFixed(track, 2));
     }
 
-    const [mapParams, setMapParams] = useState(() => {
-        const params = new MapParameters();
-        params.compute(ppos, rangeSetting, 492, trueHeading);
-
-        return params;
-    });
+    const [mapParams, setMapParams] = useState(() => (
+        new MapParameters(ppos, rangeSetting, 492, trueHeading)
+    ));
 
     useEffect(() => {
-        const newMapParams = new MapParameters();
-        newMapParams.compute(ppos, rangeSetting, 492, trueHeading);
-        setMapParams(newMapParams);
+        setMapParams(new MapParameters(ppos, rangeSetting, 492, trueHeading));
     }, [ppos.lat, ppos.long, trueHeading, rangeSetting].map((n) => MathUtils.fastToFixed(n, 6)));
 
     if (adirsAlign) {

--- a/src/instruments/src/ND/pages/PlanMode.tsx
+++ b/src/instruments/src/ND/pages/PlanMode.tsx
@@ -28,12 +28,9 @@ export const PlanMode: FC<PlanModeProps> = ({ side, symbols, adirsAlign, rangeSe
     useEffect(() => {
         clearTimeout(debounce.current);
         debounce.current = setTimeout(() => {
-            setMapParams((oldMapParams) => {
-                const newMapParams = new MapParameters();
-                newMapParams.version = oldMapParams.version;
-                newMapParams.compute({ lat: planCentreLat, long: planCentreLong }, rangeSetting / 2, 250, 0);
-                return newMapParams;
-            });
+            const newMapParams = new MapParameters();
+            newMapParams.compute({ lat: planCentreLat, long: planCentreLong }, rangeSetting / 2, 250, 0);
+            setMapParams(newMapParams);
         });
     }, [planCentreLat, planCentreLong, rangeSetting]);
 

--- a/src/instruments/src/ND/pages/PlanMode.tsx
+++ b/src/instruments/src/ND/pages/PlanMode.tsx
@@ -22,15 +22,15 @@ export const PlanMode: FC<PlanModeProps> = ({ side, symbols, adirsAlign, rangeSe
 
     const [trueHeading] = useSimVar('PLANE HEADING DEGREES TRUE', 'degrees');
 
-    const [mapParams, setMapParams] = useState<MapParameters>(new MapParameters());
+    const [mapParams, setMapParams] = useState<MapParameters>(() => (
+        new MapParameters({ lat: planCentreLat, long: planCentreLong }, rangeSetting / 2, 250, 0)
+    ));
     const debounce = useRef();
 
     useEffect(() => {
         clearTimeout(debounce.current);
         debounce.current = setTimeout(() => {
-            const newMapParams = new MapParameters();
-            newMapParams.compute({ lat: planCentreLat, long: planCentreLong }, rangeSetting / 2, 250, 0);
-            setMapParams(newMapParams);
+            setMapParams(new MapParameters({ lat: planCentreLat, long: planCentreLong }, rangeSetting / 2, 250, 0));
         });
     }, [planCentreLat, planCentreLong, rangeSetting]);
 

--- a/src/instruments/src/ND/pages/RoseMode.tsx
+++ b/src/instruments/src/ND/pages/RoseMode.tsx
@@ -44,17 +44,12 @@ export const RoseMode: FC<RoseModeProps> = ({ symbols, adirsAlign, rangeSetting,
         track = (0.025 * groundSpeed + 0.00005) * track + (1 - (0.025 * groundSpeed + 0.00005)) * heading;
     }
 
-    const [mapParams, setMapParams] = useState(() => {
-        const params = new MapParameters();
-        params.compute(ppos, rangeSetting / 2, 250, trueHeading);
-
-        return params;
-    });
+    const [mapParams, setMapParams] = useState(() => (
+        new MapParameters(ppos, rangeSetting / 2, 250, trueHeading)
+    ));
 
     useEffect(() => {
-        const newMapParams = new MapParameters();
-        newMapParams.compute(ppos, rangeSetting / 2, 250, trueHeading);
-        setMapParams(newMapParams);
+        setMapParams(new MapParameters(ppos, rangeSetting / 2, 250, trueHeading));
     }, [ppos.lat, ppos.long, trueHeading, rangeSetting].map((n) => MathUtils.fastToFixed(n, 6)));
 
     if (adirsAlign) {

--- a/src/instruments/src/ND/pages/RoseMode.tsx
+++ b/src/instruments/src/ND/pages/RoseMode.tsx
@@ -44,7 +44,7 @@ export const RoseMode: FC<RoseModeProps> = ({ symbols, adirsAlign, rangeSetting,
         track = (0.025 * groundSpeed + 0.00005) * track + (1 - (0.025 * groundSpeed + 0.00005)) * heading;
     }
 
-    const [mapParams] = useState(() => {
+    const [mapParams, setMapParams] = useState(() => {
         const params = new MapParameters();
         params.compute(ppos, rangeSetting / 2, 250, trueHeading);
 
@@ -52,7 +52,9 @@ export const RoseMode: FC<RoseModeProps> = ({ symbols, adirsAlign, rangeSetting,
     });
 
     useEffect(() => {
-        mapParams.compute(ppos, rangeSetting / 2, 250, trueHeading);
+        const newMapParams = new MapParameters();
+        newMapParams.compute(ppos, rangeSetting / 2, 250, trueHeading);
+        setMapParams(newMapParams);
     }, [ppos.lat, ppos.long, trueHeading, rangeSetting].map((n) => MathUtils.fastToFixed(n, 6)));
 
     if (adirsAlign) {
@@ -73,7 +75,6 @@ export const RoseMode: FC<RoseModeProps> = ({ symbols, adirsAlign, rangeSetting,
                                 range={rangeSetting}
                                 symbols={symbols}
                                 mapParams={mapParams}
-                                mapParamsVersion={mapParams.version}
                                 debug={false}
                             />
 

--- a/src/instruments/src/ND/utils/MapParameters.ts
+++ b/src/instruments/src/ND/utils/MapParameters.ts
@@ -13,6 +13,10 @@ export class MapParameters {
 
     public valid = false;
 
+    constructor(centerCoordinates: Coordinates, nmRadius: number, pxRadius: number, mapUpTrueDeg: number) {
+        this.compute(centerCoordinates, nmRadius, pxRadius, mapUpTrueDeg);
+    }
+
     compute(centerCoordinates: Coordinates, nmRadius: number, pxRadius: number, mapUpTrueDeg: number): void {
         this.valid = Number.isFinite(centerCoordinates.lat) && Number.isFinite(centerCoordinates.long) && Number.isFinite(pxRadius) && Number.isFinite(mapUpTrueDeg);
 

--- a/src/instruments/src/ND/utils/MapParameters.ts
+++ b/src/instruments/src/ND/utils/MapParameters.ts
@@ -11,12 +11,9 @@ export class MapParameters {
 
     public nmRadius: number;
 
-    public version = 0;
-
     public valid = false;
 
     compute(centerCoordinates: Coordinates, nmRadius: number, pxRadius: number, mapUpTrueDeg: number): void {
-        this.version++;
         this.valid = Number.isFinite(centerCoordinates.lat) && Number.isFinite(centerCoordinates.long) && Number.isFinite(pxRadius) && Number.isFinite(mapUpTrueDeg);
 
         this.mapUpTrueDeg = mapUpTrueDeg;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #7421

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This tries to fix ND render in Plan Mode, when vectors and symbols are jumping around when selecting different waypoints (scrolling).

A cause of this is that the two position simvars (`A32NX_SELECTED_WAYPOINT_LAT` and `A32NX_SELECTED_WAYPOINT_LONG`) get values from `useSimVar` independently.

`mapParams` in `PlanMode` are now fully statefull.  A new `MapParameters` is created for new computation, which kicks in re-render. Version is increased. The `mapParamsVersion}` assignment within `PlanMode` is no longer needed.

The (general) problem of `mapParams` is that only one instance was kept and recomputed, which needed children to re-render on different prop changes.

Note that `MapParameters` objects are relatively small and should not impact GC.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Load some flight plan with many waypoints.
2. Switch ND to PLAN.
3. Switch MCDU to F-PLAN.
4. Scroll through waypoints.
5. No vector jumping should be observed when scrolling on MCDU page (expect smoother transitions).
6. No plane icon jumping should be observed when scrolling on MCDU page (especially on waypoints close to the plane).
7. Fly the plane and do a regression testing on PLAN, ARC and ROSE ND modes.

Note, that the waypoints might blink when selecting waypoints when on PLAN ND mode. I suspect that this is because they are added to the SVG when within the viewport and remove when they are outside.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
