### PR TITLE
fix: flyPad ground services page fix overlapping divs 

### DIFF
--- a/src/instruments/src/EFB/Ground/Pages/ServicesPage.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/ServicesPage.tsx
@@ -474,6 +474,8 @@ export const ServicesPage = () => {
         }
     }, [groundServicesAvailable]);
 
+    const serviceIndicationCss = 'text-2xl font-bold text-utility-amber w-min';
+
     return (
         <div className="relative h-content-section-reduced">
             <GroundServiceOutline className="inset-x-0 mx-auto w-full h-full text-theme-text" />
@@ -509,8 +511,9 @@ export const ServicesPage = () => {
 
             </ServiceButtonWrapper>
 
-            {/* GPU */}
             <ServiceButtonWrapper xl={850} y={64} className="">
+
+                {/* GPU */}
                 <GroundServiceButton
                     name={t('Ground.Services.ExternalPower')}
                     state={gpuButtonState}
@@ -590,7 +593,7 @@ export const ServicesPage = () => {
             {/* Visual indications for tug and doors */}
             {!!pushBackAttached && (
                 <div
-                    className="text-2xl font-bold text-utility-amber"
+                    className={serviceIndicationCss}
                     style={{ position: 'absolute', left: 540, right: 0, top: 0 }}
                 >
                     TUG
@@ -598,7 +601,7 @@ export const ServicesPage = () => {
             )}
             {!!cabinDoorOpen && (
                 <div
-                    className="text-xl font-bold text-utility-amber"
+                    className={serviceIndicationCss}
                     style={{ position: 'absolute', left: 515, right: 0, top: 105 }}
                 >
                     CABIN
@@ -606,7 +609,7 @@ export const ServicesPage = () => {
             )}
             {!!aftDoorOpen && (
                 <div
-                    className="text-xl font-bold text-utility-amber"
+                    className={serviceIndicationCss}
                     style={{ position: 'absolute', left: 705, right: 0, top: 665 }}
                 >
                     CABIN
@@ -614,7 +617,7 @@ export const ServicesPage = () => {
             )}
             {!!cargoDoorOpen && (
                 <div
-                    className="text-xl font-bold text-utility-amber"
+                    className={serviceIndicationCss}
                     style={{ position: 'absolute', left: 705, right: 0, top: 200 }}
                 >
                     CARGO
@@ -622,7 +625,7 @@ export const ServicesPage = () => {
             )}
             {!!gpuActive && (
                 <div
-                    className="text-xl font-bold text-utility-amber"
+                    className={serviceIndicationCss}
                     style={{ position: 'absolute', left: 705, right: 0, top: 70 }}
                 >
                     GPU


### PR DESCRIPTION
## Summary of Changes
The flyPad Ground Services page has overlapping divs which caused interrupted click areas for the GPU button. 
This PR fixes these. 

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/16833201/194763247-08c35828-e712-4216-b145-ae969a496d58.png)

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Test for regression on the Ground Services page. 
Change should not have any negative impact. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
