### PR TITLE
fix: pushback did not pause when leaving flyPad Pushback page

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,6 +14,7 @@
 1. [HYD] Trimmable physical assemblies - @Crocket63 (crocket)
 1. [HYD] Simulation of the rudder mechanical assembly and yaw dampers - @Crocket63 (crocket)
 1. [FLIGHTMODEL] Reduced flap induced drag - @donstim (donbikes#4084)
+1. [EFB] Fix and improve pushback system and add API documentation - @frankkopp (Frank Kopp)
 
 ## 0.9.0
 

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -21,6 +21,7 @@
   - [Landing Gear (ATA 32)](#landing-gear-ata-32)
   - [ATC (ATA 34)](#atc-ata-34)
   - [Radio Altimeter (ATA 34)](#radio-altimeter-ata-34)
+  - [Electronic Flight Bag ATA 46](#electronic-flight-bag--ata-46-)
 
 ## Uncategorized
 
@@ -3322,3 +3323,28 @@ In the variables below, {number} should be replaced with one item in the set: { 
     - {number}
         - 0
         - 1
+
+## Electronic Flight Bag (ATA 46)
+
+- A32NX_PUSHBACK_SYSTEM_ENABLED
+    - Boolean
+    - Read/Write
+    - Whether the pushback system is enabled
+    - Further conditions are "Pushback Tug Attached" and "Aircraft On Ground" otherwise the system 
+      has no impact on the aircraft
+
+- A32NX_PUSHBACK_SPD_FACTOR
+    - Number
+    - Read/Write
+    - Determines the speed of the pushback tug from -100% to 100% 
+    - {number}
+        - -1.0
+        - 1.0
+
+- A32NX_PUSHBACK_HDG_FACTOR
+    - Number
+    - Read/Write
+    - Determines the heading of the pushback tug from max left (-1.0) to right (1.0) 
+    - {number}
+        - -1.0
+        - 1.0

--- a/src/flypad-backend/src/Pushback/Pushback.cpp
+++ b/src/flypad-backend/src/Pushback/Pushback.cpp
@@ -77,7 +77,7 @@ void Pushback::onUpdate(double deltaTime) {
     movementCounterRotAccel -= 0.5;
   }
   else if (inertiaSpeed < 0) {
-    movementCounterRotAccel += 0.5;
+    movementCounterRotAccel += 1.0;
   }
   else {
     movementCounterRotAccel = 0.0;

--- a/src/flypad-backend/src/Pushback/Pushback.cpp
+++ b/src/flypad-backend/src/Pushback/Pushback.cpp
@@ -71,13 +71,13 @@ void Pushback::onUpdate(double deltaTime) {
 
   // As we might use the elevator for taxiing we compensate for wind to avoid
   // the aircraft lifting any gears.
-  const FLOAT64 windCounterRotAccel = getWindVelBodyZ() / 1000.0;
+  const FLOAT64 windCounterRotAccel = getWindVelBodyZ() / 2000.0;
   FLOAT64 movementCounterRotAccel = windCounterRotAccel;
   if (inertiaSpeed > 0) {
-    movementCounterRotAccel -= 1.1;
+    movementCounterRotAccel -= 0.5;
   }
   else if (inertiaSpeed < 0) {
-    movementCounterRotAccel += 2.0;
+    movementCounterRotAccel += 0.5;
   }
   else {
     movementCounterRotAccel = 0.0;

--- a/src/instruments/src/EFB/Ground/Pages/PushbackPage.tsx
+++ b/src/instruments/src/EFB/Ground/Pages/PushbackPage.tsx
@@ -102,6 +102,7 @@ export const PushbackPage = () => {
                         bodyText={`${t('Pushback.DisableSystemMessageBody')}`}
                         onConfirm={() => {
                             releaseTug();
+                            setPushbackSystemEnabled(0);
                         }}
                     />,
                 );
@@ -130,10 +131,6 @@ export const PushbackPage = () => {
     };
 
     const handlePause = () => {
-        if (!pushbackPaused) {
-            setCmdHdgFactor(0);
-            setCmdSpdFactor(0);
-        }
         setPushbackPaused(!pushbackPaused);
     };
 
@@ -170,10 +167,20 @@ export const PushbackPage = () => {
                     hideProgressBar: true,
                     closeButton: false,
                 });
+                setCmdHdgFactor(0);
+                setCmdSpdFactor(0);
                 setPushbackPaused(() => true);
             }
         });
     }, []);
+
+    // called when the pushback paused state changes
+    useEffect(() => {
+        if (pushbackPaused) {
+            setCmdHdgFactor(0);
+            setCmdSpdFactor(0);
+        }
+    }, [pushbackPaused]);
 
     // Update commanded heading from rudder input
     useEffect(() => {

--- a/src/instruments/src/EFB/UtilComponents/BingMap.tsx
+++ b/src/instruments/src/EFB/UtilComponents/BingMap.tsx
@@ -20,7 +20,7 @@ export const BingMap: React.FC<BingMapProps> = ({ configFolder, mapId, range = D
         const svgMapConfig = new SvgMapConfig();
 
         svgMapConfig.load(configFolder, () => {
-            console.log(`[ReactBingMap (${mapId})] NetBingMap config loaded`);
+            // console.log(`[ReactBingMap (${mapId})] NetBingMap config loaded`);
             if (!mapRef.current) return;
 
             svgMapConfig.generateBingMap(mapRef.current);


### PR DESCRIPTION
## Summary of Changes
When leaving the flyPad Pushback page while actually pushing back should set the pushback movement to pause.
This didn't work and this PR fixes this. 

Also minor refactor to allow for better usage via LVARs in external tools. 

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Test Pushback in general.
Test leaving the Pushback page while moving. Aircraft should stop. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
