### PR TITLE
fix: Increased overall max brightness of instruments

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -83,6 +83,7 @@
 1. [MODEL] Fixed screens flickering in SU10 - @tyler58546 (tyler58546)
 1. [EFB] Added Local Files support - @ErickSharp (Erick Torres) @frankkopp (Frank Kopp)
 1. [BLEED] Added custom Wing Anti-Ice model - @omrygin, @Eagle941 (Joe)
+1. [LIGHTS] Increased max brightness of cockpit displays - @frankkopp (Frank Kopp)
 
 ## 0.8.0
 

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -618,7 +618,7 @@
                     <PART_ID>SCREEN_PFD1</PART_ID>
                     <CAMERA_TITLE>PFD</CAMERA_TITLE>
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
-                    <EMISSIVE_CODE>6</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>12</EMISSIVE_CODE>
                 </UseTemplate>
 
                 <!-- CPT EFIS GPWS G/S -->
@@ -729,7 +729,7 @@
                     <PART_ID>SCREEN_MFD1</PART_ID>
                     <CAMERA_TITLE>MFD</CAMERA_TITLE>
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
-                    <EMISSIVE_CODE>6</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>12</EMISSIVE_CODE>
                 </UseTemplate>
 
                 <!-- DCDU -->
@@ -738,7 +738,7 @@
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
                     <EMISSIVE_CODE>
                         (L:A32NX_ELEC_DC_1_BUS_IS_POWERED, Bool) if{
-                            6 (L:#PLANE_NAME#_PANEL_DCDU_L_BRIGHTNESS, percent over 100) *
+                            12 (L:#PLANE_NAME#_PANEL_DCDU_L_BRIGHTNESS, percent over 100) *
                         } els{
                             0
                         }
@@ -777,7 +777,7 @@
                     <POTENTIOMETER>90</POTENTIOMETER>
                     <PART_ID>SCREEN_PFD2</PART_ID>
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
-                    <EMISSIVE_CODE>6</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>12</EMISSIVE_CODE>
                 </UseTemplate>
 
                 <!-- F/O ND BRIGHTNESS -->
@@ -795,7 +795,7 @@
                     <POTENTIOMETER>91</POTENTIOMETER>
                     <PART_ID>SCREEN_MFD2</PART_ID>
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
-                    <EMISSIVE_CODE>6</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>12</EMISSIVE_CODE>
                 </UseTemplate>
 
                 <!-- F/O ND WX BRIGHTNESS -->
@@ -813,7 +813,7 @@
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
                     <EMISSIVE_CODE>
                         (L:A32NX_ELEC_DC_2_BUS_IS_POWERED, Bool) if{
-                            6 (L:#PLANE_NAME#_PANEL_DCDU_R_BRIGHTNESS, percent over 100) *
+                            12 (L:#PLANE_NAME#_PANEL_DCDU_R_BRIGHTNESS, percent over 100) *
                         } els{
                             0
                         }
@@ -939,7 +939,7 @@
                 <UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
                     <NODE_ID>DYN_SCREEN</NODE_ID>
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
-                    <EMISSIVE_CODE>6</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>10</EMISSIVE_CODE>
                 </UseTemplate>
                 <CameraTitle>PA</CameraTitle>
 
@@ -1013,7 +1013,7 @@
                     <PART_ID>SCREEN_EICAS1</PART_ID>
                     <CAMERA_TITLE>ECAM</CAMERA_TITLE>
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
-                    <EMISSIVE_CODE>6</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>12</EMISSIVE_CODE>
                 </UseTemplate>
 
                 <!-- LOWER ECAM SCREEN -->
@@ -1030,7 +1030,7 @@
                     <PART_ID>SCREEN_EICAS2</PART_ID>
                     <CAMERA_TITLE>ECAM</CAMERA_TITLE>
                     <!-- Effects such as pixels and glass reflections require the screen brightness to be increased -->
-                    <EMISSIVE_CODE>6</EMISSIVE_CODE>
+                    <EMISSIVE_CODE>12</EMISSIVE_CODE>
                 </UseTemplate>
             </Component>
 

--- a/src/behavior/src/A32NX_Interior_MCDU.xml
+++ b/src/behavior/src/A32NX_Interior_MCDU.xml
@@ -415,7 +415,7 @@
                 <CURSOR>Hand</CURSOR>
                 <ANIM_NAME>#ANIM_NAME_BRT_DIM#</ANIM_NAME>
                 <CODE_POS_0>
-                (L:A32NX_MCDU_#SIDE#_BRIGHTNESS) (L:A32NX_MCDU_#SIDE#_BRIGHTNESS) 0.2 * + 4 min (&gt;L:A32NX_MCDU_#SIDE#_BRIGHTNESS)
+                (L:A32NX_MCDU_#SIDE#_BRIGHTNESS) (L:A32NX_MCDU_#SIDE#_BRIGHTNESS) 0.2 * + 8 min (&gt;L:A32NX_MCDU_#SIDE#_BRIGHTNESS)
                 </CODE_POS_0>
                 <CODE_POS_2>
                 (L:A32NX_MCDU_#SIDE#_BRIGHTNESS) (L:A32NX_MCDU_#SIDE#_BRIGHTNESS) 0.2 * - 0.5 max (&gt;L:A32NX_MCDU_#SIDE#_BRIGHTNESS)


### PR DESCRIPTION
## Summary of Changes
After several reports of users considering the display being too dark esp. in certain light situations and after SU10 this PR increases the possible max brightness of instruments in the cockpit. 

The values have been checked in dark and very bright situations and also during changing cloud situations. See [0].

Feedback is welcome as this might also be a matter of taste and various opinions. 

## Screenshots (if necessary)
[0] 
https://user-images.githubusercontent.com/16833201/194756476-27f4b663-6fbb-411d-bb28-36c77f4ceef5.mp4

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Test brightness of any display (PDF, ND, ECAMs, MCDU, ISIS) in as many situations as possible including flying through scattered clouds. 
See if the displays brightness settings (except ISIS which is automatic) cover the required range for all situations. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
