### PR TITLE
feat: Added deboarding button to flyPad Payload page

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -100,6 +100,7 @@
 1. [PFD] Improve appearance of L/DEV and V/DEV scales - @tracernz (Mike)
 1. [HYD] Implemented Electro Hydrostatic actuators - @Crocket63 (crocket)
 1. [FAC] Move Speedscale computation to FAC - @lukecologne (luke)
+1. [EFB] Added deboarding button to flyPad Payload - @frankkopp (Frank Kopp)
 
 ## 0.8.0
 

--- a/src/instruments/src/EFB/Ground/Ground.tsx
+++ b/src/instruments/src/EFB/Ground/Ground.tsx
@@ -17,9 +17,9 @@ export interface StatefulButton {
 export const Ground = () => {
     const tabs: PageLink[] = [
         { name: 'Services', alias: t('Ground.Services.Title'), component: <ServicesPage /> },
-        { name: 'Pushback', alias: t('Ground.Pushback.Title'), component: <PushbackPage /> },
         { name: 'Fuel', alias: t('Ground.Fuel.Title'), component: <FuelPage /> },
         { name: 'Payload', alias: t('Ground.Payload.Title'), component: <Payload /> },
+        { name: 'Pushback', alias: t('Ground.Pushback.Title'), component: <PushbackPage /> },
     ];
 
     return (

--- a/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
@@ -1,6 +1,13 @@
 /* eslint-disable max-len */
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
-import { BriefcaseFill, CloudArrowDown, PersonFill, PlayFill, StopCircleFill } from 'react-bootstrap-icons';
+import {
+    ArrowLeftRight,
+    BoxArrowRight,
+    BriefcaseFill,
+    CloudArrowDown,
+    PersonFill,
+    StopCircleFill,
+} from 'react-bootstrap-icons';
 import { useSimVar } from '@instruments/common/simVars';
 import { Units } from '@shared/units';
 import { usePersistentProperty } from '@instruments/common/persistence';
@@ -18,10 +25,12 @@ import Card from '../../../UtilComponents/Card/Card';
 import { SelectGroup, SelectItem } from '../../../UtilComponents/Form/Select';
 import { SeatMapWidget } from './Seating/SeatMapWidget';
 import { isSimbriefDataLoaded } from '../../../Store/features/simBrief';
+import { PromptModal, useModals } from '../../../UtilComponents/Modals/Modals';
 import { useAppSelector } from '../../../Store/store';
 
 export const Payload = () => {
     const { usingMetric } = Units;
+    const { showModal } = useModals();
 
     const massUnitForDisplay = usingMetric ? 'KGS' : 'LBS';
 
@@ -133,7 +142,6 @@ export const Payload = () => {
             const perBagWeight = Units.kilogramToUser(simbriefBagWeight);
             setPaxBagWeight(perBagWeight);
             setPaxWeight(Units.kilogramToUser(simbriefPaxWeight));
-            // TODO: Popup showing that maximum passengers number is incorrect if input is greater than maximum pax count
             setTargetPax(simbriefPax > maxPax ? maxPax : simbriefPax);
             setTargetCargo(simbriefBag, Units.kilogramToUser(simbriefFreight), perBagWeight);
         } else {
@@ -328,6 +336,25 @@ export const Payload = () => {
         ...cargoDesired, ...paxDesired,
         ...desiredFlags, ...stationSize,
     ]);
+
+    const handleDeboarding = () => {
+        if (!boardingStarted) {
+            showModal(
+                <PromptModal
+                    title={`${t('Ground.Payload.DeboardConfirmationTitle')}`}
+                    bodyText={`${t('Ground.Payload.DeboardConfirmationBody')}`}
+                    confirmText={`${t('Ground.Payload.DeboardConfirmationConfirm')}`}
+                    cancelText={`${t('Ground.Payload.DeboardConfirmationCancel')}`}
+                    onConfirm={() => {
+                        setTargetPax(totalPaxDesired < totalPax ? totalPaxDesired : 0);
+                        setTargetCargo(totalPaxDesired < totalPax ? totalPaxDesired : 0, totalCargoDesired < totalCargo ? totalCargoDesired : 0);
+                        setBoardingStarted(true);
+                    }}
+                />,
+            );
+        }
+        setBoardingStarted(false);
+    };
 
     const boardingStatusClass = useMemo(() => {
         if (!boardingStarted) {
@@ -726,15 +753,31 @@ export const Payload = () => {
                                     <TooltipWrapper text={t('Ground.Payload.TT.StartBoarding')}>
                                         <button
                                             type="button"
-                                            className={`flex justify-center rounded-lg items-center ml-auto w-32 h-12 ${boardingStatusClass} bg-current`}
+                                            className={`flex justify-center rounded-lg items-center ml-auto w-24 h-12 
+                                                        ${boardingStatusClass} bg-current`}
                                             onClick={() => setBoardingStarted(!boardingStarted)}
                                         >
-                                            <div className={`${true ? 'text-theme-body' : 'text-theme-highlight'}`}>
-                                                <PlayFill size={32} className={boardingStarted ? 'hidden' : ''} />
+                                            <div className="text-theme-body">
+                                                <ArrowLeftRight size={32} className={boardingStarted ? 'hidden' : ''} />
                                                 <StopCircleFill size={32} className={boardingStarted ? '' : 'hidden'} />
                                             </div>
                                         </button>
                                     </TooltipWrapper>
+
+                                    <TooltipWrapper text={t('Ground.Payload.TT.StartDeboarding')}>
+                                        <button
+                                            type="button"
+                                            className={`flex justify-center items-center ml-1 w-16 h-12 text-theme-highlight bg-current rounded-lg 
+                                                        ${totalPax === 0 && totalCargo === 0 && 'opacity-20 pointer-events-none'}`}
+                                            onClick={() => handleDeboarding()}
+                                        >
+                                            <div className="text-theme-body">
+                                                {' '}
+                                                <BoxArrowRight size={32} className={`${boardingStarted && 'opacity-20 pointer-events-none'} : ''}`} />
+                                            </div>
+                                        </button>
+                                    </TooltipWrapper>
+
                                 </div>
                             </Card>
 
@@ -746,7 +789,9 @@ export const Payload = () => {
                                 && (
                                     <TooltipWrapper text={t('Ground.Payload.TT.FillPayloadFromSimbrief')}>
                                         <div
-                                            className="flex justify-center items-center px-2 h-auto rounded-md rounded-l-none border-2 transition duration-100 text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body border-theme-highlight"
+                                            className={`flex justify-center items-center px-2 h-auto text-theme-body 
+                                                       hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body 
+                                                       rounded-md rounded-l-none border-2 border-theme-highlight transition duration-100`}
                                             onClick={setSimBriefValues}
                                         >
                                             <CloudArrowDown size={26} />

--- a/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
@@ -804,7 +804,7 @@ export const Payload = () => {
                             <Card className="w-full h-full" childrenContainerClassName="flex flex-col w-full h-full">
                                 <div className="flex flex-row justify-between items-center">
                                     <div className="flex font-medium">
-                                        {t('Ground.Payload.LoadingTime')}
+                                        {t('Ground.Payload.BoardingTime')}
                                     </div>
 
                                     <SelectGroup>

--- a/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/Payload/Payload.tsx
@@ -803,7 +803,9 @@ export const Payload = () => {
                         <div className="flex flex-row mt-4">
                             <Card className="w-full h-full" childrenContainerClassName="flex flex-col w-full h-full">
                                 <div className="flex flex-row justify-between items-center">
-                                    <div className="flex font-medium">Loading Time </div>
+                                    <div className="flex font-medium">
+                                        {t('Ground.Payload.LoadingTime')}
+                                    </div>
 
                                     <SelectGroup>
                                         <SelectItem

--- a/src/instruments/src/EFB/Localization/en.json
+++ b/src/instruments/src/EFB/Localization/en.json
@@ -157,6 +157,7 @@
       "DeboardConfirmationBody":"Please confirm deboarding all passengers",
       "DeboardConfirmationConfirm": "Deboard",
       "DeboardConfirmationCancel":"Cancel",
+      "LoadingTime": "Loading Time",
       "TT": {
         "AircraftMustBeColdAndDarkToChangeBoardingTimes": "Aircraft Must Be On the Ground and Have Engines Shutdown to Change Boarding Duration",
         "FillPayloadFromSimbrief": "Fill Payload Information from Simbrief",

--- a/src/instruments/src/EFB/Localization/en.json
+++ b/src/instruments/src/EFB/Localization/en.json
@@ -153,6 +153,10 @@
       "Current": "Current",
       "Passengers": "Passengers",
       "Planned": "Planned",
+      "DeboardConfirmationTitle": "Deboard all Passengers?",
+      "DeboardConfirmationBody":"Please confirm deboarding all passengers",
+      "DeboardConfirmationConfirm": "Deboard",
+      "DeboardConfirmationCancel":"Cancel",
       "TT": {
         "AircraftMustBeColdAndDarkToChangeBoardingTimes": "Aircraft Must Be On the Ground and Have Engines Shutdown to Change Boarding Duration",
         "FillPayloadFromSimbrief": "Fill Payload Information from Simbrief",
@@ -162,7 +166,8 @@
         "MaxZFWCG": "Maximum ZFWCG",
         "PerPaxBagWeight": "Per Passenger Bag Weight",
         "PerPaxWeight": "Per Passenger Weight",
-        "StartBoarding": "Begin Boarding"
+        "StartBoarding": "Begin Boarding",
+        "StartDeboarding": "Begin Deboarding"
       },
       "Title": "Payload",
       "ZFW": "ZFW",


### PR DESCRIPTION
Closes #7561

## Summary of Changes

- Adds a button to the flyPad Ground-Payload page to deboard all passengers and unload cargo. 
- Changes Icon of boarding button to signify that it can be boarding or deboarding
- Reorders the tabs for the Ground pages to make them more following the procedure flow

## Screenshots (if necessary)
https://user-images.githubusercontent.com/16833201/202810935-29098dc6-8cfc-49b2-900e-d0599b6b9a28.mp4

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Test loading and unloading payload (manual, SimBrief) and make sure the buttons are behaving correctly and working as intended. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
