### PR TITLE
fix: avoid flyPad crash when SimBrief cruise profile is other than "CI"

### DIFF
--- a/src/instruments/src/EFB/Dashboard/Widgets/FlightWidget.tsx
+++ b/src/instruments/src/EFB/Dashboard/Widgets/FlightWidget.tsx
@@ -47,7 +47,7 @@ const NoSimBriefDataOverlay = ({ simbriefDataLoaded, simbriefDataPending, fetchD
                             <button
                                 type="button"
                                 onClick={fetchData}
-                                className="flex justify-center items-center p-2 space-x-4 w-full rounded-md border-2 transition duration-100 text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body border-theme-highlight"
+                                className="flex justify-center items-center p-2 space-x-4 w-full text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body rounded-md border-2 border-theme-highlight transition duration-100"
                             >
                                 <CloudArrowDown size={26} />
                                 <p className="text-current">{t('Dashboard.YourFlight.ImportSimBriefData')}</p>
@@ -100,7 +100,7 @@ export const FlightWidget = () => {
 
     const avgWind = `${weather.avgWindDir}/${weather.avgWindSpeed}`;
 
-    const eZfwUnround = weights.estZeroFuelWeight / 100;
+    const eZfwUnround = parseFloat(weights.estZeroFuelWeight) / 100;
     const eZfw = Math.round(eZfwUnround) / 10;
     const estimatedZfw = `${eZfw}`;
 
@@ -134,7 +134,7 @@ export const FlightWidget = () => {
                     </h1>
                 )}
             </div>
-            <div className="overflow-hidden relative p-6 w-full rounded-lg border-2 h-content-section-reduced border-theme-accent">
+            <div className="overflow-hidden relative p-6 w-full h-content-section-reduced rounded-lg border-2 border-theme-accent">
                 <div className="flex flex-col justify-between h-full">
                     <div className="space-y-8">
                         <div className="flex flex-row justify-between">
@@ -153,12 +153,12 @@ export const FlightWidget = () => {
                                     {schedOutParsed}
                                 </p>
                                 <div className="flex relative flex-row mx-6 w-full h-1">
-                                    <div className="absolute inset-x-0 border-b-4 border-dashed border-theme-text" />
+                                    <div className="absolute inset-x-0 border-b-4 border-theme-text border-dashed" />
 
                                     <div className="relative w-full bg-theme-highlight" style={{ width: `${flightPlanProgress}%` }}>
                                         {!!flightPlanProgress && (
                                             <IconPlane
-                                                className="absolute right-0 transform translate-x-1/2 -translate-y-1/2 fill-current text-theme-highlight"
+                                                className="absolute right-0 text-theme-highlight transform translate-x-1/2 -translate-y-1/2 fill-current"
                                                 size={50}
                                                 strokeLinejoin="miter"
                                             />
@@ -211,7 +211,7 @@ export const FlightWidget = () => {
                     <button
                         type="button"
                         onClick={fetchData}
-                        className="flex justify-center items-center p-2 space-x-4 w-full rounded-lg border-2 transition duration-100 text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body border-theme-highlight"
+                        className="flex justify-center items-center p-2 space-x-4 w-full text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body rounded-lg border-2 border-theme-highlight transition duration-100"
                     >
                         <CloudArrowDown size={26} />
                         <p className="text-current">{t('Dashboard.YourFlight.ImportSimBriefData')}</p>

--- a/src/instruments/src/EFB/SimbriefApi/simbriefParser.ts
+++ b/src/instruments/src/EFB/SimbriefApi/simbriefParser.ts
@@ -39,7 +39,7 @@ const simbriefDataParser = (simbriefJson: any): ISimbriefData => {
     // Fix/workaround for SimBrief API returning an object instead of a string when the user selected
     // something other than "CI" for the Cruise Profile (e.g. M78)
     if (typeof general.costindex !== 'string') {
-        general.costindex = 'n/a';
+        general.costindex = general.cruise_profile;
     }
 
     return {

--- a/src/instruments/src/EFB/SimbriefApi/simbriefParser.ts
+++ b/src/instruments/src/EFB/SimbriefApi/simbriefParser.ts
@@ -36,6 +36,12 @@ const simbriefDataParser = (simbriefJson: any): ISimbriefData => {
     const { text } = simbriefJson;
     const { weather } = simbriefJson;
 
+    // Fix/workaround for SimBrief API returning an object instead of a string when the user selected
+    // something other than "CI" for the Cruise Profile (e.g. M78)
+    if (typeof general.costindex !== 'string') {
+        general.costindex = 'n/a';
+    }
+
     return {
         airline: general.icao_airline,
         flightNumber: general.flight_number,


### PR DESCRIPTION
## Summary of Changes
When a user choses anything other than "CI" on the SimBrief Dispatch Options page the flyPad crashed. [0]
Root cause is that the SimBrief API returns an empty object instead of the expected string. [1][2]

This PR adds a check if the returned `general.costindex` is a string and if not it returns a string containing the cruise profile text which indicated what has been chosen in the SimBrief context [3]. 
This could of course be set to a default CI value - currently unclear what would be better. 

## Screenshots (if necessary)
[0]
![image](https://user-images.githubusercontent.com/16833201/194702813-3f59461f-5a72-4100-b3bb-41bcf152211a.png)

[1] Correct with "CI"
![image](https://user-images.githubusercontent.com/16833201/194702870-df3f8f43-b051-4166-a0c6-935bc478d763.png)

[2] Incorrect with "M78"
![image](https://user-images.githubusercontent.com/16833201/194702874-2faeaf35-2638-47b8-9699-2a182331c7af.png)

[3] Using the cruise_profile text:
![image](https://user-images.githubusercontent.com/16833201/194707063-1ecb5ec3-78cd-4900-bdea-7e91306b7351.png)

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions

- Check if SimBrief imports to flyPad and MCDU work even when Cruise Profile is set to something other than "CI".
- Check with "CI" to test for any regressions. 
- MCDU will show a "NOT ALLOWED" and the Cost Index with orange boxes but should not crash or show any other issues. 
- flyPad Dashboard should show "n/a" for Cost Index. 
- Check anything else that uses SimBrief and/or CI

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
