### PR TITLE
feat(adirs): add static pressure to ADR bus outputs

### DIFF
--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -1600,6 +1600,10 @@ In the variables below, {number} should be replaced with one item in the set: { 
     - Seconds
     - The remaining alignment duration. Zero seconds when the system is aligned or the system is not aligning.
 
+- A32NX_ADIRS_ADR_{number}_CORRECTED_AVERAGE_STATIC_PRESSURE
+    - Arinc429Word<hPa>
+    - The corrected average static pressure.
+
 - A32NX_ADIRS_ADR_{number}_ALTITUDE
     - Arinc429Word<Feet>
     - The altitude.

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -13,6 +13,7 @@ use crate::{
 use std::{fmt::Display, time::Duration};
 use uom::si::acceleration::meter_per_second_squared;
 use uom::si::{
+    pressure::hectopascal,
     angle::degree,
     angular_velocity::degree_per_second,
     f64::*,
@@ -708,6 +709,7 @@ struct AirDataReference {
     number: usize,
     is_on: bool,
 
+    corrected_average_static_pressure: AdirsData<Pressure>,
     altitude: AdirsData<Length>,
     computed_airspeed: AdirsData<Velocity>,
     mach: AdirsData<MachNumber>,
@@ -722,6 +724,7 @@ struct AirDataReference {
 }
 impl AirDataReference {
     const INITIALISATION_DURATION: Duration = Duration::from_secs(18);
+    const CORRECTED_AVERAGE_STATIC_PRESSURE: &'static str = "CORRECTED_AVERAGE_STATIC_PRESSURE";
     const ALTITUDE: &'static str = "ALTITUDE";
     const COMPUTED_AIRSPEED: &'static str = "COMPUTED_AIRSPEED";
     const MACH: &'static str = "MACH";
@@ -742,6 +745,7 @@ impl AirDataReference {
             number,
             is_on: true,
 
+            corrected_average_static_pressure: AdirsData::new_adr(context, number, Self::CORRECTED_AVERAGE_STATIC_PRESSURE),
             altitude: AdirsData::new_adr(context, number, Self::ALTITUDE),
             computed_airspeed: AdirsData::new_adr(context, number, Self::COMPUTED_AIRSPEED),
             mach: AdirsData::new_adr(context, number, Self::MACH),
@@ -801,6 +805,7 @@ impl AirDataReference {
 
         // If the ADR is off or not initialized, output all labels as FW with value 0.
         if !is_valid {
+            self.corrected_average_static_pressure.set_failure_warning();
             self.altitude.set_failure_warning();
             self.barometric_vertical_speed.set_failure_warning();
             self.computed_airspeed.set_failure_warning();
@@ -813,6 +818,7 @@ impl AirDataReference {
             self.angle_of_attack.set_failure_warning();
         } else {
             // If it is on and initialized, output normal values.
+            self.corrected_average_static_pressure.set_normal_operation_value(context.ambient_pressure());
             self.altitude
                 .set_normal_operation_value(context.indicated_altitude());
             self.barometric_vertical_speed
@@ -884,6 +890,7 @@ impl TrueAirspeedSource for AirDataReference {
 }
 impl SimulationElement for AirDataReference {
     fn write(&self, writer: &mut SimulatorWriter) {
+        self.corrected_average_static_pressure.write_to_converted(writer, |value| value.get::<hectopascal>());
         self.altitude.write_to(writer);
         self.computed_airspeed.write_to(writer);
         self.mach.write_to(writer);
@@ -1610,6 +1617,14 @@ mod tests {
             ))
         }
 
+        fn corrected_average_static_pressure(&mut self, adiru_number: usize) -> Arinc429Word<Pressure> {
+            self.read_arinc429_by_name(&output_data_id(
+                OutputDataType::Adr,
+                adiru_number,
+                AirDataReference::CORRECTED_AVERAGE_STATIC_PRESSURE,
+            ))
+        }
+
         fn altitude(&mut self, adiru_number: usize) -> Arinc429Word<Length> {
             self.read_arinc429_by_name(&output_data_id(
                 OutputDataType::Adr,
@@ -1888,6 +1903,7 @@ mod tests {
         }
 
         fn assert_adr_data_valid(&mut self, valid: bool, adiru_number: usize) {
+            assert_eq!(!self.corrected_average_static_pressure(adiru_number).is_failure_warning(), valid);
             assert_eq!(!self.altitude(adiru_number).is_failure_warning(), valid);
             assert_eq!(
                 !self.computed_airspeed(adiru_number).is_failure_warning(),
@@ -2399,6 +2415,22 @@ mod tests {
             test_bed.run();
 
             test_bed.assert_adr_data_valid(false, adiru_number);
+        }
+
+        #[rstest]
+        #[case(1)]
+        #[case(2)]
+        #[case(3)]
+        fn corrected_average_static_pressure_is_supplied_by_adr(#[case] adiru_number: usize) {
+            let mut test_bed = all_adirus_aligned_test_bed();
+            test_bed.set_ambient_pressure(Pressure::new::<hectopascal>(1013.));
+
+            test_bed.run();
+
+            assert_eq!(
+                test_bed.corrected_average_static_pressure(adiru_number).normal_value().unwrap(),
+                Pressure::new::<hectopascal>(1013.)
+            );
         }
 
         #[rstest]

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -1626,7 +1626,7 @@ mod tests {
         fn corrected_average_static_pressure(
             &mut self,
             adiru_number: usize,
-        ) -> Arinc429Word<Pressure> {
+        ) -> Arinc429Word<f64> {
             self.read_arinc429_by_name(&output_data_id(
                 OutputDataType::Adr,
                 adiru_number,
@@ -2446,7 +2446,7 @@ mod tests {
                     .corrected_average_static_pressure(adiru_number)
                     .normal_value()
                     .unwrap(),
-                Pressure::new::<hectopascal>(1013.)
+                1013.
             );
         }
 

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -2438,7 +2438,7 @@ mod tests {
 
             test_bed.run();
 
-            assert_eq!(
+            assert_about_eq!(
                 test_bed
                     .corrected_average_static_pressure(adiru_number)
                     .normal_value()

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -13,11 +13,11 @@ use crate::{
 use std::{fmt::Display, time::Duration};
 use uom::si::acceleration::meter_per_second_squared;
 use uom::si::{
-    pressure::hectopascal,
     angle::degree,
     angular_velocity::degree_per_second,
     f64::*,
     length::foot,
+    pressure::hectopascal,
     ratio::ratio,
     thermodynamic_temperature::degree_celsius,
     velocity::{foot_per_minute, knot},
@@ -745,7 +745,11 @@ impl AirDataReference {
             number,
             is_on: true,
 
-            corrected_average_static_pressure: AdirsData::new_adr(context, number, Self::CORRECTED_AVERAGE_STATIC_PRESSURE),
+            corrected_average_static_pressure: AdirsData::new_adr(
+                context,
+                number,
+                Self::CORRECTED_AVERAGE_STATIC_PRESSURE,
+            ),
             altitude: AdirsData::new_adr(context, number, Self::ALTITUDE),
             computed_airspeed: AdirsData::new_adr(context, number, Self::COMPUTED_AIRSPEED),
             mach: AdirsData::new_adr(context, number, Self::MACH),
@@ -818,7 +822,8 @@ impl AirDataReference {
             self.angle_of_attack.set_failure_warning();
         } else {
             // If it is on and initialized, output normal values.
-            self.corrected_average_static_pressure.set_normal_operation_value(context.ambient_pressure());
+            self.corrected_average_static_pressure
+                .set_normal_operation_value(context.ambient_pressure());
             self.altitude
                 .set_normal_operation_value(context.indicated_altitude());
             self.barometric_vertical_speed
@@ -890,7 +895,8 @@ impl TrueAirspeedSource for AirDataReference {
 }
 impl SimulationElement for AirDataReference {
     fn write(&self, writer: &mut SimulatorWriter) {
-        self.corrected_average_static_pressure.write_to_converted(writer, |value| value.get::<hectopascal>());
+        self.corrected_average_static_pressure
+            .write_to_converted(writer, |value| value.get::<hectopascal>());
         self.altitude.write_to(writer);
         self.computed_airspeed.write_to(writer);
         self.mach.write_to(writer);
@@ -1617,7 +1623,10 @@ mod tests {
             ))
         }
 
-        fn corrected_average_static_pressure(&mut self, adiru_number: usize) -> Arinc429Word<Pressure> {
+        fn corrected_average_static_pressure(
+            &mut self,
+            adiru_number: usize,
+        ) -> Arinc429Word<Pressure> {
             self.read_arinc429_by_name(&output_data_id(
                 OutputDataType::Adr,
                 adiru_number,
@@ -1903,7 +1912,12 @@ mod tests {
         }
 
         fn assert_adr_data_valid(&mut self, valid: bool, adiru_number: usize) {
-            assert_eq!(!self.corrected_average_static_pressure(adiru_number).is_failure_warning(), valid);
+            assert_eq!(
+                !self
+                    .corrected_average_static_pressure(adiru_number)
+                    .is_failure_warning(),
+                valid
+            );
             assert_eq!(!self.altitude(adiru_number).is_failure_warning(), valid);
             assert_eq!(
                 !self.computed_airspeed(adiru_number).is_failure_warning(),
@@ -2428,7 +2442,10 @@ mod tests {
             test_bed.run();
 
             assert_eq!(
-                test_bed.corrected_average_static_pressure(adiru_number).normal_value().unwrap(),
+                test_bed
+                    .corrected_average_static_pressure(adiru_number)
+                    .normal_value()
+                    .unwrap(),
                 Pressure::new::<hectopascal>(1013.)
             );
         }

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -1623,10 +1623,7 @@ mod tests {
             ))
         }
 
-        fn corrected_average_static_pressure(
-            &mut self,
-            adiru_number: usize,
-        ) -> Arinc429Word<f64> {
+        fn corrected_average_static_pressure(&mut self, adiru_number: usize) -> Arinc429Word<f64> {
             self.read_arinc429_by_name(&output_data_id(
                 OutputDataType::Adr,
                 adiru_number,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
As the title says. Not used yet, so not testable.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
