### PR TITLE
chore(fbw): small compilation fixes to fbw

### DIFF
--- a/src/fbw_a320/build.sh
+++ b/src/fbw_a320/build.sh
@@ -23,6 +23,7 @@ clang \
   -c \
   -Wno-unused-command-line-argument \
   -Wno-implicit-function-declaration \
+  -Wno-deprecated-non-prototype \
   --sysroot "${MSFS_SDK}/WASM/wasi-sysroot" \
   -target wasm32-unknown-wasi \
   -flto \

--- a/src/fbw_a320/src/interface/SimConnectInterface.cpp
+++ b/src/fbw_a320/src/interface/SimConnectInterface.cpp
@@ -77,7 +77,7 @@ bool SimConnectInterface::connect(bool clientDataEnabled,
     }
     // register key event handler
     // remove when aileron events can be processed via SimConnect
-    register_key_event_handler(static_cast<GAUGE_KEY_EVENT_HANDLER>(processKeyEvent), NULL);
+    register_key_event_handler_EX1(static_cast<GAUGE_KEY_EVENT_HANDLER_EX1>(processKeyEvent), NULL);
     // send initial event to FCU to force HDG mode
     execute_calculator_code("(>H:A320_Neo_FCU_HDG_PULL)", nullptr, nullptr, nullptr);
     // success
@@ -91,7 +91,7 @@ void SimConnectInterface::disconnect() {
   if (isConnected) {
     // unregister key event handler
     // remove when aileron events can be processed via SimConnect
-    unregister_key_event_handler(static_cast<GAUGE_KEY_EVENT_HANDLER>(processKeyEvent), NULL);
+    unregister_key_event_handler_EX1(static_cast<GAUGE_KEY_EVENT_HANDLER_EX1>(processKeyEvent), NULL);
     // info message
     std::cout << "WASM: Disconnecting..." << std::endl;
     // close connection
@@ -1387,7 +1387,13 @@ bool SimConnectInterface::getLoggingThrottlesEnabled() {
 }
 
 // remove when aileron events can be processed via SimConnect (which also allows to mask the events)
-void SimConnectInterface::processKeyEvent(ID32 event, UINT32 evdata, PVOID userdata) {
+void SimConnectInterface::processKeyEvent(ID32 event,
+                                          UINT32 evdata0,
+                                          UINT32 evdata1,
+                                          UINT32 evdata2,
+                                          UINT32 evdata3,
+                                          UINT32 evdata4,
+                                          PVOID userdata) {
   switch (event) {
     case KEY_AILERON_LEFT: {
       simInput.inputs[AXIS_AILERONS_SET] = std::fmin(1.0, simInput.inputs[AXIS_AILERONS_SET] + flightControlsKeyChangeAileron);
@@ -1448,7 +1454,8 @@ void SimConnectInterface::simConnectProcessDispatchMessage(SIMCONNECT_RECV* pDat
     case SIMCONNECT_RECV_ID_EXCEPTION:
       // exception
       std::cout << "WASM: Exception in SimConnect connection: ";
-      std::cout << getSimConnectExceptionString(static_cast<SIMCONNECT_EXCEPTION>(static_cast<SIMCONNECT_RECV_EXCEPTION*>(pData)->dwException));
+      std::cout << getSimConnectExceptionString(
+          static_cast<SIMCONNECT_EXCEPTION>(static_cast<SIMCONNECT_RECV_EXCEPTION*>(pData)->dwException));
       std::cout << std::endl;
       break;
 

--- a/src/fbw_a320/src/interface/SimConnectInterface.h
+++ b/src/fbw_a320/src/interface/SimConnectInterface.h
@@ -295,7 +295,7 @@ class SimConnectInterface {
   bool getLoggingThrottlesEnabled();
 
   // remove when aileron events can be processed via SimConnect
-  static void processKeyEvent(ID32 event, UINT32 evdata, PVOID userdata);
+  static void processKeyEvent(ID32 event, UINT32 evdata0, UINT32 evdata1, UINT32 evdata2, UINT32 evdata3, UINT32 evdata4, PVOID userdata);
 
   void updateSimulationRateLimits(double minSimulationRate, double maxSimulationRate);
 

--- a/src/fbw_a380/build.sh
+++ b/src/fbw_a380/build.sh
@@ -23,6 +23,7 @@ clang \
   -c \
   -Wno-unused-command-line-argument \
   -Wno-implicit-function-declaration \
+  -Wno-deprecated-non-prototype \
   --sysroot "${MSFS_SDK}/WASM/wasi-sysroot" \
   -target wasm32-unknown-wasi \
   -flto \

--- a/src/fbw_a380/src/interface/SimConnectInterface.cpp
+++ b/src/fbw_a380/src/interface/SimConnectInterface.cpp
@@ -77,7 +77,7 @@ bool SimConnectInterface::connect(bool clientDataEnabled,
     }
     // register key event handler
     // remove when aileron events can be processed via SimConnect
-    register_key_event_handler(static_cast<GAUGE_KEY_EVENT_HANDLER>(processKeyEvent), NULL);
+    register_key_event_handler_EX1(static_cast<GAUGE_KEY_EVENT_HANDLER_EX1>(processKeyEvent), NULL);
     // send initial event to FCU to force HDG mode
     execute_calculator_code("(>H:A320_Neo_FCU_HDG_PULL)", nullptr, nullptr, nullptr);
     // success
@@ -91,7 +91,7 @@ void SimConnectInterface::disconnect() {
   if (isConnected) {
     // unregister key event handler
     // remove when aileron events can be processed via SimConnect
-    unregister_key_event_handler(static_cast<GAUGE_KEY_EVENT_HANDLER>(processKeyEvent), NULL);
+    unregister_key_event_handler_EX1(static_cast<GAUGE_KEY_EVENT_HANDLER_EX1>(processKeyEvent), NULL);
     // info message
     std::cout << "WASM: Disconnecting..." << std::endl;
     // close connection
@@ -1407,7 +1407,13 @@ bool SimConnectInterface::getLoggingThrottlesEnabled() {
 }
 
 // remove when aileron events can be processed via SimConnect (which also allows to mask the events)
-void SimConnectInterface::processKeyEvent(ID32 event, UINT32 evdata, PVOID userdata) {
+void SimConnectInterface::processKeyEvent(ID32 event,
+                                          UINT32 evdata0,
+                                          UINT32 evdata1,
+                                          UINT32 evdata2,
+                                          UINT32 evdata3,
+                                          UINT32 evdata4,
+                                          PVOID userdata) {
   switch (event) {
     case KEY_AILERON_LEFT: {
       simInput.inputs[AXIS_AILERONS_SET] = std::fmin(1.0, simInput.inputs[AXIS_AILERONS_SET] + flightControlsKeyChangeAileron);

--- a/src/fbw_a380/src/interface/SimConnectInterface.h
+++ b/src/fbw_a380/src/interface/SimConnectInterface.h
@@ -12,7 +12,7 @@
 
 #include "../model/A380PrimComputer_types.h"
 #include "../model/FacComputer_types.h"
-//#include "../model/SecComputer_types.h"
+// #include "../model/SecComputer_types.h"
 
 class SimConnectInterface {
  public:
@@ -299,7 +299,7 @@ class SimConnectInterface {
   bool getLoggingThrottlesEnabled();
 
   // remove when aileron events can be processed via SimConnect
-  static void processKeyEvent(ID32 event, UINT32 evdata, PVOID userdata);
+  static void processKeyEvent(ID32 event, UINT32 evdata0, UINT32 evdata1, UINT32 evdata2, UINT32 evdata3, UINT32 evdata4, PVOID userdata);
 
   void updateSimulationRateLimits(double minSimulationRate, double maxSimulationRate);
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
* Ignore `deprecated-non-prototype` warning during C code compilation, this warning is emitted due to the zlib library, and they don't seem to plan to fix this, and instead recommend ignoring it (right now it spams many warnings)
* Use `register_key_event_handler_EX1` instead of `register_key_event_handler`, which is now deprecated.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
