### PR TITLE
fix(efb): landing calculator widget runway shows correct runway heading

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,9 +19,9 @@
 1. [EFB] Fix and improve pushback system and add API documentation - @frankkopp (Frank Kopp)
 1. [RMP] RMPs navigation backup - Julian Sebline (Julian Sebline#8476 on Discord)
 1. [SEC] Fix GND SPLR logic, add missing GND SPLR partial extension condition - @lukecologne (luke)
-1. [FMGC] Improved importing flight plans from MSFS World Map - @frankkopp (Frank Kopp)  
+1. [FMGC] Improved importing flight plans from MSFS World Map - @frankkopp (Frank Kopp)
 1. [EFB] Added boarding time indication to Payload page - @ChristianLutzCL (Christian Lutz) @frankkopp (Frank Kopp)
-
+1. [EFB] Show correct runway numbers in landing calculator's runway widget when heading is between 0-5 degrees - @2hwk (2Cas#1022)
 ## 0.9.0
 
 1. [MODEL] Add Wheel Chocks and GSE Safety Cones - @bouveng (Johan Bouveng)

--- a/src/instruments/src/EFB/Performance/Widgets/RunwayVisualizationWidget.tsx
+++ b/src/instruments/src/EFB/Performance/Widgets/RunwayVisualizationWidget.tsx
@@ -46,7 +46,7 @@ interface RunwayNumberProps {
 }
 
 const RunwayNumber = ({ heading }: RunwayNumberProps) => {
-    const displayedHeading = heading === 360 || heading === 0 ? 360 : heading! % 360;
+    const displayedHeading = (heading! % 360 < 5) ? 360 : heading! % 360;
 
     return (
         <div className="mx-auto w-min text-4xl font-bold text-white">


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Currently landing runway widget shows 18/00 when heading is between 1-5 degrees. Runway number should instead be 18/36.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/15316958/210051053-e287a6a2-6b38-4a03-8f08-f272cc4a8f9f.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Open landing calculator page on EFB. Page should first appear with no runway heading (Runway labels ??/??)
- Enter runway heading 0-4. Runway numbers should be 18/36
- Enter runway heading 5-10. Runway numbers should be 19/01
- Enter runway heading 175-184. Runway numbers should be 36/18
- Enter runway heading 355-360. Runway numbers should be 18/36

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
