### PR TITLE
feat: switch to turn on/off input from controller for pushback

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -74,6 +74,7 @@
 1. [HYD] Added optional auxiliary hydraulic section in core hydraulic circuits - @Crocket63
 1. [EFB] Added SimBridge Health Check icon to Status Bar - @frankkopp (Frank Kopp)
 1. [HYD] Fix gear extending whith dual lgciu power loss - @Crocket63 (crocket)
+1. [EFB] flyPad pushback option to ignore controller inputs - @frankkopp (Frank Kopp)
 
 ## 0.8.0
 

--- a/src/instruments/src/EFB/Ground/Pages/PushbackPage.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/PushbackPage.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 /* eslint-disable max-len */
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useSimVar, useSplitSimVar } from '@instruments/common/simVars';
 import {
     ArrowDown,
@@ -20,10 +20,13 @@ import {
 import Slider from 'rc-slider';
 import { MathUtils } from '@shared/MathUtils';
 import { toast } from 'react-toastify';
+import { usePersistentProperty } from 'react-msfs';
+import { usePersistentNumberProperty } from '@instruments/common/persistence';
 import { t } from '../../translation';
 import { TooltipWrapper } from '../../UtilComponents/TooltipWrapper';
 import { PromptModal, useModals } from '../../UtilComponents/Modals/Modals';
 import { PushbackMap } from './PushbackMap';
+import { Toggle } from '../../UtilComponents/Form/Toggle';
 
 export const PushbackPage = () => {
     const { showModal } = useModals();
@@ -43,6 +46,7 @@ export const PushbackPage = () => {
     const [pushbackAttached] = useSimVar('Pushback Attached', 'bool', 100);
     const [pushbackAngle] = useSimVar('PUSHBACK ANGLE', 'Radians', 100);
 
+    const [useControllerInput, setUseControllerInput] = usePersistentNumberProperty('PUSHBACK_USE_CONTROLLER_INPUT', 1);
     const [rudderPosition] = useSimVar('L:A32NX_RUDDER_PEDAL_POSITION', 'number', 50);
     const [elevatorPosition] = useSimVar('L:A32NX_SIDESTICK_POSITION_Y', 'number', 50);
 
@@ -174,7 +178,7 @@ export const PushbackPage = () => {
 
     // Update commanded heading from rudder input
     useEffect(() => {
-        if (!pushbackActive) {
+        if (!pushbackActive || !useControllerInput) {
             return;
         }
         // create deadzone
@@ -187,7 +191,7 @@ export const PushbackPage = () => {
 
     // Update commanded speed from elevator input
     useEffect(() => {
-        if (!pushbackActive) {
+        if (!pushbackActive || !useControllerInput) {
             return;
         }
         // create deadzone
@@ -395,7 +399,7 @@ export const PushbackPage = () => {
                 )}
 
                 {/* Manual Pushback Controls */}
-                <div className={`flex flex-col p-6 h-full space-y-4 rounded-lg border-2 border-theme-accent ${!pushbackUIAvailable && 'opacity-20 pointer-events-none'}`}>
+                <div className={`flex flex-col p-6 h-full space-y-2 rounded-lg border-2 border-theme-accent ${!pushbackUIAvailable && 'opacity-20 pointer-events-none'}`}>
                     <div className="flex flex-row space-x-4">
 
                         {/* Pushback System enabled On/Off */}
@@ -614,6 +618,17 @@ export const PushbackPage = () => {
                                     <ChevronDoubleUp />
                                 </p>
                             </div>
+                        </TooltipWrapper>
+                    </div>
+
+                    <div className={`flex flex-row items-center h-10 ${!pushbackActive && 'opacity-30'
+                    + ' pointer-events-none'}`}
+                    >
+                        <TooltipWrapper text={t('Pushback.TT.UseControllerInput')}>
+                            <div className="mr-4">
+                                {t('Pushback.UseControllerInput')}
+                            </div>
+                            <Toggle value={!!useControllerInput} onToggle={(value) => (setUseControllerInput(value ? 1 : 0))} />
                         </TooltipWrapper>
                     </div>
                 </div>

--- a/src/instruments/src/EFB/Ground/Pages/PushbackPage.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/PushbackPage.tsx
@@ -620,9 +620,7 @@ export const PushbackPage = () => {
                         </TooltipWrapper>
                     </div>
 
-                    <div className={`flex flex-row items-center h-10 ${!pushbackActive && 'opacity-30'
-                    + ' pointer-events-none'}`}
-                    >
+                    <div className={`flex flex-row items-center h-10 ${!pushbackActive && 'opacity-30 pointer-events-none'}`}>
                         <TooltipWrapper text={t('Pushback.TT.UseControllerInput')}>
                             <div className="mr-4">
                                 {t('Pushback.UseControllerInput')}

--- a/src/instruments/src/EFB/Ground/Pages/PushbackPage.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/PushbackPage.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 /* eslint-disable max-len */
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useSimVar, useSplitSimVar } from '@instruments/common/simVars';
 import {
     ArrowDown,
@@ -20,7 +20,6 @@ import {
 import Slider from 'rc-slider';
 import { MathUtils } from '@shared/MathUtils';
 import { toast } from 'react-toastify';
-import { usePersistentProperty } from 'react-msfs';
 import { usePersistentNumberProperty } from '@instruments/common/persistence';
 import { t } from '../../translation';
 import { TooltipWrapper } from '../../UtilComponents/TooltipWrapper';

--- a/src/instruments/src/EFB/Localization/en.json
+++ b/src/instruments/src/EFB/Localization/en.json
@@ -397,10 +397,12 @@
       "On": "On",
       "Title": "Parking Brake"
     },
+    "UseControllerInput": "Use Controller Input",
     "Right": "Right",
     "SystemEnabledOff": "Pushback System Off",
     "SystemEnabledOn": "Pushback System On",
     "TT": {
+      "UseControllerInput": "Turn controller input from rudder and elevator on/off",
       "CallReleaseTug": "Call or release tug",
       "CenterPlaneMode": "Center map on plane On/Off",
       "DecreaseSpeed": "Backwards or slower forwards",


### PR DESCRIPTION
## Summary of Changes
Adding a switch (persistent) to turn off input from controller for rudder and elevator for pushback. 

This was added as some users use the stick during pushback for switching views or push to talk which sometimes moves the controller beyond the 5% built-in deadzone. This movement resets the movement started by the buttons. 

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/16833201/187731732-b3f7ba5a-cbc5-4f4d-96c4-6539fb46186a.png)

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions

Turn off Controller Input 
- use buttons for pushback and test that controller input doesn't interrupt movement. 

Turn on Controller Input
- use controller to pushback
- use buttons to control pushback but do not touch controller
- use buttons to control pushback move controller -> pushback movement should stop/reset

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
