### PR TITLE
feat(sec): ground spoiler logic improvements

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -17,6 +17,7 @@
 1. [FLIGHTMODEL] Reduced flap induced drag - @donstim (donbikes#4084)
 1. [EFB] Fix and improve pushback system and add API documentation - @frankkopp (Frank Kopp)
 1. [RMP] RMPs navigation backup - Julian Sebline (Julian Sebline#8476 on Discord)
+1. [SEC] Fix GND SPLR logic, add missing GND SPLR partial extension condition - @lukecologne (luke)
 
 ## 0.9.0
 

--- a/src/fbw_a320/src/model/SecComputer.cpp
+++ b/src/fbw_a320/src/model/SecComputer.cpp
@@ -171,25 +171,25 @@ void SecComputer::step()
   real_T rtb_handleIndex;
   real_T rtb_zeta_deg;
   real_T u0;
-  real32_T rtb_y_fp;
-  real32_T rtb_y_h;
+  real32_T rtb_y_e;
+  real32_T rtb_y_fn;
   uint32_T rtb_DataTypeConversion1;
   uint32_T rtb_Switch7_c;
   uint32_T rtb_Switch9_c;
   uint32_T rtb_y;
   uint32_T rtb_y_af;
-  uint32_T rtb_y_mx;
+  uint32_T rtb_y_m;
   boolean_T rtb_VectorConcatenate[19];
   boolean_T rtb_AND1_h;
   boolean_T rtb_AND4_a;
   boolean_T rtb_NOT_bl;
   boolean_T rtb_OR;
-  boolean_T rtb_OR6;
-  boolean_T rtb_y_am;
-  boolean_T rtb_y_b;
-  boolean_T rtb_y_k4;
+  boolean_T rtb_y_ei;
+  boolean_T rtb_y_f5;
+  boolean_T rtb_y_j;
   boolean_T rtb_y_l;
-  boolean_T rtb_y_m;
+  boolean_T rtb_y_la;
+  boolean_T rtb_y_ls;
   if (SecComputer_U.in.sim_data.computer_running) {
     real_T pair1RollCommand;
     real_T pair2SpdBrkCommand;
@@ -210,14 +210,15 @@ void SecComputer::step()
     boolean_T abnormalCondition;
     boolean_T canEngageInPitch;
     boolean_T hasPriorityInPitch;
-    boolean_T leftElevatorAvail;
     boolean_T rightElevatorAvail;
     boolean_T rtb_AND2_j;
+    boolean_T rtb_BusAssignment_fz_logic_is_green_hydraulic_power_avail;
     boolean_T rtb_BusAssignment_n_logic_any_landing_gear_not_uplocked;
     boolean_T rtb_NOT2_b;
     boolean_T rtb_NOT_g;
     boolean_T rtb_OR1;
     boolean_T rtb_OR3;
+    boolean_T rtb_OR6;
     boolean_T rtb_doubleAdrFault;
     boolean_T rtb_doubleIrFault;
     boolean_T rtb_isEngagedInPitch;
@@ -237,6 +238,7 @@ void SecComputer::step()
       SecComputer_DWork.Memory_PreviousInput_n = SecComputer_P.SRFlipFlop_initial_condition_k;
       SecComputer_DWork.Delay1_DSTATE_i = SecComputer_P.Delay1_InitialCondition_l;
       SecComputer_DWork.Delay_DSTATE_n = SecComputer_P.Delay_InitialCondition_j;
+      SecComputer_DWork.Delay2_DSTATE = SecComputer_P.Delay2_InitialCondition;
       SecComputer_DWork.Delay_DSTATE = SecComputer_P.Delay_InitialCondition;
       SecComputer_DWork.icLoad = true;
       SecComputer_MATLABFunction_e_Reset(&SecComputer_DWork.sf_MATLABFunction_jk);
@@ -315,8 +317,8 @@ void SecComputer::step()
                 (SignStatusMatrix::NormalOperation)) || SecComputer_P.Constant_Value_l);
     rtb_singleIrFault = (rtb_OR || rtb_OR6);
     rtb_doubleIrFault = (rtb_OR && rtb_OR6);
-    rtb_y_l = !rtb_OR3;
-    if ((!rtb_OR1) && rtb_y_l) {
+    rtb_y_j = !rtb_OR3;
+    if ((!rtb_OR1) && rtb_y_j) {
       rtb_V_ias = (SecComputer_U.in.bus_inputs.adr_2_bus.airspeed_computed_kn.Data +
                    SecComputer_U.in.bus_inputs.adr_2_bus.airspeed_computed_kn.Data) / 2.0F;
       rtb_V_tas = (SecComputer_U.in.bus_inputs.adr_2_bus.airspeed_true_kn.Data +
@@ -330,7 +332,7 @@ void SecComputer::step()
       rtb_V_tas = SecComputer_U.in.bus_inputs.adr_1_bus.airspeed_true_kn.Data;
       rtb_mach = SecComputer_U.in.bus_inputs.adr_1_bus.mach.Data;
       rtb_alpha = SecComputer_U.in.bus_inputs.adr_1_bus.aoa_corrected_deg.Data;
-    } else if (rtb_OR1 && rtb_y_l) {
+    } else if (rtb_OR1 && rtb_y_j) {
       rtb_V_ias = SecComputer_U.in.bus_inputs.adr_2_bus.airspeed_computed_kn.Data;
       rtb_V_tas = SecComputer_U.in.bus_inputs.adr_2_bus.airspeed_true_kn.Data;
       rtb_mach = SecComputer_U.in.bus_inputs.adr_2_bus.mach.Data;
@@ -345,9 +347,9 @@ void SecComputer::step()
     rtb_eta_trim_limit_lo_d = rtb_V_ias;
     rtb_BusConversion_InsertedFor_BusAssignment_at_inport_8_BusCreator1_V_tas_kn = rtb_V_tas;
     rtb_BusConversion_InsertedFor_BusAssignment_at_inport_8_BusCreator1_mach = rtb_mach;
-    rtb_y_l = !rtb_OR;
+    rtb_y_j = !rtb_OR;
     rtb_OR1 = !rtb_OR6;
-    if (rtb_y_l && rtb_OR1) {
+    if (rtb_y_j && rtb_OR1) {
       rtb_theta = (SecComputer_U.in.bus_inputs.ir_1_bus.pitch_angle_deg.Data +
                    SecComputer_U.in.bus_inputs.ir_2_bus.pitch_angle_deg.Data) / 2.0F;
       rtb_phi = (SecComputer_U.in.bus_inputs.ir_1_bus.roll_angle_deg.Data +
@@ -366,7 +368,7 @@ void SecComputer::step()
                        SecComputer_U.in.bus_inputs.ir_2_bus.pitch_att_rate_deg_s.Data) / 2.0F;
       rtb_phi_dot = (SecComputer_U.in.bus_inputs.ir_1_bus.roll_att_rate_deg_s.Data +
                      SecComputer_U.in.bus_inputs.ir_2_bus.roll_att_rate_deg_s.Data) / 2.0F;
-    } else if (rtb_y_l && rtb_OR6) {
+    } else if (rtb_y_j && rtb_OR6) {
       rtb_theta = SecComputer_U.in.bus_inputs.ir_1_bus.pitch_angle_deg.Data;
       rtb_phi = SecComputer_U.in.bus_inputs.ir_1_bus.roll_angle_deg.Data;
       rtb_q = SecComputer_U.in.bus_inputs.ir_1_bus.body_pitch_rate_deg_s.Data;
@@ -401,81 +403,81 @@ void SecComputer::step()
     rtb_Switch5_tmp_tmp = rtb_theta;
     rtb_Switch6_m = rtb_phi;
     rtb_handleIndex = rtb_n_x;
-    SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_3, &rtb_OR);
+    SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_3, &rtb_y_ei);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_3,
       SecComputer_P.BitfromLabel13_bit, &rtb_Switch7_c);
-    rtb_OR6 = (rtb_Switch7_c != 0U);
+    rtb_OR = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_3,
       SecComputer_P.BitfromLabel12_bit, &rtb_Switch7_c);
-    rtb_y_m = (rtb_Switch7_c != 0U);
+    rtb_y_f5 = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_3,
       SecComputer_P.BitfromLabel10_bit, &rtb_Switch7_c);
-    rtb_OR6 = (rtb_OR6 || rtb_y_m || (rtb_Switch7_c != 0U));
-    rtb_y_k4 = (rtb_OR && rtb_OR6);
+    rtb_OR = (rtb_OR || rtb_y_f5 || (rtb_Switch7_c != 0U));
+    rtb_y_ls = (rtb_y_ei && rtb_OR);
     SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_3, &rtb_NOT_bl);
-    rtb_OR1 = (rtb_y_k4 && (!rtb_NOT_bl));
-    SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_3, &rtb_y_b);
+    rtb_OR6 = (rtb_y_ls && (!rtb_NOT_bl));
+    SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_3, &rtb_y_la);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_3, SecComputer_P.BitfromLabel5_bit,
       &rtb_Switch7_c);
-    rtb_y_m = (rtb_Switch7_c != 0U);
+    rtb_y_f5 = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_3, SecComputer_P.BitfromLabel4_bit,
       &rtb_Switch7_c);
-    rtb_y_am = (rtb_Switch7_c != 0U);
+    rtb_y_l = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_3, SecComputer_P.BitfromLabel2_bit,
       &rtb_Switch7_c);
-    rtb_y_m = (rtb_y_m || rtb_y_am || (rtb_Switch7_c != 0U));
-    rtb_AND4_a = (rtb_y_b && rtb_y_m);
+    rtb_y_f5 = (rtb_y_f5 || rtb_y_l || (rtb_Switch7_c != 0U));
+    rtb_AND4_a = (rtb_y_la && rtb_y_f5);
     SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_3, &rtb_NOT_bl);
-    rtb_AND4_a = (rtb_OR1 || (rtb_AND4_a && (!rtb_NOT_bl)) || (rtb_y_k4 && rtb_AND4_a));
+    rtb_AND4_a = (rtb_OR6 || (rtb_AND4_a && (!rtb_NOT_bl)) || (rtb_y_ls && rtb_AND4_a));
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_3,
       SecComputer_P.BitfromLabel15_bit, &rtb_Switch7_c);
-    rtb_y_am = (rtb_Switch7_c != 0U);
-    SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_3, &rtb_y_l);
+    rtb_y_l = (rtb_Switch7_c != 0U);
+    SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_3, &rtb_y_j);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_3,
       SecComputer_P.BitfromLabel14_bit, &rtb_Switch7_c);
-    rtb_y_k4 = (rtb_Switch7_c != 0U);
+    rtb_y_ls = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_3,
       SecComputer_P.BitfromLabel11_bit, &rtb_Switch7_c);
     rtb_AND1_h = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_3, SecComputer_P.BitfromLabel8_bit,
       &rtb_Switch7_c);
-    rtb_OR1 = ((!rtb_y_k4) && (!rtb_AND1_h) && (rtb_Switch7_c == 0U));
+    rtb_OR6 = ((!rtb_y_ls) && (!rtb_AND1_h) && (rtb_Switch7_c == 0U));
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_3,
       SecComputer_P.BitfromLabel16_bit, &rtb_Switch7_c);
     rtb_NOT_bl = (rtb_Switch7_c != 0U);
-    SecComputer_MATLABFunction_n((rtb_Switch7_c != 0U) && rtb_OR && rtb_OR6, SecComputer_U.in.time.dt,
-      SecComputer_P.ConfirmNode_isRisingEdge, SecComputer_P.ConfirmNode_timeDelay, &rtb_OR6,
+    SecComputer_MATLABFunction_n((rtb_Switch7_c != 0U) && rtb_y_ei && rtb_OR, SecComputer_U.in.time.dt,
+      SecComputer_P.ConfirmNode_isRisingEdge, SecComputer_P.ConfirmNode_timeDelay, &rtb_OR,
       &SecComputer_DWork.sf_MATLABFunction_jk);
-    rtb_OR = (rtb_y_am && rtb_y_l && rtb_OR1 && rtb_OR6);
+    rtb_OR = (rtb_y_l && rtb_y_j && rtb_OR6 && rtb_OR);
     SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_3, &rtb_AND1_h);
     SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_3, &rtb_NOT_bl);
     rtb_OR6 = ((!rtb_AND1_h) && (!rtb_NOT_bl));
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_3, SecComputer_P.BitfromLabel7_bit,
       &rtb_Switch7_c);
     rtb_NOT_bl = (rtb_Switch7_c != 0U);
-    SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_3, &rtb_y_l);
+    SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_3, &rtb_y_j);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_3, SecComputer_P.BitfromLabel6_bit,
       &rtb_Switch7_c);
     rtb_AND1_h = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_3, SecComputer_P.BitfromLabel3_bit,
       &rtb_Switch7_c);
-    rtb_y_am = (rtb_Switch7_c != 0U);
+    rtb_y_l = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_3, SecComputer_P.BitfromLabel1_bit,
       &rtb_Switch7_c);
-    rtb_OR1 = (rtb_NOT_bl && rtb_y_l && ((!rtb_AND1_h) && (!rtb_y_am) && (rtb_Switch7_c == 0U)));
+    rtb_OR1 = (rtb_NOT_bl && rtb_y_j && ((!rtb_AND1_h) && (!rtb_y_l) && (rtb_Switch7_c == 0U)));
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_3, SecComputer_P.BitfromLabel9_bit,
       &rtb_Switch7_c);
     rtb_NOT_bl = (rtb_Switch7_c != 0U);
-    SecComputer_MATLABFunction_n((rtb_Switch7_c != 0U) && rtb_y_b && rtb_y_m, SecComputer_U.in.time.dt,
+    SecComputer_MATLABFunction_n((rtb_Switch7_c != 0U) && rtb_y_la && rtb_y_f5, SecComputer_U.in.time.dt,
       SecComputer_P.ConfirmNode1_isRisingEdge, SecComputer_P.ConfirmNode1_timeDelay, &rtb_NOT_bl,
       &SecComputer_DWork.sf_MATLABFunction_dw);
-    rtb_OR6 = (rtb_OR || rtb_OR6 || (rtb_OR1 && rtb_NOT_bl));
+    rtb_OR = (rtb_OR || rtb_OR6 || (rtb_OR1 && rtb_NOT_bl));
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_2,
       SecComputer_P.BitfromLabel4_bit_c, &rtb_Switch7_c);
     rtb_NOT_bl = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_2,
       SecComputer_P.BitfromLabel6_bit_l, &rtb_Switch7_c);
-    rtb_OR = (rtb_NOT_bl || (rtb_Switch7_c != 0U));
+    rtb_OR6 = (rtb_NOT_bl || (rtb_Switch7_c != 0U));
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_2,
       SecComputer_P.BitfromLabel5_bit_a, &rtb_Switch7_c);
     rtb_NOT_bl = (rtb_Switch7_c != 0U);
@@ -486,22 +488,22 @@ void SecComputer::step()
     if (SecComputer_DWork.is_active_c8_SecComputer == 0U) {
       SecComputer_DWork.is_active_c8_SecComputer = 1U;
       SecComputer_DWork.is_c8_SecComputer = SecComputer_IN_OnGround;
-      rtb_OR1 = true;
+      rtb_OR6 = true;
     } else if (SecComputer_DWork.is_c8_SecComputer == SecComputer_IN_InAir) {
-      if ((static_cast<real_T>(rtb_OR) > 0.1) || (static_cast<real_T>(rtb_OR1) > 0.1)) {
+      if ((static_cast<real_T>(rtb_OR6) > 0.1) || (static_cast<real_T>(rtb_OR1) > 0.1)) {
         SecComputer_DWork.is_c8_SecComputer = SecComputer_IN_OnGround;
-        rtb_OR1 = true;
+        rtb_OR6 = true;
       } else {
-        rtb_OR1 = false;
+        rtb_OR6 = false;
       }
-    } else if ((!rtb_OR) && (!rtb_OR1)) {
+    } else if ((!rtb_OR6) && (!rtb_OR1)) {
       SecComputer_DWork.is_c8_SecComputer = SecComputer_IN_InAir;
-      rtb_OR1 = false;
+      rtb_OR6 = false;
     } else {
-      rtb_OR1 = true;
+      rtb_OR6 = true;
     }
 
-    rtb_OR3 = (SecComputer_U.in.sim_data.slew_on || SecComputer_U.in.sim_data.pause_on ||
+    rtb_OR1 = (SecComputer_U.in.sim_data.slew_on || SecComputer_U.in.sim_data.pause_on ||
                SecComputer_U.in.sim_data.tracking_mode_on_override);
     if (SecComputer_DWork.is_active_c30_SecComputer == 0U) {
       SecComputer_DWork.is_active_c30_SecComputer = 1U;
@@ -510,7 +512,7 @@ void SecComputer::step()
     } else {
       switch (SecComputer_DWork.is_c30_SecComputer) {
        case SecComputer_IN_Flight:
-        if (rtb_OR1 && (rtb_theta < 2.5F)) {
+        if (rtb_OR6 && (rtb_theta < 2.5F)) {
           SecComputer_DWork.on_ground_time = SecComputer_U.in.time.simulation_time;
           SecComputer_DWork.is_c30_SecComputer = SecComputer_IN_FlightToGroundTransition;
         } else {
@@ -522,7 +524,7 @@ void SecComputer::step()
         if (SecComputer_U.in.time.simulation_time - SecComputer_DWork.on_ground_time >= 5.0) {
           SecComputer_DWork.is_c30_SecComputer = SecComputer_IN_Ground;
           SecComputer_B.in_flight = 0.0;
-        } else if ((!rtb_OR1) || (rtb_theta >= 2.5F)) {
+        } else if ((!rtb_OR6) || (rtb_theta >= 2.5F)) {
           SecComputer_DWork.on_ground_time = 0.0;
           SecComputer_DWork.is_c30_SecComputer = SecComputer_IN_Flight;
           SecComputer_B.in_flight = 1.0;
@@ -530,7 +532,7 @@ void SecComputer::step()
         break;
 
        default:
-        if (((!rtb_OR1) && (rtb_theta > 8.0F)) || (SecComputer_P.Constant_Value_m > 400.0)) {
+        if (((!rtb_OR6) && (rtb_theta > 8.0F)) || (SecComputer_P.Constant_Value_m > 400.0)) {
           SecComputer_DWork.on_ground_time = 0.0;
           SecComputer_DWork.is_c30_SecComputer = SecComputer_IN_Flight;
           SecComputer_B.in_flight = 1.0;
@@ -543,13 +545,13 @@ void SecComputer::step()
 
     rtb_NOT_bl = (SecComputer_B.in_flight != 0.0);
     SecComputer_MATLABFunction_n(!SecComputer_U.in.discrete_inputs.yellow_low_pressure, SecComputer_U.in.time.dt,
-      SecComputer_P.ConfirmNode_isRisingEdge_a, SecComputer_P.ConfirmNode_timeDelay_c, &rtb_OR,
+      SecComputer_P.ConfirmNode_isRisingEdge_a, SecComputer_P.ConfirmNode_timeDelay_c, &rtb_y_ei,
       &SecComputer_DWork.sf_MATLABFunction_ndv);
     SecComputer_MATLABFunction_n(!SecComputer_U.in.discrete_inputs.blue_low_pressure, SecComputer_U.in.time.dt,
-      SecComputer_P.ConfirmNode1_isRisingEdge_j, SecComputer_P.ConfirmNode1_timeDelay_k, &rtb_y_l,
+      SecComputer_P.ConfirmNode1_isRisingEdge_j, SecComputer_P.ConfirmNode1_timeDelay_k, &rtb_y_j,
       &SecComputer_DWork.sf_MATLABFunction_gf);
     SecComputer_MATLABFunction_n(!SecComputer_U.in.discrete_inputs.green_low_pressure, SecComputer_U.in.time.dt,
-      SecComputer_P.ConfirmNode2_isRisingEdge, SecComputer_P.ConfirmNode2_timeDelay, &rtb_y_b,
+      SecComputer_P.ConfirmNode2_isRisingEdge, SecComputer_P.ConfirmNode2_timeDelay, &rtb_y_la,
       &SecComputer_DWork.sf_MATLABFunction_h);
     rtb_BusAssignment_f_logic_ir_computation_data_n_z_g = rtb_n_z;
     rtb_BusAssignment_f_logic_ir_computation_data_theta_dot_deg_s = rtb_theta_dot;
@@ -601,32 +603,32 @@ void SecComputer::step()
     }
 
     if (SecComputer_U.in.discrete_inputs.is_unit_1) {
-      leftElevatorAvail = ((!SecComputer_U.in.discrete_inputs.l_elev_servo_failed) && rtb_y_l);
-      rightElevatorAvail = ((!SecComputer_U.in.discrete_inputs.r_elev_servo_failed) && rtb_y_l);
+      rtb_OR3 = ((!SecComputer_U.in.discrete_inputs.l_elev_servo_failed) && rtb_y_j);
+      rightElevatorAvail = ((!SecComputer_U.in.discrete_inputs.r_elev_servo_failed) && rtb_y_j);
     } else {
-      leftElevatorAvail = ((!SecComputer_U.in.discrete_inputs.l_elev_servo_failed) && rtb_y_b);
-      rightElevatorAvail = ((!SecComputer_U.in.discrete_inputs.r_elev_servo_failed) && rtb_OR);
+      rtb_OR3 = ((!SecComputer_U.in.discrete_inputs.l_elev_servo_failed) && rtb_y_la);
+      rightElevatorAvail = ((!SecComputer_U.in.discrete_inputs.r_elev_servo_failed) && rtb_y_ei);
     }
 
-    rtb_thsAvail = ((!SecComputer_U.in.discrete_inputs.ths_motor_fault) && (rtb_OR || rtb_y_b));
-    canEngageInPitch = ((leftElevatorAvail || rightElevatorAvail) && (!SecComputer_U.in.discrete_inputs.is_unit_3));
+    rtb_thsAvail = ((!SecComputer_U.in.discrete_inputs.ths_motor_fault) && (rtb_y_ei || rtb_y_la));
+    canEngageInPitch = ((rtb_OR3 || rightElevatorAvail) && (!SecComputer_U.in.discrete_inputs.is_unit_3));
     if (SecComputer_U.in.discrete_inputs.is_unit_1) {
       hasPriorityInPitch = (SecComputer_U.in.discrete_inputs.pitch_not_avail_elac_1 &&
                             SecComputer_U.in.discrete_inputs.pitch_not_avail_elac_2 &&
                             SecComputer_U.in.discrete_inputs.left_elev_not_avail_sec_opp &&
                             SecComputer_U.in.discrete_inputs.right_elev_not_avail_sec_opp);
-      spoilerPair1SupplyAvail = rtb_y_l;
-      spoilerPair2SupplyAvail = rtb_OR;
+      spoilerPair1SupplyAvail = rtb_y_j;
+      spoilerPair2SupplyAvail = rtb_y_ei;
     } else {
       hasPriorityInPitch = (SecComputer_U.in.discrete_inputs.is_unit_2 &&
                             (SecComputer_U.in.discrete_inputs.pitch_not_avail_elac_1 &&
         SecComputer_U.in.discrete_inputs.pitch_not_avail_elac_2));
       if (SecComputer_U.in.discrete_inputs.is_unit_2) {
-        spoilerPair1SupplyAvail = rtb_y_b;
+        spoilerPair1SupplyAvail = rtb_y_la;
         spoilerPair2SupplyAvail = false;
       } else {
-        spoilerPair1SupplyAvail = rtb_y_b;
-        spoilerPair2SupplyAvail = rtb_OR;
+        spoilerPair1SupplyAvail = rtb_y_la;
+        spoilerPair2SupplyAvail = rtb_y_ei;
       }
     }
 
@@ -642,7 +644,7 @@ void SecComputer::step()
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.elac_1_bus.discrete_status_word_1,
       SecComputer_P.BitfromLabel_bit, &rtb_Switch7_c);
     SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.elac_1_bus.discrete_status_word_1, &rtb_AND4_a);
-    rtb_y_k4 = ((rtb_Switch7_c != 0U) && rtb_AND4_a);
+    rtb_y_ls = ((rtb_Switch7_c != 0U) && rtb_AND4_a);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.elac_2_bus.discrete_status_word_1,
       SecComputer_P.BitfromLabel1_bit_g, &rtb_Switch7_c);
     SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.elac_2_bus.discrete_status_word_1, &rtb_AND1_h);
@@ -658,20 +660,20 @@ void SecComputer::step()
     SecComputer_MATLABFunction_n(SecComputer_U.in.sim_data.slew_on, SecComputer_U.in.time.dt,
       SecComputer_P.ConfirmNode_isRisingEdge_g, SecComputer_P.ConfirmNode_timeDelay_e, &rtb_NOT_bl,
       &SecComputer_DWork.sf_MATLABFunction_k4);
-    rtb_y_am = !rtb_OR1;
-    abnormalCondition = ((!rtb_NOT_bl) && rtb_y_am && (((!rtb_doubleAdrFault) && ((rtb_mach > 0.91) || (rtb_alpha <
+    rtb_y_l = !rtb_OR6;
+    abnormalCondition = ((!rtb_NOT_bl) && rtb_y_l && (((!rtb_doubleAdrFault) && ((rtb_mach > 0.91) || (rtb_alpha <
       -10.0F) || (rtb_alpha > 40.0F) || (rtb_V_ias > 440.0F) || (rtb_V_ias < 60.0F))) || ((!rtb_doubleIrFault) &&
       ((!rtb_singleIrFault) || (!SecComputer_P.Constant_Value_l)) && ((std::abs(static_cast<real_T>(rtb_phi)) > 125.0) ||
       ((rtb_theta > 50.0F) || (rtb_theta < -30.0F))))));
-    SecComputer_DWork.abnormalConditionWasActive = (abnormalCondition || (rtb_y_am &&
+    SecComputer_DWork.abnormalConditionWasActive = (abnormalCondition || (rtb_y_l &&
       SecComputer_DWork.abnormalConditionWasActive));
     if (rtb_doubleIrFault || ((SecComputer_B.in_flight != 0.0) &&
-         ((rtb_BusAssignment_n_logic_any_landing_gear_not_uplocked && (!rtb_OR6)) || ((rtb_AND4_a || ((rtb_Switch7_c !=
-              0U) && rtb_AND1_h)) && rtb_OR6)))) {
+         ((rtb_BusAssignment_n_logic_any_landing_gear_not_uplocked && (!rtb_OR)) || ((rtb_AND4_a || ((rtb_Switch7_c !=
+              0U) && rtb_AND1_h)) && rtb_OR)))) {
       rtb_pitchLawCapability = pitch_efcs_law::DirectLaw;
     } else if ((rtb_singleAdrFault && SecComputer_P.Constant2_Value_c) || rtb_doubleAdrFault ||
-               SecComputer_DWork.abnormalConditionWasActive || ((!rtb_y_k4) && (!rtb_AND2_j) && ((!leftElevatorAvail) ||
-      (!rightElevatorAvail)))) {
+               SecComputer_DWork.abnormalConditionWasActive || ((!rtb_y_ls) && (!rtb_AND2_j) && ((!rtb_OR3) ||
+                 (!rightElevatorAvail)))) {
       rtb_pitchLawCapability = pitch_efcs_law::AlternateLaw2;
     } else {
       rtb_pitchLawCapability = pitch_efcs_law::AlternateLaw1;
@@ -702,20 +704,20 @@ void SecComputer::step()
       u0 = SecComputer_P.Saturation_LowerSat_h;
     }
 
-    SecComputer_MATLABFunction_e(SecComputer_B.in_flight != 0.0, SecComputer_P.PulseNode_isRisingEdge_h, &rtb_y_k4,
+    SecComputer_MATLABFunction_e(SecComputer_B.in_flight != 0.0, SecComputer_P.PulseNode_isRisingEdge_h, &rtb_y_ls,
       &SecComputer_DWork.sf_MATLABFunction_b4);
-    rtb_y_am = (SecComputer_U.in.discrete_inputs.pitch_not_avail_elac_1 &&
-                SecComputer_U.in.discrete_inputs.pitch_not_avail_elac_2);
-    rtb_AND1_h = (SecComputer_U.in.discrete_inputs.is_unit_1 && rtb_thsAvail && rtb_y_am);
+    rtb_y_l = (SecComputer_U.in.discrete_inputs.pitch_not_avail_elac_1 &&
+               SecComputer_U.in.discrete_inputs.pitch_not_avail_elac_2);
+    rtb_AND1_h = (SecComputer_U.in.discrete_inputs.is_unit_1 && rtb_thsAvail && rtb_y_l);
     SecComputer_DWork.Memory_PreviousInput = SecComputer_P.Logic_table[((((!rtb_AND1_h) || (std::abs
       (SecComputer_U.in.analog_inputs.ths_pos_deg) <= SecComputer_P.CompareToConstant1_const) ||
-      SecComputer_U.in.discrete_inputs.ths_override_active) + (static_cast<uint32_T>(rtb_y_k4) << 1)) << 1) +
+      SecComputer_U.in.discrete_inputs.ths_override_active) + (static_cast<uint32_T>(rtb_y_ls) << 1)) << 1) +
       SecComputer_DWork.Memory_PreviousInput];
     rtb_NOT_bl = (rtb_AND1_h && SecComputer_DWork.Memory_PreviousInput);
     rtb_AND4_a = !abnormalCondition;
     rtb_AND1_h = ((rtb_isEngagedInPitch && (SecComputer_B.in_flight != 0.0) && ((rtb_activePitchLaw !=
       SecComputer_P.EnumeratedConstant_Value_f) && rtb_AND4_a)) || rtb_NOT_bl);
-    rtb_y_k4 = rtb_AND1_h;
+    rtb_y_ls = rtb_AND1_h;
     rtb_AND2_j = rtb_NOT_bl;
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.elac_1_bus.discrete_status_word_2,
       SecComputer_P.BitfromLabel7_bit_g, &rtb_Switch7_c);
@@ -724,7 +726,7 @@ void SecComputer::step()
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.elac_2_bus.discrete_status_word_2,
       SecComputer_P.BitfromLabel6_bit_f, &rtb_Switch7_c);
     SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.elac_2_bus.discrete_status_word_2, &rtb_AND4_a);
-    rtb_y_m = ((rtb_Switch7_c != 0U) && rtb_AND4_a);
+    rtb_y_f5 = ((rtb_Switch7_c != 0U) && rtb_AND4_a);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.sfcc_1_bus.slat_flap_actual_position_word,
       SecComputer_P.BitfromLabel_bit_l, &rtb_Switch7_c);
     SecComputer_MATLABFunction_l(&SecComputer_U.in.bus_inputs.sfcc_1_bus.slat_flap_actual_position_word, &rtb_AND4_a);
@@ -744,40 +746,42 @@ void SecComputer::step()
     rtb_NOT_g = (rtb_Switch7_c == 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.elac_2_bus.discrete_status_word_1,
       SecComputer_P.BitfromLabel2_bit_p, &rtb_Switch7_c);
-    rtb_NOT_bl = (rtb_NOT_bl || rtb_y_m || (rtb_AND4_a || rtb_AND1_h) || (((!rtb_y_am) && rtb_NOT2_b && (rtb_NOT_g ||
-      (rtb_Switch7_c == 0U))) || (rtb_y_am && ((SecComputer_U.in.discrete_inputs.left_elev_not_avail_sec_opp &&
-      (!leftElevatorAvail)) || (SecComputer_U.in.discrete_inputs.right_elev_not_avail_sec_opp && (!rightElevatorAvail)))))
-                  || ((SecComputer_U.in.analog_inputs.thr_lever_1_pos >= SecComputer_P.CompareToConstant3_const) ||
-                      (SecComputer_U.in.analog_inputs.thr_lever_2_pos >= SecComputer_P.CompareToConstant4_const)));
+    rtb_NOT_bl = (rtb_NOT_bl || rtb_y_f5 || (rtb_AND4_a || rtb_AND1_h) || (((!rtb_y_l) && rtb_NOT2_b && (rtb_NOT_g ||
+      (rtb_Switch7_c == 0U))) || (rtb_y_l && ((SecComputer_U.in.discrete_inputs.left_elev_not_avail_sec_opp && (!rtb_OR3))
+      || (SecComputer_U.in.discrete_inputs.right_elev_not_avail_sec_opp && (!rightElevatorAvail))))) ||
+                  ((SecComputer_U.in.analog_inputs.thr_lever_1_pos >= SecComputer_P.CompareToConstant3_const) ||
+                   (SecComputer_U.in.analog_inputs.thr_lever_2_pos >= SecComputer_P.CompareToConstant4_const)));
     SecComputer_MATLABFunction_n(SecComputer_U.in.analog_inputs.spd_brk_lever_pos <
       SecComputer_P.CompareToConstant_const, SecComputer_U.in.time.dt, SecComputer_P.ConfirmNode_isRisingEdge_e,
-      SecComputer_P.ConfirmNode_timeDelay_eq, &rtb_y_m, &SecComputer_DWork.sf_MATLABFunction_fh);
+      SecComputer_P.ConfirmNode_timeDelay_eq, &rtb_y_f5, &SecComputer_DWork.sf_MATLABFunction_fh);
     SecComputer_DWork.Memory_PreviousInput_f = SecComputer_P.Logic_table_i[(((static_cast<uint32_T>(rtb_NOT_bl) << 1) +
-      rtb_y_m) << 1) + SecComputer_DWork.Memory_PreviousInput_f];
-    rtb_y_m = (rtb_NOT_bl || SecComputer_DWork.Memory_PreviousInput_f);
-    rtb_NOT2_b = rtb_y_l;
-    rtb_NOT_g = rtb_y_b;
-    SecComputer_MATLABFunction_e(rtb_OR1, SecComputer_P.PulseNode3_isRisingEdge, &rtb_y_b,
+      rtb_y_f5) << 1) + SecComputer_DWork.Memory_PreviousInput_f];
+    rtb_y_f5 = (rtb_NOT_bl || SecComputer_DWork.Memory_PreviousInput_f);
+    rtb_NOT2_b = rtb_y_ei;
+    rtb_NOT_g = rtb_y_j;
+    rtb_BusAssignment_fz_logic_is_green_hydraulic_power_avail = rtb_y_la;
+    SecComputer_MATLABFunction_e(rtb_OR6, SecComputer_P.PulseNode3_isRisingEdge, &rtb_y_la,
       &SecComputer_DWork.sf_MATLABFunction_nd);
-    rtb_NOT_bl = (rtb_y_b || ((SecComputer_U.in.analog_inputs.wheel_speed_left < SecComputer_P.CompareToConstant11_const)
-      && (SecComputer_U.in.analog_inputs.wheel_speed_right < SecComputer_P.CompareToConstant12_const)));
-    SecComputer_MATLABFunction_e(rtb_OR1, SecComputer_P.PulseNode2_isRisingEdge, &rtb_y_b,
+    rtb_NOT_bl = (rtb_y_la || ((SecComputer_U.in.analog_inputs.wheel_speed_left <
+      SecComputer_P.CompareToConstant11_const) && (SecComputer_U.in.analog_inputs.wheel_speed_right <
+      SecComputer_P.CompareToConstant12_const)));
+    SecComputer_MATLABFunction_e(rtb_OR6, SecComputer_P.PulseNode2_isRisingEdge, &rtb_y_la,
       &SecComputer_DWork.sf_MATLABFunction_n);
     SecComputer_DWork.Memory_PreviousInput_n = SecComputer_P.Logic_table_ii[(((static_cast<uint32_T>(rtb_NOT_bl) << 1) +
-      rtb_y_b) << 1) + SecComputer_DWork.Memory_PreviousInput_n];
+      rtb_y_la) << 1) + SecComputer_DWork.Memory_PreviousInput_n];
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_2,
       SecComputer_P.BitfromLabel4_bit_a, &rtb_Switch7_c);
     rtb_AND1_h = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_2,
       SecComputer_P.BitfromLabel6_bit_d, &rtb_Switch7_c);
-    rtb_y_b = (rtb_AND1_h && (rtb_Switch7_c != 0U));
+    rtb_y_la = (rtb_AND1_h && (rtb_Switch7_c != 0U));
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_2,
       SecComputer_P.BitfromLabel5_bit_i, &rtb_Switch7_c);
     rtb_AND1_h = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_2,
       SecComputer_P.BitfromLabel7_bit_ms, &rtb_Switch7_c);
-    SecComputer_MATLABFunction_e(rtb_y_b || (rtb_AND1_h && (rtb_Switch7_c != 0U)),
-      SecComputer_P.PulseNode1_isRisingEdge_k, &rtb_y_l, &SecComputer_DWork.sf_MATLABFunction_a);
+    SecComputer_MATLABFunction_e(rtb_y_la || (rtb_AND1_h && (rtb_Switch7_c != 0U)),
+      SecComputer_P.PulseNode1_isRisingEdge_k, &rtb_y_j, &SecComputer_DWork.sf_MATLABFunction_a);
     rtb_NOT_bl = (SecComputer_U.in.analog_inputs.spd_brk_lever_pos < SecComputer_P.CompareToConstant_const_m);
     rtb_AND1_h = ((((SecComputer_U.in.analog_inputs.spd_brk_lever_pos > SecComputer_P.CompareToConstant15_const) ||
                     rtb_NOT_bl) && ((SecComputer_U.in.analog_inputs.thr_lever_1_pos <=
@@ -787,7 +791,7 @@ void SecComputer::step()
       SecComputer_P.CompareToConstant4_const_j)) || ((SecComputer_U.in.analog_inputs.thr_lever_1_pos <=
       SecComputer_P.CompareToConstant13_const) && (SecComputer_U.in.analog_inputs.thr_lever_2_pos <
       SecComputer_P.CompareToConstant14_const))));
-    SecComputer_DWork.Delay1_DSTATE_i = (rtb_AND1_h && (rtb_y_l || ((SecComputer_U.in.analog_inputs.wheel_speed_left >=
+    SecComputer_DWork.Delay1_DSTATE_i = (rtb_AND1_h && (rtb_y_j || ((SecComputer_U.in.analog_inputs.wheel_speed_left >=
       SecComputer_P.CompareToConstant5_const) && (SecComputer_U.in.analog_inputs.wheel_speed_right >=
       SecComputer_P.CompareToConstant6_const) && SecComputer_DWork.Memory_PreviousInput_n) ||
       SecComputer_DWork.Delay1_DSTATE_i));
@@ -796,19 +800,23 @@ void SecComputer::step()
     rtb_AND4_a = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_2,
       SecComputer_P.BitfromLabel2_bit_l, &rtb_Switch7_c);
-    rtb_y_b = (rtb_AND4_a || (rtb_Switch7_c != 0U));
+    rtb_y_la = (rtb_AND4_a || (rtb_Switch7_c != 0U));
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_2,
       SecComputer_P.BitfromLabel1_bit_a, &rtb_Switch7_c);
     rtb_AND4_a = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_2,
       SecComputer_P.BitfromLabel3_bit_m, &rtb_Switch7_c);
-    rtb_y_am = (rtb_Switch7_c != 0U);
-    SecComputer_MATLABFunction_e(rtb_y_b || (rtb_AND4_a || (rtb_Switch7_c != 0U)),
-      SecComputer_P.PulseNode_isRisingEdge_hj, &rtb_y_l, &SecComputer_DWork.sf_MATLABFunction_e3);
-    SecComputer_DWork.Delay_DSTATE_n = (rtb_AND1_h && (rtb_y_l || SecComputer_DWork.Delay_DSTATE_n));
-    rtb_AND1_h = ((!SecComputer_DWork.Delay1_DSTATE_i) && SecComputer_DWork.Delay_DSTATE_n);
+    rtb_y_l = (rtb_Switch7_c != 0U);
+    SecComputer_MATLABFunction_e(rtb_y_la || (rtb_AND4_a || (rtb_Switch7_c != 0U)),
+      SecComputer_P.PulseNode_isRisingEdge_hj, &rtb_y_ei, &SecComputer_DWork.sf_MATLABFunction_e3);
+    SecComputer_DWork.Delay_DSTATE_n = (rtb_AND1_h && (rtb_y_ei || SecComputer_DWork.Delay_DSTATE_n));
+    rtb_AND4_a = (SecComputer_U.in.analog_inputs.thr_lever_2_pos <= SecComputer_P.CompareToConstant8_const);
+    SecComputer_DWork.Delay2_DSTATE = (rtb_NOT_bl && ((SecComputer_U.in.analog_inputs.thr_lever_1_pos <=
+      SecComputer_P.CompareToConstant7_const) && rtb_AND4_a) && (rtb_y_j || SecComputer_DWork.Delay2_DSTATE));
+    rtb_AND1_h = ((!SecComputer_DWork.Delay1_DSTATE_i) && (SecComputer_DWork.Delay_DSTATE_n ||
+      SecComputer_DWork.Delay2_DSTATE));
     SecComputer_Y.out.logic.total_sidestick_roll_command = pair1SpdBrkCommand;
-    rtb_y_b = rtb_NOT_bl;
+    rtb_y_la = rtb_NOT_bl;
     if (SecComputer_DWork.Delay1_DSTATE_i) {
       rtb_Switch5 = SecComputer_P.Constant_Value;
     } else if (rtb_AND1_h) {
@@ -825,7 +833,7 @@ void SecComputer::step()
       SecComputer_P.BitfromLabel4_bit_m, &rtb_Switch7_c);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.elac_2_bus.discrete_status_word_2,
       SecComputer_P.BitfromLabel5_bit_h, &rtb_y);
-    if (rtb_y_m) {
+    if (rtb_y_f5) {
       rtb_Switch3 = SecComputer_P.Constant3_Value;
     } else {
       if ((rtb_Switch7_c != 0U) || (rtb_y != 0U)) {
@@ -856,26 +864,26 @@ void SecComputer::step()
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.elac_1_bus.discrete_status_word_1,
       SecComputer_P.BitfromLabel2_bit_o, &rtb_y_af);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.elac_2_bus.discrete_status_word_1,
-      SecComputer_P.BitfromLabel3_bit_j, &rtb_y_mx);
+      SecComputer_P.BitfromLabel3_bit_j, &rtb_y_m);
     if (SecComputer_U.in.bus_inputs.elac_1_bus.roll_spoiler_command_deg.SSM == static_cast<uint32_T>(SignStatusMatrix::
          NormalOperation)) {
       pair1SpdBrkCommand = SecComputer_U.in.bus_inputs.elac_1_bus.roll_spoiler_command_deg.Data;
-      rtb_y_l = (rtb_Switch7_c != 0U);
-      rtb_AND4_a = (rtb_y_af != 0U);
+      rtb_y_j = (rtb_Switch7_c != 0U);
+      rtb_y_ei = (rtb_y_af != 0U);
     } else if (SecComputer_U.in.bus_inputs.elac_2_bus.roll_spoiler_command_deg.SSM == static_cast<uint32_T>
                (SignStatusMatrix::NormalOperation)) {
       pair1SpdBrkCommand = SecComputer_U.in.bus_inputs.elac_2_bus.roll_spoiler_command_deg.Data;
-      rtb_y_l = (rtb_y != 0U);
-      rtb_AND4_a = (rtb_y_mx != 0U);
+      rtb_y_j = (rtb_y != 0U);
+      rtb_y_ei = (rtb_y_m != 0U);
     } else {
       pair1SpdBrkCommand = rtb_Switch3 * 35.0 / 25.0;
-      rtb_y_l = true;
-      rtb_AND4_a = true;
+      rtb_y_j = true;
+      rtb_y_ei = true;
     }
 
     rtb_zeta_deg = std::fmax(std::fmin(pair1SpdBrkCommand, 35.0), -35.0);
     if (SecComputer_U.in.discrete_inputs.is_unit_1) {
-      if (rtb_y_l) {
+      if (rtb_y_j) {
         pair1RollCommand = rtb_zeta_deg;
       } else {
         pair1RollCommand = 0.0;
@@ -891,7 +899,7 @@ void SecComputer::step()
       pair2SpdBrkCommand = 0.0;
     } else {
       pair1RollCommand = 0.0;
-      if (rtb_AND4_a) {
+      if (rtb_y_ei) {
         rtb_Switch3 = rtb_zeta_deg;
       } else {
         rtb_Switch3 = 0.0;
@@ -979,7 +987,7 @@ void SecComputer::step()
     pair1RollCommand = pair1SpdBrkCommand;
     rtb_NOT_oi = rtb_handleIndex;
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.sfcc_1_bus.slat_flap_system_status_word,
-      SecComputer_P.BitfromLabel_bit_a1, &rtb_y_mx);
+      SecComputer_P.BitfromLabel_bit_a1, &rtb_y_m);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.sfcc_1_bus.slat_flap_system_status_word,
       SecComputer_P.BitfromLabel1_bit_gf, &rtb_y_af);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.sfcc_1_bus.slat_flap_system_status_word,
@@ -990,7 +998,7 @@ void SecComputer::step()
       SecComputer_P.BitfromLabel4_bit_n, &rtb_DataTypeConversion1);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.sfcc_1_bus.slat_flap_system_status_word,
       SecComputer_P.BitfromLabel5_bit_m, &rtb_Switch7_c);
-    if (rtb_y_mx != 0U) {
+    if (rtb_y_m != 0U) {
       rtb_handleIndex = 0.0;
     } else if ((rtb_y_af != 0U) && (rtb_Switch7_c != 0U)) {
       rtb_handleIndex = 1.0;
@@ -1007,16 +1015,16 @@ void SecComputer::step()
     }
 
     pair1SpdBrkCommand = (SecComputer_B.in_flight != 0.0);
-    rtb_y_l = (rtb_OR3 || ((static_cast<real_T>(rtb_activePitchLaw) != SecComputer_P.CompareToConstant2_const_f) && (
+    rtb_y_j = (rtb_OR1 || ((static_cast<real_T>(rtb_activePitchLaw) != SecComputer_P.CompareToConstant2_const_f) && (
       static_cast<real_T>(rtb_activePitchLaw) != SecComputer_P.CompareToConstant3_const_o)));
-    rtb_AND4_a = (rtb_activePitchLaw != SecComputer_P.EnumeratedConstant_Value_i);
+    rtb_y_ei = (rtb_activePitchLaw != SecComputer_P.EnumeratedConstant_Value_i);
     LawMDLOBJ2.step(&SecComputer_U.in.time.dt, &rtb_BusAssignment_f_logic_ir_computation_data_n_z_g,
                     &rtb_Switch5_tmp_tmp, &rtb_Switch6_m, &rtb_BusAssignment_f_logic_ir_computation_data_theta_dot_deg_s,
                     (const_cast<real_T*>(&SecComputer_RGND)), &SecComputer_U.in.analog_inputs.ths_pos_deg,
                     &rtb_eta_trim_limit_lo_d, &rtb_BusConversion_InsertedFor_BusAssignment_at_inport_8_BusCreator1_mach,
                     &rtb_BusConversion_InsertedFor_BusAssignment_at_inport_8_BusCreator1_V_tas_kn, &rtb_handleIndex, (
       const_cast<real_T*>(&SecComputer_RGND)), (const_cast<real_T*>(&SecComputer_RGND)), &u0, &pair1SpdBrkCommand,
-                    &rtb_y_l, &rtb_AND4_a, &rtb_eta_deg, &rtb_eta_trim_dot_deg_s, &rtb_eta_trim_limit_lo,
+                    &rtb_y_j, &rtb_y_ei, &rtb_eta_deg, &rtb_eta_trim_dot_deg_s, &rtb_eta_trim_limit_lo,
                     &rtb_eta_trim_limit_up);
     LawMDLOBJ3.step(&SecComputer_U.in.time.dt, &u0, &rtb_handleIndex, &rtb_zeta_deg, &rtb_eta_trim_limit_lo_d,
                     &pair1SpdBrkCommand);
@@ -1074,7 +1082,7 @@ void SecComputer::step()
     }
 
     rtb_zeta_deg = SecComputer_P.DiscreteTimeIntegratorVariableTsLimit_Gain * rtb_zeta_deg * SecComputer_U.in.time.dt;
-    SecComputer_DWork.icLoad = ((!rtb_y_k4) || SecComputer_DWork.icLoad);
+    SecComputer_DWork.icLoad = ((!rtb_y_ls) || SecComputer_DWork.icLoad);
     if (SecComputer_DWork.icLoad) {
       SecComputer_DWork.Delay_DSTATE_l = SecComputer_U.in.analog_inputs.ths_pos_deg - rtb_zeta_deg;
     }
@@ -1108,28 +1116,28 @@ void SecComputer::step()
     } else if (SecComputer_U.in.discrete_inputs.is_unit_2) {
       rtb_Switch8 = SecComputer_U.in.bus_inputs.elac_1_bus.elevator_double_pressurization_command_deg;
     } else {
-      rtb_y_fp = std::fmod(std::floor(SecComputer_P.Constant1_Value_m), 4.2949673E+9F);
-      rtb_Switch8.SSM = rtb_y_fp < 0.0F ? static_cast<uint32_T>(-static_cast<int32_T>(static_cast<uint32_T>(-rtb_y_fp)))
-        : static_cast<uint32_T>(rtb_y_fp);
+      rtb_y_e = std::fmod(std::floor(SecComputer_P.Constant1_Value_m), 4.2949673E+9F);
+      rtb_Switch8.SSM = rtb_y_e < 0.0F ? static_cast<uint32_T>(-static_cast<int32_T>(static_cast<uint32_T>(-rtb_y_e))) :
+        static_cast<uint32_T>(rtb_y_e);
       rtb_Switch8.Data = SecComputer_P.Constant1_Value_m;
     }
 
     SecComputer_MATLABFunction_l(&rtb_Switch8, &rtb_AND4_a);
     if (SecComputer_U.in.discrete_inputs.is_unit_1) {
-      rtb_y_l = SecComputer_U.in.discrete_inputs.pitch_not_avail_elac_1;
+      rtb_y_j = SecComputer_U.in.discrete_inputs.pitch_not_avail_elac_1;
     } else {
-      rtb_y_l = SecComputer_U.in.discrete_inputs.pitch_not_avail_elac_2;
+      rtb_y_j = SecComputer_U.in.discrete_inputs.pitch_not_avail_elac_2;
     }
 
-    rtb_NOT_bl = (rtb_y_l && (!rtb_isEngagedInPitch) && rtb_AND4_a);
+    rtb_NOT_bl = (rtb_y_j && (!rtb_isEngagedInPitch) && rtb_AND4_a);
     if (rtb_NOT_bl) {
       rtb_handleIndex = rtb_Switch8.Data;
     }
 
-    SecComputer_MATLABFunction_n(rtb_OR || rtb_NOT2_b || rtb_NOT_g, SecComputer_U.in.time.dt,
-      SecComputer_P.ConfirmNode_isRisingEdge_c, SecComputer_P.ConfirmNode_timeDelay_m, &rtb_y_am,
-      &SecComputer_DWork.sf_MATLABFunction_i);
-    rtb_y_fp = static_cast<real32_T>(SecComputer_U.in.analog_inputs.thr_lever_2_pos);
+    SecComputer_MATLABFunction_n(rtb_NOT2_b || rtb_NOT_g || rtb_BusAssignment_fz_logic_is_green_hydraulic_power_avail,
+      SecComputer_U.in.time.dt, SecComputer_P.ConfirmNode_isRisingEdge_c, SecComputer_P.ConfirmNode_timeDelay_m,
+      &rtb_y_l, &SecComputer_DWork.sf_MATLABFunction_i);
+    rtb_y_e = static_cast<real32_T>(SecComputer_U.in.analog_inputs.thr_lever_2_pos);
     rtb_VectorConcatenate[0] = (SecComputer_U.in.discrete_inputs.l_spoiler_1_servo_failed ||
       SecComputer_U.in.discrete_inputs.r_spoiler_1_servo_failed);
     rtb_VectorConcatenate[1] = (SecComputer_U.in.discrete_inputs.l_spoiler_2_servo_failed ||
@@ -1138,7 +1146,7 @@ void SecComputer::step()
     rtb_VectorConcatenate[3] = SecComputer_U.in.discrete_inputs.r_elev_servo_failed;
     rtb_VectorConcatenate[4] = spoilerPair1SupplyAvail;
     rtb_VectorConcatenate[5] = spoilerPair2SupplyAvail;
-    rtb_VectorConcatenate[6] = leftElevatorAvail;
+    rtb_VectorConcatenate[6] = rtb_OR3;
     rtb_VectorConcatenate[7] = rightElevatorAvail;
     rtb_VectorConcatenate[8] = (rtb_activePitchLaw == pitch_efcs_law::AlternateLaw2);
     rtb_VectorConcatenate[9] = ((rtb_activePitchLaw == pitch_efcs_law::AlternateLaw1) || (rtb_activePitchLaw ==
@@ -1148,18 +1156,18 @@ void SecComputer::step()
     rtb_VectorConcatenate[12] = rtb_isEngagedInPitch;
     rtb_VectorConcatenate[13] = SecComputer_P.Constant8_Value;
     rtb_VectorConcatenate[14] = SecComputer_DWork.Delay1_DSTATE_i;
-    rtb_VectorConcatenate[15] = rtb_y_b;
+    rtb_VectorConcatenate[15] = rtb_y_la;
     rtb_VectorConcatenate[16] = SecComputer_P.Constant8_Value;
     rtb_VectorConcatenate[17] = SecComputer_P.Constant8_Value;
     rtb_VectorConcatenate[18] = SecComputer_P.Constant8_Value;
-    SecComputer_MATLABFunction_c(rtb_VectorConcatenate, &rtb_y_h);
+    SecComputer_MATLABFunction_c(rtb_VectorConcatenate, &rtb_y_fn);
     rtb_VectorConcatenate[0] = SecComputer_P.Constant7_Value;
     rtb_VectorConcatenate[1] = SecComputer_P.Constant7_Value;
     rtb_VectorConcatenate[2] = SecComputer_DWork.pLeftStickDisabled;
     rtb_VectorConcatenate[3] = SecComputer_DWork.pRightStickDisabled;
     rtb_VectorConcatenate[4] = SecComputer_DWork.Delay_DSTATE_c;
     rtb_VectorConcatenate[5] = SecComputer_DWork.Delay1_DSTATE;
-    rtb_VectorConcatenate[6] = rtb_OR6;
+    rtb_VectorConcatenate[6] = rtb_OR;
     rtb_VectorConcatenate[7] = rtb_BusAssignment_n_logic_any_landing_gear_not_uplocked;
     rtb_VectorConcatenate[8] = SecComputer_P.Constant10_Value;
     rtb_VectorConcatenate[9] = SecComputer_P.Constant10_Value;
@@ -1172,7 +1180,7 @@ void SecComputer::step()
     rtb_VectorConcatenate[16] = SecComputer_P.Constant10_Value;
     rtb_VectorConcatenate[17] = SecComputer_P.Constant10_Value;
     rtb_VectorConcatenate[18] = SecComputer_P.Constant10_Value;
-    SecComputer_MATLABFunction_c(rtb_VectorConcatenate, &rtb_y_fp);
+    SecComputer_MATLABFunction_c(rtb_VectorConcatenate, &rtb_y_e);
     SecComputer_Y.out.data = SecComputer_U.in;
     SecComputer_Y.out.laws.lateral_law_outputs.left_spoiler_1_command_deg = rtb_Switch3;
     SecComputer_Y.out.laws.lateral_law_outputs.right_spoiler_1_command_deg = pair2SpdBrkCommand;
@@ -1180,35 +1188,35 @@ void SecComputer::step()
     SecComputer_Y.out.laws.lateral_law_outputs.right_spoiler_2_command_deg = rtb_NOT_oi;
     SecComputer_Y.out.laws.lateral_law_outputs.speedbrake_command_deg = rtb_Switch5;
     SecComputer_Y.out.laws.pitch_law_outputs.ths_command_deg = SecComputer_DWork.Delay_DSTATE;
-    SecComputer_Y.out.logic.on_ground = rtb_OR1;
+    SecComputer_Y.out.logic.on_ground = rtb_OR6;
     SecComputer_Y.out.logic.pitch_law_in_flight = (SecComputer_B.in_flight != 0.0);
-    SecComputer_Y.out.logic.tracking_mode_on = rtb_OR3;
+    SecComputer_Y.out.logic.tracking_mode_on = rtb_OR1;
     SecComputer_Y.out.logic.pitch_law_capability = rtb_pitchLawCapability;
     SecComputer_Y.out.logic.active_pitch_law = rtb_activePitchLaw;
     SecComputer_Y.out.logic.abnormal_condition_law_active = abnormalCondition;
     SecComputer_Y.out.logic.is_engaged_in_pitch = rtb_isEngagedInPitch;
     SecComputer_Y.out.logic.can_engage_in_pitch = canEngageInPitch;
     SecComputer_Y.out.logic.has_priority_in_pitch = hasPriorityInPitch;
-    SecComputer_Y.out.logic.left_elevator_avail = leftElevatorAvail;
+    SecComputer_Y.out.logic.left_elevator_avail = rtb_OR3;
     SecComputer_Y.out.logic.right_elevator_avail = rightElevatorAvail;
     SecComputer_Y.out.logic.ths_avail = rtb_thsAvail;
-    SecComputer_Y.out.logic.ths_active_commanded = rtb_y_k4;
+    SecComputer_Y.out.logic.ths_active_commanded = rtb_y_ls;
     SecComputer_Y.out.logic.ths_ground_setting_active = rtb_AND2_j;
     SecComputer_Y.out.logic.is_engaged_in_roll = rtb_isEngagedInRoll;
     SecComputer_Y.out.logic.spoiler_pair_1_avail = spoilerPair1SupplyAvail;
     SecComputer_Y.out.logic.spoiler_pair_2_avail = spoilerPair2SupplyAvail;
-    SecComputer_Y.out.logic.is_yellow_hydraulic_power_avail = rtb_OR;
-    SecComputer_Y.out.logic.is_blue_hydraulic_power_avail = rtb_NOT2_b;
-    SecComputer_Y.out.logic.is_green_hydraulic_power_avail = rtb_NOT_g;
+    SecComputer_Y.out.logic.is_yellow_hydraulic_power_avail = rtb_NOT2_b;
+    SecComputer_Y.out.logic.is_blue_hydraulic_power_avail = rtb_NOT_g;
+    SecComputer_Y.out.logic.is_green_hydraulic_power_avail = rtb_BusAssignment_fz_logic_is_green_hydraulic_power_avail;
     SecComputer_Y.out.logic.left_sidestick_disabled = SecComputer_DWork.pLeftStickDisabled;
     SecComputer_Y.out.logic.right_sidestick_disabled = SecComputer_DWork.pRightStickDisabled;
     SecComputer_Y.out.logic.left_sidestick_priority_locked = SecComputer_DWork.Delay_DSTATE_c;
     SecComputer_Y.out.logic.right_sidestick_priority_locked = SecComputer_DWork.Delay1_DSTATE;
     SecComputer_Y.out.logic.total_sidestick_pitch_command = u0;
-    SecComputer_Y.out.logic.ground_spoilers_armed = rtb_y_b;
+    SecComputer_Y.out.logic.ground_spoilers_armed = rtb_y_la;
     SecComputer_Y.out.logic.ground_spoilers_out = SecComputer_DWork.Delay1_DSTATE_i;
     SecComputer_Y.out.logic.partial_lift_dumping_active = rtb_AND1_h;
-    SecComputer_Y.out.logic.speed_brake_inhibited = rtb_y_m;
+    SecComputer_Y.out.logic.speed_brake_inhibited = rtb_y_f5;
     SecComputer_Y.out.logic.single_adr_failure = rtb_singleAdrFault;
     SecComputer_Y.out.logic.double_adr_failure = rtb_doubleAdrFault;
     SecComputer_Y.out.logic.cas_or_mach_disagree = SecComputer_P.Constant2_Value_c;
@@ -1230,30 +1238,30 @@ void SecComputer::step()
     SecComputer_Y.out.logic.ir_computation_data.theta_dot_deg_s = rtb_theta_dot;
     SecComputer_Y.out.logic.ir_computation_data.phi_dot_deg_s = rtb_phi_dot;
     SecComputer_Y.out.logic.any_landing_gear_not_uplocked = rtb_BusAssignment_n_logic_any_landing_gear_not_uplocked;
-    SecComputer_Y.out.logic.lgciu_uplock_disagree_or_fault = rtb_OR6;
+    SecComputer_Y.out.logic.lgciu_uplock_disagree_or_fault = rtb_OR;
     SecComputer_Y.out.discrete_outputs.thr_reverse_selected = SecComputer_P.Constant1_Value_g;
-    SecComputer_Y.out.discrete_outputs.left_elevator_ok = leftElevatorAvail;
+    SecComputer_Y.out.discrete_outputs.left_elevator_ok = rtb_OR3;
     SecComputer_Y.out.discrete_outputs.right_elevator_ok = rightElevatorAvail;
     SecComputer_Y.out.discrete_outputs.ground_spoiler_out = SecComputer_DWork.Delay1_DSTATE_i;
     SecComputer_Y.out.discrete_outputs.sec_failed = SecComputer_P.Constant2_Value_n;
-    SecComputer_Y.out.discrete_outputs.left_elevator_damping_mode = (rtb_isEngagedInPitch && leftElevatorAvail);
+    SecComputer_Y.out.discrete_outputs.left_elevator_damping_mode = (rtb_isEngagedInPitch && rtb_OR3);
     SecComputer_Y.out.discrete_outputs.right_elevator_damping_mode = (rtb_isEngagedInPitch && rightElevatorAvail);
-    SecComputer_Y.out.discrete_outputs.ths_active = (rtb_y_k4 && rtb_thsAvail);
-    SecComputer_Y.out.discrete_outputs.batt_power_supply = rtb_y_am;
-    rtb_y_l = (rtb_isEngagedInPitch || rtb_NOT_bl);
-    if (rtb_y_l && leftElevatorAvail) {
+    SecComputer_Y.out.discrete_outputs.ths_active = (rtb_y_ls && rtb_thsAvail);
+    SecComputer_Y.out.discrete_outputs.batt_power_supply = rtb_y_l;
+    rtb_y_j = (rtb_isEngagedInPitch || rtb_NOT_bl);
+    if (rtb_y_j && rtb_OR3) {
       SecComputer_Y.out.analog_outputs.left_elev_pos_order_deg = rtb_handleIndex;
     } else {
       SecComputer_Y.out.analog_outputs.left_elev_pos_order_deg = SecComputer_P.Constant_Value_h;
     }
 
-    if (rtb_y_l && rightElevatorAvail) {
+    if (rtb_y_j && rightElevatorAvail) {
       SecComputer_Y.out.analog_outputs.right_elev_pos_order_deg = rtb_handleIndex;
     } else {
       SecComputer_Y.out.analog_outputs.right_elev_pos_order_deg = SecComputer_P.Constant_Value_h;
     }
 
-    if (rtb_y_k4 && rtb_thsAvail) {
+    if (rtb_y_ls && rtb_thsAvail) {
       SecComputer_Y.out.analog_outputs.ths_pos_order_deg = SecComputer_DWork.Delay_DSTATE;
     } else {
       SecComputer_Y.out.analog_outputs.ths_pos_order_deg = SecComputer_P.Constant_Value_h;
@@ -1389,10 +1397,10 @@ void SecComputer::step()
       (SecComputer_U.in.analog_inputs.thr_lever_2_pos);
     SecComputer_Y.out.bus_outputs.discrete_status_word_1.SSM = static_cast<uint32_T>
       (SecComputer_P.EnumeratedConstant1_Value);
-    SecComputer_Y.out.bus_outputs.discrete_status_word_1.Data = rtb_y_h;
+    SecComputer_Y.out.bus_outputs.discrete_status_word_1.Data = rtb_y_fn;
     SecComputer_Y.out.bus_outputs.discrete_status_word_2.SSM = static_cast<uint32_T>
       (SecComputer_P.EnumeratedConstant1_Value);
-    SecComputer_Y.out.bus_outputs.discrete_status_word_2.Data = rtb_y_fp;
+    SecComputer_Y.out.bus_outputs.discrete_status_word_2.Data = rtb_y_e;
     SecComputer_DWork.icLoad = false;
     SecComputer_DWork.Delay_DSTATE_l = SecComputer_DWork.Delay_DSTATE;
   } else {
@@ -1409,6 +1417,7 @@ void SecComputer::initialize()
   SecComputer_DWork.Memory_PreviousInput_n = SecComputer_P.SRFlipFlop_initial_condition_k;
   SecComputer_DWork.Delay1_DSTATE_i = SecComputer_P.Delay1_InitialCondition_l;
   SecComputer_DWork.Delay_DSTATE_n = SecComputer_P.Delay_InitialCondition_j;
+  SecComputer_DWork.Delay2_DSTATE = SecComputer_P.Delay2_InitialCondition;
   SecComputer_DWork.Delay_DSTATE = SecComputer_P.Delay_InitialCondition;
   SecComputer_DWork.icLoad = true;
   LawMDLOBJ2.init();

--- a/src/fbw_a320/src/model/SecComputer.cpp
+++ b/src/fbw_a320/src/model/SecComputer.cpp
@@ -779,38 +779,33 @@ void SecComputer::step()
     SecComputer_MATLABFunction_e(rtb_y_b || (rtb_AND1_h && (rtb_Switch7_c != 0U)),
       SecComputer_P.PulseNode1_isRisingEdge_k, &rtb_y_l, &SecComputer_DWork.sf_MATLABFunction_a);
     rtb_NOT_bl = (SecComputer_U.in.analog_inputs.spd_brk_lever_pos < SecComputer_P.CompareToConstant_const_m);
-    SecComputer_DWork.Delay1_DSTATE_i = (((((SecComputer_U.in.analog_inputs.spd_brk_lever_pos >
-      SecComputer_P.CompareToConstant15_const) || rtb_NOT_bl) && ((SecComputer_U.in.analog_inputs.thr_lever_1_pos <=
-      SecComputer_P.CompareToConstant1_const_l) || (SecComputer_U.in.analog_inputs.thr_lever_2_pos <=
+    rtb_AND1_h = ((((SecComputer_U.in.analog_inputs.spd_brk_lever_pos > SecComputer_P.CompareToConstant15_const) ||
+                    rtb_NOT_bl) && ((SecComputer_U.in.analog_inputs.thr_lever_1_pos <=
+      SecComputer_P.CompareToConstant1_const_l) && (SecComputer_U.in.analog_inputs.thr_lever_2_pos <=
       SecComputer_P.CompareToConstant2_const))) || (((SecComputer_U.in.analog_inputs.thr_lever_1_pos <
       SecComputer_P.CompareToConstant3_const_a) && (SecComputer_U.in.analog_inputs.thr_lever_2_pos <=
       SecComputer_P.CompareToConstant4_const_j)) || ((SecComputer_U.in.analog_inputs.thr_lever_1_pos <=
       SecComputer_P.CompareToConstant13_const) && (SecComputer_U.in.analog_inputs.thr_lever_2_pos <
-      SecComputer_P.CompareToConstant14_const)))) && (rtb_y_l || ((SecComputer_U.in.analog_inputs.wheel_speed_left >=
+      SecComputer_P.CompareToConstant14_const))));
+    SecComputer_DWork.Delay1_DSTATE_i = (rtb_AND1_h && (rtb_y_l || ((SecComputer_U.in.analog_inputs.wheel_speed_left >=
       SecComputer_P.CompareToConstant5_const) && (SecComputer_U.in.analog_inputs.wheel_speed_right >=
       SecComputer_P.CompareToConstant6_const) && SecComputer_DWork.Memory_PreviousInput_n) ||
       SecComputer_DWork.Delay1_DSTATE_i));
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_2,
       SecComputer_P.BitfromLabel_bit_g, &rtb_Switch7_c);
-    rtb_AND1_h = (rtb_Switch7_c != 0U);
+    rtb_AND4_a = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_2,
       SecComputer_P.BitfromLabel2_bit_l, &rtb_Switch7_c);
-    rtb_y_b = (rtb_AND1_h || (rtb_Switch7_c != 0U));
+    rtb_y_b = (rtb_AND4_a || (rtb_Switch7_c != 0U));
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_1_bus.discrete_word_2,
       SecComputer_P.BitfromLabel1_bit_a, &rtb_Switch7_c);
-    rtb_AND1_h = (rtb_Switch7_c != 0U);
+    rtb_AND4_a = (rtb_Switch7_c != 0U);
     SecComputer_MATLABFunction(&SecComputer_U.in.bus_inputs.lgciu_2_bus.discrete_word_2,
       SecComputer_P.BitfromLabel3_bit_m, &rtb_Switch7_c);
-    SecComputer_MATLABFunction_e(rtb_y_b || (rtb_AND1_h || (rtb_Switch7_c != 0U)),
+    rtb_y_am = (rtb_Switch7_c != 0U);
+    SecComputer_MATLABFunction_e(rtb_y_b || (rtb_AND4_a || (rtb_Switch7_c != 0U)),
       SecComputer_P.PulseNode_isRisingEdge_hj, &rtb_y_l, &SecComputer_DWork.sf_MATLABFunction_e3);
-    SecComputer_DWork.Delay_DSTATE_n = (((((SecComputer_U.in.analog_inputs.spd_brk_lever_pos >
-      SecComputer_P.CompareToConstant10_const) || rtb_NOT_bl) && ((SecComputer_U.in.analog_inputs.thr_lever_1_pos <=
-      SecComputer_P.CompareToConstant7_const) && (SecComputer_U.in.analog_inputs.thr_lever_2_pos <=
-      SecComputer_P.CompareToConstant16_const))) || (((SecComputer_U.in.analog_inputs.thr_lever_1_pos <
-      SecComputer_P.CompareToConstant17_const) && (SecComputer_U.in.analog_inputs.thr_lever_2_pos <=
-      SecComputer_P.CompareToConstant18_const)) || ((SecComputer_U.in.analog_inputs.thr_lever_1_pos <=
-      SecComputer_P.CompareToConstant8_const) && (SecComputer_U.in.analog_inputs.thr_lever_2_pos <
-      SecComputer_P.CompareToConstant9_const)))) && (rtb_y_l || SecComputer_DWork.Delay_DSTATE_n));
+    SecComputer_DWork.Delay_DSTATE_n = (rtb_AND1_h && (rtb_y_l || SecComputer_DWork.Delay_DSTATE_n));
     rtb_AND1_h = ((!SecComputer_DWork.Delay1_DSTATE_i) && SecComputer_DWork.Delay_DSTATE_n);
     SecComputer_Y.out.logic.total_sidestick_roll_command = pair1SpdBrkCommand;
     rtb_y_b = rtb_NOT_bl;

--- a/src/fbw_a320/src/model/SecComputer.h
+++ b/src/fbw_a320/src/model/SecComputer.h
@@ -46,6 +46,7 @@ class SecComputer final
     boolean_T Delay1_DSTATE;
     boolean_T Delay1_DSTATE_i;
     boolean_T Delay_DSTATE_n;
+    boolean_T Delay2_DSTATE;
     uint8_T is_active_c30_SecComputer;
     uint8_T is_c30_SecComputer;
     uint8_T is_active_c8_SecComputer;
@@ -163,6 +164,8 @@ class SecComputer final
     real_T CompareToConstant4_const_j;
     real_T CompareToConstant13_const;
     real_T CompareToConstant14_const;
+    real_T CompareToConstant7_const;
+    real_T CompareToConstant8_const;
     real_T CompareToConstant2_const_f;
     real_T CompareToConstant3_const_o;
     real_T CompareToConstant1_const_p;
@@ -270,6 +273,7 @@ class SecComputer final
     boolean_T Logic_table_ii[16];
     boolean_T Delay1_InitialCondition_l;
     boolean_T Delay_InitialCondition_j;
+    boolean_T Delay2_InitialCondition;
     boolean_T Constant1_Value_g;
     boolean_T Constant2_Value_n;
     boolean_T Constant8_Value;

--- a/src/fbw_a320/src/model/SecComputer.h
+++ b/src/fbw_a320/src/model/SecComputer.h
@@ -163,13 +163,6 @@ class SecComputer final
     real_T CompareToConstant4_const_j;
     real_T CompareToConstant13_const;
     real_T CompareToConstant14_const;
-    real_T CompareToConstant10_const;
-    real_T CompareToConstant7_const;
-    real_T CompareToConstant16_const;
-    real_T CompareToConstant17_const;
-    real_T CompareToConstant18_const;
-    real_T CompareToConstant8_const;
-    real_T CompareToConstant9_const;
     real_T CompareToConstant2_const_f;
     real_T CompareToConstant3_const_o;
     real_T CompareToConstant1_const_p;

--- a/src/fbw_a320/src/model/SecComputer_data.cpp
+++ b/src/fbw_a320/src/model/SecComputer_data.cpp
@@ -242,6 +242,10 @@ SecComputer::Parameters_SecComputer_T SecComputer::SecComputer_P{
 
   0.0,
 
+  25.0,
+
+  25.0,
+
   1.0,
 
   2.0,
@@ -1720,6 +1724,8 @@ SecComputer::Parameters_SecComputer_T SecComputer::SecComputer_P{
 
 
   { false, true, false, false, true, true, false, false, true, false, true, true, false, false, false, false },
+
+  false,
 
   false,
 

--- a/src/fbw_a320/src/model/SecComputer_data.cpp
+++ b/src/fbw_a320/src/model/SecComputer_data.cpp
@@ -242,20 +242,6 @@ SecComputer::Parameters_SecComputer_T SecComputer::SecComputer_P{
 
   0.0,
 
-  0.05,
-
-  0.0,
-
-  0.0,
-
-  0.0,
-
-  35.0,
-
-  35.0,
-
-  0.0,
-
   1.0,
 
   2.0,


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* Fixes an issue with the ground spoiler full extension, where the spoilers would extend when only one thrust lever was at idle, instead of both.
* Adds a condition to the partial extension, to reduce a possible bounce in the case of improper thrust handling on landing: The spoilers will partially extend when
   * The Ground Spoilers are armed
   * Both thrust levers are below the CLB notch
   * Both MLGs are compressed

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
https://safetyfirst.airbus.com/app/themes/mh_newsdesk/documents/archives/a320-family-evolution-of-ground-spoiler-logic.pdf

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
