### PR TITLE
fix(efb): landing calculator autoland selection

### DIFF
--- a/src/instruments/src/EFB/Performance/Widgets/LandingWidget.tsx
+++ b/src/instruments/src/EFB/Performance/Widgets/LandingWidget.tsx
@@ -672,7 +672,7 @@ export const LandingWidget = () => {
                                     <SelectInput
                                         className="w-64"
                                         defaultValue={initialState.landing.autoland}
-                                        value={reverseThrust}
+                                        value={autoland}
                                         onChange={handleAutolandChange}
                                         options={[
                                             { value: false, displayValue: `${t('Performance.Landing.DropDownNo')}` },


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
For the landing calculator in the EFB, the 'Autoland' 'Yes/No' selection would change when the 'Reverse Thrust' selection value changed. This PR fixes this.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): SpiritZephyr#2349

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Verify the 'Autoland' selection doesn't change when the 'Reverse Thrust' selection is.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
