### PR TITLE
feat: option to use 2 independent axis for rudder

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -30,6 +30,7 @@
 1. [EFB] Added QuickControls to flyPad StatusBar - @Benjozork (Benjamin Dupont) @frankkopp (Frank Kopp)
 1. [SOUND] Fix announcements playing twice and adding check for power to PA - @frankkopp (Frank Kopp)
 1. [ENG] Adjust oil pressure table - @tracernz (Mike)
+1. [FBW] Added option to have two axis for rudder e.g. racing pedals - @frankkopp (Frank Kopp)
 
 ## 0.9.0
 

--- a/fbw-a32nx/docs/Configuration/ModelConfiguration.ini
+++ b/fbw-a32nx/docs/Configuration/ModelConfiguration.ini
@@ -97,6 +97,10 @@
 ; (there can be different value ranges supplied depending on what type of controller is assigned to that axis)
 ;disable_xbox_compatibility_rudder_axis_plus_minus = false
 
+; enable using two axis for rudder control -  "RUDDER AXIS LEFT" and "RUDDER AXIS RIGHT"
+; as this might be incompatible with some controllers, it is disabled by default
+;enable_rudder_2_axis = false
+
 [logging]
 ; enables logging of flight control related events (sidestick, rudder, flaps and spoilers)
 ; (printed values are raw values provided with the event not normalized to -1.0 to 1.0)

--- a/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
@@ -227,13 +227,15 @@ void FlyByWireInterface::loadConfiguration() {
   flightControlsKeyChangeRudder = abs(flightControlsKeyChangeRudder);
   disableXboxCompatibilityRudderAxisPlusMinus =
       INITypeConversion::getBoolean(iniStructure, "FLIGHT_CONTROLS", "DISABLE_XBOX_COMPATIBILITY_RUDDER_AXIS_PLUS_MINUS", false);
+  enableRudder2AxisMode =
+      INITypeConversion::getBoolean(iniStructure, "FLIGHT_CONTROLS", "ENABLE_RUDDER_2_AXIS", false);
 
   // print configuration into console
   std::cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_AILERON = " << flightControlsKeyChangeAileron << std::endl;
   std::cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_ELEVATOR = " << flightControlsKeyChangeElevator << std::endl;
   std::cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_RUDDER = " << flightControlsKeyChangeRudder << std::endl;
-  std::cout << "WASM: FLIGHT_CONTROLS : DISABLE_XBOX_COMPATIBILITY_RUDDER_AXIS_PLUS_MINUS = " << disableXboxCompatibilityRudderAxisPlusMinus
-            << std::endl;
+  std::cout << "WASM: FLIGHT_CONTROLS : DISABLE_XBOX_COMPATIBILITY_RUDDER_AXIS_PLUS_MINUS = " << disableXboxCompatibilityRudderAxisPlusMinus << std::endl;
+  std::cout << "WASM: FLIGHT_CONTROLS : ENABLE_RUDDER_2_AXIS = " << enableRudder2AxisMode << std::endl;
 
   // --------------------------------------------------------------------------
   // load values - logging

--- a/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.cpp
@@ -35,7 +35,7 @@ bool FlyByWireInterface::connect() {
   return simConnectInterface.connect(clientDataEnabled, autopilotStateMachineEnabled, autopilotLawsEnabled, flyByWireEnabled, elacDisabled,
                                      secDisabled, facDisabled, throttleAxis, spoilersHandler, flightControlsKeyChangeAileron,
                                      flightControlsKeyChangeElevator, flightControlsKeyChangeRudder,
-                                     disableXboxCompatibilityRudderAxisPlusMinus, idMinimumSimulationRate->get(),
+                                     disableXboxCompatibilityRudderAxisPlusMinus, enableRudder2AxisMode, idMinimumSimulationRate->get(),
                                      idMaximumSimulationRate->get(), limitSimulationRateByPerformance);
 }
 

--- a/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.h
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/FlyByWireInterface.h
@@ -87,6 +87,7 @@ class FlyByWireInterface {
   double rudderTravelLimiterPosition = 25;
 
   bool disableXboxCompatibilityRudderAxisPlusMinus = false;
+  bool enableRudder2AxisMode = false;
 
   bool clientDataEnabled = false;
 

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
@@ -1567,7 +1567,7 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       // As it might be incompatible with some controllers, it is configurable
       if (this->enableRudder2AxisMode) {
         rudderLeftAxis = tmpValue;
-        tmpValue = (rudderRightAxis + rudderLeftAxis) / 2.0;
+        tmpValue = -1 * ((rudderRightAxis - rudderLeftAxis) / 2.0);
       }
 
       simInput.inputs[AXIS_RUDDER_SET] = tmpValue;
@@ -1597,8 +1597,8 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       // This allows using two independent axis for rudder which are mapped to RUDDER AXIS LEFT and RUDDER AXIS RIGHT
       // As it might be incompatible with some controllers, it is configurable
       if (this->enableRudder2AxisMode) {
-        rudderRightAxis = tmpValue;
-        tmpValue = (rudderRightAxis - rudderLeftAxis) / 2.0;
+        rudderRightAxis = -tmpValue;
+        tmpValue = -1 * ((rudderRightAxis - rudderLeftAxis) / 2.0);
       }
 
       simInput.inputs[AXIS_RUDDER_SET] = tmpValue;

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
@@ -24,6 +24,7 @@ bool SimConnectInterface::connect(bool clientDataEnabled,
                                   double keyChangeElevator,
                                   double keyChangeRudder,
                                   bool disableXboxCompatibilityRudderPlusMinus,
+                                  bool enableRudder2AxisMode,
                                   double minSimulationRate,
                                   double maxSimulationRate,
                                   bool limitSimulationRateByPerformance) {
@@ -56,6 +57,7 @@ bool SimConnectInterface::connect(bool clientDataEnabled,
     flightControlsKeyChangeRudder = keyChangeRudder;
     // store if XBOX compatibility should be disabled for rudder axis plus/minus
     this->disableXboxCompatibilityRudderPlusMinus = disableXboxCompatibilityRudderPlusMinus;
+    this->enableRudder2AxisMode = enableRudder2AxisMode;
     // register local variables
     idFcuEventSetSPEED = std::make_unique<LocalVariable>("A320_Neo_FCU_SPEED_SET_DATA");
     idFcuEventSetHDG = std::make_unique<LocalVariable>("A320_Neo_FCU_HDG_SET_DATA");
@@ -1582,7 +1584,6 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
 
     case Events::RUDDER_AXIS_PLUS: {
       double tmpValue = 0;
-
       if (this->disableXboxCompatibilityRudderPlusMinus) {
         // normal axis
         tmpValue = -1.0 * ((static_cast<long>(event->dwData) + 16384.0) / 32768.0);

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.cpp
@@ -1566,8 +1566,8 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
       // This allows using two independent axis for rudder which are mapped to RUDDER AXIS LEFT and RUDDER AXIS RIGHT
       // As it might be incompatible with some controllers, it is configurable
       if (this->enableRudder2AxisMode) {
-        rudderLeftAxis = -tmpValue;
-        tmpValue = (rudderRightAxis - rudderLeftAxis) / 2.0;
+        rudderLeftAxis = tmpValue;
+        tmpValue = (rudderRightAxis + rudderLeftAxis) / 2.0;
       }
 
       simInput.inputs[AXIS_RUDDER_SET] = tmpValue;
@@ -1576,7 +1576,9 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
         std::cout << static_cast<long>(event->dwData);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_RUDDER_SET];
-        std::cout << " (left: " << rudderLeftAxis << ", right: " << rudderRightAxis << ")";
+        if (this->enableRudder2AxisMode) {
+          std::cout << " (left: " << rudderLeftAxis << ", right: " << rudderRightAxis << ")";
+        }
         std::cout << std::endl;
       }
       break;
@@ -1605,7 +1607,9 @@ void SimConnectInterface::simConnectProcessEvent(const SIMCONNECT_RECV_EVENT* ev
         std::cout << static_cast<long>(event->dwData);
         std::cout << " -> ";
         std::cout << simInput.inputs[AXIS_RUDDER_SET];
-        std::cout << " (left: " << rudderLeftAxis << ", right: " << rudderRightAxis << ")";
+        if (this->enableRudder2AxisMode) {
+          std::cout << " (left: " << rudderLeftAxis << ", right: " << rudderRightAxis << ")";
+        }
         std::cout << std::endl;
       }
       break;

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.h
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.h
@@ -397,7 +397,7 @@ class SimConnectInterface {
   // Therefore we need to store the last value of each axis to allow calculating these in event handlers.
   bool enableRudder2AxisMode = false;
   double rudderLeftAxis = -1;
-  double rudderRightAxis = 1;
+  double rudderRightAxis = -1;
 
   std::unique_ptr<LocalVariable> idFcuEventSetSPEED;
   std::unique_ptr<LocalVariable> idFcuEventSetHDG;

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.h
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.h
@@ -392,6 +392,13 @@ class SimConnectInterface {
   double flightControlsKeyChangeRudder = 0.0;
   bool disableXboxCompatibilityRudderPlusMinus = false;
 
+  // For user using two axis for rudder we need to calculate the combined output base on the two axis
+  // Therefore we need to store the last value of each axis to allow calculating these in event handlers.
+  // -1 is the lowest axis value, +1 highest axis value
+  bool enableRudder2AxisMode = false;
+  double rudderLeftAxis = -1;
+  double rudderRightAxis = -1;
+
   std::unique_ptr<LocalVariable> idFcuEventSetSPEED;
   std::unique_ptr<LocalVariable> idFcuEventSetHDG;
   std::unique_ptr<LocalVariable> idFcuEventSetVS;

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.h
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.h
@@ -395,10 +395,9 @@ class SimConnectInterface {
 
   // For user using two axis for rudder we need to calculate the combined output base on the two axis
   // Therefore we need to store the last value of each axis to allow calculating these in event handlers.
-  // -1 is the lowest axis value, +1 highest axis value
   bool enableRudder2AxisMode = false;
   double rudderLeftAxis = -1;
-  double rudderRightAxis = -1;
+  double rudderRightAxis = 1;
 
   std::unique_ptr<LocalVariable> idFcuEventSetSPEED;
   std::unique_ptr<LocalVariable> idFcuEventSetHDG;

--- a/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.h
+++ b/fbw-a32nx/src/wasm/fbw_a320/src/interface/SimConnectInterface.h
@@ -194,6 +194,7 @@ class SimConnectInterface {
                double keyChangeElevator,
                double keyChangeRudder,
                bool disableXboxCompatibilityRudderPlusMinus,
+               bool enableRudder2AxisMode,
                double minSimulationRate,
                double maxSimulationRate,
                bool limitSimulationRateByPerformance);

--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.cpp
@@ -35,7 +35,7 @@ bool FlyByWireInterface::connect() {
   return simConnectInterface.connect(clientDataEnabled, autopilotStateMachineEnabled, autopilotLawsEnabled, flyByWireEnabled, primDisabled,
                                      secDisabled, facDisabled, throttleAxis, spoilersHandler, flightControlsKeyChangeAileron,
                                      flightControlsKeyChangeElevator, flightControlsKeyChangeRudder,
-                                     disableXboxCompatibilityRudderAxisPlusMinus, idMinimumSimulationRate->get(),
+                                     disableXboxCompatibilityRudderAxisPlusMinus, enableRudder2AxisMode, idMinimumSimulationRate->get(),
                                      idMaximumSimulationRate->get(), limitSimulationRateByPerformance);
 }
 
@@ -227,13 +227,15 @@ void FlyByWireInterface::loadConfiguration() {
   flightControlsKeyChangeRudder = abs(flightControlsKeyChangeRudder);
   disableXboxCompatibilityRudderAxisPlusMinus =
       INITypeConversion::getBoolean(iniStructure, "FLIGHT_CONTROLS", "DISABLE_XBOX_COMPATIBILITY_RUDDER_AXIS_PLUS_MINUS", false);
+  enableRudder2AxisMode =
+      INITypeConversion::getBoolean(iniStructure, "FLIGHT_CONTROLS", "ENABLE_RUDDER_2_AXIS", false);
 
   // print configuration into console
   std::cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_AILERON = " << flightControlsKeyChangeAileron << std::endl;
   std::cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_ELEVATOR = " << flightControlsKeyChangeElevator << std::endl;
   std::cout << "WASM: FLIGHT_CONTROLS : KEY_CHANGE_RUDDER = " << flightControlsKeyChangeRudder << std::endl;
-  std::cout << "WASM: FLIGHT_CONTROLS : DISABLE_XBOX_COMPATIBILITY_RUDDER_AXIS_PLUS_MINUS = " << disableXboxCompatibilityRudderAxisPlusMinus
-            << std::endl;
+  std::cout << "WASM: FLIGHT_CONTROLS : DISABLE_XBOX_COMPATIBILITY_RUDDER_AXIS_PLUS_MINUS = " << disableXboxCompatibilityRudderAxisPlusMinus << std::endl;
+  std::cout << "WASM: FLIGHT_CONTROLS : ENABLE_RUDDER_2_AXIS = " << enableRudder2AxisMode << std::endl;
 
   // --------------------------------------------------------------------------
   // load values - logging

--- a/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.h
+++ b/fbw-a380x/src/wasm/fbw_a380/src/FlyByWireInterface.h
@@ -87,6 +87,7 @@ class FlyByWireInterface {
   double rudderTravelLimiterPosition = 25;
 
   bool disableXboxCompatibilityRudderAxisPlusMinus = false;
+  bool enableRudder2AxisMode = false;
 
   bool clientDataEnabled = false;
 

--- a/fbw-a380x/src/wasm/fbw_a380/src/interface/SimConnectInterface.h
+++ b/fbw-a380x/src/wasm/fbw_a380/src/interface/SimConnectInterface.h
@@ -198,6 +198,7 @@ class SimConnectInterface {
                double keyChangeElevator,
                double keyChangeRudder,
                bool disableXboxCompatibilityRudderPlusMinus,
+               bool enableRudder2AxisMode,
                double minSimulationRate,
                double maxSimulationRate,
                bool limitSimulationRateByPerformance);
@@ -398,6 +399,12 @@ class SimConnectInterface {
   double flightControlsKeyChangeElevator = 0.0;
   double flightControlsKeyChangeRudder = 0.0;
   bool disableXboxCompatibilityRudderPlusMinus = false;
+
+  // For user using two axis for rudder we need to calculate the combined output base on the two axis
+  // Therefore we need to store the last value of each axis to allow calculating these in event handlers.
+  bool enableRudder2AxisMode = false;
+  double rudderLeftAxis = -1;
+  double rudderRightAxis = -1;
 
   std::unique_ptr<LocalVariable> idFcuEventSetSPEED;
   std::unique_ptr<LocalVariable> idFcuEventSetHDG;


### PR DESCRIPTION
## Summary of Changes
Some few user want to use two axis to control the rudder. This is mostly the case if these users want to use racing pedals instead of flight pedals.
Normally this would not work as input to both pedals is possible which would conflict, In flight-pedals this is prevented by a physical link and also by only using one axis. 

With this PR it is possible to use two axis mapped to the MSFS `RUDDER AXIS LEFT` and `RUDDER AXIS RIGHT` inputs.
The resulting rudder value is the difference between both axis so that conflicting inputs are canceled out. 

This is option needs to be enabled in the file:
https://github.com/frankkopp/a32nx/blob/rudder-left-right/docs/Configuration/ModelConfiguration.ini 
which needs to be placed in the `work` folder of the aircraft. 

```
[flight_controls]
; enable using two axis for rudder control -  "RUDDER AXIS LEFT" and "RUDDER AXIS RIGHT"
; as this might be incompatible with some controllers, it is disabled by default
enable_rudder_2_axis = true
```

## Screenshots
![image](https://user-images.githubusercontent.com/16833201/209373765-d6df6027-68da-4a62-b747-2f77d07aea57.png)

## Contact
Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Remove existing mappings to rudder.
Add a mapping to two axis for left rudder and right rudder to  `RUDDER AXIS LEFT` and `RUDDER AXIS RIGHT.
Enable the option as described above (ini file)

Test using the rudder with the two axis. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
