### PR TITLE
feat: added pretty release name to flyPad about page

### DIFF
--- a/src/instruments/src/EFB/Settings/Pages/AboutPage.tsx
+++ b/src/instruments/src/EFB/Settings/Pages/AboutPage.tsx
@@ -13,6 +13,7 @@ interface BuildInfo {
     sha: string;
     actor: string;
     eventName: string;
+    prettyReleaseName: string;
 }
 
 interface BuildInfoEntryProps {
@@ -70,6 +71,7 @@ export const AboutPage = () => {
             sha: json.sha,
             actor: json.actor,
             eventName: json.event_name,
+            prettyReleaseName: json.pretty_release_name,
         }));
     }, []);
 
@@ -110,6 +112,7 @@ export const AboutPage = () => {
                         <BuildInfoEntry title="Ref" value={buildInfo?.ref} />
                         <BuildInfoEntry title="SHA" value={buildInfo?.sha} underline={8} />
                         <BuildInfoEntry title="Event Name" value={buildInfo?.eventName} />
+                        <BuildInfoEntry title="Pretty Release Name" value={buildInfo?.prettyReleaseName} />
                         {sentryEnabled === SentryConsentState.Given && (
                             <BuildInfoEntry title="Sentry Session ID" value={sessionId} />
                         )}


### PR DESCRIPTION
## Summary of Changes
QOL for devs and support to easier recognize the version in the flyPad Settings About page

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/16833201/204065878-ad231af3-1a59-42a6-9678-0a0dcaddffc7.png)

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Open the flyPad Settings About page and check if the new line "Pretty Release Name" is there and showing the correct information. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
