### PR TITLE
feat(efb): Add estimated boarding time

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -20,6 +20,7 @@
 1. [RMP] RMPs navigation backup - Julian Sebline (Julian Sebline#8476 on Discord)
 1. [SEC] Fix GND SPLR logic, add missing GND SPLR partial extension condition - @lukecologne (luke)
 1. [FMGC] Improved importing flight plans from MSFS World Map - @frankkopp (Frank Kopp)  
+1. [EFB] Added boarding time indication to Payload page - @ChristianLutzCL (Christian Lutz) @frankkopp (Frank Kopp)
 
 ## 0.9.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1155,3 +1155,4 @@
 1. [DCDU] Fixed MSG- and MSG+ button labels - @tyler58546 (tyler58546)
 1. [ISIS] Fixed issue where ISIS was allowing a bug to be set while in the OFF state - Patrick Macken (@Pat M on
    Discord)
+1. [EFB] Added estimated boarding time to Payload screen - @ChristianLutzCL (Christian Lutz)

--- a/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
@@ -832,13 +832,13 @@ export const Payload = () => {
                             <Card className="w-full h-full" childrenContainerClassName="flex flex-col w-full h-full">
                                 <div className="flex flex-row justify-between items-center">
                                 <div className="flex font-medium">
-+                                   {t('Ground.Payload.BoardingTime')}
-+                                    <span className="flex relative flex-row items-center ml-2 text-sm font-light">
-+                                        (
-+                                        {`${calculateBoardingTime()} ${t('Ground.Payload.EstimatedDurationUnit')}`}
-+                                        )
-+                                    </span>
-+                                </div>
+                                    {t('Ground.Payload.BoardingTime')}
+                                     <span className="flex relative flex-row items-center ml-2 text-sm font-light">
+                                         (
+                                         {`${calculateBoardingTime()} ${t('Ground.Payload.EstimatedDurationUnit')}`}
+                                         )
+                                     </span>
+                                 </div>
 
                                     <SelectGroup>
                                         <SelectItem

--- a/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
@@ -778,8 +778,6 @@ export const Payload = () => {
                                         </div>
                                     </TooltipWrapper>
 
-                                    <div className="flex relative flex-row items-center ml-4 text-sm font-light">{`Estimated duration: ${calculateBoardingTime()} minutes`}</div>
-
                                     <TooltipWrapper text={t('Ground.Payload.TT.StartBoarding')}>
                                         <button
                                             type="button"
@@ -833,9 +831,14 @@ export const Payload = () => {
                         <div className="flex flex-row mt-4">
                             <Card className="w-full h-full" childrenContainerClassName="flex flex-col w-full h-full">
                                 <div className="flex flex-row justify-between items-center">
-                                    <div className="flex font-medium">
-                                        {t('Ground.Payload.BoardingTime')}
-                                    </div>
+                                <div className="flex font-medium">
++                                   {t('Ground.Payload.BoardingTime')}
++                                    <span className="flex relative flex-row items-center ml-2 text-sm font-light">
++                                        (
++                                        {`${calculateBoardingTime()} ${t('Ground.Payload.EstimatedDurationUnit')}`}
++                                        )
++                                    </span>
++                                </div>
 
                                     <SelectGroup>
                                         <SelectItem

--- a/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
@@ -381,7 +381,7 @@ export const Payload = () => {
             estimatedTimeSeconds = estimatedCargoLoadingSeconds + differentialLoadingTime;
         }
 
-        return ` ${Math.round(estimatedTimeSeconds / 60)}`;
+        return Math.round(estimatedTimeSeconds / 60);
     };
 
     const boardingStatusClass = useMemo(() => {

--- a/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
@@ -356,7 +356,6 @@ export const Payload = () => {
         setBoardingStarted(false);
     };
 
-    // TODO: Rework A32NX_Boarding to make boardingRateMultiplier obsolete. (msDelay)
     const calculateBoardingTime = useMemo(() => {
         // factors taken from flybywire-aircraft-a320-neo/html_ui/Pages/A32NX_Core/A32NX_Boarding.js line 175+
         let boardingRateMultiplier = 0;

--- a/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
@@ -356,6 +356,34 @@ export const Payload = () => {
         setBoardingStarted(false);
     };
 
+    // TODO: Rework A32NX_Boarding to make boardingRateMultiplier obsolete. (msDelay)
+    const calculateBoardingTime = () => {
+        let estimatedTimeSeconds = 0;
+        let estimatedPaxBoardingSeconds = 0;
+        let estimatedCargoLoadingSeconds = 0;
+        const boardingRateMultiplier = 5;
+        const differentialPax = Math.abs(totalPaxDesired - totalPax);
+        const differentialCargo = Math.abs(totalCargoDesired - totalCargo);
+
+        if (boardingRate === 'REAL') {
+            estimatedPaxBoardingSeconds += differentialPax * boardingRateMultiplier;
+            estimatedCargoLoadingSeconds += (differentialCargo / 60) * boardingRateMultiplier;
+        } else if (boardingRate === 'FAST') {
+            estimatedPaxBoardingSeconds += differentialPax;
+            estimatedCargoLoadingSeconds += (differentialCargo / 60);
+        }
+
+        if (estimatedPaxBoardingSeconds > estimatedCargoLoadingSeconds) {
+            const differentialLoadingTime = Math.abs(estimatedPaxBoardingSeconds - estimatedCargoLoadingSeconds);
+            estimatedTimeSeconds = estimatedPaxBoardingSeconds + differentialLoadingTime;
+        } else {
+            const differentialLoadingTime = Math.abs(estimatedCargoLoadingSeconds - estimatedPaxBoardingSeconds);
+            estimatedTimeSeconds = estimatedCargoLoadingSeconds + differentialLoadingTime;
+        }
+
+        return ` ${Math.round(estimatedTimeSeconds / 60)}`;
+    };
+
     const boardingStatusClass = useMemo(() => {
         if (!boardingStarted) {
             return 'text-theme-highlight';
@@ -749,6 +777,8 @@ export const Payload = () => {
                                             <div className="absolute top-2 right-3 text-lg text-gray-400">{usingMetric ? 'KG' : 'LB'}</div>
                                         </div>
                                     </TooltipWrapper>
+
+                                    <div className="flex relative flex-row items-center ml-4 text-sm font-light">{`Estimated duration: ${calculateBoardingTime()} minutes`}</div>
 
                                     <TooltipWrapper text={t('Ground.Payload.TT.StartBoarding')}>
                                         <button

--- a/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
@@ -831,14 +831,14 @@ export const Payload = () => {
                         <div className="flex flex-row mt-4">
                             <Card className="w-full h-full" childrenContainerClassName="flex flex-col w-full h-full">
                                 <div className="flex flex-row justify-between items-center">
-                                <div className="flex font-medium">
-                                    {t('Ground.Payload.BoardingTime')}
-                                     <span className="flex relative flex-row items-center ml-2 text-sm font-light">
-                                         (
-                                         {`${calculateBoardingTime()} ${t('Ground.Payload.EstimatedDurationUnit')}`}
-                                         )
-                                     </span>
-                                 </div>
+                                    <div className="flex font-medium">
+                                        {t('Ground.Payload.BoardingTime')}
+                                        <span className="flex relative flex-row items-center ml-2 text-sm font-light">
+                                            (
+                                            {`${calculateBoardingTime()} ${t('Ground.Payload.EstimatedDurationUnit')}`}
+                                            )
+                                        </span>
+                                    </div>
 
                                     <SelectGroup>
                                         <SelectItem

--- a/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
@@ -781,7 +781,7 @@ export const Payload = () => {
                                     <TooltipWrapper text={t('Ground.Payload.TT.StartBoarding')}>
                                         <button
                                             type="button"
-                                            className={`flex justify-center rounded-lg items-center ml-auto w-24 h-12 
+                                            className={`flex justify-center rounded-lg items-center ml-auto w-24 h-12
                                                         ${boardingStatusClass} bg-current`}
                                             onClick={() => setBoardingStarted(!boardingStarted)}
                                         >
@@ -795,7 +795,7 @@ export const Payload = () => {
                                     <TooltipWrapper text={t('Ground.Payload.TT.StartDeboarding')}>
                                         <button
                                             type="button"
-                                            className={`flex justify-center items-center ml-1 w-16 h-12 text-theme-highlight bg-current rounded-lg 
+                                            className={`flex justify-center items-center ml-1 w-16 h-12 text-theme-highlight bg-current rounded-lg
                                                         ${totalPax === 0 && totalCargo === 0 && 'opacity-20 pointer-events-none'}`}
                                             onClick={() => handleDeboarding()}
                                         >
@@ -817,8 +817,8 @@ export const Payload = () => {
                                 && (
                                     <TooltipWrapper text={t('Ground.Payload.TT.FillPayloadFromSimbrief')}>
                                         <div
-                                            className={`flex justify-center items-center px-2 h-auto text-theme-body 
-                                                       hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body 
+                                            className={`flex justify-center items-center px-2 h-auto text-theme-body
+                                                       hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body
                                                        rounded-md rounded-l-none border-2 border-theme-highlight transition duration-100`}
                                             onClick={setSimBriefValues}
                                         >

--- a/src/instruments/src/EFB/Localization/de.json
+++ b/src/instruments/src/EFB/Localization/de.json
@@ -149,6 +149,7 @@
     },
     "Payload": {
       "BoardingTime": "Boarding-Dauer",
+      "EstimatedDurationUnit": "minuten",
       "Cargo": "Fracht",
       "Current": "Aktuell",
       "DeboardConfirmationBody": "Bitte bestätigen Sie das Aussteigen aller Passagiere",

--- a/src/instruments/src/EFB/Localization/en.json
+++ b/src/instruments/src/EFB/Localization/en.json
@@ -149,7 +149,6 @@
     },
     "Payload": {
       "BoardingTime": "Boarding Time",
-      "EstimatedDurationUnit": "minutes",
       "Cargo": "Cargo",
       "Current": "Current",
       "DeboardConfirmationBody": "Please confirm deboarding all passengers",

--- a/src/instruments/src/EFB/Localization/en.json
+++ b/src/instruments/src/EFB/Localization/en.json
@@ -149,6 +149,7 @@
     },
     "Payload": {
       "BoardingTime": "Boarding Time",
+      "EstimatedDurationUnit": "minutes",
       "Cargo": "Cargo",
       "Current": "Current",
       "DeboardConfirmationBody": "Please confirm deboarding all passengers",


### PR DESCRIPTION

Fixes #7418

## Summary of Changes
Added estimated boarding time to payload view like in fuel view

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/30475783/200147338-37679998-037b-4dec-bbc0-b8c8d78eed4d.png)

## References
---

## Additional context

Discord username (if different from GitHub):

## Testing instructions
1. Load aircraft with engines off
2. Open 'Payload' on EFB
3. Set PAX and/or CARGO -> watch 'Estimated duration'
4. Change loading time Instant/Fast/Real -> watch 'Estimated duration'
5. Start Boarding -> watch 'Estimated duration'

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
