### PR TITLE
fix: repair fdr data for support analysis 

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -83,6 +83,7 @@
 1. [MODEL] Fixed screens flickering in SU10 - @tyler58546 (tyler58546)
 1. [EFB] Added Local Files support - @ErickSharp (Erick Torres) @frankkopp (Frank Kopp)
 1. [BLEED] Added custom Wing Anti-Ice model - @omrygin, @Eagle941 (Joe)
+1. [MISC] Fix FDR data for support analysis - @frankkopp (Frank Kopp)
 
 ## 0.8.0
 

--- a/src/fbw/src/AdditionalData.h
+++ b/src/fbw/src/AdditionalData.h
@@ -45,6 +45,8 @@ struct AdditionalData {
   double inputRudder;
   // additional
   double simulation_rate;
+  double wasPaused;
+  double slew_on;
   // ambient data
   double ice_structure_percent;
   double ambient_pressure_mbar;

--- a/src/fbw/src/AdditionalData.h
+++ b/src/fbw/src/AdditionalData.h
@@ -51,6 +51,8 @@ struct AdditionalData {
   double ambient_wind_velocity_kn;
   double ambient_wind_direction_deg;
   double total_air_temperature_celsius;
+  // failures
+  double failuresActive;
   // aoa - these are not correct yet
   double alpha_floor_command;
   double protection_ap_disc;

--- a/src/fbw/src/AdditionalData.h
+++ b/src/fbw/src/AdditionalData.h
@@ -55,8 +55,9 @@ struct AdditionalData {
   double total_air_temperature_celsius;
   // failures
   double failuresActive;
-  // aoa - these are not correct yet
+  // a.floor
   double alpha_floor_condition;
+  // these are not correct yet
   double protection_ap_disc;
   double v_alpha_prot_kn;
   double v_alpha_max_kn;

--- a/src/fbw/src/AdditionalData.h
+++ b/src/fbw/src/AdditionalData.h
@@ -38,4 +38,23 @@ struct AdditionalData {
   double ls2Active;
   double IsisLsActive;
   double wingAntiIce;
+  // Fix missing data for FDR Analysis
+  // controller input data
+  double inputElevator;
+  double inputAileron;
+  double inputRudder;
+  // additional
+  double simulation_rate;
+  // ambient data
+  double ice_structure_percent;
+  double ambient_pressure_mbar;
+  double ambient_wind_velocity_kn;
+  double ambient_wind_direction_deg;
+  double total_air_temperature_celsius;
+  // aoa - these are not correct yet
+  double alpha_floor_command;
+  double protection_ap_disc;
+  double v_alpha_prot_kn;
+  double v_alpha_max_kn;
+
 };

--- a/src/fbw/src/AdditionalData.h
+++ b/src/fbw/src/AdditionalData.h
@@ -56,7 +56,7 @@ struct AdditionalData {
   // failures
   double failuresActive;
   // aoa - these are not correct yet
-  double alpha_floor_command;
+  double alpha_floor_condition;
   double protection_ap_disc;
   double v_alpha_prot_kn;
   double v_alpha_max_kn;

--- a/src/fbw/src/AdditionalData.h
+++ b/src/fbw/src/AdditionalData.h
@@ -57,9 +57,6 @@ struct AdditionalData {
   double failuresActive;
   // a.floor
   double alpha_floor_condition;
-  // these are not correct yet
-  double protection_ap_disc;
-  double v_alpha_prot_kn;
-  double v_alpha_max_kn;
-
+  // high aoa protection
+  double high_aoa_protection;
 };

--- a/src/fbw/src/FlightDataRecorder.h
+++ b/src/fbw/src/FlightDataRecorder.h
@@ -12,7 +12,7 @@
 class FlightDataRecorder {
  public:
   // IMPORTANT: this constant needs to increased with every interface change
-  const uint64_t INTERFACE_VERSION = 23;
+  const uint64_t INTERFACE_VERSION = 24;
 
   void initialize();
 

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -1053,8 +1053,10 @@ bool FlyByWireInterface::updateAdditionalData(double sampleTime) {
   additionalData.total_air_temperature_celsius = simData.total_air_temperature_celsius;
   // failure
   additionalData.failuresActive = failuresConsumer.isAnyActive() ? 1.0 : 0.0;
-  // aoa - these are not correct yet
-  additionalData.alpha_floor_command = clientDataFlyByWire.alpha_floor_command;
+  // aoa
+  additionalData.alpha_floor_condition = reinterpret_cast<Arinc429DiscreteWord*>(&facsBusOutputs[0].discrete_word_5)->bitFromValueOr(29, false) ||
+                                         reinterpret_cast<Arinc429DiscreteWord*>(&facsBusOutputs[1].discrete_word_5)->bitFromValueOr(29, false);
+  // these are not correct yet
   additionalData.protection_ap_disc = clientDataFlyByWire.protection_ap_disc;
   additionalData.v_alpha_prot_kn = clientDataFlyByWire.v_alpha_prot_kn;
   additionalData.v_alpha_max_kn = clientDataFlyByWire.v_alpha_max_kn;

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -849,6 +849,13 @@ bool FlyByWireInterface::readDataAndLocalVariables(double sampleTime) {
   if ((simData.simulationTime == previousSimulationTime) || (simData.simulationTime < 0.2)) {
     pauseDetected = true;
   } else {
+    // As fdr is not written when paused 'wasPaused' is used to detect previous pause state
+    // changes and record them in fdr
+    if (pauseDetected && !wasPaused) {
+      wasPaused = true;
+    } else {
+      wasPaused = false;
+    }
     pauseDetected = false;
   }
 
@@ -1036,6 +1043,8 @@ bool FlyByWireInterface::updateAdditionalData(double sampleTime) {
   additionalData.inputRudder = simInputs.inputs[2];
   // additional
   additionalData.simulation_rate = simData.simulation_rate;
+  additionalData.wasPaused = wasPaused;
+  additionalData.slew_on = wasInSlew;
   // ambient data
   additionalData.ice_structure_percent = simData.ice_structure_percent;
   additionalData.ambient_pressure_mbar = simData.ambient_pressure_mbar;

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -491,7 +491,7 @@ void FlyByWireInterface::setupLocalVariables() {
   idLs1Active = make_unique<LocalVariable>("BTN_LS_1_FILTER_ACTIVE");
   idLs2Active = make_unique<LocalVariable>("BTN_LS_2_FILTER_ACTIVE");
   idIsisLsActive = make_unique<LocalVariable>("A32NX_ISIS_LS_ACTIVE");
-  
+
   idWingAntiIce = make_unique<LocalVariable>("A32NX_PNEU_WING_ANTI_ICE_SYSTEM_ON");
 
   for (int i = 0; i < 2; i++) {
@@ -905,7 +905,7 @@ bool FlyByWireInterface::handleSimulationRate(double sampleTime) {
   targetSimulationRate = simData.simulation_rate;
   targetSimulationRateModified = false;
 
-  // nothing to do if simuation rate is '1x'
+  // nothing to do if simulation rate is '1x'
   if (simData.simulation_rate == 1) {
     return true;
   }
@@ -998,8 +998,7 @@ bool FlyByWireInterface::updateAdditionalData(double sampleTime) {
   additionalData.spoilers_handle_pos = idSpoilersHandlePosition->get();
   additionalData.spoilers_armed = idSpoilersArmed->get();
   additionalData.spoilers_handle_sim_pos = simData.spoilers_handle_position;
-  additionalData.ground_spoilers_active =
-      idSecGroundSpoilersOut[0]->get() || idSecGroundSpoilersOut[1]->get() || idSecGroundSpoilersOut[2]->get();
+  additionalData.ground_spoilers_active = idSecGroundSpoilersOut[0]->get() || idSecGroundSpoilersOut[1]->get() || idSecGroundSpoilersOut[2]->get();
   additionalData.flaps_handle_percent = idFlapsHandlePercent->get();
   additionalData.flaps_handle_index = idFlapsHandleIndex->get();
   additionalData.flaps_handle_configuration_index = flapsHandleIndexFlapConf->get();
@@ -1019,14 +1018,35 @@ bool FlyByWireInterface::updateAdditionalData(double sampleTime) {
   additionalData.realisticTillerEnabled = idRealisticTillerEnabled->get() == 1;
   additionalData.tillerHandlePosition = idTillerHandlePosition->get();
   additionalData.noseWheelPosition = idNoseWheelPosition->get();
-
   additionalData.syncFoEfisEnabled = idSyncFoEfisEnabled->get();
-
   additionalData.ls1Active = idLs1Active->get();
   additionalData.ls2Active = idLs2Active->get();
   additionalData.IsisLsActive = idIsisLsActive->get();
 
   additionalData.wingAntiIce = idWingAntiIce->get();
+
+  // Fix missing data for FDR Analysis
+  auto simInputs = simConnectInterface.getSimInput();
+  auto clientDataFlyByWire = simConnectInterface.getClientDataFlyByWire();
+  auto clientDataAutothrust = simConnectInterface.getClientDataAutothrust();
+
+  // controller input data
+  additionalData.inputElevator = simInputs.inputs[0];
+  additionalData.inputAileron = simInputs.inputs[1];
+  additionalData.inputRudder = simInputs.inputs[2];
+  // additional
+  additionalData.simulation_rate = simData.simulation_rate;
+  // ambient data
+  additionalData.ice_structure_percent = simData.ice_structure_percent;
+  additionalData.ambient_pressure_mbar = simData.ambient_pressure_mbar;
+  additionalData.ambient_wind_velocity_kn = simData.ambient_wind_velocity_kn;
+  additionalData.ambient_wind_direction_deg = simData.ambient_wind_direction_deg;
+  additionalData.total_air_temperature_celsius = simData.total_air_temperature_celsius;
+  // aoa - these are not correct yet
+  additionalData.alpha_floor_command = clientDataFlyByWire.alpha_floor_command;
+  additionalData.protection_ap_disc = clientDataFlyByWire.protection_ap_disc;
+  additionalData.v_alpha_prot_kn = clientDataFlyByWire.v_alpha_prot_kn;
+  additionalData.v_alpha_max_kn = clientDataFlyByWire.v_alpha_max_kn;
 
   return true;
 }

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -1042,6 +1042,8 @@ bool FlyByWireInterface::updateAdditionalData(double sampleTime) {
   additionalData.ambient_wind_velocity_kn = simData.ambient_wind_velocity_kn;
   additionalData.ambient_wind_direction_deg = simData.ambient_wind_direction_deg;
   additionalData.total_air_temperature_celsius = simData.total_air_temperature_celsius;
+  // failure
+  additionalData.failuresActive = failuresConsumer.isAnyActive() ? 1.0 : 0.0;
   // aoa - these are not correct yet
   additionalData.alpha_floor_command = clientDataFlyByWire.alpha_floor_command;
   additionalData.protection_ap_disc = clientDataFlyByWire.protection_ap_disc;

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -1057,9 +1057,8 @@ bool FlyByWireInterface::updateAdditionalData(double sampleTime) {
   additionalData.alpha_floor_condition = reinterpret_cast<Arinc429DiscreteWord*>(&facsBusOutputs[0].discrete_word_5)->bitFromValueOr(29, false) ||
                                          reinterpret_cast<Arinc429DiscreteWord*>(&facsBusOutputs[1].discrete_word_5)->bitFromValueOr(29, false);
   // these are not correct yet
-  additionalData.protection_ap_disc = clientDataFlyByWire.protection_ap_disc;
-  additionalData.v_alpha_prot_kn = clientDataFlyByWire.v_alpha_prot_kn;
-  additionalData.v_alpha_max_kn = clientDataFlyByWire.v_alpha_max_kn;
+  additionalData.high_aoa_protection = reinterpret_cast<Arinc429DiscreteWord*>(&elacsBusOutputs[0].discrete_status_word_2)->bitFromValueOr(23, false) ||
+                                       reinterpret_cast<Arinc429DiscreteWord*>(&elacsBusOutputs[1].discrete_status_word_2)->bitFromValueOr(23, false);
 
   return true;
 }

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -94,6 +94,25 @@ class FlyByWireInterface {
   bool last_ls1_active = false;
   bool last_ls2_active = false;
 
+  // Fix missing data for FDR Analysis
+  // controller input data
+  double inputElevator = 0.0;
+  double inputAileron = 0.0;
+  double inputRudder = 0.0;
+  // additional
+  double simulation_rate = 0.0;
+  // ambient data
+  double ice_structure_percent = 0.0;
+  double ambient_pressure_mbar = 0.0;
+  double ambient_wind_velocity_kn = 0.0;
+  double ambient_wind_direction_deg = 0.0;
+  double total_air_temperature_celsius = 0.0;
+  // aoa - these are not correct yet
+  double alpha_floor_command = 0.0;
+  double protection_ap_disc = 0.0;
+  double v_alpha_prot_kn = 0.0;
+  double v_alpha_max_kn = 0.0;
+
   FlightDataRecorder flightDataRecorder;
 
   SimConnectInterface simConnectInterface;

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -97,26 +97,6 @@ class FlyByWireInterface {
   bool last_ls1_active = false;
   bool last_ls2_active = false;
 
-  // Fix missing data for FDR Analysis
-  // controller input data
-  double inputElevator = 0.0;
-  double inputAileron = 0.0;
-  double inputRudder = 0.0;
-  // additional
-  double simulation_rate = 0.0;
-  // ambient data
-  double ice_structure_percent = 0.0;
-  double ambient_pressure_mbar = 0.0;
-  double ambient_wind_velocity_kn = 0.0;
-  double ambient_wind_direction_deg = 0.0;
-  double total_air_temperature_celsius = 0.0;
-  // aoa
-  double alpha_floor_condition = 0.0;
-  // these are not correct yet
-  double protection_ap_disc = 0.0;
-  double v_alpha_prot_kn = 0.0;
-  double v_alpha_max_kn = 0.0;
-
   FlightDataRecorder flightDataRecorder;
 
   SimConnectInterface simConnectInterface;
@@ -389,7 +369,7 @@ class FlyByWireInterface {
   std::unique_ptr<LocalVariable> idLs1Active;
   std::unique_ptr<LocalVariable> idLs2Active;
   std::unique_ptr<LocalVariable> idIsisLsActive;
-  
+
   std::unique_ptr<LocalVariable> idWingAntiIce;
 
   // RA bus inputs

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -66,6 +66,9 @@ class FlyByWireInterface {
   bool wasTcasEngaged = false;
 
   bool pauseDetected = false;
+  // As fdr is not written when paused 'wasPaused' is used to detect previous pause state
+  // changes and record them in fdr
+  bool wasPaused = false;
   bool wasInSlew = false;
 
   double autothrustThrustLimitReverse = -45;

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -111,7 +111,7 @@ class FlyByWireInterface {
   double ambient_wind_direction_deg = 0.0;
   double total_air_temperature_celsius = 0.0;
   // aoa - these are not correct yet
-  double alpha_floor_command = 0.0;
+  double alpha_floor_condition = 0.0;
   double protection_ap_disc = 0.0;
   double v_alpha_prot_kn = 0.0;
   double v_alpha_max_kn = 0.0;

--- a/src/fbw/src/FlyByWireInterface.h
+++ b/src/fbw/src/FlyByWireInterface.h
@@ -110,8 +110,9 @@ class FlyByWireInterface {
   double ambient_wind_velocity_kn = 0.0;
   double ambient_wind_direction_deg = 0.0;
   double total_air_temperature_celsius = 0.0;
-  // aoa - these are not correct yet
+  // aoa
   double alpha_floor_condition = 0.0;
+  // these are not correct yet
   double protection_ap_disc = 0.0;
   double v_alpha_prot_kn = 0.0;
   double v_alpha_max_kn = 0.0;

--- a/src/fbw/src/failures/FailuresConsumer.cpp
+++ b/src/fbw/src/failures/FailuresConsumer.cpp
@@ -50,3 +50,12 @@ bool FailuresConsumer::setIfFound(double identifier, bool value) {
     return true;
   }
 }
+
+bool FailuresConsumer::isAnyActive() {
+  if (std::any_of(activeFailures.begin(), activeFailures.end(), [](auto pair) {
+    return pair.second;
+  })) {
+      return true;
+  }
+  return false;
+}

--- a/src/fbw/src/failures/FailuresConsumer.cpp
+++ b/src/fbw/src/failures/FailuresConsumer.cpp
@@ -1,5 +1,6 @@
 #include "FailuresConsumer.h"
 #include <utility>
+#include <algorithm>
 
 FailuresConsumer::FailuresConsumer() {
   activeFailures.emplace(std::make_pair<Failures, bool>(Failures::Elac1, false));

--- a/src/fbw/src/failures/FailuresConsumer.h
+++ b/src/fbw/src/failures/FailuresConsumer.h
@@ -13,6 +13,8 @@ class FailuresConsumer {
 
   bool isActive(Failures failure);
 
+  bool isAnyActive();
+
   void initialize();
 
  private:

--- a/src/fdr2csv/src/FlightDataRecorderConverter.cpp
+++ b/src/fdr2csv/src/FlightDataRecorderConverter.cpp
@@ -443,6 +443,21 @@ void FlightDataRecorderConverter::writeHeader(ofstream& out, const string& delim
   fmt::print(out, "data.ls1Active{}", delimiter);
   fmt::print(out, "data.ls2Active{}", delimiter);
   fmt::print(out, "data.IsisLsActive{}", delimiter);
+  // Fix missing data for FDR Analysis
+  fmt::print(out, "data.inputElevator{}", delimiter);
+  fmt::print(out, "data.inputAileron{}", delimiter);
+  fmt::print(out, "data.inputRudder{}", delimiter);
+  fmt::print(out, "data.simulation_rate{}", delimiter);
+  fmt::print(out, "data.ice_structure_percent{}", delimiter);
+  fmt::print(out, "data.ambient_pressure_mbar{}", delimiter);
+  fmt::print(out, "data.ambient_wind_velocity_kn{}", delimiter);
+  fmt::print(out, "data.ambient_wind_direction_deg{}", delimiter);
+  fmt::print(out, "data.total_air_temperature_celsius{}", delimiter);
+  fmt::print(out, "data.alpha_floor_command{}", delimiter);
+  fmt::print(out, "data.protection_ap_disc{}", delimiter);
+  fmt::print(out, "data.v_alpha_prot_kn{}", delimiter);
+  fmt::print(out, "data.v_alpha_max_kn{}", delimiter);
+
   fmt::print(out, "\n");
 }
 
@@ -890,5 +905,19 @@ void FlightDataRecorderConverter::writeStruct(ofstream& out,
   fmt::print(out, "{}{}", data.ls1Active, delimiter);
   fmt::print(out, "{}{}", data.ls2Active, delimiter);
   fmt::print(out, "{}{}", data.IsisLsActive, delimiter);
+  // Fix missing data for FDR Analysis
+  fmt::print(out, "{}{}", data.inputElevator, delimiter);
+  fmt::print(out, "{}{}", data.inputAileron, delimiter);
+  fmt::print(out, "{}{}", data.inputRudder, delimiter);
+  fmt::print(out, "{}{}", data.simulation_rate, delimiter);
+  fmt::print(out, "{}{}", data.ice_structure_percent, delimiter);
+  fmt::print(out, "{}{}", data.ambient_pressure_mbar, delimiter);
+  fmt::print(out, "{}{}", data.ambient_wind_velocity_kn, delimiter);
+  fmt::print(out, "{}{}", data.ambient_wind_direction_deg, delimiter);
+  fmt::print(out, "{}{}", data.total_air_temperature_celsius, delimiter);
+  fmt::print(out, "{}{}", data.alpha_floor_command, delimiter);
+  fmt::print(out, "{}{}", data.protection_ap_disc, delimiter);
+  fmt::print(out, "{}{}", data.v_alpha_prot_kn, delimiter);
+  fmt::print(out, "{}{}", data.v_alpha_max_kn, delimiter);
   fmt::print(out, "\n");
 }

--- a/src/fdr2csv/src/FlightDataRecorderConverter.cpp
+++ b/src/fdr2csv/src/FlightDataRecorderConverter.cpp
@@ -443,6 +443,7 @@ void FlightDataRecorderConverter::writeHeader(ofstream& out, const string& delim
   fmt::print(out, "data.ls1Active{}", delimiter);
   fmt::print(out, "data.ls2Active{}", delimiter);
   fmt::print(out, "data.IsisLsActive{}", delimiter);
+  fmt::print(out, "data.wingAntiIce{}", delimiter);
   // Fix missing data for FDR Analysis
   // controller input data
   fmt::print(out, "data.inputElevator{}", delimiter);
@@ -914,6 +915,7 @@ void FlightDataRecorderConverter::writeStruct(ofstream& out,
   fmt::print(out, "{}{}", data.ls1Active, delimiter);
   fmt::print(out, "{}{}", data.ls2Active, delimiter);
   fmt::print(out, "{}{}", data.IsisLsActive, delimiter);
+  fmt::print(out, "{}{}", data.wingAntiIce, delimiter);
   // Fix missing data for FDR Analysis
   // controller input data
   fmt::print(out, "{}{}", data.inputElevator, delimiter);

--- a/src/fdr2csv/src/FlightDataRecorderConverter.cpp
+++ b/src/fdr2csv/src/FlightDataRecorderConverter.cpp
@@ -456,7 +456,7 @@ void FlightDataRecorderConverter::writeHeader(ofstream& out, const string& delim
   fmt::print(out, "data.ambient_wind_direction_deg{}", delimiter);
   fmt::print(out, "data.total_air_temperature_celsius{}", delimiter);
   fmt::print(out, "data.failuresActive{}", delimiter);
-  fmt::print(out, "data.alpha_floor_command{}", delimiter);
+  fmt::print(out, "data.alpha_floor_condition{}", delimiter);
   fmt::print(out, "data.protection_ap_disc{}", delimiter);
   fmt::print(out, "data.v_alpha_prot_kn{}", delimiter);
   fmt::print(out, "data.v_alpha_max_kn{}", delimiter);
@@ -926,7 +926,7 @@ void FlightDataRecorderConverter::writeStruct(ofstream& out,
   // failure
   fmt::print(out, "{}{}", data.failuresActive, delimiter);
   // aoa - these are not correct yet
-  fmt::print(out, "{}{}", data.alpha_floor_command, delimiter);
+  fmt::print(out, "{}{}", data.alpha_floor_condition, delimiter);
   fmt::print(out, "{}{}", data.protection_ap_disc, delimiter);
   fmt::print(out, "{}{}", data.v_alpha_prot_kn, delimiter);
   fmt::print(out, "{}{}", data.v_alpha_max_kn, delimiter);

--- a/src/fdr2csv/src/FlightDataRecorderConverter.cpp
+++ b/src/fdr2csv/src/FlightDataRecorderConverter.cpp
@@ -463,10 +463,12 @@ void FlightDataRecorderConverter::writeHeader(ofstream& out, const string& delim
   fmt::print(out, "data.failuresActive{}", delimiter);
   // a.floor
   fmt::print(out, "data.alpha_floor_condition{}", delimiter);
+  // high aoa protection
+  fmt::print(out, "data.high_aoa_protection{}", delimiter);
   // aoa - these are not correct yet
-  fmt::print(out, "data.protection_ap_disc{}", delimiter);
-  fmt::print(out, "data.v_alpha_prot_kn{}", delimiter);
-  fmt::print(out, "data.v_alpha_max_kn{}", delimiter);
+  //  fmt::print(out, "data.protection_ap_disc{}", delimiter);
+  //  fmt::print(out, "data.v_alpha_prot_kn{}", delimiter);
+  //  fmt::print(out, "data.v_alpha_max_kn{}", delimiter);
 
   fmt::print(out, "\n");
 }
@@ -935,10 +937,8 @@ void FlightDataRecorderConverter::writeStruct(ofstream& out,
   fmt::print(out, "{}{}", data.failuresActive, delimiter);
   // a.floor
   fmt::print(out, "{}{}", data.alpha_floor_condition, delimiter);
-  // aoa - these are not correct yet
-  fmt::print(out, "{}{}", data.protection_ap_disc, delimiter);
-  fmt::print(out, "{}{}", data.v_alpha_prot_kn, delimiter);
-  fmt::print(out, "{}{}", data.v_alpha_max_kn, delimiter);
+  // high aoa protection
+  fmt::print(out, "{}{}", data.high_aoa_protection, delimiter);
 
   fmt::print(out, "\n");
 }

--- a/src/fdr2csv/src/FlightDataRecorderConverter.cpp
+++ b/src/fdr2csv/src/FlightDataRecorderConverter.cpp
@@ -453,6 +453,7 @@ void FlightDataRecorderConverter::writeHeader(ofstream& out, const string& delim
   fmt::print(out, "data.ambient_wind_velocity_kn{}", delimiter);
   fmt::print(out, "data.ambient_wind_direction_deg{}", delimiter);
   fmt::print(out, "data.total_air_temperature_celsius{}", delimiter);
+  fmt::print(out, "data.failuresActive{}", delimiter);
   fmt::print(out, "data.alpha_floor_command{}", delimiter);
   fmt::print(out, "data.protection_ap_disc{}", delimiter);
   fmt::print(out, "data.v_alpha_prot_kn{}", delimiter);
@@ -915,6 +916,7 @@ void FlightDataRecorderConverter::writeStruct(ofstream& out,
   fmt::print(out, "{}{}", data.ambient_wind_velocity_kn, delimiter);
   fmt::print(out, "{}{}", data.ambient_wind_direction_deg, delimiter);
   fmt::print(out, "{}{}", data.total_air_temperature_celsius, delimiter);
+  fmt::print(out, "{}{}", data.failuresActive, delimiter);
   fmt::print(out, "{}{}", data.alpha_floor_command, delimiter);
   fmt::print(out, "{}{}", data.protection_ap_disc, delimiter);
   fmt::print(out, "{}{}", data.v_alpha_prot_kn, delimiter);

--- a/src/fdr2csv/src/FlightDataRecorderConverter.cpp
+++ b/src/fdr2csv/src/FlightDataRecorderConverter.cpp
@@ -448,6 +448,8 @@ void FlightDataRecorderConverter::writeHeader(ofstream& out, const string& delim
   fmt::print(out, "data.inputAileron{}", delimiter);
   fmt::print(out, "data.inputRudder{}", delimiter);
   fmt::print(out, "data.simulation_rate{}", delimiter);
+  fmt::print(out, "data.wasPaused{}", delimiter);
+  fmt::print(out, "data.slew_on{}", delimiter);
   fmt::print(out, "data.ice_structure_percent{}", delimiter);
   fmt::print(out, "data.ambient_pressure_mbar{}", delimiter);
   fmt::print(out, "data.ambient_wind_velocity_kn{}", delimiter);
@@ -907,16 +909,23 @@ void FlightDataRecorderConverter::writeStruct(ofstream& out,
   fmt::print(out, "{}{}", data.ls2Active, delimiter);
   fmt::print(out, "{}{}", data.IsisLsActive, delimiter);
   // Fix missing data for FDR Analysis
+  // controller input data
   fmt::print(out, "{}{}", data.inputElevator, delimiter);
   fmt::print(out, "{}{}", data.inputAileron, delimiter);
   fmt::print(out, "{}{}", data.inputRudder, delimiter);
+  // additional sim data
   fmt::print(out, "{}{}", data.simulation_rate, delimiter);
+  fmt::print(out, "{}{}", data.wasPaused, delimiter);
+  fmt::print(out, "{}{}", data.slew_on, delimiter);
+  // ambient data
   fmt::print(out, "{}{}", data.ice_structure_percent, delimiter);
   fmt::print(out, "{}{}", data.ambient_pressure_mbar, delimiter);
   fmt::print(out, "{}{}", data.ambient_wind_velocity_kn, delimiter);
   fmt::print(out, "{}{}", data.ambient_wind_direction_deg, delimiter);
   fmt::print(out, "{}{}", data.total_air_temperature_celsius, delimiter);
+  // failure
   fmt::print(out, "{}{}", data.failuresActive, delimiter);
+  // aoa - these are not correct yet
   fmt::print(out, "{}{}", data.alpha_floor_command, delimiter);
   fmt::print(out, "{}{}", data.protection_ap_disc, delimiter);
   fmt::print(out, "{}{}", data.v_alpha_prot_kn, delimiter);

--- a/src/fdr2csv/src/FlightDataRecorderConverter.cpp
+++ b/src/fdr2csv/src/FlightDataRecorderConverter.cpp
@@ -444,19 +444,25 @@ void FlightDataRecorderConverter::writeHeader(ofstream& out, const string& delim
   fmt::print(out, "data.ls2Active{}", delimiter);
   fmt::print(out, "data.IsisLsActive{}", delimiter);
   // Fix missing data for FDR Analysis
+  // controller input data
   fmt::print(out, "data.inputElevator{}", delimiter);
   fmt::print(out, "data.inputAileron{}", delimiter);
   fmt::print(out, "data.inputRudder{}", delimiter);
+  // additional
   fmt::print(out, "data.simulation_rate{}", delimiter);
   fmt::print(out, "data.wasPaused{}", delimiter);
   fmt::print(out, "data.slew_on{}", delimiter);
+  // ambient data
   fmt::print(out, "data.ice_structure_percent{}", delimiter);
   fmt::print(out, "data.ambient_pressure_mbar{}", delimiter);
   fmt::print(out, "data.ambient_wind_velocity_kn{}", delimiter);
   fmt::print(out, "data.ambient_wind_direction_deg{}", delimiter);
   fmt::print(out, "data.total_air_temperature_celsius{}", delimiter);
+  // failures
   fmt::print(out, "data.failuresActive{}", delimiter);
+  // a.floor
   fmt::print(out, "data.alpha_floor_condition{}", delimiter);
+  // aoa - these are not correct yet
   fmt::print(out, "data.protection_ap_disc{}", delimiter);
   fmt::print(out, "data.v_alpha_prot_kn{}", delimiter);
   fmt::print(out, "data.v_alpha_max_kn{}", delimiter);
@@ -925,10 +931,12 @@ void FlightDataRecorderConverter::writeStruct(ofstream& out,
   fmt::print(out, "{}{}", data.total_air_temperature_celsius, delimiter);
   // failure
   fmt::print(out, "{}{}", data.failuresActive, delimiter);
-  // aoa - these are not correct yet
+  // a.floor
   fmt::print(out, "{}{}", data.alpha_floor_condition, delimiter);
+  // aoa - these are not correct yet
   fmt::print(out, "{}{}", data.protection_ap_disc, delimiter);
   fmt::print(out, "{}{}", data.v_alpha_prot_kn, delimiter);
   fmt::print(out, "{}{}", data.v_alpha_max_kn, delimiter);
+
   fmt::print(out, "\n");
 }

--- a/src/fdr2csv/src/main.cpp
+++ b/src/fdr2csv/src/main.cpp
@@ -14,7 +14,7 @@
 using namespace std;
 
 // IMPORTANT: this constant needs to increased with every interface change
-const uint64_t INTERFACE_VERSION = 23;
+const uint64_t INTERFACE_VERSION = 24;
 
 int main(int argc, char* argv[]) {
   // variables for command line parameters


### PR DESCRIPTION
## Summary of Changes
Unfortunately #6913 removed many vital data points in the fdr files without adequate replacement. This renders FDR files useles for support purposes (AP Disconnect Analysis, COntroller Input Analysis, High AOA Analysis, etc.). 

This PR attempts to bring these data points back into the fdr files. 

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Testing the FDR with this PR only is not possible. It also requires the coversion tool and graph tool. 

But it shoul be test against general issues - basically anything should work as before. Probably best to simply be used in Exp. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
