### PR TITLE
ci: upload to cloudflare in master and stable pipelines

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -89,6 +89,12 @@ jobs:
         run: |
           ./scripts/cdn.sh $BUNNY_BUCKET_DESTINATION ./build-modules
           ./scripts/cdn.sh $BUNNY_BUCKET_DESTINATION ./${{ env.BUILD_DIR_NAME }}
+      - name: Upload to CloudFlare CDN
+        env:
+          CLOUDFLARE_BUCKET_PASSWORD: ${{ secrets.CLOUDFLARE_BUCKET_PASSWORD }}
+          CDN_BUCKET_DESTINATION: addons/a32nx/master
+        run: |
+          ./scripts/cf-cdn.sh $CDN_BUCKET_DESTINATION ./build-modules
       - name: Delete old GitHub Pre-Release assets
         uses: mknejp/delete-release-assets@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,12 @@ jobs:
         run: |
           ./scripts/cdn.sh $BUNNY_BUCKET_DESTINATION ./build-modules
           ./scripts/cdn.sh $BUNNY_BUCKET_DESTINATION ./${{ env.BUILD_DIR_NAME }}
+      - name: Upload to CloudFlare CDN
+        env:
+          CLOUDFLARE_BUCKET_PASSWORD: ${{ secrets.CLOUDFLARE_BUCKET_PASSWORD }}
+          CDN_BUCKET_DESTINATION: addons/a32nx/stable
+        run: |
+          ./scripts/cf-cdn.sh $CDN_BUCKET_DESTINATION ./build-modules
       - name: Delete old GitHub Pre-Release assets
         uses: mknejp/delete-release-assets@v1
         with:


### PR DESCRIPTION
## Summary of Changes

* Adds CloudFlare CDN upload step to master and stable release pipelines
* BunnyCDN steps are not removed for now

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
