### PR TITLE
feat: EFB adding brightness icon and slider in the StatusBar

### DIFF
--- a/src/instruments/src/EFB/Localization/en.json
+++ b/src/instruments/src/EFB/Localization/en.json
@@ -612,7 +612,8 @@
     "TT": {
       "ConnectedToLocalApi": "Connected to SimBridge",
       "DisconnectedFromLocalApi": "Disconnected from SimBridge",
-      "TurnOffOrShutdownEfb": "Turn off or Shutdown EFB"
+      "TurnOffOrShutdownEfb": "Turn off or Shutdown EFB",
+      "Brightness": "Click to change Brightness"
     },
     "Thu": "Thu",
     "Tue": "Tue",

--- a/src/instruments/src/EFB/StatusBar/BrightnessControl.tsx
+++ b/src/instruments/src/EFB/StatusBar/BrightnessControl.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 FlyByWire Simulations
+// SPDX-License-Identifier: GPL-3.0
+
+import React, { useRef, useState } from 'react';
+import { BrightnessHigh } from 'react-bootstrap-icons';
+import { usePersistentNumberProperty } from '@instruments/common/persistence';
+import { useSimVar } from '@instruments/common/simVars';
+import Slider from 'rc-slider';
+import { t } from '../translation';
+import { TooltipWrapper } from '../UtilComponents/TooltipWrapper';
+
+export const BrightnessControl = () => {
+    const [showSlider, setShowSlider] = useState(false);
+    const [brightnessSetting, setBrightnessSetting] = usePersistentNumberProperty('EFB_BRIGHTNESS', 0);
+    const [brightness] = useSimVar('L:A32NX_EFB_BRIGHTNESS', 'number', 500);
+    const [usingAutobrightness] = usePersistentNumberProperty('EFB_USING_AUTOBRIGHTNESS', 0);
+
+    // To prevent keyboard input (esp. END key for external view) to change
+    // the slider position. This is accomplished by a
+    // onAfterChange={() => sliderRef.current.blur()}
+    // in the Slider component props.
+    const brightnessSliderRef = useRef<any>(null);
+
+    return (
+        <>
+            {!usingAutobrightness && (
+                <TooltipWrapper text={t('StatusBar.TT.Brightness')}>
+                    <div onClick={() => setShowSlider((old) => !old)}>
+                        <BrightnessHigh size={26} />
+                    </div>
+                </TooltipWrapper>
+            )}
+            {showSlider
+                && (
+                    <div
+                        className="absolute z-40 px-2 whitespace-nowrap bg-theme-accent rounded-md border border-theme-secondary transition duration-100"
+                        style={{ top: '40px', left: '1032px' }}
+                    >
+                        <Slider
+                            ref={brightnessSliderRef}
+                            style={{ width: '18rem' }}
+                            value={usingAutobrightness ? brightness : brightnessSetting}
+                            onChange={setBrightnessSetting}
+                            onAfterChange={() => brightnessSliderRef.current.blur()}
+                            onBlur={() => setShowSlider(false)}
+                        />
+                    </div>
+                )}
+        </>
+    );
+};

--- a/src/instruments/src/EFB/StatusBar/StatusBar.tsx
+++ b/src/instruments/src/EFB/StatusBar/StatusBar.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import React, { useEffect, useRef, useState } from 'react';
-import { Power, Wifi, WifiOff } from 'react-bootstrap-icons';
+import { BrightnessHigh, Power, Wifi, WifiOff } from 'react-bootstrap-icons';
 import { useSimVar } from '@instruments/common/simVars';
 import { usePersistentNumberProperty, usePersistentProperty } from '@instruments/common/persistence';
 import { useLongPress } from 'use-long-press';
@@ -15,6 +15,7 @@ import { BatteryStatus } from './BatteryStatus';
 import { useAppSelector } from '../Store/store';
 import { initialState } from '../Store/features/simBrief';
 import { ClientState } from '../../../../simbridge-client/src';
+import { BrightnessControl } from './BrightnessControl';
 
 interface StatusBarProps {
     batteryLevel: number;
@@ -149,6 +150,7 @@ export const StatusBar = ({ batteryLevel, isCharging }: StatusBarProps) => {
             />
 
             <p>{`${dayName} ${monthName} ${dayOfMonth}`}</p>
+
             <div className="flex absolute inset-x-0 flex-row justify-center items-center mx-auto space-x-4 w-min">
                 {(timeDisplayed === 'utc' || timeDisplayed === 'both') && (
                     <p>{getZuluFormattedTime(currentUTC)}</p>
@@ -160,10 +162,12 @@ export const StatusBar = ({ batteryLevel, isCharging }: StatusBarProps) => {
                     <p>{getLocalFormattedTime(currentLocalTime)}</p>
                 )}
             </div>
-            <div className="flex items-center space-x-8">
+
+            <div className="flex items-center space-x-4">
+
                 {(!!showStatusBarFlightProgress && (data !== initialState.data)) && (
                     <div
-                        className="flex overflow-hidden flex-row items-center space-x-4 h-10"
+                        className="flex overflow-hidden flex-row items-center pr-10 space-x-4 h-10"
                         onClick={() => setShowSchedTimes((old) => !old)}
                     >
                         <div className={`${showSchedTimes ? '-translate-y-1/4' : 'translate-y-1/4'} transform transition text-right duration-100 flex flex-col space-y-1`}>
@@ -180,6 +184,8 @@ export const StatusBar = ({ batteryLevel, isCharging }: StatusBarProps) => {
                         </div>
                     </div>
                 )}
+
+                <BrightnessControl />
 
                 <TooltipWrapper text={simBridgeConnected ? t('StatusBar.TT.ConnectedToLocalApi') : t('StatusBar.TT.DisconnectedFromLocalApi')}>
                     {simBridgeConnected ? (

--- a/src/instruments/src/EFB/StatusBar/StatusBar.tsx
+++ b/src/instruments/src/EFB/StatusBar/StatusBar.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import React, { useEffect, useRef, useState } from 'react';
-import { BrightnessHigh, Power, Wifi, WifiOff } from 'react-bootstrap-icons';
+import { Power, Wifi, WifiOff } from 'react-bootstrap-icons';
 import { useSimVar } from '@instruments/common/simVars';
 import { usePersistentNumberProperty, usePersistentProperty } from '@instruments/common/persistence';
 import { useLongPress } from 'use-long-press';


### PR DESCRIPTION
Might be replaced by https://github.com/flybywiresim/a32nx/pull/7669

## Summary of Changes
To allow brightness changes quickly this PR adds a icon in the StatusBar which can be clicked to get a brightness slider to change brightness.

The icon is not visible if Auto Brightness is activated. 

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/16833201/209179414-797c95ca-eeed-4ed4-b920-56c9d297e1a9.png)

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Test the slider itself - change brightness 
Confirm that the icon is not visible if Auto Brightness is activated in the settings. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
