### PR TITLE
fix(atsu): LSK6L ATSU DLK return in ATC MENU

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 1. [ADIRU] Implemented wind speed computation from TAS/GS/HDG - @tracernz (Mike)
 1. [FMGC] Show proper transition names and final approach slope from AAU1 - @tracernz (Mike)
+1. [ATSU] Fix LSK6L not returning to ATSU DATALINK page in ATC MENU - @BravoMike99 (Bruno_pt99#5802)
 
 ## 0.9.0
 

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_ATC_Menu.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_ATC_Menu.js
@@ -65,14 +65,14 @@ class CDUAtcMenu {
         mcdu.onLeftInput[4] = () => {
             CDUAtcConnection.ShowPage(mcdu);
         };
-        
+
         mcdu.leftInputDelay[5] = () => {
             return mcdu.getDelaySwitchPage();
-        }
+        };
         mcdu.onLeftInput[5] = () => {
             CDUAtsuMenu.ShowPage(mcdu);
         };
-        
+
         mcdu.rightInputDelay[0] = () => {
             return mcdu.getDelaySwitchPage();
         };

--- a/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_ATC_Menu.js
+++ b/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/ATSU/A320_Neo_CDU_ATC_Menu.js
@@ -65,7 +65,14 @@ class CDUAtcMenu {
         mcdu.onLeftInput[4] = () => {
             CDUAtcConnection.ShowPage(mcdu);
         };
-
+        
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        }
+        mcdu.onLeftInput[5] = () => {
+            CDUAtsuMenu.ShowPage(mcdu);
+        };
+        
         mcdu.rightInputDelay[0] = () => {
             return mcdu.getDelaySwitchPage();
         };


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes the following issue:
https://discord.com/channels/738864299392630914/785976111875751956/1022941254687916132

## Summary of Changes
This pr fixes  LSK6L in ATC MENU not returning to ATSU Datalink Page.



## Screenshots (if necessary)


## References
Honeywell H3/H4 FCOM of FANS A+B & C equipped aircraft:
![FCOM](https://user-images.githubusercontent.com/119708186/206319099-6a382f94-4cf1-4d68-8d39-bddc6190493d.PNG)

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Bruno_pt99#5802

## Testing instructions
Check that pressing LSK6L on ATC MENU page returns to the ATSU Datalink Page.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
