### PR TITLE
feat: upload to cloudflare cdn on exp

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -50,6 +50,13 @@ jobs:
         run: |
           ./scripts/cdn.sh $BUNNY_BUCKET_DESTINATION ./build-modules
           ./scripts/cdn.sh $BUNNY_BUCKET_DESTINATION ./${{ env.BUILD_DIR_NAME }}
+      - name: Upload to CloudFlare CDN
+        env:
+          CLOUDFLARE_BUCKET_PASSWORD: ${{ secrets.CLOUDFLARE_BUCKET_PASSWORD }}
+          CDN_BUCKET_DESTINATION: addons/a32nx/experimental
+        run: |
+          ./scripts/cf-cdn.sh $CDN_BUCKET_DESTINATION ./build-modules
+          ./scripts/cf-cdn.sh $CDN_BUCKET_DESTINATION ./${{ env.BUILD_DIR_NAME }}
       - name: Delete old GitHub Pre-Release assets
         uses: mknejp/delete-release-assets@v1
         with:

--- a/scripts/cf-cdn.sh
+++ b/scripts/cf-cdn.sh
@@ -14,7 +14,7 @@ upload () {
 
     # Try to upload the file up to MAX_RETRY times before failing
     counter=0
-    until curl --fail -X PUT -H "X-FBW-Access-Key: $CLOUDFLARE_BUCKET_PASSWORD" --data-binary -T "$1" "$DEST"
+    until curl --fail -X PUT -H "X-FBW-Access-Key: $CLOUDFLARE_BUCKET_PASSWORD" -T "$1" "$DEST"
     do
         sleep 1
         [[ counter -eq $MAX_RETRY ]] && echo "Failed to upload file '$1'" >&2 && exit 1

--- a/scripts/cf-cdn.sh
+++ b/scripts/cf-cdn.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CDN_URL="flybywirecdn.com"
-CDN_PURGE_LINK="https://flybywirecdn/api/purgeCache?url=http://flybywirecdn.com"
+CDN_PURGE_LINK="https://flybywirecdn.com/purgeCache?url=http://flybywirecdn.com"
 CDN_DIR=${1:-"addons/a32nx/test-3"}
 LOCAL_DIR=${2:-"./build-modules"}
 

--- a/scripts/cf-cdn.sh
+++ b/scripts/cf-cdn.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+CDN_URL="flybywirecdn.com"
+CDN_PURGE_LINK="https://flybywirecdn/api/purgeCache?url=http://flybywirecdn.com"
+CDN_DIR=${1:-"addons/a32nx/test-3"}
+LOCAL_DIR=${2:-"./build-modules"}
+
+MAX_RETRY=5
+
+upload () {
+    DEST="$CDN_URL/$CDN_DIR/$(basename -- "$1")"
+    echo "Syncing file: $1"
+    echo "Destination: $DEST"
+
+    # Try to upload the file up to MAX_RETRY times before failing
+    counter=0
+    until curl --fail -X PUT -H "X-FBW-Access-Key: $CLOUDFLARE_BUCKET_PASSWORD" --data-binary -T "$1" "$DEST"
+    do
+        sleep 1
+        [[ counter -eq $MAX_RETRY ]] && echo "Failed to upload file '$1'" >&2 && exit 1
+        echo "Trying again. Try #$counter"
+        ((counter++))
+    done
+    echo ""; echo ""
+}
+
+# Upload all files
+for FILE in "${LOCAL_DIR}"/*; do
+    upload "$FILE"
+done
+
+# Purge after all uploads that the files are somewhat in sync
+echo "Purging cache"
+for FILE in "${LOCAL_DIR}"/*; do
+    DEST="$CDN_PURGE_LINK/$CDN_DIR/$(basename -- "$FILE")"
+    echo "Purging cache for file: $FILE"
+    echo "Purge URL: $DEST"
+    curl -X POST -H "X-FBW-Access-Key: $CLOUDFLARE_BUCKET_PASSWORD" -H "Content-Length: 0" "$DEST"
+done

--- a/scripts/fragment.js
+++ b/scripts/fragment.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const execute = async () => {
     try {
         const result = await fragmenter.pack({
-            packOptions: { splitFileSize: 536_870_912, keepCompleteModulesAfterSplit: true },
+            packOptions: { splitFileSize: 102_760_448, keepCompleteModulesAfterSplit: false },
             baseDir: './flybywire-aircraft-a320-neo',
             outDir: './build-modules',
             modules: [{


### PR DESCRIPTION
## Summary of Changes

This PR:

* adds a script to upload to the CloudFlare R2 CDN;
* adds a step in the experimental pipeline to upload it there as well, keeping bunnycdn for now;
* changes the fragmenter module chunk size from 500MiB to 98MiB (R2 supports 100MB uploads at most).

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
