### PR TITLE
chore: strip debug info from systems release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ members = [
 
 [profile.release]
 lto = true
+strip = true

--- a/igniter.config.mjs
+++ b/igniter.config.mjs
@@ -23,7 +23,7 @@ export default new TaskOfTasks('a32nx', [
         new ExecTask('fmgc','npm run build:fmgc', ['src/fmgc', 'flybywire-aircraft-a320-neo/html_ui/JS/fmgc']),
         new ExecTask('systems', [
             'cargo build -p a320_systems_wasm --target wasm32-wasi --release',
-            'wasm-opt -O3 -o flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/panel/systems.wasm target/wasm32-wasi/release/a320_systems_wasm.wasm',
+            'wasm-opt -O1 -o flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/panel/systems.wasm target/wasm32-wasi/release/a320_systems_wasm.wasm',
         ], ['src/systems', 'Cargo.lock', 'Cargo.toml', 'flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/panel/systems.wasm']),
         new ExecTask('systems-autopilot', [
             'src/fbw/build.sh',


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This needs https://github.com/flybywiresim/a32nx/pull/7588 to be merged as the current dev-env's rust version is too old for that feature.

Added strip = true (https://doc.rust-lang.org/cargo/reference/profiles.html#strip) option to remove debug symbols.

This makes:
 a) MSFS happy as it does not detect it as DEBUG build anymore (see screenshot).
 b) Reduce the size wasm file to 709kb
 c) Reduces wasm compile time in MSFS from ~150 seconds to ~53 seconds (i7-10700k)

Note: I had to reduce wasm-opt to level O1, everything else crashed the sim but I think the benefits are higher now.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

Before:

![systems_before](https://user-images.githubusercontent.com/19493808/200678200-5dc938ac-5d99-43e6-a6f3-22fddf3d7df1.png)


After:

![wasm_after](https://user-images.githubusercontent.com/19493808/200678222-54cf4070-eb87-42c2-9442-d727e90632c2.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Perform a flight and look for any abnormal behavior in systems (hydraulics, electrics, bleed...)

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
