### PR TITLE
fix: Fixes CDN upload workflow for CloudFlare

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -56,7 +56,6 @@ jobs:
           CDN_BUCKET_DESTINATION: addons/a32nx/experimental
         run: |
           ./scripts/cf-cdn.sh $CDN_BUCKET_DESTINATION ./build-modules
-          ./scripts/cf-cdn.sh $CDN_BUCKET_DESTINATION ./${{ env.BUILD_DIR_NAME }}
       - name: Delete old GitHub Pre-Release assets
         uses: mknejp/delete-release-assets@v1
         with:


### PR DESCRIPTION
## Summary of Changes
Fix for Exp CDN upload workflow

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
none

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
