### PR TITLE
feat: re-activated EFB status bar SimBridge health check icon 

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -71,6 +71,7 @@
 1. [ADDON] Simbridge Integration - @lucky38i (Alex)
 1. [SD] Visual and functional improvements/fixes to the HYD SD page - @lukecologne (luke)
 1. [HYD] Added optional auxiliary hydraulic section in core hydraulic circuits - @Crocket63
+1. [EFB] Added SimBridge Health Check icon to Status Bar - @frankkopp (Frank Kopp)
 
 ## 0.8.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,7 @@
 <!-- Always use "1." at the start instead of "2. " or "X. " as GitHub will auto renumber everything. -->
 <!-- Use the following format below -->
 <!--  1. [Changed Area] Title of changes - @github username (Name)  -->
+
 ## 0.9.0
 
 1. [MODEL] Add Wheel Chocks and GSE Safety Cones - @bouveng (Johan Bouveng)
@@ -21,14 +22,15 @@
 1. [HYD] Gear system now supports spawning in flight gear up - @Crocket63 (crocket)
 1. [MCDU] Added imperial runway length - @derl30n (Leon)
 1. [MCDU] Refactor and improve input handling and conversions in MCDU W&B - @sidnov (Sid)
-1. [MCDU] Improved arrivals/departure page scrolling, more true-to-life behaviour and cosmetic apperance - @2hwk (2Cas#1022)
+1. [MCDU] Improved arrivals/departure page scrolling, more true-to-life behaviour and cosmetic apperance - @2hwk (
+   2Cas#1022)
 1. [PFD] Show yellow GS reference line in correct conditions - @saschl (saschl#9432)
 1. [ECAM] Fix erroneous SLATS NOT IN T.O CONFIG warning during flaps 3 takeoff - @beheh (Benedict Etzel)
 1. [MODEL] Improved rivet mesh with more variation and detail - @Grinde (Grinde#4017)
 1. [ELEC] Make battery voltmeters update one digit at a time - @beheh (Benedict Etzel)
 1. [EWD] E/WD visual improvements - @lukecologne (luke)
-1. [SFCC] Add SFCC bus outputs  - @lukecologne (luke)
-1. [EWD] Use FPPU angles for flaps/slats display  - @lukecologne (luke)
+1. [SFCC] Add SFCC bus outputs - @lukecologne (luke)
+1. [EWD] Use FPPU angles for flaps/slats display - @lukecologne (luke)
 1. [FMGC] Basic RNP at or below 0.3 support - @tracernz (Mike)
 1. [SD] Improve F/CTL and WHEEL SD pages visuals - @lukecologne (luke)
 1. [MCDU] Added formatter to improve text alignment and ease integration - @derl30n (Leon)
@@ -56,7 +58,8 @@
 1. [ECAM] Move EWD to correct AC bus - @tracernz (Mike)
 1. [FMGC] Fix inbound leg time for holds - @tracernz (Mike)
 1. [MCDU] Improved visuals of Init-A and Init-B page - @derl30n (Leon)
-1. [MODEL] Added new animated gear gravity extension handle- @tyler58546 (tyler58546), @MoreRightRudder (Mike), @Crocket63 (crocket), @Lantarius
+1. [MODEL] Added new animated gear gravity extension handle- @tyler58546 (tyler58546), @MoreRightRudder (Mike),
+   @Crocket63 (crocket), @Lantarius
 1. [HYD] Randomised per actuator flow restrictions at plane init - @Crocket63 (crocket)
 1. [MCDU] Hide stored elements on A/C Status when there are none - @tracernz (Mike)
 1. [FMGC] Fix ident for CD legs - @tracernz (Mike)
@@ -316,7 +319,8 @@
 1. [RMP] Fixed colour of SEL indicator - @tracernz (Mike)
 1. [MISC] Added custom Autobrake event for SimConnect - @aguther (Andreas Guther)
 1. [EWD] Fixed failures not re-triggering when resolved - @tricky_dicky (Richard Pilbery)
-1. [SOUND] Prevent autopilot disconnect from sounding on C+D spawn - @tricky_dicky (Richard Pilbery) and @saschl (saschl#9432)
+1. [SOUND] Prevent autopilot disconnect from sounding on C+D spawn - @tricky_dicky (Richard Pilbery) and @saschl (
+   saschl#9432)
 1. [FMGC] Removed flight phase transition from TAKEOFF to PREFLIGHT - @beheh (Benedict Etzel)
 1. [FMGC] Added flight phase transition to DONE when on ground > 30 s and engines off - @aguther (Andreas Guther)
 1. [ATSU] Add FANS-C simulation for CPDLC - @Sven [de en] - (Sven Czarnian)
@@ -1105,4 +1109,5 @@
 1. [MISC] Standby Instrument stays ON if emergency power should be available, bug fixes - @2hwk (2Cas#1022 on discord)
 1. [CDU] Full +/- button functionality - @lhoenig (Lukas Hoenig)
 1. [DCDU] Fixed MSG- and MSG+ button labels - @tyler58546 (tyler58546)
-1. [ISIS] Fixed issue where ISIS was allowing a bug to be set while in the OFF state - Patrick Macken (@Pat M on Discord)
+1. [ISIS] Fixed issue where ISIS was allowing a bug to be set while in the OFF state - Patrick Macken (@Pat M on
+   Discord)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -22,8 +22,7 @@
 1. [HYD] Gear system now supports spawning in flight gear up - @Crocket63 (crocket)
 1. [MCDU] Added imperial runway length - @derl30n (Leon)
 1. [MCDU] Refactor and improve input handling and conversions in MCDU W&B - @sidnov (Sid)
-1. [MCDU] Improved arrivals/departure page scrolling, more true-to-life behaviour and cosmetic apperance - @2hwk (
-   2Cas#1022)
+1. [MCDU] Improved arrivals/departure page scrolling, more true-to-life behaviour and cosmetic apperance - @2hwk ( 2Cas#1022)
 1. [PFD] Show yellow GS reference line in correct conditions - @saschl (saschl#9432)
 1. [ECAM] Fix erroneous SLATS NOT IN T.O CONFIG warning during flaps 3 takeoff - @beheh (Benedict Etzel)
 1. [MODEL] Improved rivet mesh with more variation and detail - @Grinde (Grinde#4017)
@@ -58,8 +57,7 @@
 1. [ECAM] Move EWD to correct AC bus - @tracernz (Mike)
 1. [FMGC] Fix inbound leg time for holds - @tracernz (Mike)
 1. [MCDU] Improved visuals of Init-A and Init-B page - @derl30n (Leon)
-1. [MODEL] Added new animated gear gravity extension handle- @tyler58546 (tyler58546), @MoreRightRudder (Mike),
-   @Crocket63 (crocket), @Lantarius
+1. [MODEL] Added new animated gear gravity extension handle- @tyler58546 (tyler58546), @MoreRightRudder (Mike), @Crocket63 (crocket), @Lantarius
 1. [HYD] Randomised per actuator flow restrictions at plane init - @Crocket63 (crocket)
 1. [MCDU] Hide stored elements on A/C Status when there are none - @tracernz (Mike)
 1. [FMGC] Fix ident for CD legs - @tracernz (Mike)

--- a/src/instruments/src/EFB/Localization/en.json
+++ b/src/instruments/src/EFB/Localization/en.json
@@ -577,8 +577,8 @@
     "Sep": "Sep",
     "Sun": "Sun",
     "TT": {
-      "ConnectedToLocalApi": "Connected to Local API",
-      "DisconnectedFromLocalApi": "Disconnected from Local API",
+      "ConnectedToLocalApi": "Connected to SimBridge",
+      "DisconnectedFromLocalApi": "Disconnected from SimBridge",
       "TurnOffOrShutdownEfb": "Turn off or Shutdown EFB"
     },
     "Thu": "Thu",

--- a/src/instruments/src/EFB/StatusBar/StatusBar.tsx
+++ b/src/instruments/src/EFB/StatusBar/StatusBar.tsx
@@ -27,7 +27,6 @@ export const StatusBar = ({ batteryLevel, isCharging }: StatusBarProps) => {
     const [monthOfYear] = useSimVar('E:ZULU MONTH OF YEAR', 'number');
     const [dayOfMonth] = useSimVar('E:ZULU DAY OF MONTH', 'number');
     const [showStatusBarFlightProgress] = usePersistentNumberProperty('EFB_SHOW_STATUSBAR_FLIGHTPROGRESS', 1);
-    const [simbridgePort] = usePersistentProperty('CONFIG_SIMBRIDGE_PORT', '8380');
     const [simbridgeEnabled] = usePersistentProperty('CONFIG_SIMBRIDGE_ENABLED', 'AUTO ON');
 
     const history = useHistory();
@@ -94,25 +93,24 @@ export const StatusBar = ({ batteryLevel, isCharging }: StatusBarProps) => {
     const [shutoffBarPercent, setShutoffBarPercent] = useState(0);
     const shutoffTimerRef = useRef<NodeJS.Timer | null>(null);
 
-    // TODO FIXME: This is going to need some readjustment when the user config changes
     const setConnectedState = async () => {
         if (simbridgeEnabled !== 'AUTO ON') {
-            setLocalApiConnected(false);
+            setSimBridgeConnected(false);
             return;
         }
         try {
             const health = await Health.getHealth();
             if (health) {
-                setLocalApiConnected(true);
+                setSimBridgeConnected(true);
             } else {
-                setLocalApiConnected(false);
+                setSimBridgeConnected(false);
             }
         } catch (_) {
-            setLocalApiConnected(false);
+            setSimBridgeConnected(false);
         }
     };
 
-    const [localApiConnected, setLocalApiConnected] = useState(false);
+    const [simBridgeConnected, setSimBridgeConnected] = useState(false);
 
     useInterval(() => {
         setConnectedState();
@@ -200,8 +198,8 @@ export const StatusBar = ({ batteryLevel, isCharging }: StatusBarProps) => {
                     </div>
                 )}
 
-                <TooltipWrapper text={localApiConnected ? t('StatusBar.TT.ConnectedToLocalApi') : t('StatusBar.TT.DisconnectedFromLocalApi')}>
-                    {localApiConnected ? (
+                <TooltipWrapper text={simBridgeConnected ? t('StatusBar.TT.ConnectedToLocalApi') : t('StatusBar.TT.DisconnectedFromLocalApi')}>
+                    {simBridgeConnected ? (
                         <Wifi size={26} />
                     ) : (
                         <WifiOff size={26} />

--- a/src/instruments/src/EFB/StatusBar/StatusBar.tsx
+++ b/src/instruments/src/EFB/StatusBar/StatusBar.tsx
@@ -13,6 +13,8 @@ import { BatteryStatus } from './BatteryStatus';
 import { useAppSelector } from '../Store/store';
 import { initialState } from '../Store/features/simBrief';
 
+import { Health } from '../../../../simbridge-client/src';
+
 interface StatusBarProps {
     batteryLevel: number;
     isCharging: boolean;
@@ -99,11 +101,8 @@ export const StatusBar = ({ batteryLevel, isCharging }: StatusBarProps) => {
             return;
         }
         try {
-            const url = `http://localhost:${simbridgePort}/health`;
-            const healthRes = await fetch(url);
-            const healthJson = await healthRes.json();
-
-            if (healthJson.info.api.status === 'up') {
+            const health = await Health.getHealth();
+            if (health) {
                 setLocalApiConnected(true);
             } else {
                 setLocalApiConnected(false);

--- a/src/simbridge-client/src/components/Health.ts
+++ b/src/simbridge-client/src/components/Health.ts
@@ -1,0 +1,39 @@
+import { simbridgeUrl } from '../common';
+
+/**
+ * Class responsible for retrieving data related to company routes from SimBridge
+ */
+export class Health {
+    /**
+     * Used to check the state of a given service. If none is given, then main status is returned.
+     * @param serviceName The name of the service or omit for the overall status ('' || 'api || 'mcdu')
+     * @returns true if service is available, false otherwise
+     */
+    public static async getHealth(serviceName: String = ''): Promise<boolean> {
+        const response = await fetch(`${simbridgeUrl}/health`);
+        if (!response.ok) {
+            throw new Error(`SimBridge Error: ${response.status}`);
+        }
+        const healthJson = await response.json();
+        switch (serviceName) {
+        case '':
+            if (healthJson.status === 'ok') {
+                return true;
+            }
+            break;
+        case 'api':
+            if (healthJson.info.api.status === 'up') {
+                return true;
+            }
+            break;
+        case 'mcdu':
+            if (healthJson.info.mcdu.status === 'up') {
+                return true;
+            }
+            break;
+        default:
+            throw new Error(`Unknown service name: ${serviceName}`);
+        }
+        return false;
+    }
+}

--- a/src/simbridge-client/src/components/Health.ts
+++ b/src/simbridge-client/src/components/Health.ts
@@ -6,17 +6,17 @@ import { simbridgeUrl } from '../common';
 export class Health {
     /**
      * Used to check the state of a given service. If none is given, then main status is returned.
-     * @param serviceName The name of the service or omit for the overall status ('' || 'api || 'mcdu')
+     * @param serviceName The name of the service or omit for the overall status
      * @returns true if service is available, false otherwise
      */
-    public static async getHealth(serviceName: String = ''): Promise<boolean> {
+    public static async getHealth(serviceName?: 'api'|'mcdu'): Promise<boolean> {
         const response = await fetch(`${simbridgeUrl}/health`);
         if (!response.ok) {
             throw new Error(`SimBridge Error: ${response.status}`);
         }
         const healthJson = await response.json();
         switch (serviceName) {
-        case '':
+        case undefined:
             if (healthJson.status === 'ok') {
                 return true;
             }
@@ -32,7 +32,7 @@ export class Health {
             }
             break;
         default:
-            throw new Error(`Unknown service name: ${serviceName}`);
+            throw new Error(`Unknown service name: '${serviceName}'`);
         }
         return false;
     }

--- a/src/simbridge-client/src/components/Terrain.ts
+++ b/src/simbridge-client/src/components/Terrain.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2022 FlyByWire Simulations
+// SPDX-License-Identifier: GPL-3.0
+
+import { EfisSide } from '@shared/NavigationDisplay';
+import { simbridgeUrl } from '../common';
+
+export class Terrain {
+    private static endpointsAvailable: boolean = false;
+
+    public static async mapdataAvailable(): Promise<boolean> {
+        return fetch(`${simbridgeUrl}/api/v1/terrain/available`).then((response) => {
+            Terrain.endpointsAvailable = response.ok;
+            return response.ok;
+        }).catch((_ex) => {
+            Terrain.endpointsAvailable = false;
+            return false;
+        });
+    }
+
+    public static async setCurrentPosition(latitude: number, longitude: number, heading: number, altitude: number, verticalSpeed: number): Promise<void> {
+        if (Terrain.endpointsAvailable) {
+            fetch(`${simbridgeUrl}/api/v1/terrain/position`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ latitude, longitude, heading, altitude, verticalSpeed }),
+            });
+        } else {
+            throw new Error('Endpoints unavailable');
+        }
+    }
+
+    public static async setDisplaySettings(side: EfisSide, settings: {
+        active: boolean,
+        mapWidth: number,
+        mapHeight: number,
+        meterPerPixel: number,
+        mapTransitionTime: number,
+        mapTransitionFps: number,
+        arcMode: boolean,
+        gearDown: boolean
+    }): Promise<void> {
+        if (Terrain.endpointsAvailable) {
+            fetch(`${simbridgeUrl}/api/v1/terrain/displaysettings?display=${side}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(settings),
+            });
+        } else {
+            throw new Error('Endpoints unavailable');
+        }
+    }
+
+    public static async ndMapAvailable(side: EfisSide, timestamp: number): Promise<boolean> {
+        if (Terrain.endpointsAvailable) {
+            return fetch(`${simbridgeUrl}/api/v1/terrain/ndMapAvailable?display=${side}&timestamp=${timestamp}`).then((response) => {
+                if (response.ok) {
+                    return response.text().then((text) => text === 'true');
+                }
+                return false;
+            });
+        }
+
+        throw new Error('Endpoints unavailable');
+    }
+
+    public static async ndTransitionMaps(side: EfisSide, timestamp: number): Promise<string[]> {
+        if (Terrain.endpointsAvailable) {
+            return fetch(`${simbridgeUrl}/api/v1/terrain/ndmaps?display=${side}&timestamp=${timestamp}`, {
+                method: 'GET',
+                headers: { Accept: 'application/json' },
+            }).then((response) => response.json().then((imageBase64) => imageBase64));
+        }
+
+        throw new Error('Endpoints unavailable');
+    }
+
+    public static async ndTerrainRange(side: EfisSide, timestamp: number):
+    Promise<{
+        minElevation: number,
+        minElevationIsWarning: boolean,
+        minElevationIsCaution: boolean,
+        maxElevation: number,
+        maxElevationIsWarning: boolean,
+        maxElevationIsCaution: boolean
+    }> {
+        if (Terrain.endpointsAvailable) {
+            return fetch(`${simbridgeUrl}/api/v1/terrain/terrainRange?display=${side}&timestamp=${timestamp}`, {
+                method: 'GET',
+                headers: { Accept: 'application/json' },
+            }).then((response) => response.json().then((data) => data));
+        }
+
+        throw new Error('Endpoints unavailable');
+    }
+
+    public static async renderNdMap(side: EfisSide): Promise<number> {
+        if (Terrain.endpointsAvailable) {
+            return fetch(`${simbridgeUrl}/api/v1/terrain/renderMap?display=${side}`).then((response) => response.text().then((text) => parseInt(text)));
+        }
+
+        throw new Error('Endpoints unavailable');
+    }
+}

--- a/src/simbridge-client/src/index.ts
+++ b/src/simbridge-client/src/index.ts
@@ -1,4 +1,5 @@
+import { Terrain } from './components/Terrain';
 import { CompanyRoute } from './components/Coroute';
 import { Viewer } from './components/Viewer';
 
-export { CompanyRoute, Viewer };
+export { CompanyRoute, Viewer, Terrain };

--- a/src/simbridge-client/src/index.ts
+++ b/src/simbridge-client/src/index.ts
@@ -1,5 +1,6 @@
 import { Terrain } from './components/Terrain';
 import { CompanyRoute } from './components/Coroute';
 import { Viewer } from './components/Viewer';
+import { Health } from './components/Health';
 
-export { CompanyRoute, Viewer, Terrain };
+export { Health, CompanyRoute, Viewer, Terrain };


### PR DESCRIPTION
## Summary of Changes
Adds the health check status bar icon to the flyPad. 

This can be merged to master as it does not break anything if SimBridge is not running. 

## Screenshots (if necessary)
![2022-08-27_15h44_27](https://user-images.githubusercontent.com/16833201/187032976-a1b77465-d246-4dfa-acbf-1531c37975f7.png)
![image](https://user-images.githubusercontent.com/16833201/187032984-67edf6dc-3a3f-4d64-ab4a-9fc2c78e992a.png)

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Check if the icon shows the correct state of the SimBridge

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
