### PR TITLE
build: Remove generation of build_info.json

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_beta.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_beta.yaml
@@ -28,7 +28,7 @@ body:
         "actor": "Benjozork",
         "event_name": "manual"
       }
-    description: Please paste the contents from the build_info.json (located inside main aircraft folder) into the field.
+    description: Please paste the contents from the a32nx_build_info.json (located inside main aircraft folder) into the field.
     render: json
   validations:
     required: true

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 /flybywire-aircraft-a320-neo/layout.json
 /flybywire-aircraft-a320-neo/manifest.json
 /flybywire-aircraft-a320-neo/a32nx_build_info.json
-/flybywire-aircraft-a320-neo/build_info.json
 /flybywire-aircraft-a320-neo/html_ui/JS/atsu/
 /flybywire-aircraft-a320-neo/html_ui/JS/fmgc/
 /flybywire-aircraft-a320-neo/html_ui/JS/sentry-client/

--- a/scripts/metadata.js
+++ b/scripts/metadata.js
@@ -37,5 +37,4 @@ if (!filePrefixArg) {
 
 const write = (file) => writeFileSync(file, JSON.stringify(object, null, 4));
 
-write(`build_info.json`);
 write(`${filePrefixArg}_build_info.json`);


### PR DESCRIPTION
## Summary of Changes
Removed build_info.json (and any references) as build_info.json is not used any longer.
Instead a32nx_build_info.json is used since a while now.

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Should have no impact.
Possible places to double check:
- flyPad Settings About page

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
