### PR TITLE
fix(hyd): fix down elevator gain curve

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -89,6 +89,7 @@
 1. [EFB] Improved Aircraft Presets procedures - @frankkopp (Frank Kopp)
 1. [FMGC] Make DES SPD LIM available prior to descent - @tracernz (Mike)
 1. [LIGHTS] Redone cockpit emissives panels and ambient lighting -@FinalLightNL (FinalLight)
+1. [HYD] Fix incorrect gain in down pitch commands - @Crocket63 (crocket)
 
 ## 0.8.0
 

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -1005,7 +1005,8 @@ bool FlyByWireInterface::updateAdditionalData(double sampleTime) {
   additionalData.spoilers_handle_pos = idSpoilersHandlePosition->get();
   additionalData.spoilers_armed = idSpoilersArmed->get();
   additionalData.spoilers_handle_sim_pos = simData.spoilers_handle_position;
-  additionalData.ground_spoilers_active = idSecGroundSpoilersOut[0]->get() || idSecGroundSpoilersOut[1]->get() || idSecGroundSpoilersOut[2]->get();
+  additionalData.ground_spoilers_active =
+      idSecGroundSpoilersOut[0]->get() || idSecGroundSpoilersOut[1]->get() || idSecGroundSpoilersOut[2]->get();
   additionalData.flaps_handle_percent = idFlapsHandlePercent->get();
   additionalData.flaps_handle_index = idFlapsHandleIndex->get();
   additionalData.flaps_handle_configuration_index = flapsHandleIndexFlapConf->get();
@@ -1054,11 +1055,13 @@ bool FlyByWireInterface::updateAdditionalData(double sampleTime) {
   // failure
   additionalData.failuresActive = failuresConsumer.isAnyActive() ? 1.0 : 0.0;
   // aoa
-  additionalData.alpha_floor_condition = reinterpret_cast<Arinc429DiscreteWord*>(&facsBusOutputs[0].discrete_word_5)->bitFromValueOr(29, false) ||
-                                         reinterpret_cast<Arinc429DiscreteWord*>(&facsBusOutputs[1].discrete_word_5)->bitFromValueOr(29, false);
+  additionalData.alpha_floor_condition =
+      reinterpret_cast<Arinc429DiscreteWord*>(&facsBusOutputs[0].discrete_word_5)->bitFromValueOr(29, false) ||
+      reinterpret_cast<Arinc429DiscreteWord*>(&facsBusOutputs[1].discrete_word_5)->bitFromValueOr(29, false);
   // these are not correct yet
-  additionalData.high_aoa_protection = reinterpret_cast<Arinc429DiscreteWord*>(&elacsBusOutputs[0].discrete_status_word_2)->bitFromValueOr(23, false) ||
-                                       reinterpret_cast<Arinc429DiscreteWord*>(&elacsBusOutputs[1].discrete_status_word_2)->bitFromValueOr(23, false);
+  additionalData.high_aoa_protection =
+      reinterpret_cast<Arinc429DiscreteWord*>(&elacsBusOutputs[0].discrete_status_word_2)->bitFromValueOr(23, false) ||
+      reinterpret_cast<Arinc429DiscreteWord*>(&elacsBusOutputs[1].discrete_status_word_2)->bitFromValueOr(23, false);
 
   return true;
 }
@@ -1249,8 +1252,8 @@ bool FlyByWireInterface::updateElac(double sampleTime, int elacIndex) {
   elacs[elacIndex].modelInputs.in.analog_inputs.fo_roll_stick_pos = 0;
   double leftElevPos = -idLeftElevatorPosition->get();
   double rightElevPos = -idRightElevatorPosition->get();
-  elacs[elacIndex].modelInputs.in.analog_inputs.left_elevator_pos_deg = leftElevPos > 0 ? leftElevPos * 17 : leftElevPos * 30;
-  elacs[elacIndex].modelInputs.in.analog_inputs.right_elevator_pos_deg = rightElevPos > 0 ? rightElevPos * 17 : rightElevPos * 30;
+  elacs[elacIndex].modelInputs.in.analog_inputs.left_elevator_pos_deg = leftElevPos * 30;
+  elacs[elacIndex].modelInputs.in.analog_inputs.right_elevator_pos_deg = rightElevPos * 30;
   elacs[elacIndex].modelInputs.in.analog_inputs.ths_pos_deg = -simData.eta_trim_deg;
   elacs[elacIndex].modelInputs.in.analog_inputs.left_aileron_pos_deg = idLeftAileronPosition->get() * 25;
   elacs[elacIndex].modelInputs.in.analog_inputs.right_aileron_pos_deg = -idRightAileronPosition->get() * 25;
@@ -1379,8 +1382,8 @@ bool FlyByWireInterface::updateSec(double sampleTime, int secIndex) {
     secs[secIndex].modelInputs.in.analog_inputs.fo_pitch_stick_pos = 0;
     double leftElevPos = -idLeftElevatorPosition->get();
     double rightElevPos = -idRightElevatorPosition->get();
-    secs[secIndex].modelInputs.in.analog_inputs.left_elevator_pos_deg = leftElevPos > 0 ? leftElevPos * 17 : leftElevPos * 30;
-    secs[secIndex].modelInputs.in.analog_inputs.right_elevator_pos_deg = rightElevPos > 0 ? rightElevPos * 17 : rightElevPos * 30;
+    secs[secIndex].modelInputs.in.analog_inputs.left_elevator_pos_deg = leftElevPos * 30;
+    secs[secIndex].modelInputs.in.analog_inputs.right_elevator_pos_deg = rightElevPos * 30;
     secs[secIndex].modelInputs.in.analog_inputs.ths_pos_deg = -simData.eta_trim_deg;
     secs[secIndex].modelInputs.in.analog_inputs.load_factor_acc_1_g = 0;
     secs[secIndex].modelInputs.in.analog_inputs.load_factor_acc_2_g = 0;

--- a/src/systems/a320_systems/src/hydraulic/mod.rs
+++ b/src/systems/a320_systems/src/hydraulic/mod.rs
@@ -4868,6 +4868,13 @@ impl ElevatorSystemHydraulicController {
     }
 
     fn elevator_actuator_position_from_surface_angle(surface_angle: Angle) -> Ratio {
+        println!(
+            "ANGLE REQ FBW {:.2} -> Hyd val {:.2}",
+            surface_angle.get::<degree>(),
+            (-surface_angle.get::<degree>() / 47. + 17. / 47.)
+                .min(1.)
+                .max(0.),
+        );
         Ratio::new::<ratio>(
             (-surface_angle.get::<degree>() / 47. + 17. / 47.)
                 .min(1.)

--- a/src/systems/a320_systems/src/hydraulic/mod.rs
+++ b/src/systems/a320_systems/src/hydraulic/mod.rs
@@ -4868,13 +4868,6 @@ impl ElevatorSystemHydraulicController {
     }
 
     fn elevator_actuator_position_from_surface_angle(surface_angle: Angle) -> Ratio {
-        println!(
-            "ANGLE REQ FBW {:.2} -> Hyd val {:.2}",
-            surface_angle.get::<degree>(),
-            (-surface_angle.get::<degree>() / 47. + 17. / 47.)
-                .min(1.)
-                .max(0.),
-        );
         Ratio::new::<ratio>(
             (-surface_angle.get::<degree>() / 47. + 17. / 47.)
                 .min(1.)

--- a/src/systems/a320_systems_wasm/src/elevators.rs
+++ b/src/systems/a320_systems_wasm/src/elevators.rs
@@ -88,9 +88,10 @@ fn hyd_deflection_to_msfs_deflection(
 
     let normalized_angle = surface_angle / max_actual_angle;
 
-    if normalized_angle <= 0. {
-        normalized_angle * max_actual_angle / min_actual_angle
-    } else {
-        normalized_angle
-    }
+    println!(
+        "Pos normalized Hyd val {:.2} FBW fb {:.2}",
+        hyd_deflection, normalized_angle
+    );
+
+    normalized_angle
 }

--- a/src/systems/a320_systems_wasm/src/elevators.rs
+++ b/src/systems/a320_systems_wasm/src/elevators.rs
@@ -88,10 +88,5 @@ fn hyd_deflection_to_msfs_deflection(
 
     let normalized_angle = surface_angle / max_actual_angle;
 
-    println!(
-        "Pos normalized Hyd val {:.2} FBW fb {:.2}",
-        hyd_deflection, normalized_angle
-    );
-
     normalized_angle
 }

--- a/src/systems/a320_systems_wasm/src/elevators.rs
+++ b/src/systems/a320_systems_wasm/src/elevators.rs
@@ -66,8 +66,11 @@ impl VariablesToObject for PitchSimOutput {
         ]
     }
 
+    // Using a corrective factor because flight model do not have the real deflection
+    // Real deflection is -17/30
+    // If flight model deflection is -17/25, corrective factor is 17/25 / 17/30 = 1.2
     fn write(&mut self, values: Vec<f64>) -> ObjectWrite {
-        self.elevator = values[0];
+        self.elevator = 1.2 * values[0];
 
         // Not writing control feedback when in tracking mode
         ObjectWrite::on(!to_bool(values[1]))
@@ -86,7 +89,5 @@ fn hyd_deflection_to_msfs_deflection(
     let angle_zero_offset = hyd_deflection * elevator_range;
     let surface_angle = angle_zero_offset - min_actual_angle;
 
-    let normalized_angle = surface_angle / max_actual_angle;
-
-    normalized_angle
+    surface_angle / max_actual_angle
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

MSFS use the same linearity slope for down or up pitch. As elevator travel is not symmetrical, it was resulting in us having the elevator pitching down twice as fast as it should.

In direct law elevator should reach 17° down pitch at half stick, it was reporting 17° down in msfs at 1/4 of stick travel.

This should not affect normal law (exect in transient conditions maybe)

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

**This PR is linked to flight model values. Please only test in #7556 context.**

Check nothing strange happens when pitching down in normal flight or during landing/flare.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
