### PR TITLE
fix: improved layout of the ground service page service labels

### DIFF
--- a/src/instruments/src/EFB/Ground/Pages/ServicesPage.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/ServicesPage.tsx
@@ -602,7 +602,7 @@ export const ServicesPage = () => {
             {!!cabinDoorOpen && (
                 <div
                     className={serviceIndicationCss}
-                    style={{ position: 'absolute', left: 515, right: 0, top: 105 }}
+                    style={{ position: 'absolute', left: 500, right: 0, top: 100 }}
                 >
                     CABIN
                 </div>
@@ -610,7 +610,7 @@ export const ServicesPage = () => {
             {!!aftDoorOpen && (
                 <div
                     className={serviceIndicationCss}
-                    style={{ position: 'absolute', left: 705, right: 0, top: 665 }}
+                    style={{ position: 'absolute', left: 700, right: 0, top: 665 }}
                 >
                     CABIN
                 </div>
@@ -618,7 +618,7 @@ export const ServicesPage = () => {
             {!!cargoDoorOpen && (
                 <div
                     className={serviceIndicationCss}
-                    style={{ position: 'absolute', left: 705, right: 0, top: 200 }}
+                    style={{ position: 'absolute', left: 700, right: 0, top: 165 }}
                 >
                     CARGO
                 </div>
@@ -626,7 +626,7 @@ export const ServicesPage = () => {
             {!!gpuActive && (
                 <div
                     className={serviceIndicationCss}
-                    style={{ position: 'absolute', left: 705, right: 0, top: 70 }}
+                    style={{ position: 'absolute', left: 700, right: 0, top: 60 }}
                 >
                     GPU
                 </div>


### PR DESCRIPTION
## Summary of Changes
Very small improvement of the placement of the ground service page service labels 

## Screenshots (if necessary)
Before:
![image](https://user-images.githubusercontent.com/16833201/196007697-6e465144-800f-4a53-babd-b90a9618a918.png)

After:
![image](https://user-images.githubusercontent.com/16833201/196007654-826f6497-be71-4f6c-bb4f-67693b0c71ad.png)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
No testing required

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
