### PR TITLE
chore: update dev-env to 0.20.3.0 and tool chain versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ members = [
 
 [profile.release]
 lto = true
+strip = true

--- a/igniter.config.mjs
+++ b/igniter.config.mjs
@@ -6,21 +6,7 @@ export default new TaskOfTasks('a32nx', [
         new ExecTask('efb-translation', 'npm run build:efb-translation'),
     ]),
 
-    new TaskOfTasks('build', [
-        new TaskOfTasks('instruments',
-            [...getInstrumentsIgniterTasks(),
-                new ExecTask('pfd',
-                    'npm run build:pfd',
-                    ['src/instruments/src/PFD','flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/A32NX/PFD']
-                )
-            ],
-            true),
-        new ExecTask('atsu','npm run build:atsu', ['src/atsu', 'flybywire-aircraft-a320-neo/html_ui/JS/atsu']),
-        new ExecTask('sentry-client','npm run build:sentry-client', ['src/sentry-client', 'flybywire-aircraft-a320-neo/html_ui/JS/sentry-client']),
-        new ExecTask('failures','npm run build:failures', ['src/failures', 'flybywire-aircraft-a320-neo/html_ui/JS/generated/failures.js']),
-        new ExecTask('behavior','node src/behavior/build.js', ['src/behavior', 'flybywire-aircraft-a320-neo/ModelBehaviorDefs/A32NX/generated']),
-        new ExecTask('model','node src/model/build.js', ['src/model', 'flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model']),
-        new ExecTask('fmgc','npm run build:fmgc', ['src/fmgc', 'flybywire-aircraft-a320-neo/html_ui/JS/fmgc']),
+    new TaskOfTasks('wasm', [
         new ExecTask('systems', [
             'cargo build -p a320_systems_wasm --target wasm32-wasi --release',
             'wasm-opt -O3 -o flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/panel/systems.wasm target/wasm32-wasi/release/a320_systems_wasm.wasm',
@@ -37,6 +23,23 @@ export default new TaskOfTasks('a32nx', [
             'src/flypad-backend/build.sh',
             'wasm-opt -O1 -o flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/panel/flypad-backend.wasm flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/panel/flypad-backend.wasm'
         ], ['src/flypad-backend', 'flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/panel/flypad-backend.wasm']),
+    ], true),
+
+    new TaskOfTasks('build', [
+        new TaskOfTasks('instruments',
+            [...getInstrumentsIgniterTasks(),
+                new ExecTask('pfd',
+                    'npm run build:pfd',
+                    ['src/instruments/src/PFD','flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/A32NX/PFD']
+                )
+            ],
+            true),
+        new ExecTask('atsu','npm run build:atsu', ['src/atsu', 'flybywire-aircraft-a320-neo/html_ui/JS/atsu']),
+        new ExecTask('sentry-client','npm run build:sentry-client', ['src/sentry-client', 'flybywire-aircraft-a320-neo/html_ui/JS/sentry-client']),
+        new ExecTask('failures','npm run build:failures', ['src/failures', 'flybywire-aircraft-a320-neo/html_ui/JS/generated/failures.js']),
+        new ExecTask('behavior','node src/behavior/build.js', ['src/behavior', 'flybywire-aircraft-a320-neo/ModelBehaviorDefs/A32NX/generated']),
+        new ExecTask('model','node src/model/build.js', ['src/model', 'flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model']),
+        new ExecTask('fmgc','npm run build:fmgc', ['src/fmgc', 'flybywire-aircraft-a320-neo/html_ui/JS/fmgc']),
         new TaskOfTasks('simbridge', [
             new ExecTask('client', ['npm run build:simbridge-client'], ['src/simbridge-client', 'flybywire-aircraft-a320-neo/html_ui/JS/simbridge-client']),
         ]),

--- a/igniter.config.mjs
+++ b/igniter.config.mjs
@@ -9,7 +9,7 @@ export default new TaskOfTasks('a32nx', [
     new TaskOfTasks('wasm', [
         new ExecTask('systems', [
             'cargo build -p a320_systems_wasm --target wasm32-wasi --release',
-            'wasm-opt -O3 -o flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/panel/systems.wasm target/wasm32-wasi/release/a320_systems_wasm.wasm',
+            'wasm-opt -O1 -o flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/panel/systems.wasm target/wasm32-wasi/release/a320_systems_wasm.wasm',
         ], ['src/systems', 'Cargo.lock', 'Cargo.toml', 'flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/panel/systems.wasm']),
         new ExecTask('systems-autopilot', [
             'src/fbw/build.sh',

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.55"
+channel = "1.65"
 targets = [ "wasm32-wasi" ]

--- a/scripts/dev-env/run.cmd
+++ b/scripts/dev-env/run.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set image="ghcr.io/flybywiresim/dev-env@sha256:0ac0862440a8e048fe55831a9764c2ee45cca325c8789b394e87b1836742dd3c"
+set image="ghcr.io/flybywiresim/dev-env@sha256:8eff8ed27dbe218e48876afe1234f260afad4588f15e45012e1f95fb85dcb569"
 
 docker image inspect %image% 1> nul || docker system prune --filter label=flybywiresim=true -f
 docker run --rm -it -v "%cd%:/external" %image% %*

--- a/scripts/dev-env/run.cmd
+++ b/scripts/dev-env/run.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set image="ghcr.io/flybywiresim/dev-env@sha256:8974895d1d870fee5c5655ffa22e3aebff1879ca689b86c0c8f4e19c0dd4b27a"
+set image="ghcr.io/flybywiresim/dev-env@sha256:0ac0862440a8e048fe55831a9764c2ee45cca325c8789b394e87b1836742dd3c"
 
 docker image inspect %image% 1> nul || docker system prune --filter label=flybywiresim=true -f
 docker run --rm -it -v "%cd%:/external" %image% %*

--- a/scripts/dev-env/run.sh
+++ b/scripts/dev-env/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE="ghcr.io/flybywiresim/dev-env@sha256:0ac0862440a8e048fe55831a9764c2ee45cca325c8789b394e87b1836742dd3c"
+IMAGE="ghcr.io/flybywiresim/dev-env@sha256:8eff8ed27dbe218e48876afe1234f260afad4588f15e45012e1f95fb85dcb569"
 
 # only set `-it` if there is a tty
 if [ -t 0 ] && [ -t 1 ];

--- a/scripts/dev-env/run.sh
+++ b/scripts/dev-env/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE="ghcr.io/flybywiresim/dev-env@sha256:8974895d1d870fee5c5655ffa22e3aebff1879ca689b86c0c8f4e19c0dd4b27a"
+IMAGE="ghcr.io/flybywiresim/dev-env@sha256:0ac0862440a8e048fe55831a9764c2ee45cca325c8789b394e87b1836742dd3c"
 
 # only set `-it` if there is a tty
 if [ -t 0 ] && [ -t 1 ];

--- a/src/flypad-backend/build.sh
+++ b/src/flypad-backend/build.sh
@@ -42,12 +42,12 @@ clang++ \
   -I "${DIR}/src" \
   -I "${DIR}/src/Lighting" \
   -I "${DIR}/src/Aircraft" \
+  -I "${DIR}/src/Pushback" \
   "${DIR}/src/FlyPadBackend.cpp" \
   "${DIR}/src/Lighting/LightPreset.cpp" \
   "${DIR}/src/Aircraft/AircraftPreset.cpp" \
   "${DIR}/src/Pushback/Pushback.cpp" \
   "${DIR}/src/Pushback/InertialDampener.cpp"
-
 
 # restore directory
 popd

--- a/src/systems/a320_hydraulic_simulation_graphs/Cargo.toml
+++ b/src/systems/a320_hydraulic_simulation_graphs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "a320_hydraulic_simulation_graphs"
 version = "0.1.0"
 authors = ["davydecorps <38904654+crocket63@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "a320_hydraulic_simulation_graphs"

--- a/src/systems/a320_hydraulic_simulation_graphs/src/main.rs
+++ b/src/systems/a320_hydraulic_simulation_graphs/src/main.rs
@@ -499,7 +499,7 @@ impl Aircraft for A320SimpleMainElecHydraulicsTestAircraft {
 
             self.hydraulic_circuit.update(
                 &context.with_delta(cur_time_step),
-                &mut vec![&mut self.elec_pump],
+                &mut [&mut self.elec_pump],
                 None::<&mut ElectricPump>,
                 None::<&mut ElectricPump>,
                 None,

--- a/src/systems/a320_systems/Cargo.toml
+++ b/src/systems/a320_systems/Cargo.toml
@@ -2,7 +2,7 @@
 name = "a320_systems"
 version = "0.1.0"
 authors = ["FlyByWire Simulations"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 uom = "0.33.0"

--- a/src/systems/a320_systems/src/hydraulic/mod.rs
+++ b/src/systems/a320_systems/src/hydraulic/mod.rs
@@ -2288,7 +2288,7 @@ impl A320Hydraulic {
         );
         self.green_circuit.update(
             context,
-            &mut vec![&mut self.engine_driven_pump_1],
+            &mut [&mut self.engine_driven_pump_1],
             None::<&mut ElectricPump>,
             None::<&mut ElectricPump>,
             Some(&self.power_transfer_unit),
@@ -2304,7 +2304,7 @@ impl A320Hydraulic {
         );
         self.yellow_circuit.update(
             context,
-            &mut vec![&mut self.engine_driven_pump_2],
+            &mut [&mut self.engine_driven_pump_2],
             Some(&mut self.yellow_electric_pump),
             None::<&mut ElectricPump>,
             Some(&self.power_transfer_unit),
@@ -2320,7 +2320,7 @@ impl A320Hydraulic {
         );
         self.blue_circuit.update(
             context,
-            &mut vec![&mut self.blue_electric_pump],
+            &mut [&mut self.blue_electric_pump],
             Some(&mut self.ram_air_turbine),
             None::<&mut ElectricPump>,
             None,

--- a/src/systems/a320_systems/src/hydraulic/mod.rs
+++ b/src/systems/a320_systems/src/hydraulic/mod.rs
@@ -2704,8 +2704,9 @@ impl A320EngineDrivenPumpController {
 
         // Fault inhibited if on ground AND engine oil pressure is low (11KS1 elec relay)
         self.has_pressure_low_fault = self.is_pressure_low
-            && (!engine.oil_pressure_is_low()
-                || !(lgciu.right_gear_compressed(false) && lgciu.left_gear_compressed(false)));
+            && (!(engine.oil_pressure_is_low()
+                && lgciu.right_gear_compressed(false)
+                && lgciu.left_gear_compressed(false)));
     }
 
     fn update_low_air_pressure(
@@ -2844,14 +2845,7 @@ impl A320BlueElectricPumpController {
 
         self.should_pressurise = self.is_powered && should_pressurise_if_powered;
 
-        self.update_low_pressure(
-            overhead_panel,
-            hydraulic_circuit,
-            engine1,
-            engine2,
-            lgciu1,
-            lgciu2,
-        );
+        self.update_low_pressure(hydraulic_circuit, engine1, engine2, lgciu1, lgciu2);
 
         self.update_low_air_pressure(reservoir, overhead_panel);
 
@@ -2860,7 +2854,6 @@ impl A320BlueElectricPumpController {
 
     fn update_low_pressure(
         &mut self,
-        overhead_panel: &A320HydraulicOverheadPanel,
         hydraulic_circuit: &impl HydraulicPressureSensors,
         engine1: &impl Engine,
         engine2: &impl Engine,
@@ -2876,11 +2869,11 @@ impl A320BlueElectricPumpController {
             );
 
         self.has_pressure_low_fault = self.is_pressure_low
-            && (!is_both_engine_low_oil_pressure
-                || (!(lgciu1.left_gear_compressed(false) && lgciu1.right_gear_compressed(false))
-                    || !(lgciu2.left_gear_compressed(false)
-                        && lgciu2.right_gear_compressed(false)))
-                || overhead_panel.blue_epump_override_push_button_is_on());
+            && (!(is_both_engine_low_oil_pressure
+                && lgciu1.left_gear_compressed(false)
+                && lgciu1.right_gear_compressed(false)
+                && lgciu2.left_gear_compressed(false)
+                && lgciu2.right_gear_compressed(false)));
     }
 
     fn update_low_air_pressure(
@@ -4410,8 +4403,8 @@ impl SimulationElement for A320AutobrakeController {
         let sec_1_gnd_splrs_out = reader.read(&self.ground_spoilers_out_sec1_id);
         let sec_2_gnd_splrs_out = reader.read(&self.ground_spoilers_out_sec2_id);
         let sec_3_gnd_splrs_out = reader.read(&self.ground_spoilers_out_sec3_id);
-        self.ground_spoilers_are_deployed = (sec_1_gnd_splrs_out && sec_2_gnd_splrs_out)
-            || (sec_1_gnd_splrs_out && sec_3_gnd_splrs_out)
+        self.ground_spoilers_are_deployed = (sec_1_gnd_splrs_out
+            && (sec_3_gnd_splrs_out || sec_2_gnd_splrs_out))
             || (sec_2_gnd_splrs_out && sec_3_gnd_splrs_out);
         self.external_disarm_event = reader.read(&self.external_disarm_event_id);
 

--- a/src/systems/a320_systems/src/hydraulic/mod.rs
+++ b/src/systems/a320_systems/src/hydraulic/mod.rs
@@ -2845,7 +2845,14 @@ impl A320BlueElectricPumpController {
 
         self.should_pressurise = self.is_powered && should_pressurise_if_powered;
 
-        self.update_low_pressure(hydraulic_circuit, engine1, engine2, lgciu1, lgciu2);
+        self.update_low_pressure(
+            overhead_panel,
+            hydraulic_circuit,
+            engine1,
+            engine2,
+            lgciu1,
+            lgciu2,
+        );
 
         self.update_low_air_pressure(reservoir, overhead_panel);
 
@@ -2854,6 +2861,7 @@ impl A320BlueElectricPumpController {
 
     fn update_low_pressure(
         &mut self,
+        overhead_panel: &A320HydraulicOverheadPanel,
         hydraulic_circuit: &impl HydraulicPressureSensors,
         engine1: &impl Engine,
         engine2: &impl Engine,
@@ -2873,7 +2881,8 @@ impl A320BlueElectricPumpController {
                 && lgciu1.left_gear_compressed(false)
                 && lgciu1.right_gear_compressed(false)
                 && lgciu2.left_gear_compressed(false)
-                && lgciu2.right_gear_compressed(false)));
+                && lgciu2.right_gear_compressed(false)
+                && !overhead_panel.blue_epump_override_push_button_is_on()));
     }
 
     fn update_low_air_pressure(

--- a/src/systems/a320_systems_wasm/Cargo.toml
+++ b/src/systems/a320_systems_wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "a320_systems_wasm"
 version = "0.1.0"
 authors = ["FlyByWire Simulations"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/systems/a380_systems/Cargo.toml
+++ b/src/systems/a380_systems/Cargo.toml
@@ -2,7 +2,7 @@
 name = "a380_systems"
 version = "0.1.0"
 authors = ["FlyByWire Simulations"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 uom = "0.33.0"

--- a/src/systems/a380_systems/src/hydraulic/mod.rs
+++ b/src/systems/a380_systems/src/hydraulic/mod.rs
@@ -2148,7 +2148,7 @@ impl A380Hydraulic {
 
         self.green_circuit.update(
             context,
-            &mut vec![
+            &mut [
                 &mut self.engine_driven_pump_1a,
                 &mut self.engine_driven_pump_1b,
                 &mut self.engine_driven_pump_2a,
@@ -2173,7 +2173,7 @@ impl A380Hydraulic {
         );
         self.yellow_circuit.update(
             context,
-            &mut vec![
+            &mut [
                 &mut self.engine_driven_pump_3a,
                 &mut self.engine_driven_pump_3b,
                 &mut self.engine_driven_pump_4a,

--- a/src/systems/a380_systems/src/hydraulic/mod.rs
+++ b/src/systems/a380_systems/src/hydraulic/mod.rs
@@ -4075,8 +4075,8 @@ impl SimulationElement for A380AutobrakeController {
         let sec_1_gnd_splrs_out = reader.read(&self.ground_spoilers_out_sec1_id);
         let sec_2_gnd_splrs_out = reader.read(&self.ground_spoilers_out_sec2_id);
         let sec_3_gnd_splrs_out = reader.read(&self.ground_spoilers_out_sec3_id);
-        self.ground_spoilers_are_deployed = (sec_1_gnd_splrs_out && sec_2_gnd_splrs_out)
-            || (sec_1_gnd_splrs_out && sec_3_gnd_splrs_out)
+        self.ground_spoilers_are_deployed = sec_1_gnd_splrs_out
+            && (sec_3_gnd_splrs_out || sec_2_gnd_splrs_out)
             || (sec_2_gnd_splrs_out && sec_3_gnd_splrs_out);
         self.external_disarm_event = reader.read(&self.external_disarm_event_id);
 

--- a/src/systems/a380_systems/src/hydraulic/mod.rs
+++ b/src/systems/a380_systems/src/hydraulic/mod.rs
@@ -2632,8 +2632,9 @@ impl A380EngineDrivenPumpController {
 
         // TODO Fault inhibit copied from A320
         self.has_pressure_low_fault = self.is_pressure_low
-            && (!engines[self.pump_id.into_engine_index()].oil_pressure_is_low()
-                || !(lgciu.right_gear_compressed(false) && lgciu.left_gear_compressed(false)));
+            && (!(engines[self.pump_id.into_engine_index()].oil_pressure_is_low()
+                && lgciu.right_gear_compressed(false)
+                && lgciu.left_gear_compressed(false)));
     }
 
     fn update_low_air_pressure(

--- a/src/systems/a380_systems_wasm/Cargo.toml
+++ b/src/systems/a380_systems_wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "a380_systems_wasm"
 version = "0.1.0"
 authors = ["FlyByWire Simulations"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/systems/systems/Cargo.toml
+++ b/src/systems/systems/Cargo.toml
@@ -2,7 +2,7 @@
 name = "systems"
 version = "0.1.0"
 authors = ["FlyByWire Simulations"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 uom = "0.33.0"

--- a/src/systems/systems/src/air_conditioning/acs_controller.rs
+++ b/src/systems/systems/src/air_conditioning/acs_controller.rs
@@ -229,7 +229,7 @@ macro_rules! transition {
         impl From<AirConditioningState<$from>> for AirConditioningState<$to> {
             fn from(_: AirConditioningState<$from>) -> AirConditioningState<$to> {
                 AirConditioningState {
-                    aircraft_state: $to,
+                    aircraft_state: std::marker::PhantomData,
                     timer: Duration::from_secs(0),
                 }
             }
@@ -239,7 +239,7 @@ macro_rules! transition {
 
 #[derive(Copy, Clone)]
 struct AirConditioningState<S> {
-    aircraft_state: S,
+    aircraft_state: std::marker::PhantomData<S>,
     timer: Duration,
 }
 
@@ -256,7 +256,7 @@ struct Initialisation;
 impl AirConditioningState<Initialisation> {
     fn init() -> Self {
         Self {
-            aircraft_state: Initialisation,
+            aircraft_state: std::marker::PhantomData,
             timer: Duration::from_secs(0),
         }
     }

--- a/src/systems/systems/src/apu/air_intake_flap.rs
+++ b/src/systems/systems/src/apu/air_intake_flap.rs
@@ -320,7 +320,7 @@ mod air_intake_flap_tests {
 
     #[test]
     fn is_fully_open_returns_false_when_closed() {
-        let test_bed = SimulationTestBed::new(|electricity| TestAircraft::new(electricity));
+        let test_bed = SimulationTestBed::new(TestAircraft::new);
 
         assert!(!test_bed.query(|a| a.flap_is_fully_open()))
     }

--- a/src/systems/systems/src/apu/electronic_control_box.rs
+++ b/src/systems/systems/src/apu/electronic_control_box.rs
@@ -164,7 +164,7 @@ impl ElectronicControlBox {
     }
 
     pub fn update_fuel_pressure_switch_state(&mut self, fuel_pressure_switch: &FuelPressureSwitch) {
-        if self.fault == None
+        if self.fault.is_none()
             && 3. <= self.n.get::<percent>()
             && !fuel_pressure_switch.has_pressure()
         {

--- a/src/systems/systems/src/apu/mod.rs
+++ b/src/systems/systems/src/apu/mod.rs
@@ -275,7 +275,7 @@ pub trait Turbine {
     fn bleed_air_pressure(&self) -> Pressure;
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum TurbineState {
     Shutdown,
     Starting,
@@ -2109,7 +2109,7 @@ pub mod tests {
             let mut powered: bool = test_bed.apu_generator_output_within_normal_parameters();
             while test_bed.n().normal_value().unwrap().get::<percent>() < 100. {
                 let still_powered: bool = test_bed.apu_generator_output_within_normal_parameters();
-                assert!(!powered || (powered && still_powered));
+                assert!(!powered || still_powered);
                 powered = still_powered;
                 test_bed.run_with_delta(Duration::from_millis(1));
             }

--- a/src/systems/systems/src/electrical/mod.rs
+++ b/src/systems/systems/src/electrical/mod.rs
@@ -110,10 +110,10 @@ impl ElectricalBus {
         ElectricalBus {
             identifier: context.next_electrical_identifier_for_bus(bus_type),
             bus_powered_id: context
-                .get_identifier(format!("ELEC_{}_BUS_IS_POWERED", bus_type.to_string())),
+                .get_identifier(format!("ELEC_{}_BUS_IS_POWERED", bus_type)),
             bus_potential_normal_id: context.get_identifier(format!(
                 "ELEC_{}_BUS_POTENTIAL_NORMAL",
-                bus_type.to_string()
+                bus_type
             )),
             potential: ElectricPotential::new::<volt>(0.),
             bus_type,
@@ -321,11 +321,11 @@ pub trait ElectricityTransformer: ElectricalElement {
 pub struct ElectricalElementIdentifier(u32);
 impl ElectricalElementIdentifier {
     fn first() -> Self {
-        Self { 0: 1 }
+        Self(1)
     }
 
     fn next(&self) -> Self {
-        Self { 0: self.0 + 1 }
+        Self(self.0 + 1)
     }
 }
 

--- a/src/systems/systems/src/electrical/mod.rs
+++ b/src/systems/systems/src/electrical/mod.rs
@@ -109,12 +109,9 @@ impl ElectricalBus {
     pub fn new(context: &mut InitContext, bus_type: ElectricalBusType) -> ElectricalBus {
         ElectricalBus {
             identifier: context.next_electrical_identifier_for_bus(bus_type),
-            bus_powered_id: context
-                .get_identifier(format!("ELEC_{}_BUS_IS_POWERED", bus_type)),
-            bus_potential_normal_id: context.get_identifier(format!(
-                "ELEC_{}_BUS_POTENTIAL_NORMAL",
-                bus_type
-            )),
+            bus_powered_id: context.get_identifier(format!("ELEC_{}_BUS_IS_POWERED", bus_type)),
+            bus_potential_normal_id: context
+                .get_identifier(format!("ELEC_{}_BUS_POTENTIAL_NORMAL", bus_type)),
             potential: ElectricPotential::new::<volt>(0.),
             bus_type,
         }

--- a/src/systems/systems/src/failures/mod.rs
+++ b/src/systems/systems/src/failures/mod.rs
@@ -1,7 +1,7 @@
 use crate::shared::{GearActuatorId, HydraulicColor, LgciuId, ProximityDetectorId};
 use crate::simulation::SimulationElement;
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum FailureType {
     TransformerRectifier(usize),
     ReservoirLeak(HydraulicColor),

--- a/src/systems/systems/src/hydraulic/brake_circuit.rs
+++ b/src/systems/systems/src/hydraulic/brake_circuit.rs
@@ -207,12 +207,11 @@ impl BrakeCircuit {
         self.update_demands(brake_circuit_controller);
 
         // The pressure available in brakes is the one of accumulator only if accumulator has fluid
-        let actual_pressure_available: Pressure;
-        if self.accumulator.fluid_volume() > Volume::new::<gallon>(0.) {
-            actual_pressure_available = self.accumulator.raw_gas_press();
+        let actual_pressure_available = if self.accumulator.fluid_volume() > Volume::new::<gallon>(0.) {
+            self.accumulator.raw_gas_press()
         } else {
-            actual_pressure_available = section.pressure();
-        }
+            section.pressure()
+        };
 
         self.update_brake_actuators(context, actual_pressure_available);
 
@@ -330,7 +329,7 @@ impl SimulationElement for BrakeCircuit {
     }
 }
 
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub enum AutobrakeMode {
     NONE = 0,
     LOW = 1,

--- a/src/systems/systems/src/hydraulic/brake_circuit.rs
+++ b/src/systems/systems/src/hydraulic/brake_circuit.rs
@@ -207,11 +207,12 @@ impl BrakeCircuit {
         self.update_demands(brake_circuit_controller);
 
         // The pressure available in brakes is the one of accumulator only if accumulator has fluid
-        let actual_pressure_available = if self.accumulator.fluid_volume() > Volume::new::<gallon>(0.) {
-            self.accumulator.raw_gas_press()
-        } else {
-            section.pressure()
-        };
+        let actual_pressure_available =
+            if self.accumulator.fluid_volume() > Volume::new::<gallon>(0.) {
+                self.accumulator.raw_gas_press()
+            } else {
+                section.pressure()
+            };
 
         self.update_brake_actuators(context, actual_pressure_available);
 

--- a/src/systems/systems/src/hydraulic/linear_actuator.rs
+++ b/src/systems/systems/src/hydraulic/linear_actuator.rs
@@ -48,7 +48,7 @@ pub trait BoundedLinearLength {
     fn absolute_length_to_anchor(&self) -> Length;
 }
 
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum LinearActuatorMode {
     ClosedValves,
     PositionControl,

--- a/src/systems/systems/src/hydraulic/linear_actuator.rs
+++ b/src/systems/systems/src/hydraulic/linear_actuator.rs
@@ -246,7 +246,7 @@ pub trait ElectroHydrostaticPowered {
     }
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Eq, Copy, Clone)]
 pub enum ElectroHydrostaticActuatorType {
     ElectroHydrostaticActuator, // Can only run on electric mode or is damping
     ElectricalBackupHydraulicActuator, // Can run either in electric backup mode or from aircraft hydraulic pressure

--- a/src/systems/systems/src/hydraulic/mod.rs
+++ b/src/systems/systems/src/hydraulic/mod.rs
@@ -85,7 +85,7 @@ impl Fluid {
     }
 }
 
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub enum PressureSwitchState {
     Pressurised,
     NotPressurised,
@@ -901,7 +901,7 @@ impl HydraulicCircuit {
     pub fn update(
         &mut self,
         context: &UpdateContext,
-        main_section_pumps: &mut Vec<&mut dyn PressureSource>,
+        main_section_pumps: &mut [&mut dyn PressureSource],
         system_section_pump: Option<&mut impl PressureSource>,
         auxiliary_section_pump: Option<&mut impl PressureSource>,
         ptu: Option<&PowerTransferUnit>,
@@ -976,7 +976,7 @@ impl HydraulicCircuit {
     fn update_pumps(
         &mut self,
         context: &UpdateContext,
-        main_section_pumps: &mut Vec<&mut dyn PressureSource>,
+        main_section_pumps: &mut [&mut dyn PressureSource],
         system_section_pump: Option<&mut impl PressureSource>,
         auxiliary_section_pump: Option<&mut impl PressureSource>,
     ) {
@@ -1028,7 +1028,7 @@ impl HydraulicCircuit {
 
     fn update_maximum_pumping_capacities(
         &mut self,
-        main_section_pumps: &mut Vec<&mut dyn PressureSource>,
+        main_section_pumps: &mut [&mut dyn PressureSource],
         system_section_pump: &Option<&mut impl PressureSource>,
         auxiliary_section_pump: &Option<&mut impl PressureSource>,
     ) {
@@ -1119,7 +1119,7 @@ impl HydraulicCircuit {
         }
 
         let downstream_section = if to_auxiliary {
-            &self.auxiliary_section.as_ref().unwrap()
+            self.auxiliary_section.as_ref().unwrap()
         } else {
             &self.system_section
         };

--- a/src/systems/systems/src/hydraulic/trimmable_horizontal_stabilizer.rs
+++ b/src/systems/systems/src/hydraulic/trimmable_horizontal_stabilizer.rs
@@ -961,7 +961,7 @@ mod tests {
     #[case(1)]
     #[case(2)]
     fn trim_assembly_trim_up_trim_down_motor_n(#[case] motor_idx: usize) {
-        let mut test_bed = SimulationTestBed::new(|context| TestAircraft::new(context));
+        let mut test_bed = SimulationTestBed::new(TestAircraft::new);
 
         test_bed.command(|a| a.set_elec_trim_demand(Angle::new::<degree>(13.), motor_idx));
         test_bed.command(|a| a.set_no_manual_input());
@@ -1005,7 +1005,7 @@ mod tests {
 
     #[test]
     fn trim_assembly_max_motor_0() {
-        let mut test_bed = SimulationTestBed::new(|context| TestAircraft::new(context));
+        let mut test_bed = SimulationTestBed::new(TestAircraft::new);
 
         test_bed.command(|a| a.set_elec_trim_demand(Angle::new::<degree>(13.5), 0));
         test_bed.run_with_delta(Duration::from_millis(20000));
@@ -1021,7 +1021,7 @@ mod tests {
 
     #[test]
     fn trim_assembly_motor_0_without_elec_is_stuck() {
-        let mut test_bed = SimulationTestBed::new(|context| TestAircraft::new(context));
+        let mut test_bed = SimulationTestBed::new(TestAircraft::new);
 
         test_bed.command(|a| a.set_elec_trim_demand(Angle::new::<degree>(13.5), 0));
         test_bed.command(|a| a.set_no_elec_power());
@@ -1034,7 +1034,7 @@ mod tests {
 
     #[test]
     fn trim_assembly_min_motor_0() {
-        let mut test_bed = SimulationTestBed::new(|context| TestAircraft::new(context));
+        let mut test_bed = SimulationTestBed::new(TestAircraft::new);
 
         test_bed.command(|a| a.set_elec_trim_demand(Angle::new::<degree>(-4.), 0));
         test_bed.run_with_delta(Duration::from_millis(20000));

--- a/src/systems/systems/src/landing_gear/mod.rs
+++ b/src/systems/systems/src/landing_gear/mod.rs
@@ -999,7 +999,7 @@ impl LandingGearHandle for LandingGearControlInterfaceUnit {
 
 impl LgciuInterface for LandingGearControlInterfaceUnit {}
 
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum GearSystemState {
     AllUpLocked,
     Retracting,
@@ -1428,7 +1428,7 @@ mod tests {
 
     #[test]
     fn gear_state_downlock_on_init() {
-        let test_bed = SimulationTestBed::new(|context| TestGearAircraft::new(context));
+        let test_bed = SimulationTestBed::new(TestGearAircraft::new);
 
         assert!(test_bed.query(|a| a.lgcius.gear_system_state()) == GearSystemState::AllDownLocked);
     }

--- a/src/systems/systems/src/navigation/adirs.rs
+++ b/src/systems/systems/src/navigation/adirs.rs
@@ -1284,7 +1284,7 @@ impl InertialReference {
 
     fn alignment_starting(&self, selected_mode: InertialReferenceMode) -> bool {
         selected_mode != InertialReferenceMode::Off
-            && self.remaining_attitude_initialisation_duration == None
+            && self.remaining_attitude_initialisation_duration.is_none()
     }
 
     fn total_alignment_duration(configured_align_time: AlignTime, latitude: Angle) -> Duration {

--- a/src/systems/systems/src/navigation/ala52b.rs
+++ b/src/systems/systems/src/navigation/ala52b.rs
@@ -160,7 +160,7 @@ impl SimulationElement for Ala52BTransceiverPair {
 /// This enum describes the possible pin settings that the ALA-52B can be configured with. They are
 /// used to calibrate the Radio Altimeter for the length of the cables on the aircraft. It appears
 /// that A320s usually use the 57 feet setting.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Ala52BAircraftInstallationDelay {
     FortyFeet,
     FiftySevenFeet,

--- a/src/systems/systems/src/pneumatic/mod.rs
+++ b/src/systems/systems/src/pneumatic/mod.rs
@@ -439,7 +439,7 @@ impl SimulationElement for WingAntiIcePushButton {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WingAntiIcePushButtonMode {
     Off = 0,
     On = 1,
@@ -482,7 +482,7 @@ impl SimulationElement for CrossBleedValveSelectorKnob {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CrossBleedValveSelectorMode {
     Shut = 0,
     Auto = 1,
@@ -502,7 +502,7 @@ impl From<f64> for CrossBleedValveSelectorMode {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EngineState {
     Off = 0,
     On = 1,
@@ -750,7 +750,7 @@ impl PneumaticContainerWithConnector<VariableVolumeContainer> {
 
 pub struct BleedMonitoringComputerIsAliveSignal;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BleedMonitoringComputerChannelOperationMode {
     Master,
     Slave,
@@ -760,7 +760,7 @@ pub trait PressurizeableReservoir {
     fn available_volume(&self) -> Volume;
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EngineModeSelector {
     Crank = 0,
     Norm = 1,

--- a/src/systems/systems/src/shared/arinc429.rs
+++ b/src/systems/systems/src/shared/arinc429.rs
@@ -91,7 +91,7 @@ impl From<Arinc429Word<f64>> for f64 {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SignStatus {
     FailureWarning,
     NoComputedData,

--- a/src/systems/systems/src/shared/low_pass_filter.rs
+++ b/src/systems/systems/src/shared/low_pass_filter.rs
@@ -3,7 +3,7 @@ use std::ops::Mul;
 use std::ops::Sub;
 use std::time::Duration;
 
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 /// First order low pass filter
 /// y(k) = y(k-1)  +  (1-a)*( x(k) - y(k-1) ) with a = exp (-T/tau)
 /// See <https://gregstanleyandassociates.com/whitepapers/FaultDiagnosis/Filtering/Exponential-Filter/exponential-filter.htm>

--- a/src/systems/systems/src/shared/mod.rs
+++ b/src/systems/systems/src/shared/mod.rs
@@ -113,14 +113,14 @@ pub trait LgciuInterface:
 {
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(usize)]
 pub enum LgciuId {
     Lgciu1 = 0,
     Lgciu2 = 1,
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum ProximityDetectorId {
     UplockGearNose1,
     UplockGearNose2,
@@ -149,7 +149,7 @@ pub enum ProximityDetectorId {
     DownlockDoorRight2,
 }
 
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum GearActuatorId {
     GearNose,
     GearDoorNose,
@@ -220,7 +220,7 @@ pub trait SectionPressure {
     fn is_pressure_switch_pressurised(&self) -> bool;
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HydraulicColor {
     Green,
     Blue,

--- a/src/systems/systems/src/simulation/mod.rs
+++ b/src/systems/systems/src/simulation/mod.rs
@@ -42,10 +42,7 @@ pub struct VariableIdentifier(usize, usize);
 
 impl VariableIdentifier {
     pub fn new<T: Into<usize>>(variable_type: T) -> Self {
-        Self {
-            0: variable_type.into(),
-            1: 0,
-        }
+        Self(variable_type.into(), 0)
     }
 
     pub fn identifier_type(&self) -> usize {
@@ -59,10 +56,7 @@ impl VariableIdentifier {
 
 impl VariableIdentifier {
     pub fn next(&self) -> Self {
-        Self {
-            0: self.0,
-            1: self.1 + 1,
-        }
+        Self(self.0, self.1 + 1)
     }
 }
 
@@ -532,7 +526,7 @@ impl<'a> SimulatorToSimulationVisitor<'a> {
 }
 impl SimulationElementVisitor for SimulatorToSimulationVisitor<'_> {
     fn visit<T: SimulationElement>(&mut self, visited: &mut T) {
-        visited.read(&mut self.reader);
+        visited.read(self.reader);
     }
 }
 
@@ -548,7 +542,7 @@ impl<'a> SimulationToSimulatorVisitor<'a> {
 }
 impl<'a> SimulationElementVisitor for SimulationToSimulatorVisitor<'a> {
     fn visit<T: SimulationElement>(&mut self, visited: &mut T) {
-        visited.write(&mut self.writer);
+        visited.write(self.writer);
     }
 }
 

--- a/src/systems/systems/src/simulation/test.rs
+++ b/src/systems/systems/src/simulation/test.rs
@@ -511,11 +511,14 @@ impl<T: SimulationElement> From<T> for SimulationTestBed<TestAircraft<T>> {
     }
 }
 
+type UpdateBeforePowerDistributionFn<T> = dyn Fn(&mut T, &UpdateContext, &mut Electricity) + 'static;
+type UpdateAfterPowerDistributionFn<T> = dyn Fn(&mut T, &UpdateContext) + 'static;
+
 pub struct TestAircraft<T: SimulationElement> {
     element: T,
     update_before_power_distribution_fn:
-        Box<dyn Fn(&mut T, &UpdateContext, &mut Electricity) + 'static>,
-    update_after_power_distribution_fn: Box<dyn Fn(&mut T, &UpdateContext) + 'static>,
+        Box<UpdateBeforePowerDistributionFn<T>>,
+    update_after_power_distribution_fn: Box<UpdateAfterPowerDistributionFn<T>>,
 }
 impl<T: SimulationElement> TestAircraft<T> {
     pub fn new(element: T) -> Self {

--- a/src/systems/systems/src/simulation/test.rs
+++ b/src/systems/systems/src/simulation/test.rs
@@ -511,13 +511,13 @@ impl<T: SimulationElement> From<T> for SimulationTestBed<TestAircraft<T>> {
     }
 }
 
-type UpdateBeforePowerDistributionFn<T> = dyn Fn(&mut T, &UpdateContext, &mut Electricity) + 'static;
+type UpdateBeforePowerDistributionFn<T> =
+    dyn Fn(&mut T, &UpdateContext, &mut Electricity) + 'static;
 type UpdateAfterPowerDistributionFn<T> = dyn Fn(&mut T, &UpdateContext) + 'static;
 
 pub struct TestAircraft<T: SimulationElement> {
     element: T,
-    update_before_power_distribution_fn:
-        Box<UpdateBeforePowerDistributionFn<T>>,
+    update_before_power_distribution_fn: Box<UpdateBeforePowerDistributionFn<T>>,
     update_after_power_distribution_fn: Box<UpdateAfterPowerDistributionFn<T>>,
 }
 impl<T: SimulationElement> TestAircraft<T> {

--- a/src/systems/systems/src/simulation/update_context.rs
+++ b/src/systems/systems/src/simulation/update_context.rs
@@ -93,7 +93,7 @@ impl LocalAcceleration {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Velocity3D {
     velocity: [Velocity; 3],
 }
@@ -130,13 +130,6 @@ impl Velocity3D {
             self.vert_velocity().get::<meter_per_second>(),
             self.long_velocity().get::<meter_per_second>(),
         )
-    }
-}
-impl Default for Velocity3D {
-    fn default() -> Self {
-        Self {
-            velocity: [Velocity::default(); 3],
-        }
     }
 }
 

--- a/src/systems/systems_wasm/Cargo.toml
+++ b/src/systems/systems_wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "systems_wasm"
 version = "0.1.0"
 authors = ["FlyByWire Simulations"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 test = false

--- a/src/systems/systems_wasm/src/aspects.rs
+++ b/src/systems/systems_wasm/src/aspects.rs
@@ -238,12 +238,7 @@ impl<'a, 'b> MsfsAspectBuilder<'a, 'b> {
     }
 
     /// Execute the given function whenever any of the observed variable values changes.
-    pub fn on_change(
-        &mut self,
-        execute_on: ExecuteOn,
-        observed: Vec<Variable>,
-        func: OnChangeFn,
-    ) {
+    pub fn on_change(&mut self, execute_on: ExecuteOn, observed: Vec<Variable>, func: OnChangeFn) {
         let observed = self.variables.register_many(&observed);
         let starting_values = self.variables.read_many(&observed);
 

--- a/src/systems/systems_wasm/src/aspects.rs
+++ b/src/systems/systems_wasm/src/aspects.rs
@@ -187,7 +187,7 @@ impl<'a, 'b> MsfsAspectBuilder<'a, 'b> {
         let target = self.variables.register(&target);
 
         let event_to_variable = EventToVariable::new(
-            &mut self.sim_connect,
+            self.sim_connect,
             event_name,
             mapping,
             target,
@@ -213,7 +213,7 @@ impl<'a, 'b> MsfsAspectBuilder<'a, 'b> {
         let input = self.variables.register(&input);
 
         self.actions.push((
-            ToEvent::new(&mut self.sim_connect, input, mapping, write_on, event_name)?.into(),
+            ToEvent::new(self.sim_connect, input, mapping, write_on, event_name)?.into(),
             ExecuteOn::PostTick,
         ));
 
@@ -242,7 +242,7 @@ impl<'a, 'b> MsfsAspectBuilder<'a, 'b> {
         &mut self,
         execute_on: ExecuteOn,
         observed: Vec<Variable>,
-        func: Box<dyn Fn(&[f64], &[f64])>,
+        func: OnChangeFn,
     ) {
         let observed = self.variables.register_many(&observed);
         let starting_values = self.variables.read_many(&observed);
@@ -335,7 +335,7 @@ impl Aspect for MsfsAspect {
     }
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 /// Declares when to execute the action.
 pub enum ExecuteOn {
     PreTick,
@@ -496,7 +496,7 @@ pub fn min(accumulator: f64, item: f64) -> f64 {
     accumulator.min(item)
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum ObjectWrite {
     Ignore,
     ToSim,
@@ -932,17 +932,19 @@ impl ExecutableVariableAction for ToEvent {
     }
 }
 
+type OnChangeFn = Box<dyn Fn(&[f64], &[f64])>;
+
 struct OnChange {
     observed_variables: Vec<VariableIdentifier>,
     previous_values: Vec<f64>,
-    func: Box<dyn Fn(&[f64], &[f64])>,
+    func: OnChangeFn,
 }
 
 impl OnChange {
     fn new(
         observed_variables: Vec<VariableIdentifier>,
         starting_values: Vec<f64>,
-        func: Box<dyn Fn(&[f64], &[f64])>,
+        func: OnChangeFn,
     ) -> Self {
         Self {
             observed_variables,

--- a/src/systems/systems_wasm/src/lib.rs
+++ b/src/systems/systems_wasm/src/lib.rs
@@ -77,7 +77,7 @@ impl<'a, 'b> MsfsSimulationBuilder<'a, 'b> {
         builder_func: T,
     ) -> Result<Self, Box<dyn Error>> {
         let variable_registry = &mut self.variable_registry.as_mut().unwrap();
-        let mut builder = MsfsAspectBuilder::new(&mut self.sim_connect, variable_registry);
+        let mut builder = MsfsAspectBuilder::new(self.sim_connect, variable_registry);
         (builder_func)(&mut builder)?;
         self.aspects.push(Box::new(builder.build()));
 


### PR DESCRIPTION
## Summary of Changes
Required change for update to flybywire dev-env updates.
See https://github.com/flybywiresim/dev-env/pull/7

New dev-env has:
MSFS SDK 0.20.3.0
llvm/clang 15
wasi 16.0
rust 1.65 
binaryen 110

Updates Rust toolchain to use Rust 1.65.0

Also changes build grouping to improve build stability and avoid stalled wasm builds.

TODO: 
- [x] Update image sha in build scripts

Testing:
- [x] master full setup and compile
- [x] full flight with master
- [x] exp full setup and compile
- [x] full flight with exp  

New image URL:
ghcr.io/flybywiresim/dev-env@sha256:8eff8ed27dbe218e48876afe1234f260afad4588f15e45012e1f95fb85dcb569

## Screenshots (if necessary)
Also: 
![image](https://user-images.githubusercontent.com/16833201/200201925-8af3c0af-ab47-43bf-bf02-c132f3cadfc7.png)

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
For QA: 
- Does not change any user visible functions
- Please do full flights and test all systems for regressions - should all work as before

For Developers who like to test this PR:
- compilation should use new dev-env image (url see above)
- compilation should work without issues
- No changes in MSFS for the A32NX

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
