### PR TITLE
build: move production pipelines to fragmenter v0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "@babel/preset-react": "^7.12.1",
         "@babel/preset-typescript": "~7.12.7",
         "@flybywiresim/eslint-config": "~0.1.0",
-        "@flybywiresim/fragmenter": "^0.7.0-rc.1",
+        "@flybywiresim/fragmenter": "^0.7.0",
         "@flybywiresim/igniter": "^1.2.2",
         "@flybywiresim/rnp": "^2.1.0",
         "@flybywiresim/rollup-plugin-msfs": "~0.3.0",
@@ -2296,9 +2296,9 @@
       }
     },
     "node_modules/@flybywiresim/fragmenter": {
-      "version": "0.7.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.7.0-rc.1.tgz",
-      "integrity": "sha512-kxPhFHD8GXIggwVmWpyPf7Nse/msmqGMKPocHm7TdYjQl4213+027e7kGPABNAci3m/xz8wD7DB6nmTbDluF1Q==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.7.0.tgz",
+      "integrity": "sha512-0VLXyq0/tfod+RwIlPskm4Y1a7FaH2Z9llRfRoqr2cGVwq5ku0qLnC1528bfVj9mM2aJ7fTOslIL9IRAsYGAQg==",
       "dev": true,
       "dependencies": {
         "axios": "^0.27.2",
@@ -37750,9 +37750,9 @@
       }
     },
     "@flybywiresim/fragmenter": {
-      "version": "0.7.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.7.0-rc.1.tgz",
-      "integrity": "sha512-kxPhFHD8GXIggwVmWpyPf7Nse/msmqGMKPocHm7TdYjQl4213+027e7kGPABNAci3m/xz8wD7DB6nmTbDluF1Q==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.7.0.tgz",
+      "integrity": "sha512-0VLXyq0/tfod+RwIlPskm4Y1a7FaH2Z9llRfRoqr2cGVwq5ku0qLnC1528bfVj9mM2aJ7fTOslIL9IRAsYGAQg==",
       "dev": true,
       "requires": {
         "axios": "^0.27.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "@babel/preset-react": "^7.12.1",
         "@babel/preset-typescript": "~7.12.7",
         "@flybywiresim/eslint-config": "~0.1.0",
-        "@flybywiresim/fragmenter": "^0.5.1",
+        "@flybywiresim/fragmenter": "^0.7.0-rc.1",
         "@flybywiresim/igniter": "^1.2.2",
         "@flybywiresim/rnp": "^2.1.0",
         "@flybywiresim/rollup-plugin-msfs": "~0.3.0",
@@ -2296,9 +2296,45 @@
       }
     },
     "node_modules/@flybywiresim/fragmenter": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.5.2.tgz",
-      "integrity": "sha512-B9xtPd0aZM1d16Kk5F6VtdQ6k1/k5p2yFK/p5J44czpRKnxXSTs+8fg55KPLZD/gw48JtAjuXsrO4R2HzK35ww==",
+      "version": "0.7.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.7.0-rc.1.tgz",
+      "integrity": "sha512-kxPhFHD8GXIggwVmWpyPf7Nse/msmqGMKPocHm7TdYjQl4213+027e7kGPABNAci3m/xz8wD7DB6nmTbDluF1Q==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^0.27.2",
+        "split-file": "^2.3.0",
+        "url-join": "^4.0.1",
+        "zip-lib": "^0.7.3"
+      }
+    },
+    "node_modules/@flybywiresim/fragmenter/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@flybywiresim/fragmenter/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@flybywiresim/fragmenter/node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
     },
     "node_modules/@flybywiresim/igniter": {
@@ -7756,6 +7792,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-equal": {
@@ -13249,6 +13294,15 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/figgy-pudding": {
@@ -21052,6 +21106,12 @@
         "png-js": "^1.0.0"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -25968,6 +26028,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/split-file": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/split-file/-/split-file-2.3.0.tgz",
+      "integrity": "sha512-dc/0SDKvjtSjUI999vkclWQAk5xhD86pKEWWL2ULR6WrHI9/euIEMG/JSUbwbNW8IC+gYLJqynSGHwlOVmSwGA==",
+      "dev": true,
+      "dependencies": {
+        "bluebird": "^3.7.2"
+      },
+      "bin": {
+        "split-file": "split-file-cli.js"
       }
     },
     "node_modules/split-string": {
@@ -36036,6 +36108,25 @@
         "node": ">=10"
       }
     },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
+      }
+    },
     "node_modules/ylru": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.3.2.tgz",
@@ -36062,6 +36153,19 @@
       "resolved": "https://registry.npmjs.org/zepto/-/zepto-1.2.0.tgz",
       "integrity": "sha1-4Se9nmb9hGvl6rSME5SIL3wOT5g=",
       "dev": true
+    },
+    "node_modules/zip-lib": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/zip-lib/-/zip-lib-0.7.3.tgz",
+      "integrity": "sha512-hp40KYzTJvoaCRr2t6hztlPnVmHYqDUDiIn0hlfAFwVBs3/jwkLy8aZ7NVGHECeWH2Tv8WPwWyR6QuWYarIjJQ==",
+      "dev": true,
+      "dependencies": {
+        "yauzl": "^2.10.0",
+        "yazl": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   },
   "dependencies": {
@@ -37646,10 +37750,45 @@
       }
     },
     "@flybywiresim/fragmenter": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.5.2.tgz",
-      "integrity": "sha512-B9xtPd0aZM1d16Kk5F6VtdQ6k1/k5p2yFK/p5J44czpRKnxXSTs+8fg55KPLZD/gw48JtAjuXsrO4R2HzK35ww==",
-      "dev": true
+      "version": "0.7.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.7.0-rc.1.tgz",
+      "integrity": "sha512-kxPhFHD8GXIggwVmWpyPf7Nse/msmqGMKPocHm7TdYjQl4213+027e7kGPABNAci3m/xz8wD7DB6nmTbDluF1Q==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.27.2",
+        "split-file": "^2.3.0",
+        "url-join": "^4.0.1",
+        "zip-lib": "^0.7.3"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "url-join": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+          "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+          "dev": true
+        }
+      }
     },
     "@flybywiresim/igniter": {
       "version": "1.2.2",
@@ -42059,6 +42198,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true
+    },
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
@@ -46391,6 +46536,15 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "figgy-pudding": {
@@ -51373,7 +51527,7 @@
       }
     },
     "msfssdk": {
-      "version": "file:msfs-avionics-mirror\\src\\sdk\\build\\msfssdk-0.1.0.tgz"
+      "version": "file:msfs-avionics-mirror/src/sdk/build/msfssdk-0.1.0.tgz"
     },
     "multicast-dns": {
       "version": "6.2.3",
@@ -52505,6 +52659,12 @@
         "linebreak": "^1.0.2",
         "png-js": "^1.0.0"
       }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -56296,6 +56456,15 @@
             "util-deprecate": "^1.0.1"
           }
         }
+      }
+    },
+    "split-file": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/split-file/-/split-file-2.3.0.tgz",
+      "integrity": "sha512-dc/0SDKvjtSjUI999vkclWQAk5xhD86pKEWWL2ULR6WrHI9/euIEMG/JSUbwbNW8IC+gYLJqynSGHwlOVmSwGA==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.7.2"
       }
     },
     "split-string": {
@@ -64426,6 +64595,25 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
     },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3"
+      }
+    },
     "ylru": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.3.2.tgz",
@@ -64443,6 +64631,16 @@
       "resolved": "https://registry.npmjs.org/zepto/-/zepto-1.2.0.tgz",
       "integrity": "sha1-4Se9nmb9hGvl6rSME5SIL3wOT5g=",
       "dev": true
+    },
+    "zip-lib": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/zip-lib/-/zip-lib-0.7.3.tgz",
+      "integrity": "sha512-hp40KYzTJvoaCRr2t6hztlPnVmHYqDUDiIn0hlfAFwVBs3/jwkLy8aZ7NVGHECeWH2Tv8WPwWyR6QuWYarIjJQ==",
+      "dev": true,
+      "requires": {
+        "yauzl": "^2.10.0",
+        "yazl": "^2.5.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-react": "^7.12.1",
     "@babel/preset-typescript": "~7.12.7",
     "@flybywiresim/eslint-config": "~0.1.0",
-    "@flybywiresim/fragmenter": "^0.7.0-rc.1",
+    "@flybywiresim/fragmenter": "^0.7.0",
     "@flybywiresim/igniter": "^1.2.2",
     "@flybywiresim/rnp": "^2.1.0",
     "@flybywiresim/rollup-plugin-msfs": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-react": "^7.12.1",
     "@babel/preset-typescript": "~7.12.7",
     "@flybywiresim/eslint-config": "~0.1.0",
-    "@flybywiresim/fragmenter": "^0.5.1",
+    "@flybywiresim/fragmenter": "^0.7.0-rc.1",
     "@flybywiresim/igniter": "^1.2.2",
     "@flybywiresim/rnp": "^2.1.0",
     "@flybywiresim/rollup-plugin-msfs": "~0.3.0",

--- a/scripts/fragment.js
+++ b/scripts/fragment.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const execute = async () => {
     try {
         const result = await fragmenter.pack({
+            packOptions: { splitFileSize: 536_870_912, keepCompleteModulesAfterSplit: true },
             baseDir: './flybywire-aircraft-a320-neo',
             outDir: './build-modules',
             modules: [{


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

This PR moves the production and PR build piplines to use fragmenter v0.7.0.

This provides better compatibility with clients based on fragmenter <=v0.6.0, although it is not strictly needed. Updating to this is backwards compatible (with the `keepCompleteModulesAfterSplit` option), and provides the following features to new clients:

- File-splitting for files larger than 500MB
- Compressed/uncompressed module size information in the distribution manifest

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
