### PR TITLE
fix(hyd): electro hydrostatic actuator do not consume flow when in elec mode

### DIFF
--- a/src/systems/systems/src/hydraulic/linear_actuator.rs
+++ b/src/systems/systems/src/hydraulic/linear_actuator.rs
@@ -1167,14 +1167,8 @@ impl LinearActuator {
             -volume_to_actuator
         } / context.delta_as_time();
 
-        let eha_backup_mode_active = self.electro_hydrostatic_backup.is_some()
-            && self
-                .electro_hydrostatic_backup
-                .unwrap()
-                .is_electrical_mode_active();
-
         // If eha mode, we don't want to use any fluid from the circuit when actuator moves, else we compute correct volumes
-        if !eha_backup_mode_active {
+        if !self.eha_backup_is_active() {
             // If actuator is in active control, it can use fluid from its input port
             // Else it will only return fluid to reservoir or take fluid from reservoir
             //
@@ -1188,6 +1182,11 @@ impl LinearActuator {
                 self.total_volume_to_reservoir += volume_to_reservoir - volume_to_actuator;
             }
         }
+    }
+
+    fn eha_backup_is_active(&self) -> bool {
+        self.electro_hydrostatic_backup
+            .map_or(false, |eha| eha.is_electrical_mode_active())
     }
 
     pub fn set_position_target(&mut self, target_position: Ratio) {
@@ -2231,7 +2230,7 @@ mod tests {
                 self.hydraulic_assembly.linear_actuators[0]
                     .force()
                     .get::<newton>(),
-                (self.hydraulic_assembly.linear_actuators[0].used_volume() - self.hydraulic_assembly.linear_actuators[0].reservoir_return()).get::<gallon>()
+                self.hydraulic_assembly.linear_actuators[0].used_volume().get::<gallon>()
             );
         }
 
@@ -3795,6 +3794,31 @@ mod tests {
                 .query(|a| a.current_power_consumption())
                 .get::<watt>()
                 > 150.
+        );
+    }
+
+    #[test]
+    fn electro_hydrostatic_actuator_do_not_use_hydraulic_flow_when_moving() {
+        let mut test_bed = SimulationTestBed::new(|context| {
+            let tested_object = spoiler_assembly(context, true);
+            TestAircraft::new(context, Duration::from_millis(10), tested_object)
+        });
+
+        test_bed.command(|a| a.command_unlock());
+        test_bed.command(|a| a.set_pressures([Pressure::new::<psi>(0.)]));
+
+        assert!(test_bed.query(|a| a.body_position()) < Ratio::new::<ratio>(0.01));
+
+        test_bed.command(|a| a.set_ac_1_power(true));
+        test_bed.command(|a| a.command_electro_backup(true, 0));
+        test_bed.command(|a| a.command_position_control(Ratio::new::<ratio>(1.), 0));
+        test_bed.run_with_delta(Duration::from_secs_f64(0.2));
+
+        assert!(
+            test_bed
+                .query(|a| a.actuator_used_volume(0))
+                .get::<gallon>()
+                < 0.00001
         );
     }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

EHA actuators should not use hydraulic circuit flow when in electrical mode.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Covered by unit test

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
