### PR TITLE
fix: ACE fix - refactored simbridgeUrl to function call 

### DIFF
--- a/src/simbridge-client/src/common.ts
+++ b/src/simbridge-client/src/common.ts
@@ -1,3 +1,3 @@
 import { NXDataStore } from '@shared/persistence';
 
-export const simbridgeUrl: String = `http://localhost:${NXDataStore.get('CONFIG_SIMBRIDGE_PORT', '8380')}`;
+export const getSimBridgeUrl = (): string => `http://localhost:${NXDataStore.get('CONFIG_SIMBRIDGE_PORT', '8380')}`;

--- a/src/simbridge-client/src/components/Coroute.ts
+++ b/src/simbridge-client/src/components/Coroute.ts
@@ -1,4 +1,4 @@
-import { simbridgeUrl } from '../common';
+import { getSimBridgeUrl } from '../common';
 import { CoRouteDto } from '../Coroute/coroute';
 
 /**
@@ -12,7 +12,7 @@ export class CompanyRoute {
      */
     public static async getCoRoute(route: String): Promise<CoRouteDto> {
         if (route) {
-            const response = await fetch(`${simbridgeUrl}/api/v1/coroute?rteNum=${route}`);
+            const response = await fetch(`${getSimBridgeUrl()}/api/v1/coroute?rteNum=${route}`);
             if (response.status === 200) {
                 response.json();
             }
@@ -29,7 +29,7 @@ export class CompanyRoute {
      */
     public static async getRouteList(origin: String, dest: String): Promise<CoRouteDto[]> {
         if (origin || dest) {
-            const response = await fetch(`${simbridgeUrl}/api/v1/coroute/list?origin=${origin}&destination=${dest}`);
+            const response = await fetch(`${getSimBridgeUrl()}/api/v1/coroute/list?origin=${origin}&destination=${dest}`);
             if (response.ok) {
                 response.json();
             }

--- a/src/simbridge-client/src/components/Health.ts
+++ b/src/simbridge-client/src/components/Health.ts
@@ -1,4 +1,4 @@
-import { simbridgeUrl } from '../common';
+import { getSimBridgeUrl } from '../common';
 
 /**
  * Class responsible for retrieving data related to company routes from SimBridge
@@ -10,7 +10,7 @@ export class Health {
      * @returns true if service is available, false otherwise
      */
     public static async getHealth(serviceName?: 'api'|'mcdu'): Promise<boolean> {
-        const response = await fetch(`${simbridgeUrl}/health`);
+        const response = await fetch(`${getSimBridgeUrl()}/health`);
         if (!response.ok) {
             throw new Error(`SimBridge Error: ${response.status}`);
         }

--- a/src/simbridge-client/src/components/Terrain.ts
+++ b/src/simbridge-client/src/components/Terrain.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import { EfisSide } from '@shared/NavigationDisplay';
-import { simbridgeUrl } from '../common';
+import { getSimBridgeUrl } from '../common';
 
 export class Terrain {
     private static endpointsAvailable: boolean = false;
 
     public static async mapdataAvailable(): Promise<boolean> {
-        return fetch(`${simbridgeUrl}/api/v1/terrain/available`).then((response) => {
+        return fetch(`${getSimBridgeUrl()}/api/v1/terrain/available`).then((response) => {
             Terrain.endpointsAvailable = response.ok;
             return response.ok;
         }).catch((_ex) => {
@@ -19,7 +19,7 @@ export class Terrain {
 
     public static async setCurrentPosition(latitude: number, longitude: number, heading: number, altitude: number, verticalSpeed: number): Promise<void> {
         if (Terrain.endpointsAvailable) {
-            fetch(`${simbridgeUrl}/api/v1/terrain/position`, {
+            fetch(`${getSimBridgeUrl()}/api/v1/terrain/position`, {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ latitude, longitude, heading, altitude, verticalSpeed }),
@@ -40,7 +40,7 @@ export class Terrain {
         gearDown: boolean
     }): Promise<void> {
         if (Terrain.endpointsAvailable) {
-            fetch(`${simbridgeUrl}/api/v1/terrain/displaysettings?display=${side}`, {
+            fetch(`${getSimBridgeUrl()}/api/v1/terrain/displaysettings?display=${side}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(settings),
@@ -52,7 +52,7 @@ export class Terrain {
 
     public static async ndMapAvailable(side: EfisSide, timestamp: number): Promise<boolean> {
         if (Terrain.endpointsAvailable) {
-            return fetch(`${simbridgeUrl}/api/v1/terrain/ndMapAvailable?display=${side}&timestamp=${timestamp}`).then((response) => {
+            return fetch(`${getSimBridgeUrl()}/api/v1/terrain/ndMapAvailable?display=${side}&timestamp=${timestamp}`).then((response) => {
                 if (response.ok) {
                     return response.text().then((text) => text === 'true');
                 }
@@ -65,7 +65,7 @@ export class Terrain {
 
     public static async ndTransitionMaps(side: EfisSide, timestamp: number): Promise<string[]> {
         if (Terrain.endpointsAvailable) {
-            return fetch(`${simbridgeUrl}/api/v1/terrain/ndmaps?display=${side}&timestamp=${timestamp}`, {
+            return fetch(`${getSimBridgeUrl()}/api/v1/terrain/ndmaps?display=${side}&timestamp=${timestamp}`, {
                 method: 'GET',
                 headers: { Accept: 'application/json' },
             }).then((response) => response.json().then((imageBase64) => imageBase64));
@@ -84,7 +84,7 @@ export class Terrain {
         maxElevationIsCaution: boolean
     }> {
         if (Terrain.endpointsAvailable) {
-            return fetch(`${simbridgeUrl}/api/v1/terrain/terrainRange?display=${side}&timestamp=${timestamp}`, {
+            return fetch(`${getSimBridgeUrl()}/api/v1/terrain/terrainRange?display=${side}&timestamp=${timestamp}`, {
                 method: 'GET',
                 headers: { Accept: 'application/json' },
             }).then((response) => response.json().then((data) => data));
@@ -95,7 +95,7 @@ export class Terrain {
 
     public static async renderNdMap(side: EfisSide): Promise<number> {
         if (Terrain.endpointsAvailable) {
-            return fetch(`${simbridgeUrl}/api/v1/terrain/renderMap?display=${side}`).then((response) => response.text().then((text) => parseInt(text)));
+            return fetch(`${getSimBridgeUrl()}/api/v1/terrain/renderMap?display=${side}`).then((response) => response.text().then((text) => parseInt(text)));
         }
 
         throw new Error('Endpoints unavailable');

--- a/src/simbridge-client/src/components/Viewer.ts
+++ b/src/simbridge-client/src/components/Viewer.ts
@@ -1,4 +1,4 @@
-import { simbridgeUrl } from '../common';
+import { getSimBridgeUrl } from '../common';
 
 /**
  * Class pertaining to retrieving static files for general viewing from SimBridge
@@ -12,7 +12,7 @@ export class Viewer {
      */
     public static async getPDFPage(filename: string, pageNumber: number): Promise<Blob> {
         if (filename || pageNumber) {
-            const response = await fetch(`${simbridgeUrl}/api/v1/utility/pdf?filename=${filename}&pagenumber=${pageNumber}`);
+            const response = await fetch(`${getSimBridgeUrl()}/api/v1/utility/pdf?filename=${filename}&pagenumber=${pageNumber}`);
             if (response.ok) {
                 return response.blob();
             }
@@ -28,7 +28,7 @@ export class Viewer {
      */
     public static async getPDFPageNum(filename: string): Promise<Number> {
         if (filename) {
-            const response = await fetch(`${simbridgeUrl}/api/v1/utility/pdf/numpages?filename=${filename}`);
+            const response = await fetch(`${getSimBridgeUrl()}/api/v1/utility/pdf/numpages?filename=${filename}`);
             if (response.ok) {
                 return response.json();
             }
@@ -42,7 +42,7 @@ export class Viewer {
      * @returns an Array of strings
      */
     public static async getPDFList(): Promise<string[]> {
-        const response = await fetch(`${simbridgeUrl}/api/v1/utility/pdf/list`);
+        const response = await fetch(`${getSimBridgeUrl()}/api/v1/utility/pdf/list`);
         if (response.ok) {
             return response.json();
         }
@@ -56,7 +56,7 @@ export class Viewer {
      */
     public static async getImage(filename: string, pageNumber: number): Promise<Blob> {
         if (filename || pageNumber) {
-            const response = await fetch(`${simbridgeUrl}/api/v1/utility/image?filename=${filename}`);
+            const response = await fetch(`${getSimBridgeUrl()}/api/v1/utility/image?filename=${filename}`);
             if (response.ok) {
                 return response.blob();
             }
@@ -70,7 +70,7 @@ export class Viewer {
      * @returns an Array of strings
      */
     public static async getImageList(): Promise<string[]> {
-        const response = await fetch(`${simbridgeUrl}/api/v1/utility/image/list`);
+        const response = await fetch(`${getSimBridgeUrl()}/api/v1/utility/image/list`);
         if (response.ok) {
             return response.json();
         }


### PR DESCRIPTION
## Summary of Changes
ACE was currently not useable because of call the NXDataStore during initialization.
Refactoring the simbridgeUrl sttring-variable to a function call solves this issue. 

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Only impacts SimBridge features:
- Health (check the flyPad status bar for the "wifi" symbol - should show a connection when SimBridge is running/connected
- Terrain, Local Files, CoRoute are not yet on master - so nothing to test there. Will be tested in Exp. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
