### PR TITLE
refactor: Remove redundant bt setting

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1157,4 +1157,4 @@
 1. [ISIS] Fixed issue where ISIS was allowing a bug to be set while in the OFF state - Patrick Macken (@Pat M on
    Discord)
 1. [EFB] Added estimated boarding time to Payload screen - @ChristianLutzCL (Christian Lutz)
-1. [EFB] Removed redundant boarding rate setting from Realism Settings screen - @MicahBCode (Mischa Binder)
+1. [EFB] Removed redundant boarding rate setting from Realism settings screen - @MicahBCode (Mischa Binder)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,7 +19,7 @@
 1. [EFB] Fix and improve pushback system and add API documentation - @frankkopp (Frank Kopp)
 1. [RMP] RMPs navigation backup - Julian Sebline (Julian Sebline#8476 on Discord)
 1. [SEC] Fix GND SPLR logic, add missing GND SPLR partial extension condition - @lukecologne (luke)
-1. [FMGC] Improved importing flight plans from MSFS World Map - @frankkopp (Frank Kopp)  
+1. [FMGC] Improved importing flight plans from MSFS World Map - @frankkopp (Frank Kopp)
 1. [EFB] Added boarding time indication to Payload page - @ChristianLutzCL (Christian Lutz) @frankkopp (Frank Kopp)
 
 ## 0.9.0
@@ -1157,3 +1157,4 @@
 1. [ISIS] Fixed issue where ISIS was allowing a bug to be set while in the OFF state - Patrick Macken (@Pat M on
    Discord)
 1. [EFB] Added estimated boarding time to Payload screen - @ChristianLutzCL (Christian Lutz)
+1. [EFB] Removed redundant boarding rate setting from Realism Settings screen - @MicahBCode (Mischa Binder)

--- a/src/instruments/src/EFB/Settings/Pages/RealismPage.tsx
+++ b/src/instruments/src/EFB/Settings/Pages/RealismPage.tsx
@@ -19,7 +19,6 @@ export const RealismPage = () => {
     const [dmcSelfTestTime, setDmcSelfTestTime] = usePersistentProperty('CONFIG_SELF_TEST_TIME', '12');
     const [mcduInput, setMcduInput] = usePersistentProperty('MCDU_KB_INPUT', 'DISABLED');
     const [mcduTimeout, setMcduTimeout] = usePersistentProperty('CONFIG_MCDU_KB_TIMEOUT', '60');
-    const [boardingRate, setBoardingRate] = usePersistentProperty('CONFIG_BOARDING_RATE', 'REAL');
     const [realisticTiller, setRealisticTiller] = usePersistentNumberProperty('REALISTIC_TILLER_ENABLED', 0);
     const [homeCockpit, setHomeCockpit] = usePersistentProperty('HOME_COCKPIT_ENABLED', '0');
     const [autoFillChecklists, setAutoFillChecklists] = usePersistentNumberProperty('EFB_AUTOFILL_CHECKLISTS', 0);
@@ -37,12 +36,6 @@ export const RealismPage = () => {
         { name: t('Settings.Instant'), setting: '0' },
         { name: t('Settings.Fast'), setting: '5' },
         { name: t('Settings.Real'), setting: '12' },
-    ];
-
-    const boardingRateButtons: ButtonType[] = [
-        { name: t('Settings.Instant'), setting: 'INSTANT' },
-        { name: t('Settings.Fast'), setting: 'FAST' },
-        { name: t('Settings.Real'), setting: 'REAL' },
     ];
 
     return (
@@ -69,19 +62,6 @@ export const RealismPage = () => {
                         <SelectItem
                             onSelect={() => setDmcSelfTestTime(button.setting)}
                             selected={dmcSelfTestTime === button.setting}
-                        >
-                            {button.name}
-                        </SelectItem>
-                    ))}
-                </SelectGroup>
-            </SettingItem>
-
-            <SettingItem name={t('Settings.Realism.BoardingTime')}>
-                <SelectGroup>
-                    {boardingRateButtons.map((button) => (
-                        <SelectItem
-                            onSelect={() => setBoardingRate(button.setting)}
-                            selected={boardingRate === button.setting}
                         >
                             {button.name}
                         </SelectItem>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #7687 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Removed the boarding rate selection buttons in the Realism Settings Page as it is redudant. Boarding rate selection can be done on the payload page, just as the refueling rate can be done as well.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username: MicahB#3002

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Check the Settings Page
2. Navigate to the Realism Settings
3. Verify that the boarding rate setting has been removed.
4. Check the Ground Page
5. Navigate to the Payload Tab
6. Verify that the boarding rate can be selected at the bottom of the screen.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
