### PR TITLE
feat(sd): improve LO AIR PRESS indication visuals

### DIFF
--- a/src/instruments/src/SD/Pages/Hyd/Hyd.tsx
+++ b/src/instruments/src/SD/Pages/Hyd/Hyd.tsx
@@ -280,8 +280,8 @@ const HydReservoir = ({ system, x, y, lowLevel } : HydReservoirProps) => {
             <line className={lowLevel ? 'AmberLine' : 'GreenLine'} x1={0} y1={fluidHeight} x2={-12} y2={fluidHeight} />
             <line className={lowLevel ? 'AmberLine' : 'GreenLine'} x1={0} y1={fluidHeight} x2={-13} y2={fluidHeight - 11} />
 
-            <text className={lowAirPress ? 'Large Amber' : 'Hide'} x={20} y={-80}>LO AIR</text>
-            <text className={lowAirPress ? 'Large Amber' : 'Hide'} x={20} y={-50}>PRESS</text>
+            <text className={lowAirPress ? 'Large Amber' : 'Hide'} x={12} y={-72}>LO AIR</text>
+            <text className={lowAirPress ? 'Large Amber' : 'Hide'} x={12} y={-45}>PRESS</text>
         </SvgGroup>
     );
 };


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Small improvement to the visuals of the HYD SD page LO AIR PRESS indication for the reservoirs, according to IRL refs.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
| Before | After |
| -------|-------|
![lo_air_press_before](https://user-images.githubusercontent.com/39596827/185154001-504fbe23-52e1-4d26-9e28-bb2906096ce2.PNG) | ![lo_air_press_after](https://user-images.githubusercontent.com/39596827/200890910-244c028b-16b4-4b98-b774-7815c183c38d.png) |

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
