### PR TITLE
Memory leak fixes & using namespace std

### DIFF
--- a/src/fadec/src/FadecGauge.h
+++ b/src/fadec/src/FadecGauge.h
@@ -29,8 +29,6 @@
 
 #define DEFAULT_AIRCRAFT_REGISTRATION "ASX320"
 
-using namespace std;
-
 class FadecGauge {
  private:
   bool isConnected = false;
@@ -186,12 +184,12 @@ class FadecGauge {
     switch (pData->dwID) {
       case SIMCONNECT_RECV_ID_OPEN:
         // connection established
-        cout << "FADEC: SimConnect connection established" << endl;
+        std::cout << "FADEC: SimConnect connection established" << std::endl;
         break;
 
       case SIMCONNECT_RECV_ID_QUIT:
         // connection lost
-        cout << "FADEC: Received SimConnect connection quit message" << endl;
+        std::cout << "FADEC: Received SimConnect connection quit message" << std::endl;
         break;
 
       case SIMCONNECT_RECV_ID_SIMOBJECT_DATA:
@@ -201,10 +199,10 @@ class FadecGauge {
 
       case SIMCONNECT_RECV_ID_EXCEPTION:
         // exception
-        cout << "FADEC: Exception in SimConnect connection: ";
-        cout << getSimConnectExceptionString(
+        std::cout << "FADEC: Exception in SimConnect connection: ";
+        std::cout << getSimConnectExceptionString(
             static_cast<SIMCONNECT_EXCEPTION>(static_cast<SIMCONNECT_RECV_EXCEPTION*>(pData)->dwException));
-        cout << endl;
+        std::cout << std::endl;
         break;
 
       default:
@@ -222,15 +220,15 @@ class FadecGauge {
       case 8:
         simulationDataLivery = *((SimulationDataLivery*)&data->dwData);
         if(simulationDataLivery.atc_id[0] == '\0') {
-          cout << "FADEC: Use default aircraft registration " << DEFAULT_AIRCRAFT_REGISTRATION << endl;;
+          std::cout << "FADEC: Use default aircraft registration " << DEFAULT_AIRCRAFT_REGISTRATION << std::endl;
           strncpy(simulationDataLivery.atc_id, DEFAULT_AIRCRAFT_REGISTRATION, sizeof(simulationDataLivery.atc_id));
         }
         return;
 
       default:
         // print unknown request id
-        cout << "FADEC: Unknown request id in SimConnect connection: ";
-        cout << data->dwRequestID << endl;
+        std::cout << "FADEC: Unknown request id in SimConnect connection: ";
+        std::cout << data->dwRequestID << std::endl;
         return;
     }
   }

--- a/src/fbw/src/FlightDataRecorder.cpp
+++ b/src/fbw/src/FlightDataRecorder.cpp
@@ -11,7 +11,6 @@
 
 #include "FlightDataRecorder.h"
 
-using namespace std;
 using namespace mINI;
 
 void FlightDataRecorder::initialize() {
@@ -32,10 +31,10 @@ void FlightDataRecorder::initialize() {
   maximumSampleCounter = INITypeConversion::getInteger(iniStructure, "FLIGHT_DATA_RECORDER", "MAXIMUM_NUMBER_OF_ENTRIES_PER_FILE", 864000);
 
   // print configuration
-  cout << "WASM: Flight Data Recorder Configuration : Enabled                        = " << isEnabled << endl;
-  cout << "WASM: Flight Data Recorder Configuration : MaximumNumberOfFiles           = " << maximumFileCount << endl;
-  cout << "WASM: Flight Data Recorder Configuration : MaximumNumberOfEntriesPerFile  = " << maximumSampleCounter << endl;
-  cout << "WASM: Flight Data Recorder Configuration : Interface Version              = " << INTERFACE_VERSION << endl;
+  std::cout << "WASM: Flight Data Recorder Configuration : Enabled                        = " << isEnabled << std::endl;
+  std::cout << "WASM: Flight Data Recorder Configuration : MaximumNumberOfFiles           = " << maximumFileCount << std::endl;
+  std::cout << "WASM: Flight Data Recorder Configuration : MaximumNumberOfEntriesPerFile  = " << maximumSampleCounter << std::endl;
+  std::cout << "WASM: Flight Data Recorder Configuration : Interface Version              = " << INTERFACE_VERSION << std::endl;
 }
 
 void FlightDataRecorder::update(AutopilotStateMachineModelClass* autopilotStateMachine,
@@ -83,7 +82,7 @@ void FlightDataRecorder::manageFlightDataRecorderFiles() {
 
   if (!fileStream) {
     // create new file
-    fileStream = make_shared<gzofstream>(getFlightDataRecorderFilename().c_str());
+    fileStream = std::make_shared<gzofstream>(getFlightDataRecorderFilename().c_str());
     // write version to file
     fileStream->write((char*)&INTERFACE_VERSION, sizeof(INTERFACE_VERSION));
     // clean up directory
@@ -91,24 +90,24 @@ void FlightDataRecorder::manageFlightDataRecorderFiles() {
   }
 }
 
-string FlightDataRecorder::getFlightDataRecorderFilename() {
+std::string FlightDataRecorder::getFlightDataRecorderFilename() {
   // get time
-  auto in_time_t = chrono::system_clock::to_time_t(chrono::system_clock::now());
+  auto in_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
   // get filepath based on time
-  stringstream result;
-  result << put_time(gmtime(&in_time_t), "\\work\\%Y-%m-%d-%H-%M-%S.fdr");
+  std::stringstream result;
+  result << std::put_time(std::gmtime(&in_time_t), "\\work\\%Y-%m-%d-%H-%M-%S.fdr");
 
   // return result
   return result.str();
 }
 
 void FlightDataRecorder::cleanUpFlightDataRecorderFiles() {
-  // vector for directory entries
-  vector<string> files;
+  // std::vector for directory entries
+  std::vector<std::string> files;
 
   // extension
-  string extension = "fdr";
+  std::string extension = "fdr";
 
   // structure representing an directory entry
   struct dirent* directoryEntry;
@@ -118,20 +117,20 @@ void FlightDataRecorder::cleanUpFlightDataRecorderFiles() {
 
   // read directory until end
   while ((directoryEntry = readdir(directory)) != NULL) {
-    // get filename as string
-    string filename = directoryEntry->d_name;
+    // get filename as std::string
+    std::string filename = directoryEntry->d_name;
 
     // check if file has right extension
-    if (filename.find(extension, (filename.length() - extension.length())) != string::npos) {
-      files.push_back(filename);
+    if (filename.find(extension, (filename.length() - extension.length())) != std::string::npos) {
+      files.push_back(std::move(filename));
     }
   }
 
   // close directory
   closedir(directory);
 
-  // sort vector
-  sort(files.begin(), files.end(), std::greater<>());
+  // sort std::vector
+  std::sort(files.begin(), files.end(), std::greater<>());
 
   // remove older files
   while (files.size() > maximumFileCount) {

--- a/src/fbw/src/FlyByWireInterface.cpp
+++ b/src/fbw/src/FlyByWireInterface.cpp
@@ -8,7 +8,6 @@
 #include "FlyByWireInterface.h"
 #include "SimConnectData.h"
 
-using namespace std;
 using namespace mINI;
 
 bool FlyByWireInterface::connect() {
@@ -19,8 +18,8 @@ bool FlyByWireInterface::connect() {
   loadConfiguration();
 
   // setup handlers
-  spoilersHandler = make_shared<SpoilersHandler>();
-  elevatorTrimHandler = make_shared<ElevatorTrimHandler>();
+  spoilersHandler = std::make_shared<SpoilersHandler>();
+  elevatorTrimHandler = std::make_shared<ElevatorTrimHandler>();
 
   // initialize failures handler
   failuresConsumer.initialize();
@@ -186,15 +185,15 @@ void FlyByWireInterface::loadConfiguration() {
                        !autopilotLawsEnabled || !autoThrustEnabled || !flyByWireEnabled);
 
   // print configuration into console
-  cout << "WASM: MODEL     : CLIENT_DATA_ENABLED (auto)           = " << clientDataEnabled << endl;
-  cout << "WASM: MODEL     : AUTOPILOT_STATE_MACHINE_ENABLED      = " << autopilotStateMachineEnabled << endl;
-  cout << "WASM: MODEL     : AUTOPILOT_LAWS_ENABLED               = " << autopilotLawsEnabled << endl;
-  cout << "WASM: MODEL     : AUTOTHRUST_ENABLED                   = " << autoThrustEnabled << endl;
-  cout << "WASM: MODEL     : FLY_BY_WIRE_ENABLED                  = " << flyByWireEnabled << endl;
-  cout << "WASM: MODEL     : ELAC_DISABLED                        = " << elacDisabled << endl;
-  cout << "WASM: MODEL     : SEC_DISABLED                         = " << secDisabled << endl;
-  cout << "WASM: MODEL     : FAC_DISABLED                         = " << facDisabled << endl;
-  cout << "WASM: MODEL     : TAILSTRIKE_PROTECTION_ENABLED        = " << tailstrikeProtectionEnabled << endl;
+  std::cout << "WASM: MODEL     : CLIENT_DATA_ENABLED (auto)           = " << clientDataEnabled << std::endl;
+  std::cout << "WASM: MODEL     : AUTOPILOT_STATE_MACHINE_ENABLED      = " << autopilotStateMachineEnabled << std::endl;
+  std::cout << "WASM: MODEL     : AUTOPILOT_LAWS_ENABLED               = " << autopilotLawsEnabled << std::endl;
+  std::cout << "WASM: MODEL     : AUTOTHRUST_ENABLED                   = " << autoThrustEnabled << std::endl;
+  std::cout << "WASM: MODEL     : FLY_BY_WIRE_ENABLED                  = " << flyByWireEnabled << std::endl;
+  std::cout << "WASM: MODEL     : ELAC_DISABLED                        = " << elacDisabled << std::endl;
+  std::cout << "WASM: MODEL     : SEC_DISABLED                         = " << secDisabled << std::endl;
+  std::cout << "WASM: MODEL     : FAC_DISABLED                         = " << facDisabled << std::endl;
+  std::cout << "WASM: MODEL     : TAILSTRIKE_PROTECTION_ENABLED        = " << tailstrikeProtectionEnabled << std::endl;
 
   // --------------------------------------------------------------------------
   // load values - autopilot
@@ -204,10 +203,10 @@ void FlyByWireInterface::loadConfiguration() {
   simulationRateReductionEnabled = INITypeConversion::getBoolean(iniStructure, "AUTOPILOT", "SIMULATION_RATE_REDUCTION_ENABLED", true);
 
   // print configuration into console
-  cout << "WASM: AUTOPILOT : MINIMUM_SIMULATION_RATE                     = " << idMinimumSimulationRate->get() << endl;
-  cout << "WASM: AUTOPILOT : MAXIMUM_SIMULATION_RATE                     = " << idMaximumSimulationRate->get() << endl;
-  cout << "WASM: AUTOPILOT : LIMIT_SIMULATION_RATE_BY_PERFORMANCE        = " << limitSimulationRateByPerformance << endl;
-  cout << "WASM: AUTOPILOT : SIMULATION_RATE_REDUCTION_ENABLED           = " << simulationRateReductionEnabled << endl;
+  std::cout << "WASM: AUTOPILOT : MINIMUM_SIMULATION_RATE                     = " << idMinimumSimulationRate->get() << std::endl;
+  std::cout << "WASM: AUTOPILOT : MAXIMUM_SIMULATION_RATE                     = " << idMaximumSimulationRate->get() << std::endl;
+  std::cout << "WASM: AUTOPILOT : LIMIT_SIMULATION_RATE_BY_PERFORMANCE        = " << limitSimulationRateByPerformance << std::endl;
+  std::cout << "WASM: AUTOPILOT : SIMULATION_RATE_REDUCTION_ENABLED           = " << simulationRateReductionEnabled << std::endl;
 
   // --------------------------------------------------------------------------
   // load values - autothrust
@@ -217,7 +216,7 @@ void FlyByWireInterface::loadConfiguration() {
   idAutothrustThrustLimitREV->set(autothrustThrustLimitReverse);
 
   // print configuration into console
-  cout << "WASM: AUTOTHRUST : THRUST_LIMIT_REVERSE    = " << autothrustThrustLimitReverse << endl;
+  std::cout << "WASM: AUTOTHRUST : THRUST_LIMIT_REVERSE    = " << autothrustThrustLimitReverse << std::endl;
 
   // --------------------------------------------------------------------------
   // load values - flight controls
@@ -231,11 +230,11 @@ void FlyByWireInterface::loadConfiguration() {
       INITypeConversion::getBoolean(iniStructure, "FLIGHT_CONTROLS", "DISABLE_XBOX_COMPATIBILITY_RUDDER_AXIS_PLUS_MINUS", false);
 
   // print configuration into console
-  cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_AILERON = " << flightControlsKeyChangeAileron << endl;
-  cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_ELEVATOR = " << flightControlsKeyChangeElevator << endl;
-  cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_RUDDER = " << flightControlsKeyChangeRudder << endl;
-  cout << "WASM: FLIGHT_CONTROLS : DISABLE_XBOX_COMPATIBILITY_RUDDER_AXIS_PLUS_MINUS = " << disableXboxCompatibilityRudderAxisPlusMinus
-       << endl;
+  std::cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_AILERON = " << flightControlsKeyChangeAileron << std::endl;
+  std::cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_ELEVATOR = " << flightControlsKeyChangeElevator << std::endl;
+  std::cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_RUDDER = " << flightControlsKeyChangeRudder << std::endl;
+  std::cout << "WASM: FLIGHT_CONTROLS : DISABLE_XBOX_COMPATIBILITY_RUDDER_AXIS_PLUS_MINUS = " << disableXboxCompatibilityRudderAxisPlusMinus
+       << std::endl;
 
   // --------------------------------------------------------------------------
   // load values - logging
@@ -243,14 +242,14 @@ void FlyByWireInterface::loadConfiguration() {
   idLoggingThrottlesEnabled->set(INITypeConversion::getBoolean(iniStructure, "LOGGING", "THROTTLES_ENABLED", false));
 
   // print configuration into console
-  cout << "WASM: LOGGING : FLIGHT_CONTROLS_ENABLED = " << idLoggingFlightControlsEnabled->get() << endl;
-  cout << "WASM: LOGGING : THROTTLES_ENABLED = " << idLoggingThrottlesEnabled->get() << endl;
+  std::cout << "WASM: LOGGING : FLIGHT_CONTROLS_ENABLED = " << idLoggingFlightControlsEnabled->get() << std::endl;
+  std::cout << "WASM: LOGGING : THROTTLES_ENABLED = " << idLoggingThrottlesEnabled->get() << std::endl;
 
   // --------------------------------------------------------------------------
   // create axis and load configuration
   for (size_t i = 1; i <= 2; i++) {
     // create new mapping
-    auto axis = make_shared<ThrottleAxisMapping>(i);
+    auto axis = std::make_shared<ThrottleAxisMapping>(i);
     // load configuration from file
     axis->loadFromFile();
     // store axis
@@ -258,7 +257,7 @@ void FlyByWireInterface::loadConfiguration() {
   }
 
   // create mapping for 3D animation position
-  vector<pair<double, double>> mappingTable3d;
+  std::vector<std::pair<double, double>> mappingTable3d;
   mappingTable3d.emplace_back(-20.0, 0.0);
   mappingTable3d.emplace_back(0.0, 25.0);
   mappingTable3d.emplace_back(25.0, 50.0);
@@ -269,447 +268,447 @@ void FlyByWireInterface::loadConfiguration() {
 
 void FlyByWireInterface::setupLocalVariables() {
   // regsiter L variable for init state and ready signal
-  idIsReady = make_unique<LocalVariable>("A32NX_IS_READY");
-  idStartState = make_unique<LocalVariable>("A32NX_START_STATE");
+  idIsReady = std::make_unique<LocalVariable>("A32NX_IS_READY");
+  idStartState = std::make_unique<LocalVariable>("A32NX_START_STATE");
 
   // regsiter L variable for logging
-  idLoggingFlightControlsEnabled = make_unique<LocalVariable>("A32NX_LOGGING_FLIGHT_CONTROLS_ENABLED");
-  idLoggingThrottlesEnabled = make_unique<LocalVariable>("A32NX_LOGGING_THROTTLES_ENABLED");
+  idLoggingFlightControlsEnabled = std::make_unique<LocalVariable>("A32NX_LOGGING_FLIGHT_CONTROLS_ENABLED");
+  idLoggingThrottlesEnabled = std::make_unique<LocalVariable>("A32NX_LOGGING_THROTTLES_ENABLED");
 
   // register L variables for Autoland
-  idDevelopmentAutoland_condition_Flare = make_unique<LocalVariable>("A32NX_DEV_FLARE_CONDITION");
-  idDevelopmentAutoland_H_dot_c_fpm = make_unique<LocalVariable>("A32NX_DEV_FLARE_H_DOT_C");
-  idDevelopmentAutoland_delta_Theta_H_dot_deg = make_unique<LocalVariable>("A32NX_DEV_FLARE_DELTA_THETA_H_DOT");
-  idDevelopmentAutoland_delta_Theta_bz_deg = make_unique<LocalVariable>("A32NX_DEV_FLARE_DELTA_THETA_BZ");
-  idDevelopmentAutoland_delta_Theta_bx_deg = make_unique<LocalVariable>("A32NX_DEV_FLARE_DELTA_THETA_BX");
-  idDevelopmentAutoland_delta_Theta_beta_c_deg = make_unique<LocalVariable>("A32NX_DEV_FLARE_DELTA_THETA_BETA_C");
+  idDevelopmentAutoland_condition_Flare = std::make_unique<LocalVariable>("A32NX_DEV_FLARE_CONDITION");
+  idDevelopmentAutoland_H_dot_c_fpm = std::make_unique<LocalVariable>("A32NX_DEV_FLARE_H_DOT_C");
+  idDevelopmentAutoland_delta_Theta_H_dot_deg = std::make_unique<LocalVariable>("A32NX_DEV_FLARE_DELTA_THETA_H_DOT");
+  idDevelopmentAutoland_delta_Theta_bz_deg = std::make_unique<LocalVariable>("A32NX_DEV_FLARE_DELTA_THETA_BZ");
+  idDevelopmentAutoland_delta_Theta_bx_deg = std::make_unique<LocalVariable>("A32NX_DEV_FLARE_DELTA_THETA_BX");
+  idDevelopmentAutoland_delta_Theta_beta_c_deg = std::make_unique<LocalVariable>("A32NX_DEV_FLARE_DELTA_THETA_BETA_C");
 
   // register L variable for simulation rate limits
-  idMinimumSimulationRate = make_unique<LocalVariable>("A32NX_SIMULATION_RATE_LIMIT_MINIMUM");
-  idMaximumSimulationRate = make_unique<LocalVariable>("A32NX_SIMULATION_RATE_LIMIT_MAXIMUM");
+  idMinimumSimulationRate = std::make_unique<LocalVariable>("A32NX_SIMULATION_RATE_LIMIT_MINIMUM");
+  idMaximumSimulationRate = std::make_unique<LocalVariable>("A32NX_SIMULATION_RATE_LIMIT_MAXIMUM");
 
   // register L variable for performance warning
-  idPerformanceWarningActive = make_unique<LocalVariable>("A32NX_PERFORMANCE_WARNING_ACTIVE");
+  idPerformanceWarningActive = std::make_unique<LocalVariable>("A32NX_PERFORMANCE_WARNING_ACTIVE");
 
   // register L variable for external override
-  idTrackingMode = make_unique<LocalVariable>("A32NX_FLIGHT_CONTROLS_TRACKING_MODE");
-  idExternalOverride = make_unique<LocalVariable>("A32NX_EXTERNAL_OVERRIDE");
+  idTrackingMode = std::make_unique<LocalVariable>("A32NX_FLIGHT_CONTROLS_TRACKING_MODE");
+  idExternalOverride = std::make_unique<LocalVariable>("A32NX_EXTERNAL_OVERRIDE");
 
   // register L variable for FDR event
-  idFdrEvent = make_unique<LocalVariable>("A32NX_DFDR_EVENT_ON");
+  idFdrEvent = std::make_unique<LocalVariable>("A32NX_DFDR_EVENT_ON");
 
   // register L variables for the sidestick
-  idSideStickPositionX = make_unique<LocalVariable>("A32NX_SIDESTICK_POSITION_X");
-  idSideStickPositionY = make_unique<LocalVariable>("A32NX_SIDESTICK_POSITION_Y");
-  idRudderPedalPosition = make_unique<LocalVariable>("A32NX_RUDDER_PEDAL_POSITION");
-  idRudderPedalAnimationPosition = make_unique<LocalVariable>("A32NX_RUDDER_PEDAL_ANIMATION_POSITION");
-  idAutopilotNosewheelDemand = make_unique<LocalVariable>("A32NX_AUTOPILOT_NOSEWHEEL_DEMAND");
+  idSideStickPositionX = std::make_unique<LocalVariable>("A32NX_SIDESTICK_POSITION_X");
+  idSideStickPositionY = std::make_unique<LocalVariable>("A32NX_SIDESTICK_POSITION_Y");
+  idRudderPedalPosition = std::make_unique<LocalVariable>("A32NX_RUDDER_PEDAL_POSITION");
+  idRudderPedalAnimationPosition = std::make_unique<LocalVariable>("A32NX_RUDDER_PEDAL_ANIMATION_POSITION");
+  idAutopilotNosewheelDemand = std::make_unique<LocalVariable>("A32NX_AUTOPILOT_NOSEWHEEL_DEMAND");
 
   // register L variable for custom fly-by-wire interface
-  idFmaLateralMode = make_unique<LocalVariable>("A32NX_FMA_LATERAL_MODE");
-  idFmaLateralArmed = make_unique<LocalVariable>("A32NX_FMA_LATERAL_ARMED");
-  idFmaVerticalMode = make_unique<LocalVariable>("A32NX_FMA_VERTICAL_MODE");
-  idFmaVerticalArmed = make_unique<LocalVariable>("A32NX_FMA_VERTICAL_ARMED");
-  idFmaExpediteModeActive = make_unique<LocalVariable>("A32NX_FMA_EXPEDITE_MODE");
-  idFmaSpeedProtectionActive = make_unique<LocalVariable>("A32NX_FMA_SPEED_PROTECTION_MODE");
-  idFmaSoftAltModeActive = make_unique<LocalVariable>("A32NX_FMA_SOFT_ALT_MODE");
-  idFmaCruiseAltModeActive = make_unique<LocalVariable>("A32NX_FMA_CRUISE_ALT_MODE");
-  idFmaApproachCapability = make_unique<LocalVariable>("A32NX_ApproachCapability");
-  idFmaTripleClick = make_unique<LocalVariable>("A32NX_FMA_TRIPLE_CLICK");
-  idFmaModeReversion = make_unique<LocalVariable>("A32NX_FMA_MODE_REVERSION");
+  idFmaLateralMode = std::make_unique<LocalVariable>("A32NX_FMA_LATERAL_MODE");
+  idFmaLateralArmed = std::make_unique<LocalVariable>("A32NX_FMA_LATERAL_ARMED");
+  idFmaVerticalMode = std::make_unique<LocalVariable>("A32NX_FMA_VERTICAL_MODE");
+  idFmaVerticalArmed = std::make_unique<LocalVariable>("A32NX_FMA_VERTICAL_ARMED");
+  idFmaExpediteModeActive = std::make_unique<LocalVariable>("A32NX_FMA_EXPEDITE_MODE");
+  idFmaSpeedProtectionActive = std::make_unique<LocalVariable>("A32NX_FMA_SPEED_PROTECTION_MODE");
+  idFmaSoftAltModeActive = std::make_unique<LocalVariable>("A32NX_FMA_SOFT_ALT_MODE");
+  idFmaCruiseAltModeActive = std::make_unique<LocalVariable>("A32NX_FMA_CRUISE_ALT_MODE");
+  idFmaApproachCapability = std::make_unique<LocalVariable>("A32NX_ApproachCapability");
+  idFmaTripleClick = std::make_unique<LocalVariable>("A32NX_FMA_TRIPLE_CLICK");
+  idFmaModeReversion = std::make_unique<LocalVariable>("A32NX_FMA_MODE_REVERSION");
 
-  idAutopilotTcasMessageDisarm = make_unique<LocalVariable>("A32NX_AUTOPILOT_TCAS_MESSAGE_DISARM");
-  idAutopilotTcasMessageRaInhibited = make_unique<LocalVariable>("A32NX_AUTOPILOT_TCAS_MESSAGE_RA_INHIBITED");
-  idAutopilotTcasMessageTrkFpaDeselection = make_unique<LocalVariable>("A32NX_AUTOPILOT_TCAS_MESSAGE_TRK_FPA_DESELECTION");
+  idAutopilotTcasMessageDisarm = std::make_unique<LocalVariable>("A32NX_AUTOPILOT_TCAS_MESSAGE_DISARM");
+  idAutopilotTcasMessageRaInhibited = std::make_unique<LocalVariable>("A32NX_AUTOPILOT_TCAS_MESSAGE_RA_INHIBITED");
+  idAutopilotTcasMessageTrkFpaDeselection = std::make_unique<LocalVariable>("A32NX_AUTOPILOT_TCAS_MESSAGE_TRK_FPA_DESELECTION");
 
   // register L variable for flight director
-  idFlightDirectorBank = make_unique<LocalVariable>("A32NX_FLIGHT_DIRECTOR_BANK");
-  idFlightDirectorPitch = make_unique<LocalVariable>("A32NX_FLIGHT_DIRECTOR_PITCH");
-  idFlightDirectorYaw = make_unique<LocalVariable>("A32NX_FLIGHT_DIRECTOR_YAW");
+  idFlightDirectorBank = std::make_unique<LocalVariable>("A32NX_FLIGHT_DIRECTOR_BANK");
+  idFlightDirectorPitch = std::make_unique<LocalVariable>("A32NX_FLIGHT_DIRECTOR_PITCH");
+  idFlightDirectorYaw = std::make_unique<LocalVariable>("A32NX_FLIGHT_DIRECTOR_YAW");
 
   // register L variables for autoland warning
-  idAutopilotAutolandWarning = make_unique<LocalVariable>("A32NX_AUTOPILOT_AUTOLAND_WARNING");
+  idAutopilotAutolandWarning = std::make_unique<LocalVariable>("A32NX_AUTOPILOT_AUTOLAND_WARNING");
 
   // register L variables for relative speed to ground
-  idAutopilot_H_dot_radio = make_unique<LocalVariable>("A32NX_AUTOPILOT_H_DOT_RADIO");
+  idAutopilot_H_dot_radio = std::make_unique<LocalVariable>("A32NX_AUTOPILOT_H_DOT_RADIO");
 
   // register L variables for autopilot
-  idAutopilotActiveAny = make_unique<LocalVariable>("A32NX_AUTOPILOT_ACTIVE");
-  idAutopilotActive_1 = make_unique<LocalVariable>("A32NX_AUTOPILOT_1_ACTIVE");
-  idAutopilotActive_2 = make_unique<LocalVariable>("A32NX_AUTOPILOT_2_ACTIVE");
+  idAutopilotActiveAny = std::make_unique<LocalVariable>("A32NX_AUTOPILOT_ACTIVE");
+  idAutopilotActive_1 = std::make_unique<LocalVariable>("A32NX_AUTOPILOT_1_ACTIVE");
+  idAutopilotActive_2 = std::make_unique<LocalVariable>("A32NX_AUTOPILOT_2_ACTIVE");
 
-  idAutopilotAutothrustMode = make_unique<LocalVariable>("A32NX_AUTOPILOT_AUTOTHRUST_MODE");
+  idAutopilotAutothrustMode = std::make_unique<LocalVariable>("A32NX_AUTOPILOT_AUTOTHRUST_MODE");
 
   // register L variables for flight guidance
-  idFwcFlightPhase = make_unique<LocalVariable>("A32NX_FWC_FLIGHT_PHASE");
-  idFmgcFlightPhase = make_unique<LocalVariable>("A32NX_FMGC_FLIGHT_PHASE");
-  idFmgcV2 = make_unique<LocalVariable>("AIRLINER_V2_SPEED");
-  idFmgcV_APP = make_unique<LocalVariable>("AIRLINER_VAPP_SPEED");
-  idFmgcV_LS = make_unique<LocalVariable>("A32NX_SPEEDS_VLS");
-  idFmgcV_MAX = make_unique<LocalVariable>("A32NX_SPEEDS_VMAX");
+  idFwcFlightPhase = std::make_unique<LocalVariable>("A32NX_FWC_FLIGHT_PHASE");
+  idFmgcFlightPhase = std::make_unique<LocalVariable>("A32NX_FMGC_FLIGHT_PHASE");
+  idFmgcV2 = std::make_unique<LocalVariable>("AIRLINER_V2_SPEED");
+  idFmgcV_APP = std::make_unique<LocalVariable>("AIRLINER_VAPP_SPEED");
+  idFmgcV_LS = std::make_unique<LocalVariable>("A32NX_SPEEDS_VLS");
+  idFmgcV_MAX = std::make_unique<LocalVariable>("A32NX_SPEEDS_VMAX");
 
-  idFmgcAltitudeConstraint = make_unique<LocalVariable>("A32NX_FG_ALTITUDE_CONSTRAINT");
-  idFmgcThrustReductionAltitude = make_unique<LocalVariable>("AIRLINER_THR_RED_ALT");
-  idFmgcThrustReductionAltitudeGoAround = make_unique<LocalVariable>("AIRLINER_THR_RED_ALT_GOAROUND");
-  idFmgcAccelerationAltitude = make_unique<LocalVariable>("AIRLINER_ACC_ALT");
-  idFmgcAccelerationAltitudeEngineOut = make_unique<LocalVariable>("A32NX_ENG_OUT_ACC_ALT");
-  idFmgcAccelerationAltitudeGoAround = make_unique<LocalVariable>("AIRLINER_ACC_ALT_GOAROUND");
-  idFmgcAccelerationAltitudeGoAroundEngineOut = make_unique<LocalVariable>("AIRLINER_ENG_OUT_ACC_ALT_GOAROUND");
-  idFmgcCruiseAltitude = make_unique<LocalVariable>("AIRLINER_CRUISE_ALTITUDE");
-  idFmgcFlexTemperature = make_unique<LocalVariable>("AIRLINER_TO_FLEX_TEMP");
+  idFmgcAltitudeConstraint = std::make_unique<LocalVariable>("A32NX_FG_ALTITUDE_CONSTRAINT");
+  idFmgcThrustReductionAltitude = std::make_unique<LocalVariable>("AIRLINER_THR_RED_ALT");
+  idFmgcThrustReductionAltitudeGoAround = std::make_unique<LocalVariable>("AIRLINER_THR_RED_ALT_GOAROUND");
+  idFmgcAccelerationAltitude = std::make_unique<LocalVariable>("AIRLINER_ACC_ALT");
+  idFmgcAccelerationAltitudeEngineOut = std::make_unique<LocalVariable>("A32NX_ENG_OUT_ACC_ALT");
+  idFmgcAccelerationAltitudeGoAround = std::make_unique<LocalVariable>("AIRLINER_ACC_ALT_GOAROUND");
+  idFmgcAccelerationAltitudeGoAroundEngineOut = std::make_unique<LocalVariable>("AIRLINER_ENG_OUT_ACC_ALT_GOAROUND");
+  idFmgcCruiseAltitude = std::make_unique<LocalVariable>("AIRLINER_CRUISE_ALTITUDE");
+  idFmgcFlexTemperature = std::make_unique<LocalVariable>("AIRLINER_TO_FLEX_TEMP");
 
-  idFlightGuidanceAvailable = make_unique<LocalVariable>("A32NX_FG_AVAIL");
-  idFlightGuidanceCrossTrackError = make_unique<LocalVariable>("A32NX_FG_CROSS_TRACK_ERROR");
-  idFlightGuidanceTrackAngleError = make_unique<LocalVariable>("A32NX_FG_TRACK_ANGLE_ERROR");
-  idFlightGuidancePhiCommand = make_unique<LocalVariable>("A32NX_FG_PHI_COMMAND");
-  idFlightGuidancePhiLimit = make_unique<LocalVariable>("A32NX_FG_PHI_LIMIT");
-  idFlightGuidanceRequestedVerticalMode = make_unique<LocalVariable>("A32NX_FG_REQUESTED_VERTICAL_MODE");
-  idFlightGuidanceTargetAltitude = make_unique<LocalVariable>("A32NX_FG_TARGET_ALTITUDE");
-  idFlightGuidanceTargetVerticalSpeed = make_unique<LocalVariable>("A32NX_FG_TARGET_VERTICAL_SPEED");
-  idFmRnavAppSelected = make_unique<LocalVariable>("A32NX_FG_RNAV_APP_SELECTED");
-  idFmFinalCanEngage = make_unique<LocalVariable>("A32NX_FG_FINAL_CAN_ENGAGE");
+  idFlightGuidanceAvailable = std::make_unique<LocalVariable>("A32NX_FG_AVAIL");
+  idFlightGuidanceCrossTrackError = std::make_unique<LocalVariable>("A32NX_FG_CROSS_TRACK_ERROR");
+  idFlightGuidanceTrackAngleError = std::make_unique<LocalVariable>("A32NX_FG_TRACK_ANGLE_ERROR");
+  idFlightGuidancePhiCommand = std::make_unique<LocalVariable>("A32NX_FG_PHI_COMMAND");
+  idFlightGuidancePhiLimit = std::make_unique<LocalVariable>("A32NX_FG_PHI_LIMIT");
+  idFlightGuidanceRequestedVerticalMode = std::make_unique<LocalVariable>("A32NX_FG_REQUESTED_VERTICAL_MODE");
+  idFlightGuidanceTargetAltitude = std::make_unique<LocalVariable>("A32NX_FG_TARGET_ALTITUDE");
+  idFlightGuidanceTargetVerticalSpeed = std::make_unique<LocalVariable>("A32NX_FG_TARGET_VERTICAL_SPEED");
+  idFmRnavAppSelected = std::make_unique<LocalVariable>("A32NX_FG_RNAV_APP_SELECTED");
+  idFmFinalCanEngage = std::make_unique<LocalVariable>("A32NX_FG_FINAL_CAN_ENGAGE");
 
-  idTcasFault = make_unique<LocalVariable>("A32NX_TCAS_FAULT");
-  idTcasMode = make_unique<LocalVariable>("A32NX_TCAS_MODE");
-  idTcasTaOnly = make_unique<LocalVariable>("A32NX_TCAS_TA_ONLY");
-  idTcasState = make_unique<LocalVariable>("A32NX_TCAS_STATE");
-  idTcasRaCorrective = make_unique<LocalVariable>("A32NX_TCAS_RA_CORRECTIVE");
-  idTcasTargetGreenMin = make_unique<LocalVariable>("A32NX_TCAS_VSPEED_GREEN:1");
-  idTcasTargetGreenMax = make_unique<LocalVariable>("A32NX_TCAS_VSPEED_GREEN:2");
-  idTcasTargetRedMin = make_unique<LocalVariable>("A32NX_TCAS_VSPEED_RED:1");
-  idTcasTargetRedMax = make_unique<LocalVariable>("A32NX_TCAS_VSPEED_RED:2");
+  idTcasFault = std::make_unique<LocalVariable>("A32NX_TCAS_FAULT");
+  idTcasMode = std::make_unique<LocalVariable>("A32NX_TCAS_MODE");
+  idTcasTaOnly = std::make_unique<LocalVariable>("A32NX_TCAS_TA_ONLY");
+  idTcasState = std::make_unique<LocalVariable>("A32NX_TCAS_STATE");
+  idTcasRaCorrective = std::make_unique<LocalVariable>("A32NX_TCAS_RA_CORRECTIVE");
+  idTcasTargetGreenMin = std::make_unique<LocalVariable>("A32NX_TCAS_VSPEED_GREEN:1");
+  idTcasTargetGreenMax = std::make_unique<LocalVariable>("A32NX_TCAS_VSPEED_GREEN:2");
+  idTcasTargetRedMin = std::make_unique<LocalVariable>("A32NX_TCAS_VSPEED_RED:1");
+  idTcasTargetRedMax = std::make_unique<LocalVariable>("A32NX_TCAS_VSPEED_RED:2");
 
-  idFcuTrkFpaModeActive = make_unique<LocalVariable>("A32NX_TRK_FPA_MODE_ACTIVE");
-  idFcuSelectedFpa = make_unique<LocalVariable>("A32NX_AUTOPILOT_FPA_SELECTED");
-  idFcuSelectedVs = make_unique<LocalVariable>("A32NX_AUTOPILOT_VS_SELECTED");
-  idFcuSelectedHeading = make_unique<LocalVariable>("A32NX_AUTOPILOT_HEADING_SELECTED");
+  idFcuTrkFpaModeActive = std::make_unique<LocalVariable>("A32NX_TRK_FPA_MODE_ACTIVE");
+  idFcuSelectedFpa = std::make_unique<LocalVariable>("A32NX_AUTOPILOT_FPA_SELECTED");
+  idFcuSelectedVs = std::make_unique<LocalVariable>("A32NX_AUTOPILOT_VS_SELECTED");
+  idFcuSelectedHeading = std::make_unique<LocalVariable>("A32NX_AUTOPILOT_HEADING_SELECTED");
 
-  idFcuLocModeActive = make_unique<LocalVariable>("A32NX_FCU_LOC_MODE_ACTIVE");
-  idFcuApprModeActive = make_unique<LocalVariable>("A32NX_FCU_APPR_MODE_ACTIVE");
-  idFcuHeadingSync = make_unique<LocalVariable>("A32NX_FCU_HEADING_SYNC");
-  idFcuModeReversionActive = make_unique<LocalVariable>("A32NX_FCU_MODE_REVERSION_ACTIVE");
-  idFcuModeReversionTrkFpaActive = make_unique<LocalVariable>("A32NX_FCU_MODE_REVERSION_TRK_FPA_ACTIVE");
-  idFcuModeReversionTargetFpm = make_unique<LocalVariable>("A32NX_FCU_MODE_REVERSION_TARGET_FPM");
+  idFcuLocModeActive = std::make_unique<LocalVariable>("A32NX_FCU_LOC_MODE_ACTIVE");
+  idFcuApprModeActive = std::make_unique<LocalVariable>("A32NX_FCU_APPR_MODE_ACTIVE");
+  idFcuHeadingSync = std::make_unique<LocalVariable>("A32NX_FCU_HEADING_SYNC");
+  idFcuModeReversionActive = std::make_unique<LocalVariable>("A32NX_FCU_MODE_REVERSION_ACTIVE");
+  idFcuModeReversionTrkFpaActive = std::make_unique<LocalVariable>("A32NX_FCU_MODE_REVERSION_TRK_FPA_ACTIVE");
+  idFcuModeReversionTargetFpm = std::make_unique<LocalVariable>("A32NX_FCU_MODE_REVERSION_TARGET_FPM");
 
-  idThrottlePosition3d_1 = make_unique<LocalVariable>("A32NX_3D_THROTTLE_LEVER_POSITION_1");
-  idThrottlePosition3d_2 = make_unique<LocalVariable>("A32NX_3D_THROTTLE_LEVER_POSITION_2");
+  idThrottlePosition3d_1 = std::make_unique<LocalVariable>("A32NX_3D_THROTTLE_LEVER_POSITION_1");
+  idThrottlePosition3d_2 = std::make_unique<LocalVariable>("A32NX_3D_THROTTLE_LEVER_POSITION_2");
 
-  idAutothrustStatus = make_unique<LocalVariable>("A32NX_AUTOTHRUST_STATUS");
-  idAutothrustMode = make_unique<LocalVariable>("A32NX_AUTOTHRUST_MODE");
-  idAutothrustModeMessage = make_unique<LocalVariable>("A32NX_AUTOTHRUST_MODE_MESSAGE");
-  idAutothrustDisabled = make_unique<LocalVariable>("A32NX_AUTOTHRUST_DISABLED");
-  idAutothrustThrustLeverWarningFlex = make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LEVER_WARNING_FLEX");
-  idAutothrustThrustLeverWarningToga = make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LEVER_WARNING_TOGA");
-  idAutothrustDisconnect = make_unique<LocalVariable>("A32NX_AUTOTHRUST_DISCONNECT");
+  idAutothrustStatus = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_STATUS");
+  idAutothrustMode = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_MODE");
+  idAutothrustModeMessage = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_MODE_MESSAGE");
+  idAutothrustDisabled = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_DISABLED");
+  idAutothrustThrustLeverWarningFlex = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LEVER_WARNING_FLEX");
+  idAutothrustThrustLeverWarningToga = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LEVER_WARNING_TOGA");
+  idAutothrustDisconnect = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_DISCONNECT");
 
-  idAirConditioningPack_1 = make_unique<LocalVariable>("A32NX_OVHD_COND_PACK_1_PB_IS_ON");
-  idAirConditioningPack_2 = make_unique<LocalVariable>("A32NX_OVHD_COND_PACK_2_PB_IS_ON");
+  idAirConditioningPack_1 = std::make_unique<LocalVariable>("A32NX_OVHD_COND_PACK_1_PB_IS_ON");
+  idAirConditioningPack_2 = std::make_unique<LocalVariable>("A32NX_OVHD_COND_PACK_2_PB_IS_ON");
 
-  idAutothrustThrustLimitType = make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT_TYPE");
-  idAutothrustThrustLimit = make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT");
-  idAutothrustThrustLimitREV = make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT_REV");
-  idAutothrustThrustLimitIDLE = make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT_IDLE");
-  idAutothrustThrustLimitCLB = make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT_CLB");
-  idAutothrustThrustLimitMCT = make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT_MCT");
-  idAutothrustThrustLimitFLX = make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT_FLX");
-  idAutothrustThrustLimitTOGA = make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT_TOGA");
-  thrustLeverAngle_1 = make_unique<LocalVariable>("A32NX_AUTOTHRUST_TLA:1");
-  thrustLeverAngle_2 = make_unique<LocalVariable>("A32NX_AUTOTHRUST_TLA:2");
-  idAutothrustN1_TLA_1 = make_unique<LocalVariable>("A32NX_AUTOTHRUST_TLA_N1:1");
-  idAutothrustN1_TLA_2 = make_unique<LocalVariable>("A32NX_AUTOTHRUST_TLA_N1:2");
-  idAutothrustReverse_1 = make_unique<LocalVariable>("A32NX_AUTOTHRUST_REVERSE:1");
-  idAutothrustReverse_2 = make_unique<LocalVariable>("A32NX_AUTOTHRUST_REVERSE:2");
-  idAutothrustN1_c_1 = make_unique<LocalVariable>("A32NX_AUTOTHRUST_N1_COMMANDED:1");
-  idAutothrustN1_c_2 = make_unique<LocalVariable>("A32NX_AUTOTHRUST_N1_COMMANDED:2");
+  idAutothrustThrustLimitType = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT_TYPE");
+  idAutothrustThrustLimit = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT");
+  idAutothrustThrustLimitREV = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT_REV");
+  idAutothrustThrustLimitIDLE = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT_IDLE");
+  idAutothrustThrustLimitCLB = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT_CLB");
+  idAutothrustThrustLimitMCT = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT_MCT");
+  idAutothrustThrustLimitFLX = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT_FLX");
+  idAutothrustThrustLimitTOGA = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_THRUST_LIMIT_TOGA");
+  thrustLeverAngle_1 = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_TLA:1");
+  thrustLeverAngle_2 = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_TLA:2");
+  idAutothrustN1_TLA_1 = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_TLA_N1:1");
+  idAutothrustN1_TLA_2 = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_TLA_N1:2");
+  idAutothrustReverse_1 = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_REVERSE:1");
+  idAutothrustReverse_2 = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_REVERSE:2");
+  idAutothrustN1_c_1 = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_N1_COMMANDED:1");
+  idAutothrustN1_c_2 = std::make_unique<LocalVariable>("A32NX_AUTOTHRUST_N1_COMMANDED:2");
 
-  idMasterWarning = make_unique<LocalVariable>("A32NX_MASTER_WARNING");
-  idMasterCaution = make_unique<LocalVariable>("A32NX_MASTER_CAUTION");
-  idParkBrakeLeverPos = make_unique<LocalVariable>("A32NX_PARK_BRAKE_LEVER_POS");
-  idBrakePedalLeftPos = make_unique<LocalVariable>("A32NX_LEFT_BRAKE_PEDAL_INPUT");
-  idBrakePedalRightPos = make_unique<LocalVariable>("A32NX_RIGHT_BRAKE_PEDAL_INPUT");
-  idAutobrakeArmedMode = make_unique<LocalVariable>("A32NX_AUTOBRAKES_ARMED_MODE");
-  idAutobrakeDecelLight = make_unique<LocalVariable>("A32NX_AUTOBRAKES_DECEL_LIGHT");
-  idFlapsHandlePercent = make_unique<LocalVariable>("A32NX_FLAPS_HANDLE_PERCENT");
-  idFlapsHandleIndex = make_unique<LocalVariable>("A32NX_FLAPS_HANDLE_INDEX");
-  idHydraulicGreenPressure = make_unique<LocalVariable>("A32NX_HYD_GREEN_SYSTEM_1_SECTION_PRESSURE");
-  idHydraulicBluePressure = make_unique<LocalVariable>("A32NX_HYD_BLUE_SYSTEM_1_SECTION_PRESSURE");
-  idHydraulicYellowPressure = make_unique<LocalVariable>("A32NX_HYD_YELLOW_SYSTEM_1_SECTION_PRESSURE");
+  idMasterWarning = std::make_unique<LocalVariable>("A32NX_MASTER_WARNING");
+  idMasterCaution = std::make_unique<LocalVariable>("A32NX_MASTER_CAUTION");
+  idParkBrakeLeverPos = std::make_unique<LocalVariable>("A32NX_PARK_BRAKE_LEVER_POS");
+  idBrakePedalLeftPos = std::make_unique<LocalVariable>("A32NX_LEFT_BRAKE_PEDAL_INPUT");
+  idBrakePedalRightPos = std::make_unique<LocalVariable>("A32NX_RIGHT_BRAKE_PEDAL_INPUT");
+  idAutobrakeArmedMode = std::make_unique<LocalVariable>("A32NX_AUTOBRAKES_ARMED_MODE");
+  idAutobrakeDecelLight = std::make_unique<LocalVariable>("A32NX_AUTOBRAKES_DECEL_LIGHT");
+  idFlapsHandlePercent = std::make_unique<LocalVariable>("A32NX_FLAPS_HANDLE_PERCENT");
+  idFlapsHandleIndex = std::make_unique<LocalVariable>("A32NX_FLAPS_HANDLE_INDEX");
+  idHydraulicGreenPressure = std::make_unique<LocalVariable>("A32NX_HYD_GREEN_SYSTEM_1_SECTION_PRESSURE");
+  idHydraulicBluePressure = std::make_unique<LocalVariable>("A32NX_HYD_BLUE_SYSTEM_1_SECTION_PRESSURE");
+  idHydraulicYellowPressure = std::make_unique<LocalVariable>("A32NX_HYD_YELLOW_SYSTEM_1_SECTION_PRESSURE");
 
-  engineEngine1N2 = make_unique<LocalVariable>("A32NX_ENGINE_N2:1");
-  engineEngine2N2 = make_unique<LocalVariable>("A32NX_ENGINE_N2:2");
-  engineEngine1N1 = make_unique<LocalVariable>("A32NX_ENGINE_N1:1");
-  engineEngine2N1 = make_unique<LocalVariable>("A32NX_ENGINE_N1:2");
-  engineEngineIdleN1 = make_unique<LocalVariable>("A32NX_ENGINE_IDLE_N1");
-  engineEngineIdleN2 = make_unique<LocalVariable>("A32NX_ENGINE_IDLE_N2");
-  engineEngineIdleFF = make_unique<LocalVariable>("A32NX_ENGINE_IDLE_FF");
-  engineEngineIdleEGT = make_unique<LocalVariable>("A32NX_ENGINE_IDLE_EGT");
-  engineEngine1EGT = make_unique<LocalVariable>("A32NX_ENGINE_EGT:1");
-  engineEngine2EGT = make_unique<LocalVariable>("A32NX_ENGINE_EGT:2");
-  engineEngine1Oil = make_unique<LocalVariable>("A32NX_ENGINE_TANK_OIL:1");
-  engineEngine2Oil = make_unique<LocalVariable>("A32NX_ENGINE_TANK_OIL:2");
-  engineEngine1TotalOil = make_unique<LocalVariable>("A32NX_ENGINE_TOTAL_OIL:1");
-  engineEngine2TotalOil = make_unique<LocalVariable>("A32NX_ENGINE_TOTAL_OIL:2");
-  engineEngine1FF = make_unique<LocalVariable>("A32NX_ENGINE_FF:1");
-  engineEngine2FF = make_unique<LocalVariable>("A32NX_ENGINE_FF:2");
-  engineEngine1PreFF = make_unique<LocalVariable>("A32NX_ENGINE_PRE_FF:1");
-  engineEngine2PreFF = make_unique<LocalVariable>("A32NX_ENGINE_PRE_FF:2");
-  engineEngineImbalance = make_unique<LocalVariable>("A32NX_ENGINE_IMBALANCE");
-  engineFuelUsedLeft = make_unique<LocalVariable>("A32NX_FUEL_USED:1");
-  engineFuelUsedRight = make_unique<LocalVariable>("A32NX_FUEL_USED:2");
-  engineFuelLeftPre = make_unique<LocalVariable>("A32NX_FUEL_LEFT_PRE");
-  engineFuelRightPre = make_unique<LocalVariable>("A32NX_FUEL_RIGHT_PRE");
-  engineFuelAuxLeftPre = make_unique<LocalVariable>("A32NX_FUEL_AUX_LEFT_PRE");
-  engineFuelAuxRightPre = make_unique<LocalVariable>("A32NX_FUEL_AUX_RIGHT_PRE");
-  engineFuelCenterPre = make_unique<LocalVariable>("A32NX_FUEL_CENTER_PRE");
-  engineEngineCycleTime = make_unique<LocalVariable>("A32NX_ENGINE_CYCLE_TIME");
-  engineEngine1State = make_unique<LocalVariable>("A32NX_ENGINE_STATE:1");
-  engineEngine2State = make_unique<LocalVariable>("A32NX_ENGINE_STATE:2");
-  engineEngine1Timer = make_unique<LocalVariable>("A32NX_ENGINE_TIMER:1");
-  engineEngine2Timer = make_unique<LocalVariable>("A32NX_ENGINE_TIMER:2");
+  engineEngine1N2 = std::make_unique<LocalVariable>("A32NX_ENGINE_N2:1");
+  engineEngine2N2 = std::make_unique<LocalVariable>("A32NX_ENGINE_N2:2");
+  engineEngine1N1 = std::make_unique<LocalVariable>("A32NX_ENGINE_N1:1");
+  engineEngine2N1 = std::make_unique<LocalVariable>("A32NX_ENGINE_N1:2");
+  engineEngineIdleN1 = std::make_unique<LocalVariable>("A32NX_ENGINE_IDLE_N1");
+  engineEngineIdleN2 = std::make_unique<LocalVariable>("A32NX_ENGINE_IDLE_N2");
+  engineEngineIdleFF = std::make_unique<LocalVariable>("A32NX_ENGINE_IDLE_FF");
+  engineEngineIdleEGT = std::make_unique<LocalVariable>("A32NX_ENGINE_IDLE_EGT");
+  engineEngine1EGT = std::make_unique<LocalVariable>("A32NX_ENGINE_EGT:1");
+  engineEngine2EGT = std::make_unique<LocalVariable>("A32NX_ENGINE_EGT:2");
+  engineEngine1Oil = std::make_unique<LocalVariable>("A32NX_ENGINE_TANK_OIL:1");
+  engineEngine2Oil = std::make_unique<LocalVariable>("A32NX_ENGINE_TANK_OIL:2");
+  engineEngine1TotalOil = std::make_unique<LocalVariable>("A32NX_ENGINE_TOTAL_OIL:1");
+  engineEngine2TotalOil = std::make_unique<LocalVariable>("A32NX_ENGINE_TOTAL_OIL:2");
+  engineEngine1FF = std::make_unique<LocalVariable>("A32NX_ENGINE_FF:1");
+  engineEngine2FF = std::make_unique<LocalVariable>("A32NX_ENGINE_FF:2");
+  engineEngine1PreFF = std::make_unique<LocalVariable>("A32NX_ENGINE_PRE_FF:1");
+  engineEngine2PreFF = std::make_unique<LocalVariable>("A32NX_ENGINE_PRE_FF:2");
+  engineEngineImbalance = std::make_unique<LocalVariable>("A32NX_ENGINE_IMBALANCE");
+  engineFuelUsedLeft = std::make_unique<LocalVariable>("A32NX_FUEL_USED:1");
+  engineFuelUsedRight = std::make_unique<LocalVariable>("A32NX_FUEL_USED:2");
+  engineFuelLeftPre = std::make_unique<LocalVariable>("A32NX_FUEL_LEFT_PRE");
+  engineFuelRightPre = std::make_unique<LocalVariable>("A32NX_FUEL_RIGHT_PRE");
+  engineFuelAuxLeftPre = std::make_unique<LocalVariable>("A32NX_FUEL_AUX_LEFT_PRE");
+  engineFuelAuxRightPre = std::make_unique<LocalVariable>("A32NX_FUEL_AUX_RIGHT_PRE");
+  engineFuelCenterPre = std::make_unique<LocalVariable>("A32NX_FUEL_CENTER_PRE");
+  engineEngineCycleTime = std::make_unique<LocalVariable>("A32NX_ENGINE_CYCLE_TIME");
+  engineEngine1State = std::make_unique<LocalVariable>("A32NX_ENGINE_STATE:1");
+  engineEngine2State = std::make_unique<LocalVariable>("A32NX_ENGINE_STATE:2");
+  engineEngine1Timer = std::make_unique<LocalVariable>("A32NX_ENGINE_TIMER:1");
+  engineEngine2Timer = std::make_unique<LocalVariable>("A32NX_ENGINE_TIMER:2");
 
-  flapsHandleIndexFlapConf = make_unique<LocalVariable>("A32NX_FLAPS_CONF_INDEX");
-  flapsPosition = make_unique<LocalVariable>("A32NX_LEFT_FLAPS_ANGLE");
+  flapsHandleIndexFlapConf = std::make_unique<LocalVariable>("A32NX_FLAPS_CONF_INDEX");
+  flapsPosition = std::make_unique<LocalVariable>("A32NX_LEFT_FLAPS_ANGLE");
 
-  idSpoilersArmed = make_unique<LocalVariable>("A32NX_SPOILERS_ARMED");
-  idSpoilersHandlePosition = make_unique<LocalVariable>("A32NX_SPOILERS_HANDLE_POSITION");
+  idSpoilersArmed = std::make_unique<LocalVariable>("A32NX_SPOILERS_ARMED");
+  idSpoilersHandlePosition = std::make_unique<LocalVariable>("A32NX_SPOILERS_HANDLE_POSITION");
 
-  idRudderPosition = make_unique<LocalVariable>("A32NX_RUDDER_DEFLECTION_DEMAND");
+  idRudderPosition = std::make_unique<LocalVariable>("A32NX_RUDDER_DEFLECTION_DEMAND");
 
-  idRadioReceiverUsageEnabled = make_unique<LocalVariable>("A32NX_RADIO_RECEIVER_USAGE_ENABLED");
-  idRadioReceiverLocalizerValid = make_unique<LocalVariable>("A32NX_RADIO_RECEIVER_LOC_IS_VALID");
-  idRadioReceiverLocalizerDeviation = make_unique<LocalVariable>("A32NX_RADIO_RECEIVER_LOC_DEVIATION");
-  idRadioReceiverLocalizerDistance = make_unique<LocalVariable>("A32NX_RADIO_RECEIVER_LOC_DISTANCE");
-  idRadioReceiverGlideSlopeValid = make_unique<LocalVariable>("A32NX_RADIO_RECEIVER_GS_IS_VALID");
-  idRadioReceiverGlideSlopeDeviation = make_unique<LocalVariable>("A32NX_RADIO_RECEIVER_GS_DEVIATION");
+  idRadioReceiverUsageEnabled = std::make_unique<LocalVariable>("A32NX_RADIO_RECEIVER_USAGE_ENABLED");
+  idRadioReceiverLocalizerValid = std::make_unique<LocalVariable>("A32NX_RADIO_RECEIVER_LOC_IS_VALID");
+  idRadioReceiverLocalizerDeviation = std::make_unique<LocalVariable>("A32NX_RADIO_RECEIVER_LOC_DEVIATION");
+  idRadioReceiverLocalizerDistance = std::make_unique<LocalVariable>("A32NX_RADIO_RECEIVER_LOC_DISTANCE");
+  idRadioReceiverGlideSlopeValid = std::make_unique<LocalVariable>("A32NX_RADIO_RECEIVER_GS_IS_VALID");
+  idRadioReceiverGlideSlopeDeviation = std::make_unique<LocalVariable>("A32NX_RADIO_RECEIVER_GS_DEVIATION");
 
-  idRealisticTillerEnabled = make_unique<LocalVariable>("A32NX_REALISTIC_TILLER_ENABLED");
-  idTillerHandlePosition = make_unique<LocalVariable>("A32NX_TILLER_HANDLE_POSITION");
-  idNoseWheelPosition = make_unique<LocalVariable>("A32NX_NOSE_WHEEL_POSITION");
+  idRealisticTillerEnabled = std::make_unique<LocalVariable>("A32NX_REALISTIC_TILLER_ENABLED");
+  idTillerHandlePosition = std::make_unique<LocalVariable>("A32NX_TILLER_HANDLE_POSITION");
+  idNoseWheelPosition = std::make_unique<LocalVariable>("A32NX_NOSE_WHEEL_POSITION");
 
-  idSyncFoEfisEnabled = make_unique<LocalVariable>("A32NX_FO_SYNC_EFIS_ENABLED");
+  idSyncFoEfisEnabled = std::make_unique<LocalVariable>("A32NX_FO_SYNC_EFIS_ENABLED");
 
-  idLs1Active = make_unique<LocalVariable>("BTN_LS_1_FILTER_ACTIVE");
-  idLs2Active = make_unique<LocalVariable>("BTN_LS_2_FILTER_ACTIVE");
-  idIsisLsActive = make_unique<LocalVariable>("A32NX_ISIS_LS_ACTIVE");
+  idLs1Active = std::make_unique<LocalVariable>("BTN_LS_1_FILTER_ACTIVE");
+  idLs2Active = std::make_unique<LocalVariable>("BTN_LS_2_FILTER_ACTIVE");
+  idIsisLsActive = std::make_unique<LocalVariable>("A32NX_ISIS_LS_ACTIVE");
 
-  idWingAntiIce = make_unique<LocalVariable>("A32NX_PNEU_WING_ANTI_ICE_SYSTEM_ON");
+  idWingAntiIce = std::make_unique<LocalVariable>("A32NX_PNEU_WING_ANTI_ICE_SYSTEM_ON");
 
   for (int i = 0; i < 2; i++) {
-    string idString = std::to_string(i + 1);
-    idRadioAltimeterHeight[i] = make_unique<LocalVariable>("A32NX_RA_" + idString + "_RADIO_ALTITUDE");
+    std::string idString = std::to_string(i + 1);
+    idRadioAltimeterHeight[i] = std::make_unique<LocalVariable>("A32NX_RA_" + idString + "_RADIO_ALTITUDE");
   }
 
   for (int i = 0; i < 2; i++) {
-    string idString = std::to_string(i + 1);
-    idLgciuNoseGearCompressed[i] = make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_NOSE_GEAR_COMPRESSED");
-    idLgciuLeftMainGearCompressed[i] = make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_LEFT_GEAR_COMPRESSED");
-    idLgciuRightMainGearCompressed[i] = make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_RIGHT_GEAR_COMPRESSED");
-    idLgciuDiscreteWord1[i] = make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_DISCRETE_WORD_1");
-    idLgciuDiscreteWord2[i] = make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_DISCRETE_WORD_2");
-    idLgciuDiscreteWord3[i] = make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_DISCRETE_WORD_3");
+    std::string idString = std::to_string(i + 1);
+    idLgciuNoseGearCompressed[i] = std::make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_NOSE_GEAR_COMPRESSED");
+    idLgciuLeftMainGearCompressed[i] = std::make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_LEFT_GEAR_COMPRESSED");
+    idLgciuRightMainGearCompressed[i] = std::make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_RIGHT_GEAR_COMPRESSED");
+    idLgciuDiscreteWord1[i] = std::make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_DISCRETE_WORD_1");
+    idLgciuDiscreteWord2[i] = std::make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_DISCRETE_WORD_2");
+    idLgciuDiscreteWord3[i] = std::make_unique<LocalVariable>("A32NX_LGCIU_" + idString + "_DISCRETE_WORD_3");
   }
 
-  idSfccSlatFlapComponentStatusWord = make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_COMPONENT_STATUS_WORD");
-  idSfccSlatFlapSystemStatusWord = make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD");
-  idSfccSlatFlapActualPositionWord = make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD");
-  idSfccSlatActualPositionWord = make_unique<LocalVariable>("A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD");
-  idSfccFlapActualPositionWord = make_unique<LocalVariable>("A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD");
+  idSfccSlatFlapComponentStatusWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_COMPONENT_STATUS_WORD");
+  idSfccSlatFlapSystemStatusWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_SYSTEM_STATUS_WORD");
+  idSfccSlatFlapActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_FLAP_ACTUAL_POSITION_WORD");
+  idSfccSlatActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_SLAT_ACTUAL_POSITION_WORD");
+  idSfccFlapActualPositionWord = std::make_unique<LocalVariable>("A32NX_SFCC_FLAP_ACTUAL_POSITION_WORD");
 
   for (int i = 0; i < 3; i++) {
-    string idString = std::to_string(i + 1);
-    idAdrAltitudeCorrected[i] = make_unique<LocalVariable>("A32NX_ADIRS_ADR_" + idString + "_ALTITUDE");
-    idAdrMach[i] = make_unique<LocalVariable>("A32NX_ADIRS_ADR_" + idString + "_MACH");
-    idAdrAirspeedComputed[i] = make_unique<LocalVariable>("A32NX_ADIRS_ADR_" + idString + "_COMPUTED_AIRSPEED");
-    idAdrAirspeedTrue[i] = make_unique<LocalVariable>("A32NX_ADIRS_ADR_" + idString + "_TRUE_AIRSPEED");
-    idAdrVerticalSpeed[i] = make_unique<LocalVariable>("A32NX_ADIRS_ADR_" + idString + "_BAROMETRIC_VERTICAL_SPEED");
-    idAdrAoaCorrected[i] = make_unique<LocalVariable>("A32NX_ADIRS_ADR_" + idString + "_ANGLE_OF_ATTACK");
+    std::string idString = std::to_string(i + 1);
+    idAdrAltitudeCorrected[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_ADR_" + idString + "_ALTITUDE");
+    idAdrMach[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_ADR_" + idString + "_MACH");
+    idAdrAirspeedComputed[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_ADR_" + idString + "_COMPUTED_AIRSPEED");
+    idAdrAirspeedTrue[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_ADR_" + idString + "_TRUE_AIRSPEED");
+    idAdrVerticalSpeed[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_ADR_" + idString + "_BAROMETRIC_VERTICAL_SPEED");
+    idAdrAoaCorrected[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_ADR_" + idString + "_ANGLE_OF_ATTACK");
     idAdrCorrectedAverageStaticPressure[i] =
-        make_unique<LocalVariable>("A32NX_ADIRS_ADR_" + idString + "_CORRECTED_AVERAGE_STATIC_PRESSURE");
+        std::make_unique<LocalVariable>("A32NX_ADIRS_ADR_" + idString + "_CORRECTED_AVERAGE_STATIC_PRESSURE");
 
-    idIrLatitude[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_LATITUDE");
-    idIrLongitude[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_LONGITUDE");
-    idIrGroundSpeed[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_GROUND_SPEED");
-    idIrWindSpeed[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_WIND_VELOCITY");
-    idIrWindDirectionTrue[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_WIND_DIRECTION");
-    idIrTrackAngleMagnetic[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_TRACK");
-    idIrHeadingMagnetic[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_HEADING");
-    idIrDriftAngle[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_DRIFT_ANGLE");
-    idIrFlightPathAngle[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_FLIGHT_PATH_ANGLE");
-    idIrPitchAngle[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_PITCH");
-    idIrRollAngle[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_ROLL");
-    idIrBodyPitchRate[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_BODY_PITCH_RATE");
-    idIrBodyRollRate[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_BODY_ROLL_RATE");
-    idIrBodyYawRate[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_BODY_YAW_RATE");
-    idIrBodyLongAccel[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_BODY_LONGITUDINAL_ACC");
-    idIrBodyLatAccel[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_BODY_LATERAL_ACC");
-    idIrBodyNormalAccel[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_BODY_NORMAL_ACC");
-    idIrTrackAngleRate[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_HEADING_RATE");
-    idIrPitchAttRate[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_PITCH_ATT_RATE");
-    idIrRollAttRate[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_ROLL_ATT_RATE");
-    idIrInertialVerticalSpeed[i] = make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_VERTICAL_SPEED");
+    idIrLatitude[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_LATITUDE");
+    idIrLongitude[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_LONGITUDE");
+    idIrGroundSpeed[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_GROUND_SPEED");
+    idIrWindSpeed[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_WIND_VELOCITY");
+    idIrWindDirectionTrue[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_WIND_DIRECTION");
+    idIrTrackAngleMagnetic[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_TRACK");
+    idIrHeadingMagnetic[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_HEADING");
+    idIrDriftAngle[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_DRIFT_ANGLE");
+    idIrFlightPathAngle[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_FLIGHT_PATH_ANGLE");
+    idIrPitchAngle[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_PITCH");
+    idIrRollAngle[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_ROLL");
+    idIrBodyPitchRate[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_BODY_PITCH_RATE");
+    idIrBodyRollRate[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_BODY_ROLL_RATE");
+    idIrBodyYawRate[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_BODY_YAW_RATE");
+    idIrBodyLongAccel[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_BODY_LONGITUDINAL_ACC");
+    idIrBodyLatAccel[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_BODY_LATERAL_ACC");
+    idIrBodyNormalAccel[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_BODY_NORMAL_ACC");
+    idIrTrackAngleRate[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_HEADING_RATE");
+    idIrPitchAttRate[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_PITCH_ATT_RATE");
+    idIrRollAttRate[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_ROLL_ATT_RATE");
+    idIrInertialVerticalSpeed[i] = std::make_unique<LocalVariable>("A32NX_ADIRS_IR_" + idString + "_VERTICAL_SPEED");
   }
 
   for (int i = 0; i < 2; i++) {
-    string idString = std::to_string(i + 1);
+    std::string idString = std::to_string(i + 1);
 
-    idFcdcDiscreteWord1[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_DISCRETE_WORD_1");
-    idFcdcDiscreteWord2[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_DISCRETE_WORD_2");
-    idFcdcDiscreteWord3[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_DISCRETE_WORD_3");
-    idFcdcDiscreteWord4[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_DISCRETE_WORD_4");
-    idFcdcDiscreteWord5[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_DISCRETE_WORD_5");
-    idFcdcCaptRollCommand[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_CAPT_ROLL_COMMAND");
-    idFcdcFoRollCommand[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_FO_ROLL_COMMAND");
-    idFcdcCaptPitchCommand[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_CAPT_PITCH_COMMAND");
-    idFcdcFoPitchCommand[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_FO_PITCH_COMMAND");
-    idFcdcRudderPedalPos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_RUDDER_PEDAL_POS");
-    idFcdcAileronLeftPos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_AILERON_LEFT_POS");
-    idFcdcElevatorLeftPos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_ELEVATOR_LEFT_POS");
-    idFcdcAileronRightPos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_AILERON_RIGHT_POS");
-    idFcdcElevatorRightPos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_ELEVATOR_RIGHT_POS");
-    idFcdcElevatorTrimPos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_ELEVATOR_TRIM_POS");
-    idFcdcSpoilerLeft1Pos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_LEFT_1_POS");
-    idFcdcSpoilerLeft2Pos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_LEFT_2_POS");
-    idFcdcSpoilerLeft3Pos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_LEFT_3_POS");
-    idFcdcSpoilerLeft4Pos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_LEFT_4_POS");
-    idFcdcSpoilerLeft5Pos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_LEFT_5_POS");
-    idFcdcSpoilerRight1Pos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_RIGHT_1_POS");
-    idFcdcSpoilerRight2Pos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_RIGHT_2_POS");
-    idFcdcSpoilerRight3Pos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_RIGHT_3_POS");
-    idFcdcSpoilerRight4Pos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_RIGHT_4_POS");
-    idFcdcSpoilerRight5Pos[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_RIGHT_5_POS");
+    idFcdcDiscreteWord1[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_DISCRETE_WORD_1");
+    idFcdcDiscreteWord2[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_DISCRETE_WORD_2");
+    idFcdcDiscreteWord3[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_DISCRETE_WORD_3");
+    idFcdcDiscreteWord4[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_DISCRETE_WORD_4");
+    idFcdcDiscreteWord5[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_DISCRETE_WORD_5");
+    idFcdcCaptRollCommand[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_CAPT_ROLL_COMMAND");
+    idFcdcFoRollCommand[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_FO_ROLL_COMMAND");
+    idFcdcCaptPitchCommand[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_CAPT_PITCH_COMMAND");
+    idFcdcFoPitchCommand[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_FO_PITCH_COMMAND");
+    idFcdcRudderPedalPos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_RUDDER_PEDAL_POS");
+    idFcdcAileronLeftPos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_AILERON_LEFT_POS");
+    idFcdcElevatorLeftPos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_ELEVATOR_LEFT_POS");
+    idFcdcAileronRightPos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_AILERON_RIGHT_POS");
+    idFcdcElevatorRightPos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_ELEVATOR_RIGHT_POS");
+    idFcdcElevatorTrimPos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_ELEVATOR_TRIM_POS");
+    idFcdcSpoilerLeft1Pos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_LEFT_1_POS");
+    idFcdcSpoilerLeft2Pos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_LEFT_2_POS");
+    idFcdcSpoilerLeft3Pos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_LEFT_3_POS");
+    idFcdcSpoilerLeft4Pos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_LEFT_4_POS");
+    idFcdcSpoilerLeft5Pos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_LEFT_5_POS");
+    idFcdcSpoilerRight1Pos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_RIGHT_1_POS");
+    idFcdcSpoilerRight2Pos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_RIGHT_2_POS");
+    idFcdcSpoilerRight3Pos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_RIGHT_3_POS");
+    idFcdcSpoilerRight4Pos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_RIGHT_4_POS");
+    idFcdcSpoilerRight5Pos[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_SPOILER_RIGHT_5_POS");
 
-    idFcdcPriorityCaptGreen[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_PRIORITY_LIGHT_CAPT_GREEN_ON");
-    idFcdcPriorityCaptRed[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_PRIORITY_LIGHT_CAPT_RED_ON");
-    idFcdcPriorityFoGreen[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_PRIORITY_LIGHT_FO_GREEN_ON");
-    idFcdcPriorityFoRed[i] = make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_PRIORITY_LIGHT_FO_RED_ON");
+    idFcdcPriorityCaptGreen[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_PRIORITY_LIGHT_CAPT_GREEN_ON");
+    idFcdcPriorityCaptRed[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_PRIORITY_LIGHT_CAPT_RED_ON");
+    idFcdcPriorityFoGreen[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_PRIORITY_LIGHT_FO_GREEN_ON");
+    idFcdcPriorityFoRed[i] = std::make_unique<LocalVariable>("A32NX_FCDC_" + idString + "_PRIORITY_LIGHT_FO_RED_ON");
   }
 
-  idThsOverrideActive = make_unique<LocalVariable>("A32NX_HYD_THS_TRIM_MANUAL_OVERRIDE");
+  idThsOverrideActive = std::make_unique<LocalVariable>("A32NX_HYD_THS_TRIM_MANUAL_OVERRIDE");
 
   for (int i = 0; i < 2; i++) {
-    string idString = std::to_string(i + 1);
+    std::string idString = std::to_string(i + 1);
 
-    idElacPushbuttonPressed[i] = make_unique<LocalVariable>("A32NX_ELAC_" + idString + "_PUSHBUTTON_PRESSED");
-    idElacDigitalOpValidated[i] = make_unique<LocalVariable>("A32NX_ELAC_" + idString + "_DIGITAL_OP_VALIDATED");
+    idElacPushbuttonPressed[i] = std::make_unique<LocalVariable>("A32NX_ELAC_" + idString + "_PUSHBUTTON_PRESSED");
+    idElacDigitalOpValidated[i] = std::make_unique<LocalVariable>("A32NX_ELAC_" + idString + "_DIGITAL_OP_VALIDATED");
   }
 
   for (int i = 0; i < 3; i++) {
-    string idString = std::to_string(i + 1);
+    std::string idString = std::to_string(i + 1);
 
-    idSecPushbuttonPressed[i] = make_unique<LocalVariable>("A32NX_SEC_" + idString + "_PUSHBUTTON_PRESSED");
-    idSecFaultLightOn[i] = make_unique<LocalVariable>("A32NX_SEC_" + idString + "_FAULT_LIGHT_ON");
-    idSecGroundSpoilersOut[i] = make_unique<LocalVariable>("A32NX_SEC_" + idString + "_GROUND_SPOILER_OUT");
+    idSecPushbuttonPressed[i] = std::make_unique<LocalVariable>("A32NX_SEC_" + idString + "_PUSHBUTTON_PRESSED");
+    idSecFaultLightOn[i] = std::make_unique<LocalVariable>("A32NX_SEC_" + idString + "_FAULT_LIGHT_ON");
+    idSecGroundSpoilersOut[i] = std::make_unique<LocalVariable>("A32NX_SEC_" + idString + "_GROUND_SPOILER_OUT");
   }
 
   for (int i = 0; i < 2; i++) {
-    string idString = std::to_string(i + 1);
+    std::string idString = std::to_string(i + 1);
 
-    idFacPushbuttonPressed[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_PUSHBUTTON_PRESSED");
-    idFacHealthy[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_HEALTHY");
+    idFacPushbuttonPressed[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_PUSHBUTTON_PRESSED");
+    idFacHealthy[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_HEALTHY");
 
-    idFacDiscreteWord1[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_DISCRETE_WORD_1");
-    idFacGammaA[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_GAMMA_A");
-    idFacGammaT[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_GAMMA_T");
-    idFacWeight[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_WEIGHT");
-    idFacCenterOfGravity[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_CENTER_OF_GRAVITY");
-    idFacSideslipTarget[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_SIDESLIP_TARGET");
-    idFacSlatAngle[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_SLATS_ANGLE");
-    idFacFlapAngle[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_FLAPS_ANGLE");
-    idFacDiscreteWord2[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_DISCRETE_WORD_2");
-    idFacRudderTravelLimitCommand[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_RUDDER_TRAVEL_LIMIT_COMMAND");
-    idFacDeltaRYawDamperVoted[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_DELTA_R_YAW_DAMPER");
-    idFacEstimatedSideslip[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_ESTIMATED_SIDESLIP");
-    idFacVAlphaLim[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_ALPHA_LIM");
-    idFacVLs[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_LS");
-    idFacVStall[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_STALL_1G");
-    idFacVAlphaProt[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_ALPHA_PROT");
-    idFacVStallWarn[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_STALL_WARN");
-    idFacSpeedTrend[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_SPEED_TREND");
-    idFacV3[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_3");
-    idFacV4[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_4");
-    idFacVMan[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_MAN");
-    idFacVMax[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_MAX");
-    idFacVFeNext[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_FE_NEXT");
-    idFacDiscreteWord3[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_DISCRETE_WORD_3");
-    idFacDiscreteWord4[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_DISCRETE_WORD_4");
-    idFacDiscreteWord5[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_DISCRETE_WORD_5");
-    idFacDeltaRRudderTrim[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_DELTA_R_RUDDER_TRIM");
-    idFacRudderTrimPos[i] = make_unique<LocalVariable>("A32NX_FAC_" + idString + "_RUDDER_TRIM_POS");
+    idFacDiscreteWord1[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_DISCRETE_WORD_1");
+    idFacGammaA[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_GAMMA_A");
+    idFacGammaT[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_GAMMA_T");
+    idFacWeight[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_WEIGHT");
+    idFacCenterOfGravity[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_CENTER_OF_GRAVITY");
+    idFacSideslipTarget[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_SIDESLIP_TARGET");
+    idFacSlatAngle[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_SLATS_ANGLE");
+    idFacFlapAngle[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_FLAPS_ANGLE");
+    idFacDiscreteWord2[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_DISCRETE_WORD_2");
+    idFacRudderTravelLimitCommand[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_RUDDER_TRAVEL_LIMIT_COMMAND");
+    idFacDeltaRYawDamperVoted[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_DELTA_R_YAW_DAMPER");
+    idFacEstimatedSideslip[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_ESTIMATED_SIDESLIP");
+    idFacVAlphaLim[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_ALPHA_LIM");
+    idFacVLs[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_LS");
+    idFacVStall[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_STALL_1G");
+    idFacVAlphaProt[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_ALPHA_PROT");
+    idFacVStallWarn[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_STALL_WARN");
+    idFacSpeedTrend[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_SPEED_TREND");
+    idFacV3[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_3");
+    idFacV4[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_4");
+    idFacVMan[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_MAN");
+    idFacVMax[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_MAX");
+    idFacVFeNext[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_V_FE_NEXT");
+    idFacDiscreteWord3[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_DISCRETE_WORD_3");
+    idFacDiscreteWord4[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_DISCRETE_WORD_4");
+    idFacDiscreteWord5[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_DISCRETE_WORD_5");
+    idFacDeltaRRudderTrim[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_DELTA_R_RUDDER_TRIM");
+    idFacRudderTrimPos[i] = std::make_unique<LocalVariable>("A32NX_FAC_" + idString + "_RUDDER_TRIM_POS");
   }
 
   for (int i = 0; i < 2; i++) {
-    string aileronStringLeft = i == 0 ? "BLUE" : "GREEN";
-    string aileronStringRight = i == 0 ? "GREEN" : "BLUE";
-    string elevatorStringLeft = i == 0 ? "BLUE" : "GREEN";
-    string elevatorStringRight = i == 0 ? "BLUE" : "YELLOW";
-    string yawDamperString = i == 0 ? "GREEN" : "YELLOW";
-    string idString = std::to_string(i + 1);
+    std::string aileronStringLeft = i == 0 ? "BLUE" : "GREEN";
+    std::string aileronStringRight = i == 0 ? "GREEN" : "BLUE";
+    std::string elevatorStringLeft = i == 0 ? "BLUE" : "GREEN";
+    std::string elevatorStringRight = i == 0 ? "BLUE" : "YELLOW";
+    std::string yawDamperString = i == 0 ? "GREEN" : "YELLOW";
+    std::string idString = std::to_string(i + 1);
 
-    idLeftAileronSolenoidEnergized[i] = make_unique<LocalVariable>("A32NX_LEFT_AIL_" + aileronStringLeft + "_SERVO_SOLENOID_ENERGIZED");
-    idLeftAileronCommandedPosition[i] = make_unique<LocalVariable>("A32NX_LEFT_AIL_" + aileronStringLeft + "_COMMANDED_POSITION");
-    idRightAileronSolenoidEnergized[i] = make_unique<LocalVariable>("A32NX_RIGHT_AIL_" + aileronStringRight + "_SERVO_SOLENOID_ENERGIZED");
-    idRightAileronCommandedPosition[i] = make_unique<LocalVariable>("A32NX_RIGHT_AIL_" + aileronStringRight + "_COMMANDED_POSITION");
-    idLeftElevatorSolenoidEnergized[i] = make_unique<LocalVariable>("A32NX_LEFT_ELEV_" + elevatorStringLeft + "_SERVO_SOLENOID_ENERGIZED");
-    idLeftElevatorCommandedPosition[i] = make_unique<LocalVariable>("A32NX_LEFT_ELEV_" + elevatorStringLeft + "_COMMANDED_POSITION");
+    idLeftAileronSolenoidEnergized[i] = std::make_unique<LocalVariable>("A32NX_LEFT_AIL_" + aileronStringLeft + "_SERVO_SOLENOID_ENERGIZED");
+    idLeftAileronCommandedPosition[i] = std::make_unique<LocalVariable>("A32NX_LEFT_AIL_" + aileronStringLeft + "_COMMANDED_POSITION");
+    idRightAileronSolenoidEnergized[i] = std::make_unique<LocalVariable>("A32NX_RIGHT_AIL_" + aileronStringRight + "_SERVO_SOLENOID_ENERGIZED");
+    idRightAileronCommandedPosition[i] = std::make_unique<LocalVariable>("A32NX_RIGHT_AIL_" + aileronStringRight + "_COMMANDED_POSITION");
+    idLeftElevatorSolenoidEnergized[i] = std::make_unique<LocalVariable>("A32NX_LEFT_ELEV_" + elevatorStringLeft + "_SERVO_SOLENOID_ENERGIZED");
+    idLeftElevatorCommandedPosition[i] = std::make_unique<LocalVariable>("A32NX_LEFT_ELEV_" + elevatorStringLeft + "_COMMANDED_POSITION");
     idRightElevatorSolenoidEnergized[i] =
-        make_unique<LocalVariable>("A32NX_RIGHT_ELEV_" + elevatorStringRight + "_SERVO_SOLENOID_ENERGIZED");
-    idRightElevatorCommandedPosition[i] = make_unique<LocalVariable>("A32NX_RIGHT_ELEV_" + elevatorStringRight + "_COMMANDED_POSITION");
+        std::make_unique<LocalVariable>("A32NX_RIGHT_ELEV_" + elevatorStringRight + "_SERVO_SOLENOID_ENERGIZED");
+    idRightElevatorCommandedPosition[i] = std::make_unique<LocalVariable>("A32NX_RIGHT_ELEV_" + elevatorStringRight + "_COMMANDED_POSITION");
 
-    idYawDamperSolenoidEnergized[i] = make_unique<LocalVariable>("A32NX_YAW_DAMPER_" + yawDamperString + "_SERVO_SOLENOID_ENERGIZED");
-    idYawDamperCommandedPosition[i] = make_unique<LocalVariable>("A32NX_YAW_DAMPER_" + yawDamperString + "_COMMANDED_POSITION");
-    idRudderTrimActiveModeCommanded[i] = make_unique<LocalVariable>("A32NX_RUDDER_TRIM_" + idString + "_ACTIVE_MODE_COMMANDED");
-    idRudderTrimCommandedPosition[i] = make_unique<LocalVariable>("A32NX_RUDDER_TRIM_" + idString + "_COMMANDED_POSITION");
+    idYawDamperSolenoidEnergized[i] = std::make_unique<LocalVariable>("A32NX_YAW_DAMPER_" + yawDamperString + "_SERVO_SOLENOID_ENERGIZED");
+    idYawDamperCommandedPosition[i] = std::make_unique<LocalVariable>("A32NX_YAW_DAMPER_" + yawDamperString + "_COMMANDED_POSITION");
+    idRudderTrimActiveModeCommanded[i] = std::make_unique<LocalVariable>("A32NX_RUDDER_TRIM_" + idString + "_ACTIVE_MODE_COMMANDED");
+    idRudderTrimCommandedPosition[i] = std::make_unique<LocalVariable>("A32NX_RUDDER_TRIM_" + idString + "_COMMANDED_POSITION");
     idRudderTravelLimitActiveModeCommanded[i] =
-        make_unique<LocalVariable>("A32NX_RUDDER_TRAVEL_LIM_" + idString + "_ACTIVE_MODE_COMMANDED");
-    idRudderTravelLimCommandedPosition[i] = make_unique<LocalVariable>("A32NX_RUDDER_TRAVEL_LIM_" + idString + "_COMMANDED_POSITION");
+        std::make_unique<LocalVariable>("A32NX_RUDDER_TRAVEL_LIM_" + idString + "_ACTIVE_MODE_COMMANDED");
+    idRudderTravelLimCommandedPosition[i] = std::make_unique<LocalVariable>("A32NX_RUDDER_TRAVEL_LIM_" + idString + "_COMMANDED_POSITION");
   }
 
   for (int i = 0; i < 3; i++) {
-    string idString = std::to_string(i + 1);
+    std::string idString = std::to_string(i + 1);
 
-    idTHSActiveModeCommanded[i] = make_unique<LocalVariable>("A32NX_THS_" + idString + "_ACTIVE_MODE_COMMANDED");
-    idTHSCommandedPosition[i] = make_unique<LocalVariable>("A32NX_THS_" + idString + "_COMMANDED_POSITION");
+    idTHSActiveModeCommanded[i] = std::make_unique<LocalVariable>("A32NX_THS_" + idString + "_ACTIVE_MODE_COMMANDED");
+    idTHSCommandedPosition[i] = std::make_unique<LocalVariable>("A32NX_THS_" + idString + "_COMMANDED_POSITION");
   }
 
   for (int i = 0; i < 2; i++) {
-    string idString = std::to_string(i + 1);
-    idElevFaultLeft[i] = make_unique<LocalVariable>("A32NX_LEFT_ELEV_SERVO_" + idString + "_FAILED");
-    idElevFaultRight[i] = make_unique<LocalVariable>("A32NX_RIGHT_ELEV_SERVO_" + idString + "_FAILED");
-    idAilFaultLeft[i] = make_unique<LocalVariable>("A32NX_LEFT_AIL_SERVO_" + idString + "_FAILED");
-    idAilFaultRight[i] = make_unique<LocalVariable>("A32NX_RIGHT_AIL_SERVO_" + idString + "_FAILED");
+    std::string idString = std::to_string(i + 1);
+    idElevFaultLeft[i] = std::make_unique<LocalVariable>("A32NX_LEFT_ELEV_SERVO_" + idString + "_FAILED");
+    idElevFaultRight[i] = std::make_unique<LocalVariable>("A32NX_RIGHT_ELEV_SERVO_" + idString + "_FAILED");
+    idAilFaultLeft[i] = std::make_unique<LocalVariable>("A32NX_LEFT_AIL_SERVO_" + idString + "_FAILED");
+    idAilFaultRight[i] = std::make_unique<LocalVariable>("A32NX_RIGHT_AIL_SERVO_" + idString + "_FAILED");
   }
 
   for (int i = 0; i < 5; i++) {
-    string idString = std::to_string(i + 1);
-    idLeftSpoilerCommandedPosition[i] = make_unique<LocalVariable>("A32NX_LEFT_SPOILER_" + idString + "_COMMANDED_POSITION");
-    idRightSpoilerCommandedPosition[i] = make_unique<LocalVariable>("A32NX_RIGHT_SPOILER_" + idString + "_COMMANDED_POSITION");
+    std::string idString = std::to_string(i + 1);
+    idLeftSpoilerCommandedPosition[i] = std::make_unique<LocalVariable>("A32NX_LEFT_SPOILER_" + idString + "_COMMANDED_POSITION");
+    idRightSpoilerCommandedPosition[i] = std::make_unique<LocalVariable>("A32NX_RIGHT_SPOILER_" + idString + "_COMMANDED_POSITION");
 
-    idLeftSpoilerPosition[i] = make_unique<LocalVariable>("A32NX_HYD_SPOILER_" + idString + "_LEFT_DEFLECTION");
-    idRightSpoilerPosition[i] = make_unique<LocalVariable>("A32NX_HYD_SPOILER_" + idString + "_RIGHT_DEFLECTION");
+    idLeftSpoilerPosition[i] = std::make_unique<LocalVariable>("A32NX_HYD_SPOILER_" + idString + "_LEFT_DEFLECTION");
+    idRightSpoilerPosition[i] = std::make_unique<LocalVariable>("A32NX_HYD_SPOILER_" + idString + "_RIGHT_DEFLECTION");
 
-    idSplrFaultLeft[i] = make_unique<LocalVariable>("A32NX_LEFT_SPLR_" + idString + "_SERVO_FAILED");
-    idSplrFaultRight[i] = make_unique<LocalVariable>("A32NX_RIGHT_SPLR_" + idString + "_SERVO_FAILED");
+    idSplrFaultLeft[i] = std::make_unique<LocalVariable>("A32NX_LEFT_SPLR_" + idString + "_SERVO_FAILED");
+    idSplrFaultRight[i] = std::make_unique<LocalVariable>("A32NX_RIGHT_SPLR_" + idString + "_SERVO_FAILED");
   }
 
-  idLeftAileronPosition = make_unique<LocalVariable>("A32NX_HYD_AILERON_LEFT_DEFLECTION");
-  idRightAileronPosition = make_unique<LocalVariable>("A32NX_HYD_AILERON_RIGHT_DEFLECTION");
-  idLeftElevatorPosition = make_unique<LocalVariable>("A32NX_HYD_ELEVATOR_LEFT_DEFLECTION");
-  idRightElevatorPosition = make_unique<LocalVariable>("A32NX_HYD_ELEVATOR_RIGHT_DEFLECTION");
+  idLeftAileronPosition = std::make_unique<LocalVariable>("A32NX_HYD_AILERON_LEFT_DEFLECTION");
+  idRightAileronPosition = std::make_unique<LocalVariable>("A32NX_HYD_AILERON_RIGHT_DEFLECTION");
+  idLeftElevatorPosition = std::make_unique<LocalVariable>("A32NX_HYD_ELEVATOR_LEFT_DEFLECTION");
+  idRightElevatorPosition = std::make_unique<LocalVariable>("A32NX_HYD_ELEVATOR_RIGHT_DEFLECTION");
 
-  idElecDcBus2Powered = make_unique<LocalVariable>("A32NX_ELEC_DC_2_BUS_IS_POWERED");
-  idElecDcEssShedBusPowered = make_unique<LocalVariable>("A32NX_ELEC_DC_ESS_SHED_BUS_IS_POWERED");
-  idElecDcEssBusPowered = make_unique<LocalVariable>("A32NX_ELEC_DC_ESS_BUS_IS_POWERED");
-  idElecBat1HotBusPowered = make_unique<LocalVariable>("A32NX_ELEC_DC_HOT_1_BUS_IS_POWERED");
+  idElecDcBus2Powered = std::make_unique<LocalVariable>("A32NX_ELEC_DC_2_BUS_IS_POWERED");
+  idElecDcEssShedBusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_DC_ESS_SHED_BUS_IS_POWERED");
+  idElecDcEssBusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_DC_ESS_BUS_IS_POWERED");
+  idElecBat1HotBusPowered = std::make_unique<LocalVariable>("A32NX_ELEC_DC_HOT_1_BUS_IS_POWERED");
 
-  idHydYellowSystemPressure = make_unique<LocalVariable>("A32NX_HYD_YELLOW_SYSTEM_1_SECTION_PRESSURE");
-  idHydGreenSystemPressure = make_unique<LocalVariable>("A32NX_HYD_GREEN_SYSTEM_1_SECTION_PRESSURE");
-  idHydBlueSystemPressure = make_unique<LocalVariable>("A32NX_HYD_BLUE_SYSTEM_1_SECTION_PRESSURE");
-  idHydYellowPressurised = make_unique<LocalVariable>("A32NX_HYD_YELLOW_SYSTEM_1_SECTION_PRESSURE_SWITCH");
-  idHydGreenPressurised = make_unique<LocalVariable>("A32NX_HYD_GREEN_SYSTEM_1_SECTION_PRESSURE_SWITCH");
-  idHydBluePressurised = make_unique<LocalVariable>("A32NX_HYD_BLUE_SYSTEM_1_SECTION_PRESSURE_SWITCH");
+  idHydYellowSystemPressure = std::make_unique<LocalVariable>("A32NX_HYD_YELLOW_SYSTEM_1_SECTION_PRESSURE");
+  idHydGreenSystemPressure = std::make_unique<LocalVariable>("A32NX_HYD_GREEN_SYSTEM_1_SECTION_PRESSURE");
+  idHydBlueSystemPressure = std::make_unique<LocalVariable>("A32NX_HYD_BLUE_SYSTEM_1_SECTION_PRESSURE");
+  idHydYellowPressurised = std::make_unique<LocalVariable>("A32NX_HYD_YELLOW_SYSTEM_1_SECTION_PRESSURE_SWITCH");
+  idHydGreenPressurised = std::make_unique<LocalVariable>("A32NX_HYD_GREEN_SYSTEM_1_SECTION_PRESSURE_SWITCH");
+  idHydBluePressurised = std::make_unique<LocalVariable>("A32NX_HYD_BLUE_SYSTEM_1_SECTION_PRESSURE_SWITCH");
 
-  idCaptPriorityButtonPressed = make_unique<LocalVariable>("A32NX_PRIORITY_TAKEOVER:1");
-  idFoPriorityButtonPressed = make_unique<LocalVariable>("A32NX_PRIORITY_TAKEOVER:2");
+  idCaptPriorityButtonPressed = std::make_unique<LocalVariable>("A32NX_PRIORITY_TAKEOVER:1");
+  idFoPriorityButtonPressed = std::make_unique<LocalVariable>("A32NX_PRIORITY_TAKEOVER:2");
 }
 
 bool FlyByWireInterface::handleFcuInitialization(double sampleTime) {
@@ -732,8 +731,8 @@ bool FlyByWireInterface::handleFcuInitialization(double sampleTime) {
   // determine if we need to run init code
   if (idStartState->get() >= 5 && timeSinceReady > 6.0) {
     // init FCU for in flight configuration
-    double targetAltitude = round(simData.H_ind_ft / 1000.0) * 1000.0;
-    double targetHeading = fmod(round(simData.Psi_magnetic_deg / 10.0) * 10.0, 360.0);
+    double targetAltitude = std::round(simData.H_ind_ft / 1000.0) * 1000.0;
+    double targetHeading = std::fmod(std::round(simData.Psi_magnetic_deg / 10.0) * 10.0, 360.0);
     simConnectInterface.sendEvent(SimConnectInterface::A32NX_FCU_SPD_PUSH);
     simConnectInterface.sendEvent(SimConnectInterface::A32NX_FCU_HDG_SET, targetHeading);
     simConnectInterface.sendEvent(SimConnectInterface::A32NX_FCU_HDG_PULL);
@@ -748,7 +747,7 @@ bool FlyByWireInterface::handleFcuInitialization(double sampleTime) {
     wasFcuInitialized = true;
   } else if (idStartState->get() == 4 && timeSinceReady > 1.0) {
     // init FCU for on runway -> ready for take-off
-    double targetHeading = fmod(round(simData.Psi_magnetic_deg), 360.0);
+    double targetHeading = std::fmod(std::round(simData.Psi_magnetic_deg), 360.0);
     simConnectInterface.sendEvent(SimConnectInterface::A32NX_FCU_SPD_SET, 150);
     simConnectInterface.sendEvent(SimConnectInterface::A32NX_FCU_SPD_PULL);
     simConnectInterface.sendEvent(SimConnectInterface::A32NX_FCU_HDG_SET, targetHeading);
@@ -784,13 +783,13 @@ bool FlyByWireInterface::readDataAndLocalVariables(double sampleTime) {
 
   // request data
   if (!simConnectInterface.requestData()) {
-    cout << "WASM: Request data failed!" << endl;
+    std::cout << "WASM: Request data failed!" << std::endl;
     return false;
   }
 
   // read data
   if (!simConnectInterface.readData()) {
-    cout << "WASM: Read data failed!" << endl;
+    std::cout << "WASM: Read data failed!" << std::endl;
     return false;
   }
 
@@ -885,10 +884,10 @@ bool FlyByWireInterface::updatePerformanceMonitoring(double sampleTime) {
   if (lowPerformanceTimer >= LOW_PERFORMANCE_TIMER_THRESHOLD) {
     if (idPerformanceWarningActive->get() <= 0) {
       idPerformanceWarningActive->set(1);
-      cout << "WASM: WARNING Performance issues detected, at least stable ";
-      cout << round(simConnectInterface.getSimData().simulation_rate / MAX_ACCEPTABLE_SAMPLE_TIME);
-      cout << " fps or more are needed at this simrate!";
-      cout << endl;
+      std::cout << "WASM: WARNING Performance issues detected, at least stable ";
+      std::cout << std::round(simConnectInterface.getSimData().simulation_rate / MAX_ACCEPTABLE_SAMPLE_TIME);
+      std::cout << " fps or more are needed at this simrate!";
+      std::cout << std::endl;
     }
   } else if (idPerformanceWarningActive > 0) {
     idPerformanceWarningActive->set(0);
@@ -925,8 +924,8 @@ bool FlyByWireInterface::handleSimulationRate(double sampleTime) {
     // sed event to reduce simulation rate
     simConnectInterface.sendEvent(SimConnectInterface::Events::SIM_RATE_DECR, 0, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
     // log event of reduction
-    cout << "WASM: WARNING Reducing simulation rate to " << simData.simulation_rate / 2;
-    cout << " (maximum allowed is " << idMaximumSimulationRate->get() << ")!" << endl;
+    std::cout << "WASM: WARNING Reducing simulation rate to " << simData.simulation_rate / 2;
+    std::cout << " (maximum allowed is " << idMaximumSimulationRate->get() << ")!" << std::endl;
   }
 
   // check if simulation rate reduction is enabled
@@ -949,9 +948,9 @@ bool FlyByWireInterface::handleSimulationRate(double sampleTime) {
     // reset low performance timer
     lowPerformanceTimer = 0;
     // log event of reduction
-    cout << "WASM: WARNING Reducing simulation rate from " << simData.simulation_rate;
-    cout << " to " << simData.simulation_rate / 2;
-    cout << " due to performance issues or abnormal situation!" << endl;
+    std::cout << "WASM: WARNING Reducing simulation rate from " << simData.simulation_rate;
+    std::cout << " to " << simData.simulation_rate / 2;
+    std::cout << " due to performance issues or abnormal situation!" << std::endl;
   }
 
   // success
@@ -1706,7 +1705,7 @@ bool FlyByWireInterface::updateServoSolenoidStatus() {
   outputZetaTrim.zeta_trim_pos = -(facsAnalogOutputs[0].rudder_trim_order_deg + facsAnalogOutputs[1].rudder_trim_order_deg) / 20;
   if (facsDiscreteOutputs[0].rudder_trim_engaged || facsDiscreteOutputs[1].rudder_trim_engaged) {
     if (!simConnectInterface.sendData(outputZetaTrim)) {
-      cout << "WASM: Write data failed!" << endl;
+      std::cout << "WASM: Write data failed!" << std::endl;
       return false;
     }
   }
@@ -2444,11 +2443,11 @@ bool FlyByWireInterface::updateAutothrust(double sampleTime) {
     idAutothrustDisabled->set(autoThrust.getExternalOutputs().out.data_computed.ATHR_disabled);
 
     // write output to sim --------------------------------------------------------------------------------------------
-    SimOutputThrottles simOutputThrottles = {fmin(99.9999999999999, autoThrustOutput.sim_throttle_lever_1_pos),
-                                             fmin(99.9999999999999, autoThrustOutput.sim_throttle_lever_2_pos),
+    SimOutputThrottles simOutputThrottles = {std::fmin(99.9999999999999, autoThrustOutput.sim_throttle_lever_1_pos),
+                                             std::fmin(99.9999999999999, autoThrustOutput.sim_throttle_lever_2_pos),
                                              autoThrustOutput.sim_thrust_mode_1, autoThrustOutput.sim_thrust_mode_2};
     if (!simConnectInterface.sendData(simOutputThrottles)) {
-      cout << "WASM: Write data failed!" << endl;
+      std::cout << "WASM: Write data failed!" << std::endl;
       return false;
     }
   } else {

--- a/src/fbw/src/InterpolatingLookupTable.cpp
+++ b/src/fbw/src/InterpolatingLookupTable.cpp
@@ -1,8 +1,6 @@
 #include "InterpolatingLookupTable.h"
 
-using namespace std;
-
-void InterpolatingLookupTable::initialize(vector<pair<double, double>> mapping, double minimum, double maximum) {
+void InterpolatingLookupTable::initialize(std::vector<std::pair<double, double>> mapping, double minimum, double maximum) {
   mappingTable = std::move(mapping);
   mappingMinimum = minimum;
   mappingMaximum = maximum;

--- a/src/fbw/src/ThrottleAxisMapping.cpp
+++ b/src/fbw/src/ThrottleAxisMapping.cpp
@@ -3,7 +3,6 @@
 #include <cmath>
 #include "ini_type_conversion.h"
 
-using namespace std;
 using namespace mINI;
 
 ThrottleAxisMapping::ThrottleAxisMapping(unsigned int id) {
@@ -11,7 +10,7 @@ ThrottleAxisMapping::ThrottleAxisMapping(unsigned int id) {
   this->id = id;
 
   // update string variables
-  string stringId = to_string(id);
+  auto stringId = std::to_string(id);
   CONFIGURATION_SECTION_AXIS = CONFIGURATION_SECTION_AXIS.append(stringId);
   LVAR_INPUT_VALUE = LVAR_INPUT_VALUE.append(stringId);
   LVAR_THRUST_LEVER_ANGLE = LVAR_THRUST_LEVER_ANGLE.append(stringId);
@@ -31,24 +30,24 @@ ThrottleAxisMapping::ThrottleAxisMapping(unsigned int id) {
   LVAR_DETENT_TOGA_HIGH = LVAR_DETENT_TOGA_HIGH.append(stringId);
 
   // register local variables
-  idInputValue = make_unique<LocalVariable>(LVAR_INPUT_VALUE.c_str());
-  idThrustLeverAngle = make_unique<LocalVariable>(LVAR_THRUST_LEVER_ANGLE.c_str());
-  idUsingConfig = make_unique<LocalVariable>(LVAR_LOAD_CONFIG.c_str());
-  idUseReverseOnAxis = make_unique<LocalVariable>(LVAR_USE_REVERSE_ON_AXIS.c_str());
-  idIncrementNormal = make_unique<LocalVariable>(LVAR_INCREMENT_NORMAL.c_str());
-  idIncrementSmall = make_unique<LocalVariable>(LVAR_INCREMENT_SMALL.c_str());
-  idDetentReverseLow = make_unique<LocalVariable>(LVAR_DETENT_REVERSE_LOW.c_str());
-  idDetentReverseHigh = make_unique<LocalVariable>(LVAR_DETENT_REVERSE_HIGH.c_str());
-  idDetentReverseIdleLow = make_unique<LocalVariable>(LVAR_DETENT_REVERSEIDLE_LOW.c_str());
-  idDetentReverseIdleHigh = make_unique<LocalVariable>(LVAR_DETENT_REVERSEIDLE_HIGH.c_str());
-  idDetentIdleLow = make_unique<LocalVariable>(LVAR_DETENT_IDLE_LOW.c_str());
-  idDetentIdleHigh = make_unique<LocalVariable>(LVAR_DETENT_IDLE_HIGH.c_str());
-  idDetentClimbLow = make_unique<LocalVariable>(LVAR_DETENT_CLIMB_LOW.c_str());
-  idDetentClimbHigh = make_unique<LocalVariable>(LVAR_DETENT_CLIMB_HIGH.c_str());
-  idDetentFlexMctLow = make_unique<LocalVariable>(LVAR_DETENT_FLEXMCT_LOW.c_str());
-  idDetentFlexMctHigh = make_unique<LocalVariable>(LVAR_DETENT_FLEXMCT_HIGH.c_str());
-  idDetentTogaLow = make_unique<LocalVariable>(LVAR_DETENT_TOGA_LOW.c_str());
-  idDetentTogaHigh = make_unique<LocalVariable>(LVAR_DETENT_TOGA_HIGH.c_str());
+  idInputValue = std::make_unique<LocalVariable>(LVAR_INPUT_VALUE.c_str());
+  idThrustLeverAngle = std::make_unique<LocalVariable>(LVAR_THRUST_LEVER_ANGLE.c_str());
+  idUsingConfig = std::make_unique<LocalVariable>(LVAR_LOAD_CONFIG.c_str());
+  idUseReverseOnAxis = std::make_unique<LocalVariable>(LVAR_USE_REVERSE_ON_AXIS.c_str());
+  idIncrementNormal = std::make_unique<LocalVariable>(LVAR_INCREMENT_NORMAL.c_str());
+  idIncrementSmall = std::make_unique<LocalVariable>(LVAR_INCREMENT_SMALL.c_str());
+  idDetentReverseLow = std::make_unique<LocalVariable>(LVAR_DETENT_REVERSE_LOW.c_str());
+  idDetentReverseHigh = std::make_unique<LocalVariable>(LVAR_DETENT_REVERSE_HIGH.c_str());
+  idDetentReverseIdleLow = std::make_unique<LocalVariable>(LVAR_DETENT_REVERSEIDLE_LOW.c_str());
+  idDetentReverseIdleHigh = std::make_unique<LocalVariable>(LVAR_DETENT_REVERSEIDLE_HIGH.c_str());
+  idDetentIdleLow = std::make_unique<LocalVariable>(LVAR_DETENT_IDLE_LOW.c_str());
+  idDetentIdleHigh = std::make_unique<LocalVariable>(LVAR_DETENT_IDLE_HIGH.c_str());
+  idDetentClimbLow = std::make_unique<LocalVariable>(LVAR_DETENT_CLIMB_LOW.c_str());
+  idDetentClimbHigh = std::make_unique<LocalVariable>(LVAR_DETENT_CLIMB_HIGH.c_str());
+  idDetentFlexMctLow = std::make_unique<LocalVariable>(LVAR_DETENT_FLEXMCT_LOW.c_str());
+  idDetentFlexMctHigh = std::make_unique<LocalVariable>(LVAR_DETENT_FLEXMCT_HIGH.c_str());
+  idDetentTogaLow = std::make_unique<LocalVariable>(LVAR_DETENT_TOGA_LOW.c_str());
+  idDetentTogaHigh = std::make_unique<LocalVariable>(LVAR_DETENT_TOGA_HIGH.c_str());
 }
 
 void ThrottleAxisMapping::setInFlight() {
@@ -81,7 +80,7 @@ bool ThrottleAxisMapping::loadFromLocalVariables() {
 
 bool ThrottleAxisMapping::applyDefaults() {
   Configuration configuration;
-  cout << "WASM: Throttle configuration set to use default" << endl;
+  std::cout << "WASM: Throttle configuration set to use default" << std::endl;
   configuration = getDefaultConfiguration();
 
   // save values to local variables
@@ -102,7 +101,7 @@ bool ThrottleAxisMapping::loadFromFile() {
   // read configuration from file or use default
   Configuration configuration;
   if (!iniFile.read(iniStructure)) {
-    cout << "WASM: failed to read throttle configuration from disk -> create and use default" << endl;
+    std::cout << "WASM: failed to read throttle configuration from disk -> create and use default" << std::endl;
     configuration = getDefaultConfiguration();
   } else {
     configuration = loadConfigurationFromIniStructure(iniStructure);
@@ -354,20 +353,20 @@ ThrottleAxisMapping::Configuration ThrottleAxisMapping::loadConfigurationFromIni
 
 void ThrottleAxisMapping::storeConfigurationInIniStructure(INIStructure& structure, const Configuration& configuration) {
   structure[CONFIGURATION_SECTION_COMMON]["REVERSE_ON_AXIS"] = configuration.useReverseOnAxis ? "true" : "false";
-  structure[CONFIGURATION_SECTION_COMMON]["KEY_INCREMENT_NORMAL"] = to_string(configuration.incrementNormal);
-  structure[CONFIGURATION_SECTION_COMMON]["KEY_INCREMENT_SMALL"] = to_string(configuration.incrementSmall);
-  structure[CONFIGURATION_SECTION_AXIS]["REVERSE_LOW"] = to_string(configuration.reverseLow);
-  structure[CONFIGURATION_SECTION_AXIS]["REVERSE_HIGH"] = to_string(configuration.reverseHigh);
-  structure[CONFIGURATION_SECTION_AXIS]["REVERSE_IDLE_LOW"] = to_string(configuration.reverseIdleLow);
-  structure[CONFIGURATION_SECTION_AXIS]["REVERSE_IDLE_HIGH"] = to_string(configuration.reverseIdleHigh);
-  structure[CONFIGURATION_SECTION_AXIS]["IDLE_LOW"] = to_string(configuration.idleLow);
-  structure[CONFIGURATION_SECTION_AXIS]["IDLE_HIGH"] = to_string(configuration.idleHigh);
-  structure[CONFIGURATION_SECTION_AXIS]["CLIMB_LOW"] = to_string(configuration.climbLow);
-  structure[CONFIGURATION_SECTION_AXIS]["CLIMB_HIGH"] = to_string(configuration.climbHigh);
-  structure[CONFIGURATION_SECTION_AXIS]["FLEX_MCT_LOW"] = to_string(configuration.flxMctLow);
-  structure[CONFIGURATION_SECTION_AXIS]["FLEX_MCT_HIGH"] = to_string(configuration.flxMctHigh);
-  structure[CONFIGURATION_SECTION_AXIS]["TOGA_LOW"] = to_string(configuration.togaLow);
-  structure[CONFIGURATION_SECTION_AXIS]["TOGA_HIGH"] = to_string(configuration.togaHigh);
+  structure[CONFIGURATION_SECTION_COMMON]["KEY_INCREMENT_NORMAL"] = std::to_string(configuration.incrementNormal);
+  structure[CONFIGURATION_SECTION_COMMON]["KEY_INCREMENT_SMALL"] = std::to_string(configuration.incrementSmall);
+  structure[CONFIGURATION_SECTION_AXIS]["REVERSE_LOW"] = std::to_string(configuration.reverseLow);
+  structure[CONFIGURATION_SECTION_AXIS]["REVERSE_HIGH"] = std::to_string(configuration.reverseHigh);
+  structure[CONFIGURATION_SECTION_AXIS]["REVERSE_IDLE_LOW"] = std::to_string(configuration.reverseIdleLow);
+  structure[CONFIGURATION_SECTION_AXIS]["REVERSE_IDLE_HIGH"] = std::to_string(configuration.reverseIdleHigh);
+  structure[CONFIGURATION_SECTION_AXIS]["IDLE_LOW"] = std::to_string(configuration.idleLow);
+  structure[CONFIGURATION_SECTION_AXIS]["IDLE_HIGH"] = std::to_string(configuration.idleHigh);
+  structure[CONFIGURATION_SECTION_AXIS]["CLIMB_LOW"] = std::to_string(configuration.climbLow);
+  structure[CONFIGURATION_SECTION_AXIS]["CLIMB_HIGH"] = std::to_string(configuration.climbHigh);
+  structure[CONFIGURATION_SECTION_AXIS]["FLEX_MCT_LOW"] = std::to_string(configuration.flxMctLow);
+  structure[CONFIGURATION_SECTION_AXIS]["FLEX_MCT_HIGH"] = std::to_string(configuration.flxMctHigh);
+  structure[CONFIGURATION_SECTION_AXIS]["TOGA_LOW"] = std::to_string(configuration.togaLow);
+  structure[CONFIGURATION_SECTION_AXIS]["TOGA_HIGH"] = std::to_string(configuration.togaHigh);
 }
 
 void ThrottleAxisMapping::updateMappingFromConfiguration(const Configuration& configuration) {
@@ -378,8 +377,8 @@ void ThrottleAxisMapping::updateMappingFromConfiguration(const Configuration& co
   incrementNormal = configuration.incrementNormal;
   incrementSmall = configuration.incrementSmall;
 
-  // mapping table vector
-  vector<pair<double, double>> mappingTable;
+  // mapping table std::vector
+  std::vector<std::pair<double, double>> mappingTable;
 
   if (configuration.useReverseOnAxis) {
     // reverse

--- a/src/fbw/src/interface/SimConnectInterface.cpp
+++ b/src/fbw/src/interface/SimConnectInterface.cpp
@@ -4,8 +4,6 @@
 #include <map>
 #include <vector>
 
-using namespace std;
-
 // remove when aileron events can be processed via SimConnect
 bool SimConnectInterface::loggingFlightControlsEnabled = false;
 // remove when aileron events can be processed via SimConnect
@@ -31,7 +29,7 @@ bool SimConnectInterface::connect(bool clientDataEnabled,
                                   double maxSimulationRate,
                                   bool limitSimulationRateByPerformance) {
   // info message
-  cout << "WASM: Connecting..." << endl;
+  std::cout << "WASM: Connecting..." << std::endl;
 
   // connect
   HRESULT result = SimConnect_Open(&hSimConnect, "FlyByWire", nullptr, 0, 0, 0);
@@ -39,7 +37,7 @@ bool SimConnectInterface::connect(bool clientDataEnabled,
   if (S_OK == result) {
     // we are now connected
     isConnected = true;
-    cout << "WASM: Connected" << endl;
+    std::cout << "WASM: Connected" << std::endl;
     // store throttle axis handler
     this->throttleAxis = throttleAxis;
     // store spoilers handler
@@ -62,9 +60,9 @@ bool SimConnectInterface::connect(bool clientDataEnabled,
     // store if XBOX compatibility should be disabled for rudder axis plus/minus
     this->disableXboxCompatibilityRudderPlusMinus = disableXboxCompatibilityRudderPlusMinus;
     // register local variables
-    idFcuEventSetSPEED = make_unique<LocalVariable>("A320_Neo_FCU_SPEED_SET_DATA");
-    idFcuEventSetHDG = make_unique<LocalVariable>("A320_Neo_FCU_HDG_SET_DATA");
-    idFcuEventSetVS = make_unique<LocalVariable>("A320_Neo_FCU_VS_SET_DATA");
+    idFcuEventSetSPEED = std::make_unique<LocalVariable>("A320_Neo_FCU_SPEED_SET_DATA");
+    idFcuEventSetHDG = std::make_unique<LocalVariable>("A320_Neo_FCU_HDG_SET_DATA");
+    idFcuEventSetVS = std::make_unique<LocalVariable>("A320_Neo_FCU_VS_SET_DATA");
     // add data to definition
     bool prepareResult = prepareSimDataSimConnectDataDefinitions();
     prepareResult &= prepareSimInputSimConnectDataDefinitions();
@@ -75,7 +73,7 @@ bool SimConnectInterface::connect(bool clientDataEnabled,
     // check result
     if (!prepareResult) {
       // failed to add data definition -> disconnect
-      cout << "WASM: Failed to prepare data definitions" << endl;
+      std::cout << "WASM: Failed to prepare data definitions" << std::endl;
       disconnect();
       // failed to connect
       return false;
@@ -98,7 +96,7 @@ void SimConnectInterface::disconnect() {
     // remove when aileron events can be processed via SimConnect
     unregister_key_event_handler(static_cast<GAUGE_KEY_EVENT_HANDLER>(processKeyEvent), NULL);
     // info message
-    cout << "WASM: Disconnecting..." << endl;
+    std::cout << "WASM: Disconnecting..." << std::endl;
     // close connection
     SimConnect_Close(hSimConnect);
     // set flag
@@ -106,7 +104,7 @@ void SimConnectInterface::disconnect() {
     // reset handle
     hSimConnect = 0;
     // info message
-    cout << "WASM: Disconnected" << endl;
+    std::cout << "WASM: Disconnected" << std::endl;
   }
 }
 
@@ -1395,24 +1393,24 @@ bool SimConnectInterface::getLoggingThrottlesEnabled() {
 void SimConnectInterface::processKeyEvent(ID32 event, UINT32 evdata, PVOID userdata) {
   switch (event) {
     case KEY_AILERON_LEFT: {
-      simInput.inputs[AXIS_AILERONS_SET] = fmin(1.0, simInput.inputs[AXIS_AILERONS_SET] + flightControlsKeyChangeAileron);
+      simInput.inputs[AXIS_AILERONS_SET] = std::fmin(1.0, simInput.inputs[AXIS_AILERONS_SET] + flightControlsKeyChangeAileron);
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: AILERONS_LEFT: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_AILERONS_SET];
-        cout << endl;
+        std::cout << "WASM: AILERONS_LEFT: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_AILERONS_SET];
+        std::cout << std::endl;
       }
       break;
     }
     case KEY_AILERON_RIGHT: {
-      simInput.inputs[AXIS_AILERONS_SET] = fmax(-1.0, simInput.inputs[AXIS_AILERONS_SET] - flightControlsKeyChangeAileron);
+      simInput.inputs[AXIS_AILERONS_SET] = std::fmax(-1.0, simInput.inputs[AXIS_AILERONS_SET] - flightControlsKeyChangeAileron);
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: AILERONS_RIGHT: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_AILERONS_SET];
-        cout << endl;
+        std::cout << "WASM: AILERONS_RIGHT: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_AILERONS_SET];
+        std::cout << std::endl;
       }
       break;
     }
@@ -1426,12 +1424,12 @@ void SimConnectInterface::simConnectProcessDispatchMessage(SIMCONNECT_RECV* pDat
   switch (pData->dwID) {
     case SIMCONNECT_RECV_ID_OPEN:
       // connection established
-      cout << "WASM: SimConnect connection established" << endl;
+      std::cout << "WASM: SimConnect connection established" << std::endl;
       break;
 
     case SIMCONNECT_RECV_ID_QUIT:
       // connection lost
-      cout << "WASM: Received SimConnect connection quit message" << endl;
+      std::cout << "WASM: Received SimConnect connection quit message" << std::endl;
       disconnect();
       break;
 
@@ -1452,9 +1450,9 @@ void SimConnectInterface::simConnectProcessDispatchMessage(SIMCONNECT_RECV* pDat
 
     case SIMCONNECT_RECV_ID_EXCEPTION:
       // exception
-      cout << "WASM: Exception in SimConnect connection: ";
-      cout << getSimConnectExceptionString(static_cast<SIMCONNECT_EXCEPTION>(static_cast<SIMCONNECT_RECV_EXCEPTION*>(pData)->dwException));
-      cout << endl;
+      std::cout << "WASM: Exception in SimConnect connection: ";
+      std::cout << getSimConnectExceptionString(static_cast<SIMCONNECT_EXCEPTION>(static_cast<SIMCONNECT_RECV_EXCEPTION*>(pData)->dwException));
+      std::cout << std::endl;
       break;
 
     default:
@@ -1468,11 +1466,11 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::AXIS_ELEVATOR_SET: {
       simInput.inputs[AXIS_ELEVATOR_SET] = static_cast<long>(event->dwData) / 16384.0;
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: AXIS_ELEVATOR_SET: ";
-        cout << static_cast<long>(event->dwData);
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_ELEVATOR_SET];
-        cout << endl;
+        std::cout << "WASM: AXIS_ELEVATOR_SET: ";
+        std::cout << static_cast<long>(event->dwData);
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_ELEVATOR_SET];
+        std::cout << std::endl;
       }
       break;
     }
@@ -1480,11 +1478,11 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::AXIS_AILERONS_SET: {
       simInput.inputs[AXIS_AILERONS_SET] = static_cast<long>(event->dwData) / 16384.0;
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: AXIS_AILERONS_SET: ";
-        cout << static_cast<long>(event->dwData);
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_AILERONS_SET];
-        cout << endl;
+        std::cout << "WASM: AXIS_AILERONS_SET: ";
+        std::cout << static_cast<long>(event->dwData);
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_AILERONS_SET];
+        std::cout << std::endl;
       }
       break;
     }
@@ -1492,11 +1490,11 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::AXIS_RUDDER_SET: {
       simInput.inputs[AXIS_RUDDER_SET] = static_cast<long>(event->dwData) / 16384.0;
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: AXIS_RUDDER_SET: ";
-        cout << static_cast<long>(event->dwData);
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_RUDDER_SET];
-        cout << endl;
+        std::cout << "WASM: AXIS_RUDDER_SET: ";
+        std::cout << static_cast<long>(event->dwData);
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_RUDDER_SET];
+        std::cout << std::endl;
       }
       break;
     }
@@ -1504,23 +1502,23 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::RUDDER_SET: {
       simInput.inputs[AXIS_RUDDER_SET] = static_cast<long>(event->dwData) / 16384.0;
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: RUDDER_SET: ";
-        cout << static_cast<long>(event->dwData);
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_RUDDER_SET];
-        cout << endl;
+        std::cout << "WASM: RUDDER_SET: ";
+        std::cout << static_cast<long>(event->dwData);
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_RUDDER_SET];
+        std::cout << std::endl;
       }
       break;
     }
 
     case Events::RUDDER_LEFT: {
-      simInput.inputs[AXIS_RUDDER_SET] = fmin(1.0, simInput.inputs[AXIS_RUDDER_SET] + flightControlsKeyChangeRudder);
+      simInput.inputs[AXIS_RUDDER_SET] = std::fmin(1.0, simInput.inputs[AXIS_RUDDER_SET] + flightControlsKeyChangeRudder);
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: RUDDER_LEFT: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_RUDDER_SET];
-        cout << endl;
+        std::cout << "WASM: RUDDER_LEFT: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_RUDDER_SET];
+        std::cout << std::endl;
       }
       break;
     }
@@ -1528,23 +1526,23 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::RUDDER_CENTER: {
       simInput.inputs[AXIS_RUDDER_SET] = 0.0;
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: RUDDER_CENTER: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_RUDDER_SET];
-        cout << endl;
+        std::cout << "WASM: RUDDER_CENTER: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_RUDDER_SET];
+        std::cout << std::endl;
       }
       break;
     }
 
     case Events::RUDDER_RIGHT: {
-      simInput.inputs[AXIS_RUDDER_SET] = fmax(-1.0, simInput.inputs[AXIS_RUDDER_SET] - flightControlsKeyChangeRudder);
+      simInput.inputs[AXIS_RUDDER_SET] = std::fmax(-1.0, simInput.inputs[AXIS_RUDDER_SET] - flightControlsKeyChangeRudder);
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: RUDDER_RIGHT: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_RUDDER_SET];
-        cout << endl;
+        std::cout << "WASM: RUDDER_RIGHT: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_RUDDER_SET];
+        std::cout << std::endl;
       }
       break;
     }
@@ -1558,11 +1556,11 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
         simInput.inputs[AXIS_RUDDER_SET] = +1.0 * (static_cast<long>(event->dwData) / 16384.0);
       }
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: RUDDER_AXIS_MINUS: ";
-        cout << static_cast<long>(event->dwData);
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_RUDDER_SET];
-        cout << endl;
+        std::cout << "WASM: RUDDER_AXIS_MINUS: ";
+        std::cout << static_cast<long>(event->dwData);
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_RUDDER_SET];
+        std::cout << std::endl;
       }
       break;
     }
@@ -1576,11 +1574,11 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
         simInput.inputs[AXIS_RUDDER_SET] = -1.0 * (static_cast<long>(event->dwData) / 16384.0);
       }
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: RUDDER_AXIS_PLUS: ";
-        cout << static_cast<long>(event->dwData);
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_RUDDER_SET];
-        cout << endl;
+        std::cout << "WASM: RUDDER_AXIS_PLUS: ";
+        std::cout << static_cast<long>(event->dwData);
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_RUDDER_SET];
+        std::cout << std::endl;
       }
       break;
     }
@@ -1588,9 +1586,9 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::RUDDER_TRIM_LEFT: {
       simInputRudderTrim.rudderTrimSwitchLeft = true;
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: RUDDER_TRIM_LEFT: ";
-        cout << "(no data)";
-        cout << endl;
+        std::cout << "WASM: RUDDER_TRIM_LEFT: ";
+        std::cout << "(no data)";
+        std::cout << std::endl;
       }
       break;
     }
@@ -1598,9 +1596,9 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::RUDDER_TRIM_RESET: {
       simInputRudderTrim.rudderTrimReset = true;
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: RUDDER_TRIM_RESET: ";
-        cout << "(no data)";
-        cout << endl;
+        std::cout << "WASM: RUDDER_TRIM_RESET: ";
+        std::cout << "(no data)";
+        std::cout << std::endl;
       }
       break;
     }
@@ -1608,27 +1606,27 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::RUDDER_TRIM_RIGHT: {
       simInputRudderTrim.rudderTrimSwitchRight = true;
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: RUDDER_TRIM_RIGHT: ";
-        cout << "(no data)";
-        cout << endl;
+        std::cout << "WASM: RUDDER_TRIM_RIGHT: ";
+        std::cout << "(no data)";
+        std::cout << std::endl;
       }
       break;
     }
 
     case Events::RUDDER_TRIM_SET: {
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: RUDDER_TRIM_SET: ";
-        cout << static_cast<long>(event->dwData);
-        cout << endl;
+        std::cout << "WASM: RUDDER_TRIM_SET: ";
+        std::cout << static_cast<long>(event->dwData);
+        std::cout << std::endl;
       }
       break;
     }
 
     case Events::RUDDER_TRIM_SET_EX1: {
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: RUDDER_TRIM_SET_EX1: ";
-        cout << static_cast<long>(event->dwData);
-        cout << endl;
+        std::cout << "WASM: RUDDER_TRIM_SET_EX1: ";
+        std::cout << static_cast<long>(event->dwData);
+        std::cout << std::endl;
       }
       break;
     }
@@ -1636,35 +1634,35 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::AILERON_SET: {
       simInput.inputs[AXIS_AILERONS_SET] = static_cast<long>(event->dwData) / 16384.0;
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: AILERON_SET: ";
-        cout << static_cast<long>(event->dwData);
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_AILERONS_SET];
-        cout << endl;
+        std::cout << "WASM: AILERON_SET: ";
+        std::cout << static_cast<long>(event->dwData);
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_AILERONS_SET];
+        std::cout << std::endl;
       }
       break;
     }
 
     case Events::AILERONS_LEFT: {
-      simInput.inputs[AXIS_AILERONS_SET] = fmin(1.0, simInput.inputs[AXIS_AILERONS_SET] + flightControlsKeyChangeAileron);
+      simInput.inputs[AXIS_AILERONS_SET] = std::fmin(1.0, simInput.inputs[AXIS_AILERONS_SET] + flightControlsKeyChangeAileron);
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: AILERONS_LEFT: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_AILERONS_SET];
-        cout << endl;
+        std::cout << "WASM: AILERONS_LEFT: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_AILERONS_SET];
+        std::cout << std::endl;
       }
       break;
     }
 
     case Events::AILERONS_RIGHT: {
-      simInput.inputs[AXIS_AILERONS_SET] = fmax(-1.0, simInput.inputs[AXIS_AILERONS_SET] - flightControlsKeyChangeAileron);
+      simInput.inputs[AXIS_AILERONS_SET] = std::fmax(-1.0, simInput.inputs[AXIS_AILERONS_SET] - flightControlsKeyChangeAileron);
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: AILERONS_RIGHT: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_AILERONS_SET];
-        cout << endl;
+        std::cout << "WASM: AILERONS_RIGHT: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_AILERONS_SET];
+        std::cout << std::endl;
       }
       break;
     }
@@ -1673,13 +1671,13 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       simInput.inputs[AXIS_RUDDER_SET] = 0.0;
       simInput.inputs[AXIS_AILERONS_SET] = 0.0;
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: CENTER_AILER_RUDDER: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_AILERONS_SET];
-        cout << " / ";
-        cout << simInput.inputs[AXIS_RUDDER_SET];
-        cout << endl;
+        std::cout << "WASM: CENTER_AILER_RUDDER: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_AILERONS_SET];
+        std::cout << " / ";
+        std::cout << simInput.inputs[AXIS_RUDDER_SET];
+        std::cout << std::endl;
       }
       break;
     }
@@ -1687,143 +1685,143 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::ELEVATOR_SET: {
       simInput.inputs[AXIS_ELEVATOR_SET] = static_cast<long>(event->dwData) / 16384.0;
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: ELEVATOR_SET: ";
-        cout << static_cast<long>(event->dwData);
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_ELEVATOR_SET];
-        cout << endl;
+        std::cout << "WASM: ELEVATOR_SET: ";
+        std::cout << static_cast<long>(event->dwData);
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_ELEVATOR_SET];
+        std::cout << std::endl;
       }
       break;
     }
 
     case Events::ELEV_DOWN: {
-      simInput.inputs[AXIS_ELEVATOR_SET] = fmin(1.0, simInput.inputs[AXIS_ELEVATOR_SET] + flightControlsKeyChangeElevator);
+      simInput.inputs[AXIS_ELEVATOR_SET] = std::fmin(1.0, simInput.inputs[AXIS_ELEVATOR_SET] + flightControlsKeyChangeElevator);
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: ELEV_DOWN: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_ELEVATOR_SET];
-        cout << endl;
+        std::cout << "WASM: ELEV_DOWN: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_ELEVATOR_SET];
+        std::cout << std::endl;
       }
       break;
     }
 
     case Events::ELEV_UP: {
-      simInput.inputs[AXIS_ELEVATOR_SET] = fmax(-1.0, simInput.inputs[AXIS_ELEVATOR_SET] - flightControlsKeyChangeElevator);
+      simInput.inputs[AXIS_ELEVATOR_SET] = std::fmax(-1.0, simInput.inputs[AXIS_ELEVATOR_SET] - flightControlsKeyChangeElevator);
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: ELEV_UP: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << simInput.inputs[AXIS_ELEVATOR_SET];
-        cout << endl;
+        std::cout << "WASM: ELEV_UP: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << simInput.inputs[AXIS_ELEVATOR_SET];
+        std::cout << std::endl;
       }
       break;
     }
 
     case Events::AUTOPILOT_OFF: {
       simInputAutopilot.AP_disconnect = 1;
-      cout << "WASM: event triggered: AUTOPILOT_OFF" << endl;
+      std::cout << "WASM: event triggered: AUTOPILOT_OFF" << std::endl;
       break;
     }
 
     case Events::AUTOPILOT_ON: {
       simInputAutopilot.AP_engage = 1;
-      cout << "WASM: event triggered: AUTOPILOT_ON" << endl;
+      std::cout << "WASM: event triggered: AUTOPILOT_ON" << std::endl;
       break;
     }
 
     case Events::TOGGLE_FLIGHT_DIRECTOR: {
-      cout << "WASM: event triggered: TOGGLE_FLIGHT_DIRECTOR:" << static_cast<long>(event->dwData) << endl;
+      std::cout << "WASM: event triggered: TOGGLE_FLIGHT_DIRECTOR:" << static_cast<long>(event->dwData) << std::endl;
       break;
     }
 
     case Events::AP_MASTER: {
       simInputAutopilot.AP_1_push = 1;
-      cout << "WASM: event triggered: AP_MASTER" << endl;
+      std::cout << "WASM: event triggered: AP_MASTER" << std::endl;
       break;
     }
 
     case Events::AUTOPILOT_DISENGAGE_SET: {
       if (static_cast<long>(event->dwData) == 1) {
         simInputAutopilot.AP_disconnect = 1;
-        cout << "WASM: event triggered: AUTOPILOT_DISENGAGE_SET" << endl;
+        std::cout << "WASM: event triggered: AUTOPILOT_DISENGAGE_SET" << std::endl;
       }
       break;
     }
 
     case Events::AUTOPILOT_DISENGAGE_TOGGLE: {
       simInputAutopilot.AP_1_push = 1;
-      cout << "WASM: event triggered: AUTOPILOT_DISENGAGE_TOGGLE" << endl;
+      std::cout << "WASM: event triggered: AUTOPILOT_DISENGAGE_TOGGLE" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_AP_1_PUSH: {
       simInputAutopilot.AP_1_push = 1;
-      cout << "WASM: event triggered: A32NX_FCU_AP_1_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_AP_1_PUSH" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_AP_2_PUSH: {
       simInputAutopilot.AP_2_push = 1;
-      cout << "WASM: event triggered: A32NX_FCU_AP_2_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_AP_2_PUSH" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_AP_DISCONNECT_PUSH: {
       simInputAutopilot.AP_disconnect = 1;
-      cout << "WASM: event triggered: A32NX_FCU_AP_DISCONNECT_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_AP_DISCONNECT_PUSH" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_ATHR_PUSH: {
       simInputThrottles.ATHR_push = 1;
-      cout << "WASM: event triggered: A32NX_FCU_ATHR_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_ATHR_PUSH" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_ATHR_DISCONNECT_PUSH: {
       simInputThrottles.ATHR_disconnect = 1;
-      cout << "WASM: event triggered: A32NX_FCU_ATHR_DISCONNECT_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_ATHR_DISCONNECT_PUSH" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_SPD_INC: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_INC)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_SPD_INC" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_SPD_INC" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_SPD_DEC: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_DEC)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_SPD_DEC" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_SPD_DEC" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_SPD_SET: {
       idFcuEventSetSPEED->set(static_cast<long>(event->dwData));
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_SET)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_SPD_SET: " << static_cast<long>(event->dwData) << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_SPD_SET: " << static_cast<long>(event->dwData) << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_SPD_PUSH:
     case Events::AP_AIRSPEED_ON: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_PUSH)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_SPD_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_SPD_PUSH" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_SPD_PULL:
     case Events::AP_AIRSPEED_OFF: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_PULL)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_SPD_PULL" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_SPD_PULL" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_SPD_MACH_TOGGLE_PUSH:
     case Events::AP_MACH_HOLD: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_TOGGLE_SPEED_MACH)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_SPD_MACH_TOGGLE_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_SPD_MACH_TOGGLE_PUSH" << std::endl;
       break;
     }
 
@@ -1831,7 +1829,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_HDG_INC_TRACK) } els{ (>H:A320_Neo_FCU_HDG_INC_HEADING) }",
           nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_HDG_INC" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_HDG_INC" << std::endl;
       break;
     }
 
@@ -1839,47 +1837,47 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_HDG_DEC_TRACK) } els{ (>H:A320_Neo_FCU_HDG_DEC_HEADING) }",
           nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_HDG_DEC" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_HDG_DEC" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_HDG_SET: {
       idFcuEventSetHDG->set(static_cast<long>(event->dwData));
       execute_calculator_code("(>H:A320_Neo_FCU_HDG_SET)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_HDG_SET: " << static_cast<long>(event->dwData) << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_HDG_SET: " << static_cast<long>(event->dwData) << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_HDG_PUSH:
     case Events::AP_HDG_HOLD_ON: {
       execute_calculator_code("(>H:A320_Neo_FCU_HDG_PUSH)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_HDG_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_HDG_PUSH" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_HDG_PULL:
     case Events::AP_HDG_HOLD_OFF: {
       execute_calculator_code("(>H:A320_Neo_FCU_HDG_PULL)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_HDG_PULL" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_HDG_PULL" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_TRK_FPA_TOGGLE_PUSH:
     case Events::AP_VS_HOLD: {
       execute_calculator_code("(L:A32NX_TRK_FPA_MODE_ACTIVE) ! (>L:A32NX_TRK_FPA_MODE_ACTIVE)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_TRK_FPA_TOGGLE_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_TRK_FPA_TOGGLE_PUSH" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_TO_AP_HDG_PUSH: {
       simInputAutopilot.HDG_push = 1;
-      cout << "WASM: event triggered: A32NX_FCU_TO_AP_HDG_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_TO_AP_HDG_PUSH" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_TO_AP_HDG_PULL: {
       simInputAutopilot.HDG_pull = 1;
-      cout << "WASM: event triggered: A32NX_FCU_TO_AP_HDG_PULL" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_TO_AP_HDG_PULL" << std::endl;
       break;
     }
 
@@ -1904,7 +1902,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
             "(>H:A320_Neo_CDU_AP_INC_ALT)",
             nullptr, nullptr, nullptr);
       }
-      cout << "WASM: event triggered: A32NX_FCU_ALT_INC" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_ALT_INC" << std::endl;
       break;
     }
 
@@ -1930,17 +1928,17 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
             "+ 100 max (>K:2:AP_ALT_VAR_SET_ENGLISH) (>H:AP_KNOB_Down) (>H:A320_Neo_CDU_AP_DEC_ALT)",
             nullptr, nullptr, nullptr);
       }
-      cout << "WASM: event triggered: A32NX_FCU_ALT_DEC" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_ALT_DEC" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_ALT_SET: {
       long value = 100 * (static_cast<long>(event->dwData) / 100);
-      ostringstream stringStream;
+      std::ostringstream stringStream;
       stringStream << value;
       stringStream << " (>K:3:AP_ALT_VAR_SET_ENGLISH)";
       execute_calculator_code(stringStream.str().c_str(), nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_ALT_SET: " << value << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_ALT_SET: " << value << std::endl;
       break;
     }
 
@@ -1951,18 +1949,18 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
           "if{ 1000 (>L:XMLVAR_Autopilot_Altitude_Increment) } "
           "els{ 100 (>L:XMLVAR_Autopilot_Altitude_Increment) }",
           nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_ALT_INCREMENT_TOGGLE" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_ALT_INCREMENT_TOGGLE" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_ALT_INCREMENT_SET: {
       long value = static_cast<long>(event->dwData);
       if (value == 100 || value == 1000) {
-        ostringstream stringStream;
+        std::ostringstream stringStream;
         stringStream << value;
         stringStream << " (>L:XMLVAR_Autopilot_Altitude_Increment)";
         execute_calculator_code(stringStream.str().c_str(), nullptr, nullptr, nullptr);
-        cout << "WASM: event triggered: A32NX_FCU_ALT_INCREMENT_SET: " << value << endl;
+        std::cout << "WASM: event triggered: A32NX_FCU_ALT_INCREMENT_SET: " << value << std::endl;
       }
       break;
     }
@@ -1971,7 +1969,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::AP_ALT_HOLD_ON: {
       simInputAutopilot.ALT_push = 1;
       execute_calculator_code("(>H:A320_Neo_CDU_MODE_MANAGED_ALTITUDE)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_ALT_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_ALT_PUSH" << std::endl;
       break;
     }
 
@@ -1979,7 +1977,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::AP_ALT_HOLD_OFF: {
       simInputAutopilot.ALT_pull = 1;
       execute_calculator_code("(>H:A320_Neo_CDU_MODE_SELECTED_ALTITUDE)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_ALT_PULL" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_ALT_PULL" << std::endl;
       break;
     }
 
@@ -1988,7 +1986,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_VS_INC_FPA) } els{ (>H:A320_Neo_FCU_VS_INC_VS) } "
           "(>H:A320_Neo_CDU_VS)",
           nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_VS_INC" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_VS_INC" << std::endl;
       break;
     }
 
@@ -1997,76 +1995,76 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_VS_DEC_FPA) } els{ (>H:A320_Neo_FCU_VS_DEC_VS) } "
           "(>H:A320_Neo_CDU_VS)",
           nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_VS_DEC" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_VS_DEC" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_VS_SET: {
       idFcuEventSetVS->set(static_cast<long>(event->dwData));
       execute_calculator_code("(>H:A320_Neo_FCU_VS_SET) (>H:A320_Neo_CDU_VS)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_VS_SET: " << static_cast<long>(event->dwData) << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_VS_SET: " << static_cast<long>(event->dwData) << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_VS_PUSH:
     case Events::AP_VS_ON: {
       execute_calculator_code("(>H:A320_Neo_FCU_VS_PUSH) (>H:A320_Neo_CDU_VS)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_VS_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_VS_PUSH" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_VS_PULL:
     case Events::AP_VS_OFF: {
       execute_calculator_code("(>H:A320_Neo_FCU_VS_PULL) (>H:A320_Neo_CDU_VS)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_FCU_VS_PULL" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_VS_PULL" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_TO_AP_VS_PUSH: {
       simInputAutopilot.VS_push = 1;
-      cout << "WASM: event triggered: A32NX_FCU_TO_AP_VS_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_TO_AP_VS_PUSH" << std::endl;
       break;
     }
     case Events::A32NX_FCU_TO_AP_VS_PULL: {
       simInputAutopilot.VS_pull = 1;
-      cout << "WASM: event triggered: A32NX_FCU_TO_AP_VS_PULL" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_TO_AP_VS_PULL" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_LOC_PUSH: {
       simInputAutopilot.LOC_push = 1;
-      cout << "WASM: event triggered: A32NX_FCU_LOC_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_LOC_PUSH" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_APPR_PUSH: {
       simInputAutopilot.APPR_push = 1;
-      cout << "WASM: event triggered: A32NX_FCU_APPR_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_APPR_PUSH" << std::endl;
       break;
     }
 
     case Events::A32NX_FCU_EXPED_PUSH:
     case Events::AP_ATT_HOLD: {
       simInputAutopilot.EXPED_push = 1;
-      cout << "WASM: event triggered: A32NX_FCU_EXPED_PUSH" << endl;
+      std::cout << "WASM: event triggered: A32NX_FCU_EXPED_PUSH" << std::endl;
       break;
     }
 
     case Events::A32NX_FMGC_DIR_TO_TRIGGER: {
       simInputAutopilot.DIR_TO_trigger = 1;
-      cout << "WASM: event triggered: A32NX_FMGC_DIR_TO_TRIGGER" << endl;
+      std::cout << "WASM: event triggered: A32NX_FMGC_DIR_TO_TRIGGER" << std::endl;
       break;
     }
 
     case Events::A32NX_EFIS_L_CHRONO_PUSHED: {
       execute_calculator_code("(>H:A32NX_EFIS_L_CHRONO_PUSHED)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_EFIS_L_CHRONO_PUSHED" << endl;
+      std::cout << "WASM: event triggered: A32NX_EFIS_L_CHRONO_PUSHED" << std::endl;
       break;
     }
 
     case Events::A32NX_EFIS_R_CHRONO_PUSHED: {
       execute_calculator_code("(>H:A32NX_EFIS_R_CHRONO_PUSHED)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: A32NX_EFIS_R_CHRONO_PUSHED" << endl;
+      std::cout << "WASM: event triggered: A32NX_EFIS_R_CHRONO_PUSHED" << std::endl;
       break;
     }
 
@@ -2077,31 +2075,31 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       // } else {
       //   execute_calculator_code("(>H:A320_Neo_FCU_SPEED_PULL)", nullptr, nullptr, nullptr);
       // }
-      cout << "WASM: event triggered: SPEED_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << endl;
+      std::cout << "WASM: event triggered: SPEED_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << std::endl;
       break;
     }
 
     case Events::AP_SPD_VAR_INC: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_INC)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: AP_SPD_VAR_INC" << endl;
+      std::cout << "WASM: event triggered: AP_SPD_VAR_INC" << std::endl;
       break;
     }
 
     case Events::AP_SPD_VAR_DEC: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_DEC)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: AP_SPD_VAR_DEC" << endl;
+      std::cout << "WASM: event triggered: AP_SPD_VAR_DEC" << std::endl;
       break;
     }
 
     case Events::AP_MACH_VAR_INC: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_INC)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: AP_MACH_VAR_INC" << endl;
+      std::cout << "WASM: event triggered: AP_MACH_VAR_INC" << std::endl;
       break;
     }
 
     case Events::AP_MACH_VAR_DEC: {
       execute_calculator_code("(>H:A320_Neo_FCU_SPEED_DEC)", nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: AP_MACH_VAR_DEC" << endl;
+      std::cout << "WASM: event triggered: AP_MACH_VAR_DEC" << std::endl;
       break;
     }
 
@@ -2112,7 +2110,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       // } else {
       //   execute_calculator_code("(>H:A320_Neo_FCU_VS_PULL)", nullptr, nullptr, nullptr);
       // }
-      cout << "WASM: event triggered: HEADING_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << endl;
+      std::cout << "WASM: event triggered: HEADING_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << std::endl;
       break;
     }
 
@@ -2120,7 +2118,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_HDG_INC_TRACK) } els{ (>H:A320_Neo_FCU_HDG_INC_HEADING) }",
           nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: HEADING_BUG_INC" << endl;
+      std::cout << "WASM: event triggered: HEADING_BUG_INC" << std::endl;
       break;
     }
 
@@ -2128,7 +2126,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_HDG_DEC_TRACK) } els{ (>H:A320_Neo_FCU_HDG_DEC_HEADING) }",
           nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: HEADING_BUG_DEC" << endl;
+      std::cout << "WASM: event triggered: HEADING_BUG_DEC" << std::endl;
       break;
     }
 
@@ -2139,7 +2137,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       // } else {
       //   execute_calculator_code("(>H:A320_Neo_FCU_ALT_PULL) (>H:A320_Neo_CDU_MODE_SELECTED_ALTITUDE)", nullptr, nullptr, nullptr);
       // }
-      cout << "WASM: event triggered: ALTITUDE_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << endl;
+      std::cout << "WASM: event triggered: ALTITUDE_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << std::endl;
       break;
     }
 
@@ -2149,7 +2147,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
           "(L:XMLVAR_Autopilot_Altitude_Increment) % - 49000 min (>K:2:AP_ALT_VAR_SET_ENGLISH) (>H:AP_KNOB_Up) "
           "(>H:A320_Neo_CDU_AP_INC_ALT)",
           nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: AP_ALT_VAR_INC" << endl;
+      std::cout << "WASM: event triggered: AP_ALT_VAR_INC" << std::endl;
       break;
     }
 
@@ -2159,7 +2157,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
           "(A:AUTOPILOT ALTITUDE LOCK VAR:3, feet) (L:XMLVAR_Autopilot_Altitude_Increment) % - (L:XMLVAR_Autopilot_Altitude_Increment) % "
           "+ 100 max (>K:2:AP_ALT_VAR_SET_ENGLISH) (>H:AP_KNOB_Down) (>H:A320_Neo_CDU_AP_DEC_ALT)",
           nullptr, nullptr, nullptr);
-      cout << "WASM: event triggered: AP_ALT_VAR_DEC" << endl;
+      std::cout << "WASM: event triggered: AP_ALT_VAR_DEC" << std::endl;
       break;
     }
 
@@ -2170,7 +2168,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       // } else {
       //   execute_calculator_code("(>H:A320_Neo_FCU_VS_PULL)", nullptr, nullptr, nullptr);
       // }
-      cout << "WASM: event triggered: VS_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << endl;
+      std::cout << "WASM: event triggered: VS_SLOT_INDEX_SET: " << static_cast<long>(event->dwData) << std::endl;
       break;
     }
 
@@ -2178,7 +2176,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_VS_INC_FPA) } els{ (>H:A320_Neo_FCU_VS_INC_VS) }", nullptr,
           nullptr, nullptr);
-      cout << "WASM: event triggered: AP_VS_VAR_INC" << endl;
+      std::cout << "WASM: event triggered: AP_VS_VAR_INC" << std::endl;
       break;
     }
 
@@ -2186,70 +2184,70 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       execute_calculator_code(
           "(L:A32NX_TRK_FPA_MODE_ACTIVE, bool) 1 == if{ (>H:A320_Neo_FCU_VS_DEC_FPA) } els{ (>H:A320_Neo_FCU_VS_DEC_VS) }", nullptr,
           nullptr, nullptr);
-      cout << "WASM: event triggered: AP_VS_VAR_DEC" << endl;
+      std::cout << "WASM: event triggered: AP_VS_VAR_DEC" << std::endl;
       break;
     }
 
     case Events::AP_APR_HOLD: {
       simInputAutopilot.APPR_push = 1;
-      cout << "WASM: event triggered: AP_APR_HOLD" << endl;
+      std::cout << "WASM: event triggered: AP_APR_HOLD" << std::endl;
       break;
     }
 
     case Events::AP_LOC_HOLD: {
       simInputAutopilot.LOC_push = 1;
-      cout << "WASM: event triggered: AP_LOC_HOLD" << endl;
+      std::cout << "WASM: event triggered: AP_LOC_HOLD" << std::endl;
       break;
     }
 
     case Events::AUTO_THROTTLE_ARM: {
       simInputThrottles.ATHR_push = 1;
-      cout << "WASM: event triggered: AUTO_THROTTLE_ARM" << endl;
+      std::cout << "WASM: event triggered: AUTO_THROTTLE_ARM" << std::endl;
       break;
     }
 
     case Events::AUTO_THROTTLE_DISCONNECT: {
       simInputThrottles.ATHR_disconnect = 1;
-      cout << "WASM: event triggered: AUTO_THROTTLE_DISCONNECT" << endl;
+      std::cout << "WASM: event triggered: AUTO_THROTTLE_DISCONNECT" << std::endl;
       break;
     }
 
     case Events::A32NX_ATHR_RESET_DISABLE: {
       simInputThrottles.ATHR_reset_disable = 1;
-      cout << "WASM: event triggered: ATHR_RESET_DISABLE" << endl;
+      std::cout << "WASM: event triggered: ATHR_RESET_DISABLE" << std::endl;
       break;
     }
 
     case Events::AUTO_THROTTLE_TO_GA: {
       throttleAxis[0]->onEventThrottleFull();
       throttleAxis[1]->onEventThrottleFull();
-      cout << "WASM: event triggered: AUTO_THROTTLE_TO_GA (treated like THROTTLE_FULL)" << endl;
+      std::cout << "WASM: event triggered: AUTO_THROTTLE_TO_GA (treated like THROTTLE_FULL)" << std::endl;
       break;
     }
 
     case Events::A32NX_THROTTLE_MAPPING_SET_DEFAULTS: {
-      cout << "WASM: event triggered: THROTTLE_MAPPING_SET_DEFAULTS" << endl;
+      std::cout << "WASM: event triggered: THROTTLE_MAPPING_SET_DEFAULTS" << std::endl;
       throttleAxis[0]->applyDefaults();
       throttleAxis[1]->applyDefaults();
       break;
     }
 
     case Events::A32NX_THROTTLE_MAPPING_LOAD_FROM_FILE: {
-      cout << "WASM: event triggered: THROTTLE_MAPPING_LOAD_FROM_FILE" << endl;
+      std::cout << "WASM: event triggered: THROTTLE_MAPPING_LOAD_FROM_FILE" << std::endl;
       throttleAxis[0]->loadFromFile();
       throttleAxis[1]->loadFromFile();
       break;
     }
 
     case Events::A32NX_THROTTLE_MAPPING_LOAD_FROM_LOCAL_VARIABLES: {
-      cout << "WASM: event triggered: THROTTLE_MAPPING_LOAD_FROM_LOCAL_VARIABLES" << endl;
+      std::cout << "WASM: event triggered: THROTTLE_MAPPING_LOAD_FROM_LOCAL_VARIABLES" << std::endl;
       throttleAxis[0]->loadFromLocalVariables();
       throttleAxis[1]->loadFromLocalVariables();
       break;
     }
 
     case Events::A32NX_THROTTLE_MAPPING_SAVE_TO_FILE: {
-      cout << "WASM: event triggered: THROTTLE_MAPPING_SAVE_TO_FILE" << endl;
+      std::cout << "WASM: event triggered: THROTTLE_MAPPING_SAVE_TO_FILE" << std::endl;
       throttleAxis[0]->saveToFile();
       throttleAxis[1]->saveToFile();
       break;
@@ -2259,7 +2257,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleSet(static_cast<long>(event->dwData));
       throttleAxis[1]->onEventThrottleSet(static_cast<long>(event->dwData));
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_SET: " << static_cast<long>(event->dwData) << endl;
+        std::cout << "WASM: THROTTLE_SET: " << static_cast<long>(event->dwData) << std::endl;
       }
       break;
     }
@@ -2267,7 +2265,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE1_SET: {
       throttleAxis[0]->onEventThrottleSet(static_cast<long>(event->dwData));
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE1_SET: " << static_cast<long>(event->dwData) << endl;
+        std::cout << "WASM: THROTTLE1_SET: " << static_cast<long>(event->dwData) << std::endl;
       }
       break;
     }
@@ -2275,7 +2273,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE2_SET: {
       throttleAxis[1]->onEventThrottleSet(static_cast<long>(event->dwData));
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE2_SET: " << static_cast<long>(event->dwData) << endl;
+        std::cout << "WASM: THROTTLE2_SET: " << static_cast<long>(event->dwData) << std::endl;
       }
       break;
     }
@@ -2284,7 +2282,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleSet(static_cast<long>(event->dwData));
       throttleAxis[1]->onEventThrottleSet(static_cast<long>(event->dwData));
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_AXIS_SET_EX1: " << static_cast<long>(event->dwData) << endl;
+        std::cout << "WASM: THROTTLE_AXIS_SET_EX1: " << static_cast<long>(event->dwData) << std::endl;
       }
       break;
     }
@@ -2292,7 +2290,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE1_AXIS_SET_EX1: {
       throttleAxis[0]->onEventThrottleSet(static_cast<long>(event->dwData));
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE1_AXIS_SET_EX1: " << static_cast<long>(event->dwData) << endl;
+        std::cout << "WASM: THROTTLE1_AXIS_SET_EX1: " << static_cast<long>(event->dwData) << std::endl;
       }
       break;
     }
@@ -2300,7 +2298,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE2_AXIS_SET_EX1: {
       throttleAxis[1]->onEventThrottleSet(static_cast<long>(event->dwData));
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE2_AXIS_SET_EX1: " << static_cast<long>(event->dwData) << endl;
+        std::cout << "WASM: THROTTLE2_AXIS_SET_EX1: " << static_cast<long>(event->dwData) << std::endl;
       }
       break;
     }
@@ -2309,7 +2307,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleFull();
       throttleAxis[1]->onEventThrottleFull();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_FULL" << endl;
+        std::cout << "WASM: THROTTLE_FULL" << std::endl;
       }
       break;
     }
@@ -2318,7 +2316,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleCut();
       throttleAxis[1]->onEventThrottleCut();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_CUT" << endl;
+        std::cout << "WASM: THROTTLE_CUT" << std::endl;
       }
       break;
     }
@@ -2327,7 +2325,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleIncrease();
       throttleAxis[1]->onEventThrottleIncrease();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_INCR" << endl;
+        std::cout << "WASM: THROTTLE_INCR" << std::endl;
       }
       break;
     }
@@ -2336,7 +2334,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleDecrease();
       throttleAxis[1]->onEventThrottleDecrease();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_DECR" << endl;
+        std::cout << "WASM: THROTTLE_DECR" << std::endl;
       }
       break;
     }
@@ -2345,7 +2343,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleIncreaseSmall();
       throttleAxis[1]->onEventThrottleIncreaseSmall();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_INCR_SMALL" << endl;
+        std::cout << "WASM: THROTTLE_INCR_SMALL" << std::endl;
       }
       break;
     }
@@ -2354,7 +2352,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleDecreaseSmall();
       throttleAxis[1]->onEventThrottleDecreaseSmall();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_DECR_SMALL" << endl;
+        std::cout << "WASM: THROTTLE_DECR_SMALL" << std::endl;
       }
       break;
     }
@@ -2363,7 +2361,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleSet_10();
       throttleAxis[1]->onEventThrottleSet_10();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_10" << endl;
+        std::cout << "WASM: THROTTLE_10" << std::endl;
       }
       break;
     }
@@ -2372,7 +2370,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleSet_20();
       throttleAxis[1]->onEventThrottleSet_20();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_20" << endl;
+        std::cout << "WASM: THROTTLE_20" << std::endl;
       }
       break;
     }
@@ -2381,7 +2379,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleSet_30();
       throttleAxis[1]->onEventThrottleSet_30();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_30" << endl;
+        std::cout << "WASM: THROTTLE_30" << std::endl;
       }
       break;
     }
@@ -2390,7 +2388,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleSet_40();
       throttleAxis[1]->onEventThrottleSet_40();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_40" << endl;
+        std::cout << "WASM: THROTTLE_40" << std::endl;
       }
       break;
     }
@@ -2399,7 +2397,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleSet_50();
       throttleAxis[1]->onEventThrottleSet_50();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_50" << endl;
+        std::cout << "WASM: THROTTLE_50" << std::endl;
       }
       break;
     }
@@ -2408,7 +2406,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleSet_50();
       throttleAxis[1]->onEventThrottleSet_60();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_60" << endl;
+        std::cout << "WASM: THROTTLE_60" << std::endl;
       }
       break;
     }
@@ -2417,7 +2415,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleSet_70();
       throttleAxis[1]->onEventThrottleSet_70();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_70" << endl;
+        std::cout << "WASM: THROTTLE_70" << std::endl;
       }
       break;
     }
@@ -2426,7 +2424,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleSet_80();
       throttleAxis[1]->onEventThrottleSet_80();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_80" << endl;
+        std::cout << "WASM: THROTTLE_80" << std::endl;
       }
       break;
     }
@@ -2435,7 +2433,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventThrottleSet_90();
       throttleAxis[1]->onEventThrottleSet_90();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_90" << endl;
+        std::cout << "WASM: THROTTLE_90" << std::endl;
       }
       break;
     }
@@ -2443,7 +2441,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE1_FULL: {
       throttleAxis[0]->onEventThrottleFull();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE1_FULL" << endl;
+        std::cout << "WASM: THROTTLE1_FULL" << std::endl;
       }
       break;
     }
@@ -2451,7 +2449,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE1_CUT: {
       throttleAxis[0]->onEventThrottleCut();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE1_CUT" << endl;
+        std::cout << "WASM: THROTTLE1_CUT" << std::endl;
       }
       break;
     }
@@ -2459,7 +2457,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE1_INCR: {
       throttleAxis[0]->onEventThrottleIncrease();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE1_INCR" << endl;
+        std::cout << "WASM: THROTTLE1_INCR" << std::endl;
       }
       break;
     }
@@ -2467,7 +2465,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE1_DECR: {
       throttleAxis[0]->onEventThrottleDecrease();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE1_DECR" << endl;
+        std::cout << "WASM: THROTTLE1_DECR" << std::endl;
       }
       break;
     }
@@ -2475,7 +2473,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE1_INCR_SMALL: {
       throttleAxis[0]->onEventThrottleIncreaseSmall();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE1_INCR_SMALL" << endl;
+        std::cout << "WASM: THROTTLE1_INCR_SMALL" << std::endl;
       }
       break;
     }
@@ -2483,7 +2481,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE1_DECR_SMALL: {
       throttleAxis[0]->onEventThrottleDecreaseSmall();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE1_DECR_SMALL" << endl;
+        std::cout << "WASM: THROTTLE1_DECR_SMALL" << std::endl;
       }
       break;
     }
@@ -2491,7 +2489,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE2_FULL: {
       throttleAxis[1]->onEventThrottleFull();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE2_FULL" << endl;
+        std::cout << "WASM: THROTTLE2_FULL" << std::endl;
       }
       break;
     }
@@ -2499,7 +2497,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE2_CUT: {
       throttleAxis[1]->onEventThrottleCut();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE2_CUT" << endl;
+        std::cout << "WASM: THROTTLE2_CUT" << std::endl;
       }
       break;
     }
@@ -2507,7 +2505,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE2_INCR: {
       throttleAxis[1]->onEventThrottleIncrease();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE2_INCR" << endl;
+        std::cout << "WASM: THROTTLE2_INCR" << std::endl;
       }
       break;
     }
@@ -2515,7 +2513,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE2_DECR: {
       throttleAxis[1]->onEventThrottleDecrease();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE2_DECR" << endl;
+        std::cout << "WASM: THROTTLE2_DECR" << std::endl;
       }
       break;
     }
@@ -2523,7 +2521,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE2_INCR_SMALL: {
       throttleAxis[1]->onEventThrottleIncreaseSmall();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE2_INCR_SMALL" << endl;
+        std::cout << "WASM: THROTTLE2_INCR_SMALL" << std::endl;
       }
       break;
     }
@@ -2531,7 +2529,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::THROTTLE2_DECR_SMALL: {
       throttleAxis[1]->onEventThrottleDecreaseSmall();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE2_DECR_SMALL" << endl;
+        std::cout << "WASM: THROTTLE2_DECR_SMALL" << std::endl;
       }
       break;
     }
@@ -2540,7 +2538,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventReverseToggle();
       throttleAxis[1]->onEventReverseToggle();
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_REVERSE_THRUST_TOGGLE" << endl;
+        std::cout << "WASM: THROTTLE_REVERSE_THRUST_TOGGLE" << std::endl;
       }
       break;
     }
@@ -2548,7 +2546,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       throttleAxis[0]->onEventReverseHold(static_cast<bool>(event->dwData));
       throttleAxis[1]->onEventReverseHold(static_cast<bool>(event->dwData));
       if (loggingThrottlesEnabled) {
-        cout << "WASM: THROTTLE_REVERSE_THRUST_HOLD: " << static_cast<long>(event->dwData) << endl;
+        std::cout << "WASM: THROTTLE_REVERSE_THRUST_HOLD: " << static_cast<long>(event->dwData) << std::endl;
       }
       break;
     }
@@ -2556,13 +2554,13 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::SPOILERS_ON: {
       spoilersHandler->onEventSpoilersOn();
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: SPOILERS_ON: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << spoilersHandler->getHandlePosition();
-        cout << " / ";
-        cout << spoilersHandler->getIsArmed();
-        cout << endl;
+        std::cout << "WASM: SPOILERS_ON: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << spoilersHandler->getHandlePosition();
+        std::cout << " / ";
+        std::cout << spoilersHandler->getIsArmed();
+        std::cout << std::endl;
       }
       break;
     }
@@ -2570,13 +2568,13 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::SPOILERS_OFF: {
       spoilersHandler->onEventSpoilersOff();
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: SPOILERS_OFF: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << spoilersHandler->getHandlePosition();
-        cout << " / ";
-        cout << spoilersHandler->getIsArmed();
-        cout << endl;
+        std::cout << "WASM: SPOILERS_OFF: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << spoilersHandler->getHandlePosition();
+        std::cout << " / ";
+        std::cout << spoilersHandler->getIsArmed();
+        std::cout << std::endl;
       }
       break;
     }
@@ -2584,13 +2582,13 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::SPOILERS_TOGGLE: {
       spoilersHandler->onEventSpoilersToggle();
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: SPOILERS_TOGGLE: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << spoilersHandler->getHandlePosition();
-        cout << " / ";
-        cout << spoilersHandler->getIsArmed();
-        cout << endl;
+        std::cout << "WASM: SPOILERS_TOGGLE: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << spoilersHandler->getHandlePosition();
+        std::cout << " / ";
+        std::cout << spoilersHandler->getIsArmed();
+        std::cout << std::endl;
       }
       break;
     }
@@ -2598,13 +2596,13 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::SPOILERS_SET: {
       spoilersHandler->onEventSpoilersSet(static_cast<long>(event->dwData));
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: SPOILERS_SET: ";
-        cout << static_cast<long>(event->dwData);
-        cout << " -> ";
-        cout << spoilersHandler->getHandlePosition();
-        cout << " / ";
-        cout << spoilersHandler->getIsArmed();
-        cout << endl;
+        std::cout << "WASM: SPOILERS_SET: ";
+        std::cout << static_cast<long>(event->dwData);
+        std::cout << " -> ";
+        std::cout << spoilersHandler->getHandlePosition();
+        std::cout << " / ";
+        std::cout << spoilersHandler->getIsArmed();
+        std::cout << std::endl;
       }
       break;
     }
@@ -2612,13 +2610,13 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::AXIS_SPOILER_SET: {
       spoilersHandler->onEventSpoilersAxisSet(static_cast<long>(event->dwData));
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: AXIS_SPOILER_SET: ";
-        cout << static_cast<long>(event->dwData);
-        cout << " -> ";
-        cout << spoilersHandler->getHandlePosition();
-        cout << " / ";
-        cout << spoilersHandler->getIsArmed();
-        cout << endl;
+        std::cout << "WASM: AXIS_SPOILER_SET: ";
+        std::cout << static_cast<long>(event->dwData);
+        std::cout << " -> ";
+        std::cout << spoilersHandler->getHandlePosition();
+        std::cout << " / ";
+        std::cout << spoilersHandler->getIsArmed();
+        std::cout << std::endl;
       }
       break;
     }
@@ -2626,13 +2624,13 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::SPOILERS_ARM_ON: {
       spoilersHandler->onEventSpoilersArmOn();
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: SPOILERS_ARM_ON: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << spoilersHandler->getHandlePosition();
-        cout << " / ";
-        cout << spoilersHandler->getIsArmed();
-        cout << endl;
+        std::cout << "WASM: SPOILERS_ARM_ON: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << spoilersHandler->getHandlePosition();
+        std::cout << " / ";
+        std::cout << spoilersHandler->getIsArmed();
+        std::cout << std::endl;
       }
       break;
     }
@@ -2640,13 +2638,13 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::SPOILERS_ARM_OFF: {
       spoilersHandler->onEventSpoilersArmOff();
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: SPOILERS_ARM_OFF: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << spoilersHandler->getHandlePosition();
-        cout << " / ";
-        cout << spoilersHandler->getIsArmed();
-        cout << endl;
+        std::cout << "WASM: SPOILERS_ARM_OFF: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << spoilersHandler->getHandlePosition();
+        std::cout << " / ";
+        std::cout << spoilersHandler->getIsArmed();
+        std::cout << std::endl;
       }
       break;
     }
@@ -2654,13 +2652,13 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::SPOILERS_ARM_TOGGLE: {
       spoilersHandler->onEventSpoilersArmToggle();
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: SPOILERS_ARM_TOGGLE: ";
-        cout << "(no data)";
-        cout << " -> ";
-        cout << spoilersHandler->getHandlePosition();
-        cout << " / ";
-        cout << spoilersHandler->getIsArmed();
-        cout << endl;
+        std::cout << "WASM: SPOILERS_ARM_TOGGLE: ";
+        std::cout << "(no data)";
+        std::cout << " -> ";
+        std::cout << spoilersHandler->getHandlePosition();
+        std::cout << " / ";
+        std::cout << spoilersHandler->getIsArmed();
+        std::cout << std::endl;
       }
       break;
     }
@@ -2668,13 +2666,13 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::SPOILERS_ARM_SET: {
       spoilersHandler->onEventSpoilersArmSet(static_cast<long>(event->dwData) == 1);
       if (loggingFlightControlsEnabled) {
-        cout << "WASM: SPOILERS_ARM_SET: ";
-        cout << static_cast<long>(event->dwData);
-        cout << " -> ";
-        cout << spoilersHandler->getHandlePosition();
-        cout << " / ";
-        cout << spoilersHandler->getIsArmed();
-        cout << endl;
+        std::cout << "WASM: SPOILERS_ARM_SET: ";
+        std::cout << static_cast<long>(event->dwData);
+        std::cout << " -> ";
+        std::cout << spoilersHandler->getHandlePosition();
+        std::cout << " / ";
+        std::cout << spoilersHandler->getIsArmed();
+        std::cout << std::endl;
       }
       break;
     }
@@ -2686,13 +2684,13 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       if ((simData.simulation_rate < maxSimulationRate && theoreticalFrameRate >= 8) || simData.simulation_rate < 1 ||
           !limitSimulationRateByPerformance) {
         sendEvent(Events::SIM_RATE_INCR, 0, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
-        cout << "WASM: Simulation rate " << simData.simulation_rate;
-        cout << " -> " << simData.simulation_rate * 2;
-        cout << " (theoretical fps " << theoreticalFrameRate << ")" << endl;
+        std::cout << "WASM: Simulation rate " << simData.simulation_rate;
+        std::cout << " -> " << simData.simulation_rate * 2;
+        std::cout << " (theoretical fps " << theoreticalFrameRate << ")" << std::endl;
       } else {
-        cout << "WASM: Simulation rate " << simData.simulation_rate;
-        cout << " -> " << simData.simulation_rate;
-        cout << " (limited by max sim rate or theoretical fps " << theoreticalFrameRate << ")" << endl;
+        std::cout << "WASM: Simulation rate " << simData.simulation_rate;
+        std::cout << " -> " << simData.simulation_rate;
+        std::cout << " (limited by max sim rate or theoretical fps " << theoreticalFrameRate << ")" << std::endl;
       }
       break;
     }
@@ -2700,13 +2698,13 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::SIM_RATE_DECR: {
       if (simData.simulation_rate > minSimulationRate) {
         sendEvent(Events::SIM_RATE_DECR, 0, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
-        cout << "WASM: Simulation rate " << simData.simulation_rate;
-        cout << " -> " << simData.simulation_rate / 2;
-        cout << endl;
+        std::cout << "WASM: Simulation rate " << simData.simulation_rate;
+        std::cout << " -> " << simData.simulation_rate / 2;
+        std::cout << std::endl;
       } else {
-        cout << "WASM: Simulation rate " << simData.simulation_rate;
-        cout << " -> " << simData.simulation_rate;
-        cout << " (limited by min sim rate)" << endl;
+        std::cout << "WASM: Simulation rate " << simData.simulation_rate;
+        std::cout << " -> " << simData.simulation_rate;
+        std::cout << " (limited by min sim rate)" << std::endl;
       }
       break;
     }
@@ -2714,7 +2712,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
     case Events::SIM_RATE_SET: {
       long targetSimulationRate = min(maxSimulationRate, max(1, static_cast<long>(event->dwData)));
       sendEvent(Events::SIM_RATE_SET, targetSimulationRate, SIMCONNECT_GROUP_PRIORITY_DEFAULT);
-      cout << "WASM: Simulation Rate set to " << targetSimulationRate << endl;
+      std::cout << "WASM: Simulation Rate set to " << targetSimulationRate << std::endl;
       break;
     }
 
@@ -2733,8 +2731,8 @@ void SimConnectInterface::simConnectProcessSimObjectData(const SIMCONNECT_RECV_S
 
     default:
       // print unknown request id
-      cout << "WASM: Unknown request id in SimConnect connection: ";
-      cout << data->dwRequestID << endl;
+      std::cout << "WASM: Unknown request id in SimConnect connection: ";
+      std::cout << data->dwRequestID << std::endl;
       return;
   }
 }
@@ -2819,8 +2817,8 @@ void SimConnectInterface::simConnectProcessClientData(const SIMCONNECT_RECV_CLIE
 
     default:
       // print unknown request id
-      cout << "WASM: Unknown request id in SimConnect connection: ";
-      cout << data->dwRequestID << endl;
+      std::cout << "WASM: Unknown request id in SimConnect connection: ";
+      std::cout << data->dwRequestID << std::endl;
       return;
   }
 }
@@ -2833,7 +2831,7 @@ bool SimConnectInterface::sendClientData(SIMCONNECT_DATA_DEFINITION_ID id, DWORD
 
   // check if client data is enabled
   if (!clientDataEnabled) {
-    cout << "WASM: Client data is disabled but tried to write it!";
+    std::cout << "WASM: Client data is disabled but tried to write it!";
     return true;
   }
 
@@ -2872,8 +2870,8 @@ bool SimConnectInterface::sendData(SIMCONNECT_DATA_DEFINITION_ID id, DWORD size,
 bool SimConnectInterface::addDataDefinition(const HANDLE connectionHandle,
                                             const SIMCONNECT_DATA_DEFINITION_ID id,
                                             const SIMCONNECT_DATATYPE dataType,
-                                            const string& dataName,
-                                            const string& dataUnit) {
+                                            const std::string& dataName,
+                                            const std::string& dataUnit) {
   HRESULT result =
       SimConnect_AddToDataDefinition(connectionHandle, id, dataName.c_str(),
                                      SimConnectInterface::isSimConnectDataTypeStruct(dataType) ? nullptr : dataUnit.c_str(), dataType);
@@ -2884,7 +2882,7 @@ bool SimConnectInterface::addDataDefinition(const HANDLE connectionHandle,
 bool SimConnectInterface::addInputDataDefinition(const HANDLE connectionHandle,
                                                  const SIMCONNECT_DATA_DEFINITION_ID groupId,
                                                  const SIMCONNECT_CLIENT_EVENT_ID eventId,
-                                                 const string& eventName,
+                                                 const std::string& eventName,
                                                  const bool maskEvent) {
   HRESULT result = SimConnect_MapClientEventToSimEvent(connectionHandle, eventId, eventName.c_str());
 

--- a/src/fdr2csv/src/FlightDataRecorderConverter.cpp
+++ b/src/fdr2csv/src/FlightDataRecorderConverter.cpp
@@ -3,9 +3,7 @@
 #include "fmt/include/fmt/core.h"
 #include "fmt/include/fmt/ostream.h"
 
-using namespace std;
-
-void FlightDataRecorderConverter::writeHeader(ofstream& out, const string& delimiter) {
+void FlightDataRecorderConverter::writeHeader(std::ofstream& out, const std::string& delimiter) {
   fmt::print(out, "ap_sm.time.dt{}", delimiter);
   fmt::print(out, "ap_sm.time.simulation_time{}", delimiter);
   fmt::print(out, "ap_sm.data.aircraft_position.lat{}", delimiter);
@@ -473,8 +471,8 @@ void FlightDataRecorderConverter::writeHeader(ofstream& out, const string& delim
   fmt::print(out, "\n");
 }
 
-void FlightDataRecorderConverter::writeStruct(ofstream& out,
-                                              const string& delimiter,
+void FlightDataRecorderConverter::writeStruct(std::ofstream& out,
+                                              const std::string& delimiter,
                                               const ap_sm_output& ap_sm,
                                               const ap_raw_output& ap_law,
                                               const athr_out& athr,

--- a/src/fdr2csv/src/main.cpp
+++ b/src/fdr2csv/src/main.cpp
@@ -11,16 +11,14 @@
 #include "fmt/include/fmt/core.h"
 #include "zfstream.h"
 
-using namespace std;
-
 // IMPORTANT: this constant needs to increased with every interface change
 const uint64_t INTERFACE_VERSION = 24;
 
 int main(int argc, char* argv[]) {
   // variables for command line parameters
-  string inFilePath;
-  string outFilePath;
-  string delimiter = ",";
+  std::string inFilePath;
+  std::string outFilePath;
+  std::string delimiter = ",";
   bool noCompression = false;
   bool printStructSize = false;
   bool printGetFileInterfaceVersion = false;
@@ -39,7 +37,7 @@ int main(int argc, char* argv[]) {
   // parse command line
   try {
     args.parse(argc, argv);
-  } catch (runtime_error const& e) {
+  } catch (std::runtime_error const& e) {
     fmt::print("{}\n", e.what());
     return -1;
   }
@@ -47,7 +45,7 @@ int main(int argc, char* argv[]) {
   // print help
   if (oPrintHelp) {
     args.printHelp();
-    cout << endl;
+    std::cout << std::endl;
     return 0;
   }
 
@@ -56,7 +54,7 @@ int main(int argc, char* argv[]) {
     fmt::print("Input file parameter missing!\n");
     return 1;
   }
-  if (!filesystem::exists(inFilePath)) {
+  if (!std::filesystem::exists(inFilePath)) {
     fmt::print("Input file does not exist!\n");
     return 1;
   }
@@ -66,11 +64,11 @@ int main(int argc, char* argv[]) {
   }
 
   // create input stream
-  istream* in;
+  std::unique_ptr<std::istream> in;
   if (!noCompression) {
-    in = new gzifstream(inFilePath.c_str());
+    in = std::make_unique<gzifstream>(inFilePath.c_str());
   } else {
-    in = new ifstream(inFilePath.c_str(), ios::in | ios::binary);
+    in = std::make_unique<std::ifstream>(inFilePath.c_str(), std::ios::in | std::ios::binary);
   }
 
   // check if stream is ok
@@ -85,7 +83,7 @@ int main(int argc, char* argv[]) {
 
   // print file version if requested and return
   if (printGetFileInterfaceVersion) {
-    cout << fileFormatVersion << endl;
+    std::cout << fileFormatVersion << std::endl;
     return 0;
   } else if (INTERFACE_VERSION != fileFormatVersion) {
     fmt::print("ERROR: mismatch between converter and file version (expected {}, got {})\n", INTERFACE_VERSION, fileFormatVersion);
@@ -97,9 +95,9 @@ int main(int argc, char* argv[]) {
              delimiter);
 
   // output stream
-  ofstream out;
+  std::ofstream out;
   // open the output file
-  out.open(outFilePath, ios::out | ios::trunc);
+  out.open(outFilePath, std::ios::out | std::ios::trunc);
   // check if file is open
   if (!out.is_open()) {
     fmt::print("Failed to create output file!\n");

--- a/src/flypad-backend/src/Aircraft/AircraftPreset.cpp
+++ b/src/flypad-backend/src/Aircraft/AircraftPreset.cpp
@@ -38,7 +38,7 @@ void AircraftPreset::onUpdate(double deltaTime) {
     // needs to be initialized
     if (!loadingIsActive) {
       // check if procedure ID exists
-      vector<ProcedureStep*>* requestedProcedure = procedures.getProcedure(loadAircraftPresetRequest);
+      const auto* requestedProcedure = procedures.getProcedure(loadAircraftPresetRequest);
       if (requestedProcedure == nullptr) {
         std::cout << "FLYPAD_BACKEND: Preset " << loadAircraftPresetRequest << " not found!"
                   << std::endl;

--- a/src/flypad-backend/src/Aircraft/AircraftPreset.h
+++ b/src/flypad-backend/src/Aircraft/AircraftPreset.h
@@ -17,8 +17,6 @@
 #include "AircraftProcedures.h"
 #include "../Units.h"
 
-using namespace std;
-
 /**
  * Class for handling aircraft presets.
  */
@@ -42,7 +40,7 @@ private:
   // current procedure ID
   int64_t currentProcedureID = 0;
   // current procedure
-  vector<struct ProcedureStep*>* currentProcedure = nullptr;
+  const std::vector<const ProcedureStep*>* currentProcedure = nullptr;
   // flag to signal that a loading process is ongoing
   bool loadingIsActive = false;
   // in ms

--- a/src/flypad-backend/src/Aircraft/AircraftProcedures.h
+++ b/src/flypad-backend/src/Aircraft/AircraftProcedures.h
@@ -3,8 +3,7 @@
 #include <map>
 #include <string>
 #include <vector>
-
-using namespace std;
+#include <array>
 
 struct ProcedureStep {
   std::string description;
@@ -29,272 +28,264 @@ struct ProcedureStep {
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 // @formatter:off
-static vector<ProcedureStep*>* POWERED_CONFIG_ON = new vector<ProcedureStep*>{
+static const std::vector<ProcedureStep> POWERED_CONFIG_ON = {
   // SOP: PRELIMINARY COCKPIT PREPARATION
-  new ProcedureStep {"BAT1 On",                  1010, false, 1000, "(L:A32NX_OVHD_ELEC_BAT_1_PB_IS_AUTO)",                 "1 (>L:A32NX_OVHD_ELEC_BAT_1_PB_IS_AUTO)"},
-  new ProcedureStep {"BAT2 On",                  1020, false, 3000, "(L:A32NX_OVHD_ELEC_BAT_2_PB_IS_AUTO)",                 "1 (>L:A32NX_OVHD_ELEC_BAT_2_PB_IS_AUTO)"},
+  {"BAT1 On",                  1010, false, 1000, "(L:A32NX_OVHD_ELEC_BAT_1_PB_IS_AUTO)",                 "1 (>L:A32NX_OVHD_ELEC_BAT_1_PB_IS_AUTO)"},
+  {"BAT2 On",                  1020, false, 3000, "(L:A32NX_OVHD_ELEC_BAT_2_PB_IS_AUTO)",                 "1 (>L:A32NX_OVHD_ELEC_BAT_2_PB_IS_AUTO)"},
 
-  new ProcedureStep {"EXT PWR On",               1030, false, 3000, "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) "
+  {"EXT PWR On",               1030, false, 3000, "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) "
                                                                     "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) && "
                                                                     "(L:A32NX_ENGINE_STATE:1) 1 == || "
                                                                     "(L:A32NX_ENGINE_STATE:2) 1 == || "
                                                                     "(A:EXTERNAL POWER ON:1, BOOL) ||",                     "(A:EXTERNAL POWER ON:1, BOOL) ! if{ 1 (>K:TOGGLE_EXTERNAL_POWER) }"},
 
   // if no Ext Pwr is available we start the APU here with a bat only fire test
-  new ProcedureStep {"APU Fire Test On",         1035, false, 2000, "(L:A32NX_ELEC_AC_1_BUS_IS_POWERED)",                   "1 (>L:A32NX_FIRE_TEST_APU)"},
-  new ProcedureStep {"APU Fire Test Off",        1036, false, 2000, "(L:A32NX_ELEC_AC_1_BUS_IS_POWERED)",                   "0 (>L:A32NX_FIRE_TEST_APU)"},
-  new ProcedureStep {"APU Master On",            1040, false, 3000, "(L:A32NX_ELEC_AC_1_BUS_IS_POWERED)",                   "1 (>L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON)"},
-  new ProcedureStep {"APU Start On",             1050, false, 1000, "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) ! "
+  {"APU Fire Test On",         1035, false, 2000, "(L:A32NX_ELEC_AC_1_BUS_IS_POWERED)",                   "1 (>L:A32NX_FIRE_TEST_APU)"},
+  {"APU Fire Test Off",        1036, false, 2000, "(L:A32NX_ELEC_AC_1_BUS_IS_POWERED)",                   "0 (>L:A32NX_FIRE_TEST_APU)"},
+  {"APU Master On",            1040, false, 3000, "(L:A32NX_ELEC_AC_1_BUS_IS_POWERED)",                   "1 (>L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON)"},
+  {"APU Start On",             1050, false, 1000, "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) ! "
                                                                     "(L:A32NX_OVHD_APU_START_PB_IS_AVAILABLE) ||",          "1 (>L:A32NX_OVHD_APU_START_PB_IS_ON)"},
 
-  new ProcedureStep {"Waiting on AC BUS Availability", 1060, true,  2000, "",                                               "(L:A32NX_ELEC_AC_1_BUS_IS_POWERED)"},
+  {"Waiting on AC BUS Availability", 1060, true,  2000, "",                                               "(L:A32NX_ELEC_AC_1_BUS_IS_POWERED)"},
 
   // SOP: COCKPIT PREPARATION
-  new ProcedureStep {"Crew Oxy On",              1120, false, 1000, "(L:PUSH_OVHD_OXYGEN_CREW) 0 ==",                       "0 (>L:PUSH_OVHD_OXYGEN_CREW)"},
-  new ProcedureStep {"GND CTL On",               1110, false, 1000, "(L:A32NX_ENGINE_STATE:1) 1 == "
+  {"Crew Oxy On",              1120, false, 1000, "(L:PUSH_OVHD_OXYGEN_CREW) 0 ==",                       "0 (>L:PUSH_OVHD_OXYGEN_CREW)"},
+  {"GND CTL On",               1110, false, 1000, "(L:A32NX_ENGINE_STATE:1) 1 == "
                                                                     "(L:A32NX_ENGINE_STATE:2) 1 == || "
                                                                     "(L:A32NX_RCDR_GROUND_CONTROL_ON) 1 == ||",             "1 (>L:A32NX_RCDR_GROUND_CONTROL_ON)"},
-  new ProcedureStep {"CVR Test On",              1115, false, 5000, "(L:A32NX_AIRCRAFT_PRESET_CVR_TEST_DONE)",              "1 (>L:A32NX_RCDR_TEST)"},
-  new ProcedureStep {"CVR Test Off",             1116, false, 2000, "(L:A32NX_AIRCRAFT_PRESET_CVR_TEST_DONE)",              "0 (>L:A32NX_RCDR_TEST) 1 (>L:A32NX_AIRCRAFT_PRESET_CVR_TEST_DONE)"},
+  {"CVR Test On",              1115, false, 5000, "(L:A32NX_AIRCRAFT_PRESET_CVR_TEST_DONE)",              "1 (>L:A32NX_RCDR_TEST)"},
+  {"CVR Test Off",             1116, false, 2000, "(L:A32NX_AIRCRAFT_PRESET_CVR_TEST_DONE)",              "0 (>L:A32NX_RCDR_TEST) 1 (>L:A32NX_AIRCRAFT_PRESET_CVR_TEST_DONE)"},
 
-  new ProcedureStep {"ADIRS 1 Nav",              1080, false, 500,  "(L:A32NX_OVHD_ADIRS_IR_1_MODE_SELECTOR_KNOB) 1 ==",    "1 (>L:A32NX_OVHD_ADIRS_IR_1_MODE_SELECTOR_KNOB)"},
-  new ProcedureStep {"ADIRS 2 Nav",              1090, false, 500,  "(L:A32NX_OVHD_ADIRS_IR_2_MODE_SELECTOR_KNOB) 1 ==",    "1 (>L:A32NX_OVHD_ADIRS_IR_2_MODE_SELECTOR_KNOB)"},
-  new ProcedureStep {"ADIRS 3 Nav",              1100, false, 1500, "(L:A32NX_OVHD_ADIRS_IR_3_MODE_SELECTOR_KNOB) 1 ==",    "1 (>L:A32NX_OVHD_ADIRS_IR_3_MODE_SELECTOR_KNOB)"},
+  {"ADIRS 1 Nav",              1080, false, 500,  "(L:A32NX_OVHD_ADIRS_IR_1_MODE_SELECTOR_KNOB) 1 ==",    "1 (>L:A32NX_OVHD_ADIRS_IR_1_MODE_SELECTOR_KNOB)"},
+  {"ADIRS 2 Nav",              1090, false, 500,  "(L:A32NX_OVHD_ADIRS_IR_2_MODE_SELECTOR_KNOB) 1 ==",    "1 (>L:A32NX_OVHD_ADIRS_IR_2_MODE_SELECTOR_KNOB)"},
+  {"ADIRS 3 Nav",              1100, false, 1500, "(L:A32NX_OVHD_ADIRS_IR_3_MODE_SELECTOR_KNOB) 1 ==",    "1 (>L:A32NX_OVHD_ADIRS_IR_3_MODE_SELECTOR_KNOB)"},
 
-  new ProcedureStep {"Strobe Auto",              2120, false, 1000, "(A:LIGHT STROBE, Bool)",                               "1 (>L:STROBE_0_AUTO) 0 (>K:STROBES_ON)"},
-  new ProcedureStep {"Nav & Logo Lt On",         1070, false, 1000, "(A:LIGHT LOGO, Bool) (A:LIGHT NAV, Bool) &&",          "1 (>K:2:LOGO_LIGHTS_SET) 1 (>K:2:NAV_LIGHTS_SET)"},
+  {"Strobe Auto",              2120, false, 1000, "(A:LIGHT STROBE, Bool)",                               "1 (>L:STROBE_0_AUTO) 0 (>K:STROBES_ON)"},
+  {"Nav & Logo Lt On",         1070, false, 1000, "(A:LIGHT LOGO, Bool) (A:LIGHT NAV, Bool) &&",          "1 (>K:2:LOGO_LIGHTS_SET) 1 (>K:2:NAV_LIGHTS_SET)"},
 
-  new ProcedureStep {"SEAT BELTS On",            2140, false, 1000, "(A:CABIN SEATBELTS ALERT SWITCH:1, BOOL)",             "(A:CABIN SEATBELTS ALERT SWITCH:1, BOOL) ! if{ 1 (>K:CABIN_SEATBELTS_ALERT_SWITCH_TOGGLE) }"},
-  new ProcedureStep {"NO SMOKING Auto",          1130, false, 1000, "(L:XMLVAR_SWITCH_OVHD_INTLT_NOSMOKING_POSITION) 1 ==", "1 (>L:XMLVAR_SWITCH_OVHD_INTLT_NOSMOKING_POSITION)"},
-  new ProcedureStep {"EMER EXT Lt Arm",          1140, false, 1000, "(L:XMLVAR_SWITCH_OVHD_INTLT_EMEREXIT_POSITION) 1 ==",  "1 (>L:XMLVAR_SWITCH_OVHD_INTLT_EMEREXIT_POSITION)"},
+  {"SEAT BELTS On",            2140, false, 1000, "(A:CABIN SEATBELTS ALERT SWITCH:1, BOOL)",             "(A:CABIN SEATBELTS ALERT SWITCH:1, BOOL) ! if{ 1 (>K:CABIN_SEATBELTS_ALERT_SWITCH_TOGGLE) }"},
+  {"NO SMOKING Auto",          1130, false, 1000, "(L:XMLVAR_SWITCH_OVHD_INTLT_NOSMOKING_POSITION) 1 ==", "1 (>L:XMLVAR_SWITCH_OVHD_INTLT_NOSMOKING_POSITION)"},
+  {"EMER EXT Lt Arm",          1140, false, 1000, "(L:XMLVAR_SWITCH_OVHD_INTLT_EMEREXIT_POSITION) 1 ==",  "1 (>L:XMLVAR_SWITCH_OVHD_INTLT_EMEREXIT_POSITION)"},
 
   // For the fire tests the FWC needs to be initialized
   // The correct variables to wait for are: A32NX_FWS_FWC_1_NORMAL and A32NX_FWS_FWC_2_NORMAL. But
   // as these are only on Exp this first iteration uses A32NX_FWC_FLIGHT_PHASE which also work on
   // master and is equivalent for this specific purpose. Will be changed when the FWC is on master.
-  new ProcedureStep {"Waiting on FWC Initialization", 1065, true,  5000, "",                                                "(L:A32NX_FWC_FLIGHT_PHASE)"},
-  new ProcedureStep {"Waiting...",                    9999, false, 5000, "(L:A32NX_AIRCRAFT_PRESET_FWC_INIT_DONE)",         "1 (>L:A32NX_AIRCRAFT_PRESET_FWC_INIT_DONE)"},
+  {"Waiting on FWC Initialization", 1065, true,  5000, "",                                                "(L:A32NX_FWC_FLIGHT_PHASE)"},
+  {"Waiting...",                    9999, false, 5000, "(L:A32NX_AIRCRAFT_PRESET_FWC_INIT_DONE)",         "1 (>L:A32NX_AIRCRAFT_PRESET_FWC_INIT_DONE)"},
 
   // APU fire test
-  new ProcedureStep {"APU Fire Test On",         1035, false, 2000, "(L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_APU_DONE)",         "1 (>L:A32NX_FIRE_TEST_APU)"},
-  new ProcedureStep {"APU Fire Test Off",        1036, false, 2000, "(L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_APU_DONE)",         "0 (>L:A32NX_FIRE_TEST_APU) 1 (>L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_APU_DONE)"},
+  {"APU Fire Test On",         1035, false, 2000, "(L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_APU_DONE)",         "1 (>L:A32NX_FIRE_TEST_APU)"},
+  {"APU Fire Test Off",        1036, false, 2000, "(L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_APU_DONE)",         "0 (>L:A32NX_FIRE_TEST_APU) 1 (>L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_APU_DONE)"},
 
     // After fire test we start the APU
-  new ProcedureStep {"APU Master On",            1041, false, 3000, "(L:A32NX_ENGINE_STATE:1) 1 == "
+  {"APU Master On",            1041, false, 3000, "(L:A32NX_ENGINE_STATE:1) 1 == "
                                                                     "(L:A32NX_ENGINE_STATE:2) 1 == && "
                                                                     "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) 1 == ||",      "1 (>L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON)"},
-  new ProcedureStep {"APU Start On",             1051, false, 1000, "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) ! "
+  {"APU Start On",             1051, false, 1000, "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) ! "
                                                                     "(L:A32NX_OVHD_APU_START_PB_IS_AVAILABLE) ||",        "1 (>L:A32NX_OVHD_APU_START_PB_IS_ON)"},
 
   // ENG fire test
-  new ProcedureStep {"ENG 1 Fire Test On",       2002, false, 2000, "(L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG1_DONE)",      "1 (>L:A32NX_FIRE_TEST_ENG1)"},
-  new ProcedureStep {"ENG 1 Fire Test Off",      2003, false, 2000, "(L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG1_DONE)",      "0 (>L:A32NX_FIRE_TEST_ENG1) 1 (>L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG1_DONE)"},
-  new ProcedureStep {"ENG 2 Fire Test On",       2004, false, 2000, "(L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG2_DONE)",      "1 (>L:A32NX_FIRE_TEST_ENG2)"},
-  new ProcedureStep {"ENG 2 Fire Test Off",      2005, false, 2000, "(L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG2_DONE)",      "0 (>L:A32NX_FIRE_TEST_ENG2) 1 (>L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG2_DONE)"},
+  {"ENG 1 Fire Test On",       2002, false, 2000, "(L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG1_DONE)",      "1 (>L:A32NX_FIRE_TEST_ENG1)"},
+  {"ENG 1 Fire Test Off",      2003, false, 2000, "(L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG1_DONE)",      "0 (>L:A32NX_FIRE_TEST_ENG1) 1 (>L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG1_DONE)"},
+  {"ENG 2 Fire Test On",       2004, false, 2000, "(L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG2_DONE)",      "1 (>L:A32NX_FIRE_TEST_ENG2)"},
+  {"ENG 2 Fire Test Off",      2005, false, 2000, "(L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG2_DONE)",      "0 (>L:A32NX_FIRE_TEST_ENG2) 1 (>L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG2_DONE)"},
 
-  new ProcedureStep {"Waiting on APU Availability", 1150, true,  2000, "",                                                "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) ! (L:A32NX_OVHD_APU_START_PB_IS_AVAILABLE) ||"},
-  new ProcedureStep {"APU Bleed On",                1160, false, 1000, "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) ! "
+  {"Waiting on APU Availability", 1150, true,  2000, "",                                                "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) ! (L:A32NX_OVHD_APU_START_PB_IS_AVAILABLE) ||"},
+  {"APU Bleed On",                1160, false, 1000, "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) ! "
                                                                        "(L:A32NX_OVHD_PNEU_APU_BLEED_PB_IS_ON) ||",       "1 (>L:A32NX_OVHD_PNEU_APU_BLEED_PB_IS_ON)"},
 };
 
-static vector<ProcedureStep*>* POWERED_CONFIG_OFF = new vector<ProcedureStep*>{
-  new ProcedureStep {"NO SMOKING Off",        1170, false, 1000, "(L:XMLVAR_SWITCH_OVHD_INTLT_NOSMOKING_POSITION) 2 ==", "2 (>L:XMLVAR_SWITCH_OVHD_INTLT_NOSMOKING_POSITION)"},
-  new ProcedureStep {"EMER EXT Lt Off",       1180, false, 1500, "(L:XMLVAR_SWITCH_OVHD_INTLT_EMEREXIT_POSITION) 2 ==",  "2 (>L:XMLVAR_SWITCH_OVHD_INTLT_EMEREXIT_POSITION)"},
-  new ProcedureStep {"GND CTL Off",           1200, false, 1000, "(L:A32NX_RCDR_GROUND_CONTROL_ON) 0 ==",                "0 (>L:A32NX_RCDR_GROUND_CONTROL_ON)"},
-  new ProcedureStep {"SEAT BELTS Off",        2200, false, 2000, "(A:CABIN SEATBELTS ALERT SWITCH:1, BOOL) !",           "(A:CABIN SEATBELTS ALERT SWITCH:1, BOOL) if{ 1 (>K:CABIN_SEATBELTS_ALERT_SWITCH_TOGGLE) }"},
-  new ProcedureStep {"Strobe Off",            2180, false, 1000, "(A:LIGHT STROBE, Bool) !",                             "0 (>L:STROBE_0_AUTO) 0 (>K:STROBES_OFF)"},
-  new ProcedureStep {"Nav & Logo Lt Off",     1240, false, 500,  "(A:LIGHT LOGO, Bool) ! (A:LIGHT NAV, Bool) ! &&",      "0 (>K:2:LOGO_LIGHTS_SET) 0 (>K:2:NAV_LIGHTS_SET)"},
-  new ProcedureStep {"Crew Oxy Off",          1190, false, 1000, "(L:PUSH_OVHD_OXYGEN_CREW) 1 ==",                       "1 (>L:PUSH_OVHD_OXYGEN_CREW)"},
-  new ProcedureStep {"ADIRS 3 Off",           1210, false, 500,  "(L:A32NX_OVHD_ADIRS_IR_3_MODE_SELECTOR_KNOB) 0 ==",    "0 (>L:A32NX_OVHD_ADIRS_IR_3_MODE_SELECTOR_KNOB)"},
-  new ProcedureStep {"ADIRS 2 Off",           1220, false, 500,  "(L:A32NX_OVHD_ADIRS_IR_2_MODE_SELECTOR_KNOB) 0 ==",    "0 (>L:A32NX_OVHD_ADIRS_IR_2_MODE_SELECTOR_KNOB)"},
-  new ProcedureStep {"ADIRS 1 Off",           1230, false, 1000, "(L:A32NX_OVHD_ADIRS_IR_1_MODE_SELECTOR_KNOB) 0 ==",    "0 (>L:A32NX_OVHD_ADIRS_IR_1_MODE_SELECTOR_KNOB)"},
-  new ProcedureStep {"APU Bleed Off",         1250, false, 1500, "(L:A32NX_OVHD_PNEU_APU_BLEED_PB_IS_ON) 0 ==",          "0 (>L:A32NX_OVHD_PNEU_APU_BLEED_PB_IS_ON)"},
-  new ProcedureStep {"APU Master Off",        1260, false, 2000, "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) 0 ==",           "0 (>L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON)"},
-  new ProcedureStep {"EXT PWR Off",           1270, false, 3000, "(A:EXTERNAL POWER ON:1, BOOL) !",                      "(A:EXTERNAL POWER ON:1, BOOL) if{ 1 (>K:TOGGLE_EXTERNAL_POWER) }"},
-  new ProcedureStep {"BAT2 Off",              1280, false, 100,  "(L:A32NX_OVHD_ELEC_BAT_2_PB_IS_AUTO) 0 ==",            "0 (>L:A32NX_OVHD_ELEC_BAT_2_PB_IS_AUTO)"},
-  new ProcedureStep {"BAT1 Off",              1290, false, 1000, "(L:A32NX_OVHD_ELEC_BAT_1_PB_IS_AUTO) 0 ==",            "0 (>L:A32NX_OVHD_ELEC_BAT_1_PB_IS_AUTO)"},
-  new ProcedureStep {"AC BUS Off Check",      1300, true,  2000, "",                                                     "(L:A32NX_ELEC_AC_1_BUS_IS_POWERED) !"},
-  new ProcedureStep {"CVR Test Reset",        1117, false, 0,    "",                                                     "0 (>L:A32NX_AIRCRAFT_PRESET_CVR_TEST_DONE)"},
-  new ProcedureStep {"APU Fire Test Reset",   1037, false, 0,    "",                                                     "0 (>L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_APU_DONE)"},
-  new ProcedureStep {"ENG 1 Fire Test Reset", 2006, false, 0,    "",                                                     "0 (>L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG1_DONE)"},
-  new ProcedureStep {"ENG 2 Fire Test Reset", 2007, false, 0,    "",                                                     "0 (>L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG2_DONE)"},
-  new ProcedureStep {"FWC Init Reset",        1066, false, 0,    "",                                                     "0 (>L:A32NX_AIRCRAFT_PRESET_FWC_INIT_DONE)"},
+static const std::vector<ProcedureStep> POWERED_CONFIG_OFF = {
+  {"NO SMOKING Off",        1170, false, 1000, "(L:XMLVAR_SWITCH_OVHD_INTLT_NOSMOKING_POSITION) 2 ==", "2 (>L:XMLVAR_SWITCH_OVHD_INTLT_NOSMOKING_POSITION)"},
+  {"EMER EXT Lt Off",       1180, false, 1500, "(L:XMLVAR_SWITCH_OVHD_INTLT_EMEREXIT_POSITION) 2 ==",  "2 (>L:XMLVAR_SWITCH_OVHD_INTLT_EMEREXIT_POSITION)"},
+  {"GND CTL Off",           1200, false, 1000, "(L:A32NX_RCDR_GROUND_CONTROL_ON) 0 ==",                "0 (>L:A32NX_RCDR_GROUND_CONTROL_ON)"},
+  {"SEAT BELTS Off",        2200, false, 2000, "(A:CABIN SEATBELTS ALERT SWITCH:1, BOOL) !",           "(A:CABIN SEATBELTS ALERT SWITCH:1, BOOL) if{ 1 (>K:CABIN_SEATBELTS_ALERT_SWITCH_TOGGLE) }"},
+  {"Strobe Off",            2180, false, 1000, "(A:LIGHT STROBE, Bool) !",                             "0 (>L:STROBE_0_AUTO) 0 (>K:STROBES_OFF)"},
+  {"Nav & Logo Lt Off",     1240, false, 500,  "(A:LIGHT LOGO, Bool) ! (A:LIGHT NAV, Bool) ! &&",      "0 (>K:2:LOGO_LIGHTS_SET) 0 (>K:2:NAV_LIGHTS_SET)"},
+  {"Crew Oxy Off",          1190, false, 1000, "(L:PUSH_OVHD_OXYGEN_CREW) 1 ==",                       "1 (>L:PUSH_OVHD_OXYGEN_CREW)"},
+  {"ADIRS 3 Off",           1210, false, 500,  "(L:A32NX_OVHD_ADIRS_IR_3_MODE_SELECTOR_KNOB) 0 ==",    "0 (>L:A32NX_OVHD_ADIRS_IR_3_MODE_SELECTOR_KNOB)"},
+  {"ADIRS 2 Off",           1220, false, 500,  "(L:A32NX_OVHD_ADIRS_IR_2_MODE_SELECTOR_KNOB) 0 ==",    "0 (>L:A32NX_OVHD_ADIRS_IR_2_MODE_SELECTOR_KNOB)"},
+  {"ADIRS 1 Off",           1230, false, 1000, "(L:A32NX_OVHD_ADIRS_IR_1_MODE_SELECTOR_KNOB) 0 ==",    "0 (>L:A32NX_OVHD_ADIRS_IR_1_MODE_SELECTOR_KNOB)"},
+  {"APU Bleed Off",         1250, false, 1500, "(L:A32NX_OVHD_PNEU_APU_BLEED_PB_IS_ON) 0 ==",          "0 (>L:A32NX_OVHD_PNEU_APU_BLEED_PB_IS_ON)"},
+  {"APU Master Off",        1260, false, 2000, "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) 0 ==",           "0 (>L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON)"},
+  {"EXT PWR Off",           1270, false, 3000, "(A:EXTERNAL POWER ON:1, BOOL) !",                      "(A:EXTERNAL POWER ON:1, BOOL) if{ 1 (>K:TOGGLE_EXTERNAL_POWER) }"},
+  {"BAT2 Off",              1280, false, 100,  "(L:A32NX_OVHD_ELEC_BAT_2_PB_IS_AUTO) 0 ==",            "0 (>L:A32NX_OVHD_ELEC_BAT_2_PB_IS_AUTO)"},
+  {"BAT1 Off",              1290, false, 1000, "(L:A32NX_OVHD_ELEC_BAT_1_PB_IS_AUTO) 0 ==",            "0 (>L:A32NX_OVHD_ELEC_BAT_1_PB_IS_AUTO)"},
+  {"AC BUS Off Check",      1300, true,  2000, "",                                                     "(L:A32NX_ELEC_AC_1_BUS_IS_POWERED) !"},
+  {"CVR Test Reset",        1117, false, 0,    "",                                                     "0 (>L:A32NX_AIRCRAFT_PRESET_CVR_TEST_DONE)"},
+  {"APU Fire Test Reset",   1037, false, 0,    "",                                                     "0 (>L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_APU_DONE)"},
+  {"ENG 1 Fire Test Reset", 2006, false, 0,    "",                                                     "0 (>L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG1_DONE)"},
+  {"ENG 2 Fire Test Reset", 2007, false, 0,    "",                                                     "0 (>L:A32NX_AIRCRAFT_PRESET_FIRE_TEST_ENG2_DONE)"},
+  {"FWC Init Reset",        1066, false, 0,    "",                                                     "0 (>L:A32NX_AIRCRAFT_PRESET_FWC_INIT_DONE)"},
 };
 
-static vector<ProcedureStep*>* PUSHBACK_CONFIG_ON = new vector<ProcedureStep*> {
+static const std::vector<ProcedureStep> PUSHBACK_CONFIG_ON = {
   // SOP: BEFORE PUSHBACK OR START
-  new ProcedureStep {"EXT PWR Off",             2000, false, 3000, "(A:EXTERNAL POWER ON:1, BOOL) !",               "(A:EXTERNAL POWER ON:1, BOOL) if{ 1 (>K:TOGGLE_EXTERNAL_POWER) }"},
-  new ProcedureStep {"Beacon On",               2130, false, 1000, "(A:LIGHT BEACON, Bool)",                        "0 (>K:BEACON_LIGHTS_ON)"},
-  new ProcedureStep {"FUEL PUMP 2 On",          2010, false, 100,  "(A:FUELSYSTEM PUMP SWITCH:2, Bool)",            "2 (>K:FUELSYSTEM_PUMP_ON)"},
-  new ProcedureStep {"FUEL PUMP 5 On",          2020, false, 500,  "(A:FUELSYSTEM PUMP SWITCH:5, Bool)",            "5 (>K:FUELSYSTEM_PUMP_ON)"},
-  new ProcedureStep {"FUEL PUMP 1 On",          2030, false, 100,  "(A:FUELSYSTEM PUMP SWITCH:1, Bool)",            "1 (>K:FUELSYSTEM_PUMP_ON)"},
-  new ProcedureStep {"FUEL PUMP 4 On",          2040, false, 500,  "(A:FUELSYSTEM PUMP SWITCH:4, Bool)",            "4 (>K:FUELSYSTEM_PUMP_ON)"},
-  new ProcedureStep {"FUEL PUMP 3 On",          2050, false, 100,  "(A:FUELSYSTEM PUMP SWITCH:3, Bool)",            "3 (>K:FUELSYSTEM_PUMP_ON)"},
-  new ProcedureStep {"FUEL PUMP 6 On",          2060, false, 2000, "(A:FUELSYSTEM PUMP SWITCH:6, Bool)",            "6 (>K:FUELSYSTEM_PUMP_ON)"},
-  new ProcedureStep {"COCKPIT DOOR LCK",        2110, false, 2000, "(L:A32NX_COCKPIT_DOOR_LOCKED) 1 ==",            "1 (>L:A32NX_COCKPIT_DOOR_LOCKED)"},
-  new ProcedureStep {"Await ADIRS 1 Alignment", 2150, true,  2000, "",                                              "(L:A32NX_ADIRS_ADIRU_1_STATE) 2 =="},
-  new ProcedureStep {"Await ADIRS 2 Alignment", 2160, true,  2000, "",                                              "(L:A32NX_ADIRS_ADIRU_2_STATE) 2 =="},
-  new ProcedureStep {"Await ADIRS 3 Alignment", 2170, true,  2000, "",                                              "(L:A32NX_ADIRS_ADIRU_3_STATE) 2 =="},
+  {"EXT PWR Off",             2000, false, 3000, "(A:EXTERNAL POWER ON:1, BOOL) !",               "(A:EXTERNAL POWER ON:1, BOOL) if{ 1 (>K:TOGGLE_EXTERNAL_POWER) }"},
+  {"Beacon On",               2130, false, 1000, "(A:LIGHT BEACON, Bool)",                        "0 (>K:BEACON_LIGHTS_ON)"},
+  {"FUEL PUMP 2 On",          2010, false, 100,  "(A:FUELSYSTEM PUMP SWITCH:2, Bool)",            "2 (>K:FUELSYSTEM_PUMP_ON)"},
+  {"FUEL PUMP 5 On",          2020, false, 500,  "(A:FUELSYSTEM PUMP SWITCH:5, Bool)",            "5 (>K:FUELSYSTEM_PUMP_ON)"},
+  {"FUEL PUMP 1 On",          2030, false, 100,  "(A:FUELSYSTEM PUMP SWITCH:1, Bool)",            "1 (>K:FUELSYSTEM_PUMP_ON)"},
+  {"FUEL PUMP 4 On",          2040, false, 500,  "(A:FUELSYSTEM PUMP SWITCH:4, Bool)",            "4 (>K:FUELSYSTEM_PUMP_ON)"},
+  {"FUEL PUMP 3 On",          2050, false, 100,  "(A:FUELSYSTEM PUMP SWITCH:3, Bool)",            "3 (>K:FUELSYSTEM_PUMP_ON)"},
+  {"FUEL PUMP 6 On",          2060, false, 2000, "(A:FUELSYSTEM PUMP SWITCH:6, Bool)",            "6 (>K:FUELSYSTEM_PUMP_ON)"},
+  {"COCKPIT DOOR LCK",        2110, false, 2000, "(L:A32NX_COCKPIT_DOOR_LOCKED) 1 ==",            "1 (>L:A32NX_COCKPIT_DOOR_LOCKED)"},
+  {"Await ADIRS 1 Alignment", 2150, true,  2000, "",                                              "(L:A32NX_ADIRS_ADIRU_1_STATE) 2 =="},
+  {"Await ADIRS 2 Alignment", 2160, true,  2000, "",                                              "(L:A32NX_ADIRS_ADIRU_2_STATE) 2 =="},
+  {"Await ADIRS 3 Alignment", 2170, true,  2000, "",                                              "(L:A32NX_ADIRS_ADIRU_3_STATE) 2 =="},
 };
 
-static vector<ProcedureStep*>* PUSHBACK_CONFIG_OFF = new vector<ProcedureStep*>{
-  new ProcedureStep {"COCKPIT DOOR OP", 2250, false, 2000, "(L:A32NX_COCKPIT_DOOR_LOCKED) 0 ==",          "0 (>L:A32NX_COCKPIT_DOOR_LOCKED)"},
-  new ProcedureStep {"FUEL PUMP 2 Off", 2260, false, 100,  "(A:FUELSYSTEM PUMP SWITCH:2, Bool) !",        "2 (>K:FUELSYSTEM_PUMP_OFF)"},
-  new ProcedureStep {"FUEL PUMP 5 Off", 2270, false, 500,  "(A:FUELSYSTEM PUMP SWITCH:5, Bool) !",        "5 (>K:FUELSYSTEM_PUMP_OFF)"},
-  new ProcedureStep {"FUEL PUMP 1 Off", 2280, false, 100,  "(A:FUELSYSTEM PUMP SWITCH:1, Bool) !",        "1 (>K:FUELSYSTEM_PUMP_OFF)"},
-  new ProcedureStep {"FUEL PUMP 4 Off", 2290, false, 500,  "(A:FUELSYSTEM PUMP SWITCH:4, Bool) !",        "4 (>K:FUELSYSTEM_PUMP_OFF)"},
-  new ProcedureStep {"FUEL PUMP 3 Off", 2300, false, 100,  "(A:FUELSYSTEM PUMP SWITCH:3, Bool) !",        "3 (>K:FUELSYSTEM_PUMP_OFF)"},
-  new ProcedureStep {"FUEL PUMP 6 Off", 2310, false, 1000, "(A:FUELSYSTEM PUMP SWITCH:6, Bool) !",        "6 (>K:FUELSYSTEM_PUMP_OFF)"},
-  new ProcedureStep {"Beacon Off",      2190, false, 1000, "(A:LIGHT BEACON, Bool) !",                    "0 (>K:BEACON_LIGHTS_OFF)"},
+static const std::vector<ProcedureStep> PUSHBACK_CONFIG_OFF = {
+  {"COCKPIT DOOR OP", 2250, false, 2000, "(L:A32NX_COCKPIT_DOOR_LOCKED) 0 ==",          "0 (>L:A32NX_COCKPIT_DOOR_LOCKED)"},
+  {"FUEL PUMP 2 Off", 2260, false, 100,  "(A:FUELSYSTEM PUMP SWITCH:2, Bool) !",        "2 (>K:FUELSYSTEM_PUMP_OFF)"},
+  {"FUEL PUMP 5 Off", 2270, false, 500,  "(A:FUELSYSTEM PUMP SWITCH:5, Bool) !",        "5 (>K:FUELSYSTEM_PUMP_OFF)"},
+  {"FUEL PUMP 1 Off", 2280, false, 100,  "(A:FUELSYSTEM PUMP SWITCH:1, Bool) !",        "1 (>K:FUELSYSTEM_PUMP_OFF)"},
+  {"FUEL PUMP 4 Off", 2290, false, 500,  "(A:FUELSYSTEM PUMP SWITCH:4, Bool) !",        "4 (>K:FUELSYSTEM_PUMP_OFF)"},
+  {"FUEL PUMP 3 Off", 2300, false, 100,  "(A:FUELSYSTEM PUMP SWITCH:3, Bool) !",        "3 (>K:FUELSYSTEM_PUMP_OFF)"},
+  {"FUEL PUMP 6 Off", 2310, false, 1000, "(A:FUELSYSTEM PUMP SWITCH:6, Bool) !",        "6 (>K:FUELSYSTEM_PUMP_OFF)"},
+  {"Beacon Off",      2190, false, 1000, "(A:LIGHT BEACON, Bool) !",                    "0 (>K:BEACON_LIGHTS_OFF)"},
 };
 
-static vector<ProcedureStep*>* TAXI_CONFIG_ON = new vector<ProcedureStep*>{
+static const std::vector<ProcedureStep> TAXI_CONFIG_ON = {
   // SOP: ENGINE START
-  new ProcedureStep {"ENG MODE SEL START",   3000, false, 3000,  "(L:A32NX_ENGINE_STATE:1) 1 == "
+  {"ENG MODE SEL START",   3000, false, 3000,  "(L:A32NX_ENGINE_STATE:1) 1 == "
                                                                  "(L:A32NX_ENGINE_STATE:2) 1 == && "
                                                                  "(K:TURBINE_IGNITION_SWITCH_SET1) 2 == "
                                                                  "(K:TURBINE_IGNITION_SWITCH_SET2) 2 == && ||",      "2 (>K:TURBINE_IGNITION_SWITCH_SET1) 2 (>K:TURBINE_IGNITION_SWITCH_SET2)"},
-  new ProcedureStep {"ENG 2 ON",             3010, false, 60000, "(A:FUELSYSTEM VALVE OPEN:2, Bool)",                "2 (>K:FUELSYSTEM_VALVE_OPEN)"},
-  new ProcedureStep {"Await ENG 2 AVAIL",    3020, true,  5000,  "",                                                 "(L:A32NX_ENGINE_STATE:2) 1 =="},
-  new ProcedureStep {"ENG 1 ON",             3030, false, 60000, "(A:FUELSYSTEM VALVE OPEN:1, Bool)",                "1 (>K:FUELSYSTEM_VALVE_OPEN)"},
-  new ProcedureStep {"Await ENG 1 AVAIL",    3040, true,  5000,  "",                                                 "(L:A32NX_ENGINE_STATE:1) 1 =="},
+  {"ENG 2 ON",             3010, false, 60000, "(A:FUELSYSTEM VALVE OPEN:2, Bool)",                "2 (>K:FUELSYSTEM_VALVE_OPEN)"},
+  {"Await ENG 2 AVAIL",    3020, true,  5000,  "",                                                 "(L:A32NX_ENGINE_STATE:2) 1 =="},
+  {"ENG 1 ON",             3030, false, 60000, "(A:FUELSYSTEM VALVE OPEN:1, Bool)",                "1 (>K:FUELSYSTEM_VALVE_OPEN)"},
+  {"Await ENG 1 AVAIL",    3040, true,  5000,  "",                                                 "(L:A32NX_ENGINE_STATE:1) 1 =="},
   // SOP: AFTER START
-  new ProcedureStep {"ENG MODE SEL NORM",    3050, false, 3000,  "(A:TURB ENG IGNITION SWITCH EX1:1, Bool) 1 == "
+  {"ENG MODE SEL NORM",    3050, false, 3000,  "(A:TURB ENG IGNITION SWITCH EX1:1, Bool) 1 == "
                                                                  "(A:TURB ENG IGNITION SWITCH EX1:2, Bool) 1 == &&", "1 (>K:TURBINE_IGNITION_SWITCH_SET1) 1 (>K:TURBINE_IGNITION_SWITCH_SET2)"},
-  new ProcedureStep {"APU Bleed Off",        3060, false, 2000,  "(L:A32NX_OVHD_PNEU_APU_BLEED_PB_IS_ON) 0 ==",      "0 (>L:A32NX_OVHD_PNEU_APU_BLEED_PB_IS_ON)"},
-  new ProcedureStep {"APU Master Off",       3070, false, 2000,  "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) 0 ==",       "0 (>L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON)"},
-  new ProcedureStep {"Spoiler Arm",          3090, false, 2000,  "(L:A32NX_SPOILERS_ARMED) 1 ==",                    "1 (>K:SPOILERS_ARM_SET)"},
-  new ProcedureStep {"Rudder Trim Reset",    3100, false, 2000,  "(A:RUDDER TRIM, Radians) 0 ==",                    "0 (>K:RUDDER_TRIM_SET)"},
-  new ProcedureStep {"Flaps 1",              3110, false, 3000,  "(L:A32NX_FLAPS_HANDLE_INDEX) 1 ==",                "1 (>L:A32NX_FLAPS_HANDLE_INDEX)"},
+  {"APU Bleed Off",        3060, false, 2000,  "(L:A32NX_OVHD_PNEU_APU_BLEED_PB_IS_ON) 0 ==",      "0 (>L:A32NX_OVHD_PNEU_APU_BLEED_PB_IS_ON)"},
+  {"APU Master Off",       3070, false, 2000,  "(L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON) 0 ==",       "0 (>L:A32NX_OVHD_APU_MASTER_SW_PB_IS_ON)"},
+  {"Spoiler Arm",          3090, false, 2000,  "(L:A32NX_SPOILERS_ARMED) 1 ==",                    "1 (>K:SPOILERS_ARM_SET)"},
+  {"Rudder Trim Reset",    3100, false, 2000,  "(A:RUDDER TRIM, Radians) 0 ==",                    "0 (>K:RUDDER_TRIM_SET)"},
+  {"Flaps 1",              3110, false, 3000,  "(L:A32NX_FLAPS_HANDLE_INDEX) 1 ==",                "1 (>L:A32NX_FLAPS_HANDLE_INDEX)"},
   // SOP: TAXI
-  new ProcedureStep {"NOSE Lt Taxi",         3120, false, 1000,  "(A:CIRCUIT SWITCH ON:20, Bool)",                   "0 (>L:LIGHTING_LANDING_1) (A:CIRCUIT SWITCH ON:20, Bool) ! if{ 20 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
-  new ProcedureStep {"RWY TURN OFF Lt L On", 3130, false, 0,     "(A:CIRCUIT SWITCH ON:21, Bool)",                   "(A:CIRCUIT SWITCH ON:21, Bool) ! if{ 21 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
-  new ProcedureStep {"RWY TURN OFF Lt R On", 3140, false, 2000,  "(A:CIRCUIT SWITCH ON:22, Bool)",                   "(A:CIRCUIT SWITCH ON:22, Bool) ! if{ 22 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
-  new ProcedureStep {"PWS Auto",             2070, false, 1000,  "(L:A32NX_SWITCH_RADAR_PWS_POSITION) 1 ==",         "1 (>L:A32NX_SWITCH_RADAR_PWS_POSITION)"},
-  new ProcedureStep {"Transponder On",       2080, false, 1000,  "(L:A32NX_TRANSPONDER_MODE) 1 ==",                  "1 (>L:A32NX_TRANSPONDER_MODE)"},
-  new ProcedureStep {"ATC ALT RPTG On",      2090, false, 1000,  "(L:A32NX_SWITCH_ATC_ALT) 1 ==",                    "1 (>L:A32NX_SWITCH_ATC_ALT)"},
-  new ProcedureStep {"TCAS TRAFFIC ABV",     2100, false, 2000,  "(L:A32NX_SWITCH_TCAS_TRAFFIC_POSITION) 2 ==",      "2 (>L:A32NX_SWITCH_TCAS_TRAFFIC_POSITION)"},
-  new ProcedureStep {"Autobrake Max",        3080, false, 2000,  "(L:A32NX_AUTOBRAKES_ARMED_MODE) 3 ==",             "3 (>L:A32NX_AUTOBRAKES_ARMED_MODE_SET)"},
-  new ProcedureStep {"TERR ON ND Capt. On",  3080, false, 2000,  "(L:A32NX_EFIS_TERR_L_ACTIVE) 1 ==",                "1 (>L:A32NX_EFIS_TERR_L_ACTIVE)"},
-  new ProcedureStep {"T.O. Config",          3085, false, 2000,  "",                                                 "1 (>L:A32NX_TO_CONFIG_NORMAL)"},
+  {"NOSE Lt Taxi",         3120, false, 1000,  "(A:CIRCUIT SWITCH ON:20, Bool)",                   "0 (>L:LIGHTING_LANDING_1) (A:CIRCUIT SWITCH ON:20, Bool) ! if{ 20 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
+  {"RWY TURN OFF Lt L On", 3130, false, 0,     "(A:CIRCUIT SWITCH ON:21, Bool)",                   "(A:CIRCUIT SWITCH ON:21, Bool) ! if{ 21 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
+  {"RWY TURN OFF Lt R On", 3140, false, 2000,  "(A:CIRCUIT SWITCH ON:22, Bool)",                   "(A:CIRCUIT SWITCH ON:22, Bool) ! if{ 22 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
+  {"PWS Auto",             2070, false, 1000,  "(L:A32NX_SWITCH_RADAR_PWS_POSITION) 1 ==",         "1 (>L:A32NX_SWITCH_RADAR_PWS_POSITION)"},
+  {"Transponder On",       2080, false, 1000,  "(L:A32NX_TRANSPONDER_MODE) 1 ==",                  "1 (>L:A32NX_TRANSPONDER_MODE)"},
+  {"ATC ALT RPTG On",      2090, false, 1000,  "(L:A32NX_SWITCH_ATC_ALT) 1 ==",                    "1 (>L:A32NX_SWITCH_ATC_ALT)"},
+  {"TCAS TRAFFIC ABV",     2100, false, 2000,  "(L:A32NX_SWITCH_TCAS_TRAFFIC_POSITION) 2 ==",      "2 (>L:A32NX_SWITCH_TCAS_TRAFFIC_POSITION)"},
+  {"Autobrake Max",        3080, false, 2000,  "(L:A32NX_AUTOBRAKES_ARMED_MODE) 3 ==",             "3 (>L:A32NX_AUTOBRAKES_ARMED_MODE_SET)"},
+  {"TERR ON ND Capt. On",  3080, false, 2000,  "(L:A32NX_EFIS_TERR_L_ACTIVE) 1 ==",                "1 (>L:A32NX_EFIS_TERR_L_ACTIVE)"},
+  {"T.O. Config",          3085, false, 2000,  "",                                                 "1 (>L:A32NX_TO_CONFIG_NORMAL)"},
 };
 
-static vector<ProcedureStep*>* TAXI_CONFIG_OFF = new vector<ProcedureStep*>{
-  new ProcedureStep {"TERR ON ND Capt. Off",  3080, false, 2000,  "(L:A32NX_EFIS_TERR_L_ACTIVE) 0 ==",          "0 (>L:A32NX_EFIS_TERR_L_ACTIVE)"},
-  new ProcedureStep {"Autobrake Off",         3180, false, 2000, "(L:A32NX_AUTOBRAKES_ARMED_MODE) 0 ==",        "0 (>L:A32NX_AUTOBRAKES_ARMED_MODE_SET)"},
-  new ProcedureStep {"TCAS TRAFFIC ABV",      2240, false, 1000, "(L:A32NX_SWITCH_TCAS_TRAFFIC_POSITION) 2 ==", "2 (>L:A32NX_SWITCH_TCAS_TRAFFIC_POSITION)"},
-  new ProcedureStep {"ATC ALT RPTG Off",      2230, false, 1000, "(L:A32NX_SWITCH_ATC_ALT) 1 ==",               "1 (>L:A32NX_SWITCH_ATC_ALT)"},
-  new ProcedureStep {"Transponder Off",       2220, false, 1000, "(L:A32NX_TRANSPONDER_MODE) 0 ==",             "0 (>L:A32NX_TRANSPONDER_MODE)"},
-  new ProcedureStep {"PWS Off",               2210, false, 1000, "(L:A32NX_SWITCH_RADAR_PWS_POSITION) 0 ==",    "0 (>L:A32NX_SWITCH_RADAR_PWS_POSITION)"},
-  new ProcedureStep {"RWY TURN OFF Lt L Off", 3160, false, 0,    "(A:CIRCUIT SWITCH ON:21, Bool) !",            "(A:CIRCUIT SWITCH ON:21, Bool) if{ 21 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
-  new ProcedureStep {"RWY TURN OFF Lt R Off", 3170, false, 2000, "(A:CIRCUIT SWITCH ON:22, Bool) !",            "(A:CIRCUIT SWITCH ON:22, Bool) if{ 22 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
-  new ProcedureStep {"NOSE Lt Taxi",          3150, false, 1000, "(A:CIRCUIT SWITCH ON:20, Bool) !",            "2 (>L:LIGHTING_LANDING_1) (A:CIRCUIT SWITCH ON:20, Bool) if{ 20 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
-  new ProcedureStep {"Flaps 0",               3210, false, 2000, "(L:A32NX_FLAPS_HANDLE_INDEX) 0 ==",           "0 (>L:A32NX_FLAPS_HANDLE_INDEX)"},
-  new ProcedureStep {"Rudder Trim Reset",     3200, false, 2000, "(A:RUDDER TRIM, Radians) 0 ==",               "0 (>K:RUDDER_TRIM_SET)"},
-  new ProcedureStep {"Spoiler Disarm",        3190, false, 2000, "(L:A32NX_SPOILERS_ARMED) 0 ==",               "0 (>K:SPOILERS_ARM_SET)"},
-  new ProcedureStep {"ENG 1 Off",             3220, false, 2000, "(A:FUELSYSTEM VALVE OPEN:1, Bool) !",         "1 (>K:FUELSYSTEM_VALVE_CLOSE)"},
-  new ProcedureStep {"ENG 2 Off",             3230, false, 2000, "(A:FUELSYSTEM VALVE OPEN:2, Bool) !",         "2 (>K:FUELSYSTEM_VALVE_CLOSE)"},
-  new ProcedureStep {"ENG 1 N1 <3%",          3240, true,  1000, "",                                            "(L:A32NX_ENGINE_N1:1) 3 <"},
-  new ProcedureStep {"ENG 2 N1 <3%",          3250, true,  1000, "",                                            "(L:A32NX_ENGINE_N1:2) 3 <"},
+static const std::vector<ProcedureStep> TAXI_CONFIG_OFF = {
+  {"TERR ON ND Capt. Off",  3080, false, 2000,  "(L:A32NX_EFIS_TERR_L_ACTIVE) 0 ==",          "0 (>L:A32NX_EFIS_TERR_L_ACTIVE)"},
+  {"Autobrake Off",         3180, false, 2000, "(L:A32NX_AUTOBRAKES_ARMED_MODE) 0 ==",        "0 (>L:A32NX_AUTOBRAKES_ARMED_MODE_SET)"},
+  {"TCAS TRAFFIC ABV",      2240, false, 1000, "(L:A32NX_SWITCH_TCAS_TRAFFIC_POSITION) 2 ==", "2 (>L:A32NX_SWITCH_TCAS_TRAFFIC_POSITION)"},
+  {"ATC ALT RPTG Off",      2230, false, 1000, "(L:A32NX_SWITCH_ATC_ALT) 1 ==",               "1 (>L:A32NX_SWITCH_ATC_ALT)"},
+  {"Transponder Off",       2220, false, 1000, "(L:A32NX_TRANSPONDER_MODE) 0 ==",             "0 (>L:A32NX_TRANSPONDER_MODE)"},
+  {"PWS Off",               2210, false, 1000, "(L:A32NX_SWITCH_RADAR_PWS_POSITION) 0 ==",    "0 (>L:A32NX_SWITCH_RADAR_PWS_POSITION)"},
+  {"RWY TURN OFF Lt L Off", 3160, false, 0,    "(A:CIRCUIT SWITCH ON:21, Bool) !",            "(A:CIRCUIT SWITCH ON:21, Bool) if{ 21 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
+  {"RWY TURN OFF Lt R Off", 3170, false, 2000, "(A:CIRCUIT SWITCH ON:22, Bool) !",            "(A:CIRCUIT SWITCH ON:22, Bool) if{ 22 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
+  {"NOSE Lt Taxi",          3150, false, 1000, "(A:CIRCUIT SWITCH ON:20, Bool) !",            "2 (>L:LIGHTING_LANDING_1) (A:CIRCUIT SWITCH ON:20, Bool) if{ 20 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
+  {"Flaps 0",               3210, false, 2000, "(L:A32NX_FLAPS_HANDLE_INDEX) 0 ==",           "0 (>L:A32NX_FLAPS_HANDLE_INDEX)"},
+  {"Rudder Trim Reset",     3200, false, 2000, "(A:RUDDER TRIM, Radians) 0 ==",               "0 (>K:RUDDER_TRIM_SET)"},
+  {"Spoiler Disarm",        3190, false, 2000, "(L:A32NX_SPOILERS_ARMED) 0 ==",               "0 (>K:SPOILERS_ARM_SET)"},
+  {"ENG 1 Off",             3220, false, 2000, "(A:FUELSYSTEM VALVE OPEN:1, Bool) !",         "1 (>K:FUELSYSTEM_VALVE_CLOSE)"},
+  {"ENG 2 Off",             3230, false, 2000, "(A:FUELSYSTEM VALVE OPEN:2, Bool) !",         "2 (>K:FUELSYSTEM_VALVE_CLOSE)"},
+  {"ENG 1 N1 <3%",          3240, true,  1000, "",                                            "(L:A32NX_ENGINE_N1:1) 3 <"},
+  {"ENG 2 N1 <3%",          3250, true,  1000, "",                                            "(L:A32NX_ENGINE_N1:2) 3 <"},
 };
 
-static vector<ProcedureStep*>* TAKEOFF_CONFIG_ON = new vector<ProcedureStep*>{
+static const std::vector<ProcedureStep> TAKEOFF_CONFIG_ON = {
   // SOP: TAXI
-  new ProcedureStep {"WX Radar On",       4000, false, 1000, "(L:XMLVAR_A320_WEATHERRADAR_SYS) 0 ==",  "0 (>L:XMLVAR_A320_WEATHERRADAR_SYS)"},
-  new ProcedureStep {"WX Radar Mode",     4010, false, 1000, "(L:XMLVAR_A320_WEATHERRADAR_MODE) 1 ==", "1 (>L:XMLVAR_A320_WEATHERRADAR_MODE)"},
+  {"WX Radar On",       4000, false, 1000, "(L:XMLVAR_A320_WEATHERRADAR_SYS) 0 ==",  "0 (>L:XMLVAR_A320_WEATHERRADAR_SYS)"},
+  {"WX Radar Mode",     4010, false, 1000, "(L:XMLVAR_A320_WEATHERRADAR_MODE) 1 ==", "1 (>L:XMLVAR_A320_WEATHERRADAR_MODE)"},
   // SOP: BEFORE TAKEOFF
-  new ProcedureStep {"TCAS Switch TA/RA", 4020, false, 2000, "(L:A32NX_SWITCH_TCAS_POSITION) 2 ==",    "2 (>L:A32NX_SWITCH_TCAS_POSITION)"},
-  new ProcedureStep {"Strobe On",         2120, false, 1000, "(A:LIGHT STROBE, Bool)",                 "0 (>L:STROBE_0_AUTO) 0 (>K:STROBES_ON)"},
-  new ProcedureStep {"Cabin Ready",       2125, false, 1000, "",                                       "1 (>L:A32NX_CABIN_READY)"},
+  {"TCAS Switch TA/RA", 4020, false, 2000, "(L:A32NX_SWITCH_TCAS_POSITION) 2 ==",    "2 (>L:A32NX_SWITCH_TCAS_POSITION)"},
+  {"Strobe On",         2120, false, 1000, "(A:LIGHT STROBE, Bool)",                 "0 (>L:STROBE_0_AUTO) 0 (>K:STROBES_ON)"},
+  {"Cabin Ready",       2125, false, 1000, "",                                       "1 (>L:A32NX_CABIN_READY)"},
   // SOP: TAKE OFF
-  new ProcedureStep {"NOSE Lt Takeoff",   4030, false, 1000, "(A:CIRCUIT SWITCH ON:17, Bool)",         "(A:CIRCUIT SWITCH ON:17, Bool) ! if{ 17 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
-  new ProcedureStep {"LL Lt L On",        4040, false, 0,    "(A:CIRCUIT SWITCH ON:18, Bool)",         "0 (>L:LIGHTING_LANDING_2) 0 (>L:LANDING_2_RETRACTED) (A:CIRCUIT SWITCH ON:18, Bool) ! if{ 18 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
-  new ProcedureStep {"LL Lt R On",        4050, false, 1000, "(A:CIRCUIT SWITCH ON:19, Bool)",         "0 (>L:LIGHTING_LANDING_3) 0 (>L:LANDING_3_RETRACTED) (A:CIRCUIT SWITCH ON:19, Bool) ! if{ 19 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
+  {"NOSE Lt Takeoff",   4030, false, 1000, "(A:CIRCUIT SWITCH ON:17, Bool)",         "(A:CIRCUIT SWITCH ON:17, Bool) ! if{ 17 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
+  {"LL Lt L On",        4040, false, 0,    "(A:CIRCUIT SWITCH ON:18, Bool)",         "0 (>L:LIGHTING_LANDING_2) 0 (>L:LANDING_2_RETRACTED) (A:CIRCUIT SWITCH ON:18, Bool) ! if{ 18 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
+  {"LL Lt R On",        4050, false, 1000, "(A:CIRCUIT SWITCH ON:19, Bool)",         "0 (>L:LIGHTING_LANDING_3) 0 (>L:LANDING_3_RETRACTED) (A:CIRCUIT SWITCH ON:19, Bool) ! if{ 19 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
 };
 
-static vector<ProcedureStep*>* TAKEOFF_CONFIG_OFF = new vector<ProcedureStep*>{
-  new ProcedureStep {"LL Lt L Off",       4060, false, 0,    "(A:CIRCUIT SWITCH ON:18, Bool) ! (L:LANDING_2_RETRACTED) &&", "2 (>L:LIGHTING_LANDING_2) 1 (>L:LANDING_2_RETRACTED) (A:CIRCUIT SWITCH ON:18, Bool) if{ 18 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
-  new ProcedureStep {"LL Lt R Off",       4070, false, 1000, "(A:CIRCUIT SWITCH ON:19, Bool) ! (L:LANDING_3_RETRACTED) &&", "2 (>L:LIGHTING_LANDING_3) 1 (>L:LANDING_3_RETRACTED) (A:CIRCUIT SWITCH ON:19, Bool) if{ 19 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
-  new ProcedureStep {"NOSE Lt Takeoff",   4080, false, 2000, "(A:CIRCUIT SWITCH ON:17, Bool) !",                            "(A:CIRCUIT SWITCH ON:17, Bool) if{ 17 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
-  new ProcedureStep {"Strobe Auto",       2180, false, 1000, "(A:LIGHT STROBE, Bool) !",                                    "1 (>L:STROBE_0_AUTO) 0 (>K:STROBES_OFF)"},
-  new ProcedureStep {"TCAS Switch TA/RA", 4090, false, 1000, "(L:A32NX_SWITCH_TCAS_POSITION) 0 ==",                         "0 (>L:A32NX_SWITCH_TCAS_POSITION)"},
-  new ProcedureStep {"WX Radar Mode",     4110, false, 1000, "(L:XMLVAR_A320_WEATHERRADAR_MODE) 1 ==",                      "1 (>L:XMLVAR_A320_WEATHERRADAR_MODE)"},
-  new ProcedureStep {"WX Radar Off",      4100, false, 1000, "(L:XMLVAR_A320_WEATHERRADAR_SYS) 1 ==",                       "1 (>L:XMLVAR_A320_WEATHERRADAR_SYS)"},
+static const std::vector<ProcedureStep> TAKEOFF_CONFIG_OFF = {
+  {"LL Lt L Off",       4060, false, 0,    "(A:CIRCUIT SWITCH ON:18, Bool) ! (L:LANDING_2_RETRACTED) &&", "2 (>L:LIGHTING_LANDING_2) 1 (>L:LANDING_2_RETRACTED) (A:CIRCUIT SWITCH ON:18, Bool) if{ 18 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
+  {"LL Lt R Off",       4070, false, 1000, "(A:CIRCUIT SWITCH ON:19, Bool) ! (L:LANDING_3_RETRACTED) &&", "2 (>L:LIGHTING_LANDING_3) 1 (>L:LANDING_3_RETRACTED) (A:CIRCUIT SWITCH ON:19, Bool) if{ 19 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
+  {"NOSE Lt Takeoff",   4080, false, 2000, "(A:CIRCUIT SWITCH ON:17, Bool) !",                            "(A:CIRCUIT SWITCH ON:17, Bool) if{ 17 (>K:ELECTRICAL_CIRCUIT_TOGGLE)"},
+  {"Strobe Auto",       2180, false, 1000, "(A:LIGHT STROBE, Bool) !",                                    "1 (>L:STROBE_0_AUTO) 0 (>K:STROBES_OFF)"},
+  {"TCAS Switch TA/RA", 4090, false, 1000, "(L:A32NX_SWITCH_TCAS_POSITION) 0 ==",                         "0 (>L:A32NX_SWITCH_TCAS_POSITION)"},
+  {"WX Radar Mode",     4110, false, 1000, "(L:XMLVAR_A320_WEATHERRADAR_MODE) 1 ==",                      "1 (>L:XMLVAR_A320_WEATHERRADAR_MODE)"},
+  {"WX Radar Off",      4100, false, 1000, "(L:XMLVAR_A320_WEATHERRADAR_SYS) 1 ==",                       "1 (>L:XMLVAR_A320_WEATHERRADAR_SYS)"},
 };
 // @formatter:on
 
 class AircraftProcedures {
-  vector<ProcedureStep*>* coldAndDark = new vector<ProcedureStep*>;
-  vector<ProcedureStep*>* powered = new vector<ProcedureStep*>;
-  vector<ProcedureStep*>* readyForPushback = new vector<ProcedureStep*>;
-  vector<ProcedureStep*>* readyForTaxi = new vector<ProcedureStep*>;
-  vector<ProcedureStep*>* readyForTakeoff = new vector<ProcedureStep*>;
-  // just to get a list of IDs
-  vector<ProcedureStep*>* all = new vector<ProcedureStep*>;
+  std::vector<const ProcedureStep*> coldAndDark;
+  std::vector<const ProcedureStep*> powered;
+  std::vector<const ProcedureStep*> readyForPushback;
+  std::vector<const ProcedureStep*> readyForTaxi;
+  std::vector<const ProcedureStep*> readyForTakeoff;
+
+  void printProcedure(const std::vector<const ProcedureStep*>& procedures) {
+    std::for_each(begin(procedures), end(procedures), [](const auto* procedure) {
+        std::cout << procedure->id << " = " << procedure->description << std::endl;
+    });
+  }
+
+  void doInsertProcedures(std::vector<const ProcedureStep*>& dest, const std::vector<ProcedureStep>& src) {
+    std::transform(begin(src), end(src), back_inserter(dest), [](const auto& procedure) {
+      return &procedure;
+    });
+  }
+
+    void insertProcedures(std::vector<const ProcedureStep*>& dest, const std::vector<ProcedureStep>& a, const std::vector<ProcedureStep>& b,
+                          const std::vector<ProcedureStep>& c, const std::vector<ProcedureStep>& d) {
+    dest.reserve(a.size() + b.size() + c.size() + d.size());
+    for (const auto& p : {a, b, c, d}) {
+      doInsertProcedures(dest, p);
+    }
+  }
 
 public:
   AircraftProcedures() {
     // Map the procedure groups
 
 #ifdef DEBUG
-    // This is used to generate a list of IDs which can be printed to console to
-    // add them to the EFB code to display the current step.
-    all->insert(all->end(), POWERED_CONFIG_ON->begin(), POWERED_CONFIG_ON->end());
-    all->insert(all->end(), PUSHBACK_CONFIG_ON->begin(), PUSHBACK_CONFIG_ON->end());
-    all->insert(all->end(), TAXI_CONFIG_ON->begin(), TAXI_CONFIG_ON->end());
-    all->insert(all->end(), TAKEOFF_CONFIG_ON->begin(), TAKEOFF_CONFIG_ON->end());
-    all->insert(all->end(), TAKEOFF_CONFIG_OFF->begin(), TAKEOFF_CONFIG_OFF->end());
-    all->insert(all->end(), TAXI_CONFIG_OFF->begin(), TAXI_CONFIG_OFF->end());
-    all->insert(all->end(), PUSHBACK_CONFIG_OFF->begin(), PUSHBACK_CONFIG_OFF->end());
-    all->insert(all->end(), POWERED_CONFIG_OFF->begin(), POWERED_CONFIG_OFF->end());
-
-    std::for_each(all->begin(), all->end(), [&](ProcedureStep* item) {
-      std::cout << item->id << " = " << item->description << std::endl;
-    });
+    // P{rint to console to add them to the EFB code to display the current step.
+    printProcedure(POWERED_CONFIG_ON);
+    printProcedure(PUSHBACK_CONFIG_ON);
+    printProcedure(TAXI_CONFIG_ON);
+    printProcedure(TAKEOFF_CONFIG_ON);
+    printProcedure(TAKEOFF_CONFIG_OFF);
+    printProcedure(TAXI_CONFIG_OFF);
+    printProcedure(PUSHBACK_CONFIG_OFF);
+    printProcedure(POWERED_CONFIG_OFF);
 #endif
-
-    coldAndDark->insert(coldAndDark->end(), TAKEOFF_CONFIG_OFF->begin(), TAKEOFF_CONFIG_OFF->end());
-    coldAndDark->insert(coldAndDark->end(), TAXI_CONFIG_OFF->begin(), TAXI_CONFIG_OFF->end());
-    coldAndDark->insert(coldAndDark->end(), PUSHBACK_CONFIG_OFF->begin(), PUSHBACK_CONFIG_OFF->end());
-    coldAndDark->insert(coldAndDark->end(), POWERED_CONFIG_OFF->begin(), POWERED_CONFIG_OFF->end());
-
-    powered->insert(powered->end(), TAKEOFF_CONFIG_OFF->begin(), TAKEOFF_CONFIG_OFF->end());
-    powered->insert(powered->end(), TAXI_CONFIG_OFF->begin(), TAXI_CONFIG_OFF->end());
-    powered->insert(powered->end(), PUSHBACK_CONFIG_OFF->begin(), PUSHBACK_CONFIG_OFF->end());
-    powered->insert(powered->end(), POWERED_CONFIG_ON->begin(), POWERED_CONFIG_ON->end());
-
-    readyForPushback->insert(readyForPushback->end(), TAKEOFF_CONFIG_OFF->begin(), TAKEOFF_CONFIG_OFF->end());
-    readyForPushback->insert(readyForPushback->end(), TAXI_CONFIG_OFF->begin(), TAXI_CONFIG_OFF->end());
-    readyForPushback->insert(readyForPushback->end(), POWERED_CONFIG_ON->begin(), POWERED_CONFIG_ON->end());
-    readyForPushback->insert(readyForPushback->end(), PUSHBACK_CONFIG_ON->begin(), PUSHBACK_CONFIG_ON->end());
-
-    readyForTaxi->insert(readyForTaxi->end(), TAKEOFF_CONFIG_OFF->begin(), TAKEOFF_CONFIG_OFF->end());
-    readyForTaxi->insert(readyForTaxi->end(), POWERED_CONFIG_ON->begin(), POWERED_CONFIG_ON->end());
-    readyForTaxi->insert(readyForTaxi->end(), PUSHBACK_CONFIG_ON->begin(), PUSHBACK_CONFIG_ON->end());
-    readyForTaxi->insert(readyForTaxi->end(), TAXI_CONFIG_ON->begin(), TAXI_CONFIG_ON->end());
-
-    readyForTakeoff->insert(readyForTakeoff->end(), POWERED_CONFIG_ON->begin(), POWERED_CONFIG_ON->end());
-    readyForTakeoff->insert(readyForTakeoff->end(), PUSHBACK_CONFIG_ON->begin(), PUSHBACK_CONFIG_ON->end());
-    readyForTakeoff->insert(readyForTakeoff->end(), TAXI_CONFIG_ON->begin(), TAXI_CONFIG_ON->end());
-    readyForTakeoff->insert(readyForTakeoff->end(), TAKEOFF_CONFIG_ON->begin(), TAKEOFF_CONFIG_ON->end());
+    insertProcedures(coldAndDark, TAKEOFF_CONFIG_OFF, TAXI_CONFIG_OFF, PUSHBACK_CONFIG_OFF, POWERED_CONFIG_OFF);
+    insertProcedures(powered, TAKEOFF_CONFIG_OFF, TAXI_CONFIG_OFF, PUSHBACK_CONFIG_OFF, POWERED_CONFIG_ON);
+    insertProcedures(readyForPushback, TAKEOFF_CONFIG_OFF, TAXI_CONFIG_OFF, POWERED_CONFIG_ON, PUSHBACK_CONFIG_ON);
+    insertProcedures(readyForTaxi, TAKEOFF_CONFIG_OFF, POWERED_CONFIG_ON, PUSHBACK_CONFIG_ON, TAXI_CONFIG_ON);
+    insertProcedures(readyForTakeoff, POWERED_CONFIG_ON, PUSHBACK_CONFIG_ON, TAXI_CONFIG_ON, TAKEOFF_CONFIG_ON);
   }
 
   [[nodiscard]]
-  vector<ProcedureStep*>* getProcedure(int64_t pID) const {
+  const std::vector<const ProcedureStep*>* getProcedure(int64_t pID) const {
     switch (pID) {
       case 1:
-        return coldAndDark;
+        return &coldAndDark;
       case 2:
-        return powered;
+        return &powered;
       case 3:
-        return readyForPushback;
+        return &readyForPushback;
       case 4:
-        return readyForTaxi;
+        return &readyForTaxi;
       case 5:
-        return readyForTakeoff;
+        return &readyForTakeoff;
       default:
         return nullptr;
     }
   }
-
 };

--- a/src/flypad-backend/src/FlyPadBackend.cpp
+++ b/src/flypad-backend/src/FlyPadBackend.cpp
@@ -145,8 +145,8 @@ void FlyPadBackend::simConnectProcessSimObjectData(const SIMCONNECT_RECV_SIMOBJE
       return;
 
     default:
-      cout << "FLYPAD_BACKEND: Unknown request id in SimConnect connection: ";
-      cout << data->dwRequestID << endl;
+      std::cout << "FLYPAD_BACKEND: Unknown request id in SimConnect connection: ";
+      std::cout << data->dwRequestID << std::endl;
       return;
   }
 }
@@ -154,11 +154,11 @@ void FlyPadBackend::simConnectProcessSimObjectData(const SIMCONNECT_RECV_SIMOBJE
 void FlyPadBackend::simConnectProcessDispatchMessage(SIMCONNECT_RECV* pData, DWORD* cbData) {
   switch (pData->dwID) {
     case SIMCONNECT_RECV_ID_OPEN:
-      cout << "FLYPAD_BACKEND: SimConnect connection established" << endl;
+      std::cout << "FLYPAD_BACKEND: SimConnect connection established" << std::endl;
       break;
 
     case SIMCONNECT_RECV_ID_QUIT:
-      cout << "FLYPAD_BACKEND: Received SimConnect connection quit message" << endl;
+      std::cout << "FLYPAD_BACKEND: Received SimConnect connection quit message" << std::endl;
       break;
 
     case SIMCONNECT_RECV_ID_SIMOBJECT_DATA:
@@ -166,11 +166,11 @@ void FlyPadBackend::simConnectProcessDispatchMessage(SIMCONNECT_RECV* pData, DWO
       break;
 
     case SIMCONNECT_RECV_ID_EXCEPTION:
-      cout << "FLYPAD_BACKEND: Exception in SimConnect connection: ";
-      cout << getSimConnectExceptionString(
+      std::cout << "FLYPAD_BACKEND: Exception in SimConnect connection: ";
+      std::cout << getSimConnectExceptionString(
         static_cast<SIMCONNECT_EXCEPTION>(
           static_cast<SIMCONNECT_RECV_EXCEPTION*>(pData)->dwException));
-      cout << endl;
+      std::cout << std::endl;
       break;
 
     default:

--- a/src/flypad-backend/src/FlyPadBackend.h
+++ b/src/flypad-backend/src/FlyPadBackend.h
@@ -24,8 +24,6 @@
 #include <memory>
 #include <string>
 
-using namespace std;
-
 // IDs for data structures - must be mapped to data structs
 enum DataStructureIDs {
   SimulationDataID,

--- a/src/flypad-backend/src/Pushback/Pushback.h
+++ b/src/flypad-backend/src/Pushback/Pushback.h
@@ -17,9 +17,12 @@
 
 class InertialDampener;
 
-using namespace std;
-
+#ifdef __cpp_lib_math_constants
+#include <numbers>
+constexpr double PI = std::numbers::pi;
+#else
 constexpr double PI = 3.14159265358979323846;
+#endif
 
 /**
  * Class for handling aircraft presets.


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes [#[7572]](https://github.com/flybywiresim/a32nx/issues/7572)

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- Removes unwanted namespace pollution from `using namespace std` in header files
- Removes `using namespace std` in source files
- Fixes multiple memory leaks
- Uses static initialization on the stack instead of static initialization on the heap using `new`

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
See issue.

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
I'd suggest also using `clang`'s C++20, instead of C++14 is now used afaik. I tried using [fold expressions](https://en.cppreference.com/w/cpp/language/fold) but got a compiler error.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
See issue.

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Not sure, I saw the code and I improved it. Functionality wise, nothing should've changed although the following files have been changed:
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/flypad-backend/src/FlyPadBackend.h#L27
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/flypad-backend/src/Aircraft/AircraftPreset.h#L20
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/flypad-backend/src/Pushback/Pushback.h#L20
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/flypad-backend/src/Aircraft/AircraftProcedures.h#L7
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/fadec/src/FadecGauge.h#L32
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/fbw/src/FlightDataRecorder.cpp#L14
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/fbw/src/FlyByWireInterface.cpp#L11
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/fbw/src/InterpolatingLookupTable.cpp#L3
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/fbw/src/ThrottleAxisMapping.cpp#L6
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/fbw/src/interface/SimConnectInterface.cpp#L7
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/fdr2csv/src/FlightDataRecorderConverter.cpp#L6
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/fdr2csv/src/main.cpp#L14
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/fdr2csv/src/main.cpp#L69
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/flypad-backend/src/Aircraft/AircraftProcedures.h#L32 and
- https://github.com/flybywiresim/a32nx/blob/660b3bbc7e68c1a22a74bf1f9b1210b00895beec/src/flypad-backend/src/Aircraft/AircraftProcedures.h#L227

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
