### PR TITLE
feat(navigation): update A380 radio altimters

### DIFF
--- a/src/systems/a380_systems/src/navigation.rs
+++ b/src/systems/a380_systems/src/navigation.rs
@@ -12,6 +12,7 @@ use uom::si::length::{foot, meter};
 pub struct A380RadioAltimeters {
     radio_altimeter_1: A380RadioAltimeter,
     radio_altimeter_2: A380RadioAltimeter,
+    radio_altimeter_3: A380RadioAltimeter,
 }
 
 impl A380RadioAltimeters {
@@ -22,17 +23,17 @@ impl A380RadioAltimeters {
                 1,
                 ElectricalBusType::AlternatingCurrent(1),
                 AntennaInstallation::new(
-                    // Sim CG minus RA height over ground
-                    Length::new::<foot>(8.617) - Length::new::<meter>(1.8),
+                    // Sim alt over ground minus RA height over ground
+                    Length::new::<foot>(14.75) - Length::new::<meter>(3.78),
                     // Aft distance from Sim CG
-                    Length::new::<meter>(9.89),
+                    Length::new::<meter>(12.50),
                     // Electric length of the antennas and cable modeling some material variation
-                    Length::new::<foot>(22.4),
+                    Length::new::<foot>(27.0),
                 ),
                 AntennaInstallation::new(
-                    Length::new::<foot>(8.617) - Length::new::<meter>(1.8),
-                    Length::new::<meter>(9.19),
-                    Length::new::<foot>(22.4),
+                    Length::new::<foot>(14.75) - Length::new::<meter>(3.69),
+                    Length::new::<meter>(11.69),
+                    Length::new::<foot>(27.0),
                 ),
             ),
             radio_altimeter_2: A380RadioAltimeter::new(
@@ -40,14 +41,29 @@ impl A380RadioAltimeters {
                 2,
                 ElectricalBusType::AlternatingCurrent(2),
                 AntennaInstallation::new(
-                    Length::new::<foot>(8.617) - Length::new::<meter>(1.8),
-                    Length::new::<meter>(11.27),
-                    Length::new::<foot>(21.4),
+                    Length::new::<foot>(14.75) - Length::new::<meter>(3.89),
+                    Length::new::<meter>(13.35),
+                    Length::new::<foot>(26.2),
                 ),
                 AntennaInstallation::new(
-                    Length::new::<foot>(8.617) - Length::new::<meter>(1.8),
-                    Length::new::<meter>(11.96),
-                    Length::new::<foot>(21.4),
+                    Length::new::<foot>(14.75) - Length::new::<meter>(4.01),
+                    Length::new::<meter>(14.20),
+                    Length::new::<foot>(26.2),
+                ),
+            ),
+            radio_altimeter_3: A380RadioAltimeter::new(
+                context,
+                3,
+                ElectricalBusType::AlternatingCurrent(2),
+                AntennaInstallation::new(
+                    Length::new::<foot>(14.75) - Length::new::<meter>(4.27),
+                    Length::new::<meter>(15.90),
+                    Length::new::<foot>(25.4),
+                ),
+                AntennaInstallation::new(
+                    Length::new::<foot>(14.75) - Length::new::<meter>(4.14),
+                    Length::new::<meter>(15.05),
+                    Length::new::<foot>(25.4),
                 ),
             ),
         }
@@ -56,6 +72,7 @@ impl A380RadioAltimeters {
     pub fn update(&mut self, context: &UpdateContext) {
         self.radio_altimeter_1.update(context);
         self.radio_altimeter_2.update(context);
+        self.radio_altimeter_3.update(context);
     }
 }
 
@@ -63,6 +80,7 @@ impl SimulationElement for A380RadioAltimeters {
     fn accept<T: SimulationElementVisitor>(&mut self, visitor: &mut T) {
         self.radio_altimeter_1.accept(visitor);
         self.radio_altimeter_2.accept(visitor);
+        self.radio_altimeter_3.accept(visitor);
 
         visitor.visit(self);
     }
@@ -85,7 +103,7 @@ impl A380RadioAltimeter {
             radio_altimeter: Ala52BRadioAltimeter::new(
                 context,
                 number,
-                Ala52BAircraftInstallationDelay::FiftySevenFeet,
+                Ala52BAircraftInstallationDelay::EightyFeet,
                 powered_by,
             ),
             transceivers: Ala52BTransceiverPair::new(context, transmitter, receiver),

--- a/src/systems/a380_systems_wasm/src/lib.rs
+++ b/src/systems/a380_systems_wasm/src/lib.rs
@@ -158,6 +158,7 @@ async fn systems(mut gauge: msfs::Gauge) -> Result<(), Box<dyn Error>> {
         ),
         (34_000, FailureType::RadioAltimeter(1)),
         (34_001, FailureType::RadioAltimeter(2)),
+        (34_002, FailureType::RadioAltimeter(3)),
     ])
     .provides_aircraft_variable("ACCELERATION BODY X", "feet per second squared", 0)?
     .provides_aircraft_variable("ACCELERATION BODY Y", "feet per second squared", 0)?

--- a/src/systems/systems/src/navigation/ala52b.rs
+++ b/src/systems/systems/src/navigation/ala52b.rs
@@ -61,13 +61,14 @@ impl Ala52BTransceiverPair {
     /// Returns the height over ground of the physical transmitter antenna.
     fn transmitter_height_over_ground(&self) -> Length {
         let vertical_offset = self.pitch.sin() * self.transmitter.z();
-        self.alt_above_ground + vertical_offset - self.transmitter.y()
+        (self.alt_above_ground + vertical_offset - self.transmitter.y())
+            .max(Length::new::<foot>(0.))
     }
 
     /// Returns the height over ground of the physical receiver antenna.
     fn receiver_height_over_ground(&self) -> Length {
         let vertical_offset = self.pitch.sin() * self.receiver.z();
-        self.alt_above_ground + vertical_offset - self.receiver.y()
+        (self.alt_above_ground + vertical_offset - self.receiver.y()).max(Length::new::<foot>(0.))
     }
 
     /// Returns the direct distance between the antennas (usually along the aircraft's fuselage)


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR updates the `a380_systems` for the triple radio altimeter setup of the A380. It also calibrates the radio altimeter heights according to the current A380X model.

We also introduce a minor guard in the ALA52B transceiver modeling to prevent an invalid negative height from being used for the offset timing generation.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Should not be required, as this only tweaks some numbers on the A380.
However if you do have access and want to test, you can try this [systems.wasm (needs unzipping)](https://github.com/flybywiresim/a32nx/files/10003273/systems.zip) file.

<!-- DO NOT DELETE THIS -->

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
