### PR TITLE
fix: Fixed sound, cones and chocks which depend on LIGHT BEACON (ON)) var

### DIFF
--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO.xml
@@ -530,7 +530,7 @@
                 <FREQUENCY>10</FREQUENCY>
                 <UPDATE_CODE>
                     (A:SURFACE RELATIVE GROUND SPEED, feet per second) 0.1 &gt; ! (&gt;L:A32NX_IS_STATIONARY, bool)
-                    (A:SIM ON GROUND, bool) (L:A32NX_ENGINE_N1:1, Number) 3.5 &lt; and (L:A32NX_ENGINE_N1:2, Number) 3.5 &lt; and (L:A32NX_HYD_NW_STRG_DISC_ECAM_MEMO, bool) 0 == and (A:LIGHT BEACON ON, bool) 0 == and (&gt;L:A32NX_GND_EQP_IS_VISIBLE, bool)
+                    (A:SIM ON GROUND, bool) (L:A32NX_ENGINE_N1:1, Number) 3.5 &lt; and (L:A32NX_ENGINE_N1:2, Number) 3.5 &lt; and (L:A32NX_HYD_NW_STRG_DISC_ECAM_MEMO, bool) 0 == and (A:LIGHT BEACON, bool) 0 == and (&gt;L:A32NX_GND_EQP_IS_VISIBLE, bool)
                 </UPDATE_CODE>
             </UseTemplate>
 

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/sound/sound.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/sound/sound.xml
@@ -2263,14 +2263,14 @@
 
         <Sound WwiseEvent="welcomeonboard" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="false" LocalVar="A32NX_SOUND_BOARDING_COMPLETE">
             <Range LowerBound="1" />
-            <Requires SimVar="LIGHT BEACON" Index="0" Units="Bool">
+            <Requires SimVar="LIGHT BEACON ON" Index="0" Units="Bool">
                 <Range UpperBound="0" />
             </Requires>
             <WwiseRTPC LocalVar="A32NX_COCKPIT_DOOR_LOCKED" RTPCAttackTime="0.5" RTPCReleaseTime="0.5" Units="bool" Index="1" RTPCName="LOCALVAR_A32NX_COCKPIT_DOOR_LOCKED" />
             <WwiseRTPC LocalVar="A32NX_SOUND_ANNOUNCEMENTS_ENABLED" Units="number" Index="0" RTPCName="LOCALVAR_A32NX_ANNOUNCEMENT_TOGGLE" />
         </Sound>
 
-        <Sound WwiseEvent="armdoors" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="true" SimVar="LIGHT BEACON" Index="0" Units="Bool">
+        <Sound WwiseEvent="armdoors" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="true" SimVar="LIGHT BEACON ON" Index="0" Units="Bool">
             <Range LowerBound="1" />
             <WwiseRTPC LocalVar="A32NX_COCKPIT_DOOR_LOCKED" RTPCAttackTime="0.5" RTPCReleaseTime="0.5" Units="bool" Index="1" RTPCName="LOCALVAR_A32NX_COCKPIT_DOOR_LOCKED" />
             <WwiseRTPC LocalVar="A32NX_SOUND_ANNOUNCEMENTS_ENABLED" Units="number" Index="0" RTPCName="LOCALVAR_A32NX_ANNOUNCEMENT_TOGGLE" />
@@ -2279,7 +2279,7 @@
             </Requires>
         </Sound>
 
-        <Sound WwiseEvent="safetydemo" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="true" SimVar="LIGHT BEACON" Index="0" Units="Bool">
+        <Sound WwiseEvent="safetydemo" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="true" SimVar="LIGHT BEACON ON" Index="0" Units="Bool">
             <Range LowerBound="1" />
             <WwiseRTPC LocalVar="A32NX_COCKPIT_DOOR_LOCKED" RTPCAttackTime="0.5" RTPCReleaseTime="0.5" Units="bool" Index="1" RTPCName="LOCALVAR_A32NX_COCKPIT_DOOR_LOCKED" />
             <WwiseRTPC LocalVar="A32NX_SOUND_ANNOUNCEMENTS_ENABLED" Units="number" Index="0" RTPCName="LOCALVAR_A32NX_ANNOUNCEMENT_TOGGLE" />

--- a/src/behavior/src/A32NX_Exterior.xml
+++ b/src/behavior/src/A32NX_Exterior.xml
@@ -211,7 +211,7 @@
         <DefaultTemplateParameters>
             <GND_ENABLE_OVRD></GND_ENABLE_OVRD>
             <GND_EQUIPMENT_LOGIC>
-                (A:SIM ON GROUND, bool) (L:A32NX_ENGINE_N1:1, Number) 3.5 &lt; and (L:A32NX_ENGINE_N1:2, Number) 3.5 &lt; and (L:A32NX_HYD_NW_STRG_DISC_ECAM_MEMO, bool) 0 == and (A:LIGHT BEACON ON, bool) 0 == and
+                (A:SIM ON GROUND, bool) (L:A32NX_ENGINE_N1:1, Number) 3.5 &lt; and (L:A32NX_ENGINE_N1:2, Number) 3.5 &lt; and (L:A32NX_HYD_NW_STRG_DISC_ECAM_MEMO, bool) 0 == and (A:LIGHT BEACON, bool) 0 == and
             </GND_EQUIPMENT_LOGIC>
         </DefaultTemplateParameters>
         <Component ID="#NODE_ID#" Node="#NODE_ID#">

--- a/src/behavior/src/A32NX_Interior_Handling.xml
+++ b/src/behavior/src/A32NX_Interior_Handling.xml
@@ -104,7 +104,7 @@
             <DRAG_SPEED>30</DRAG_SPEED>
             <POSITION_TYPE>O</POSITION_TYPE>
             <POSITION_VAR>Position</POSITION_VAR>
-            <EVENT_SPEED Process="True">16383 10 /</EVENT_SPEED>
+            <EVENT_SPEED Process="Float">16383 10 /</EVENT_SPEED>
             <TOOLTIPID>TT:COCKPIT.TOOLTIPS.SPEEDBRAKE_LEVER</TOOLTIPID>
         </DefaultTemplateParameters>
         <OverrideTemplateParameters>

--- a/src/systems/a320_systems/src/hydraulic/mod.rs
+++ b/src/systems/a320_systems/src/hydraulic/mod.rs
@@ -3847,7 +3847,7 @@ impl A320BrakingForce {
                 .get_identifier("RIGHT_FLAPS_POSITION_PERCENT".to_owned()),
 
             enabled_chocks_id: context.get_identifier("MODEL_WHEELCHOCKS_ENABLED".to_owned()),
-            light_beacon_on_id: context.get_identifier("LIGHT BEACON ON".to_owned()),
+            light_beacon_on_id: context.get_identifier("LIGHT BEACON".to_owned()),
 
             left_braking_force: 0.,
             right_braking_force: 0.,

--- a/src/systems/a320_systems_wasm/src/lib.rs
+++ b/src/systems/a320_systems_wasm/src/lib.rs
@@ -207,6 +207,7 @@ async fn systems(mut gauge: msfs::Gauge) -> Result<(), Box<dyn Error>> {
     .provides_aircraft_variable("INDICATED ALTITUDE", "Feet", 0)?
     .provides_aircraft_variable("INTERACTIVE POINT OPEN:0", "Percent", 0)?
     .provides_aircraft_variable("INTERACTIVE POINT OPEN:3", "Percent", 0)?
+    .provides_aircraft_variable("LIGHT BEACON", "Bool", 0)?
     .provides_aircraft_variable("LIGHT BEACON ON", "Bool", 0)?
     .provides_aircraft_variable("PLANE ALT ABOVE GROUND", "Feet", 0)?
     .provides_aircraft_variable("PLANE PITCH DEGREES", "Degrees", 0)?

--- a/src/systems/a380_systems/src/hydraulic/mod.rs
+++ b/src/systems/a380_systems/src/hydraulic/mod.rs
@@ -3906,7 +3906,7 @@ impl A380BrakingForce {
                 .get_identifier("RIGHT_FLAPS_POSITION_PERCENT".to_owned()),
 
             enabled_chocks_id: context.get_identifier("MODEL_WHEELCHOCKS_ENABLED".to_owned()),
-            light_beacon_on_id: context.get_identifier("LIGHT BEACON ON".to_owned()),
+            light_beacon_on_id: context.get_identifier("LIGHT BEACON".to_owned()),
 
             left_braking_force: 0.,
             right_braking_force: 0.,

--- a/src/systems/a380_systems_wasm/src/lib.rs
+++ b/src/systems/a380_systems_wasm/src/lib.rs
@@ -191,6 +191,7 @@ async fn systems(mut gauge: msfs::Gauge) -> Result<(), Box<dyn Error>> {
     .provides_aircraft_variable("INDICATED ALTITUDE", "Feet", 0)?
     .provides_aircraft_variable("INTERACTIVE POINT OPEN:0", "Percent", 0)?
     .provides_aircraft_variable("INTERACTIVE POINT OPEN:3", "Percent", 0)?
+    .provides_aircraft_variable("LIGHT BEACON", "Bool", 0)?
     .provides_aircraft_variable("LIGHT BEACON ON", "Bool", 0)?
     .provides_aircraft_variable("PLANE ALT ABOVE GROUND", "Feet", 0)?
     .provides_aircraft_variable("PLANE PITCH DEGREES", "Degrees", 0)?


### PR DESCRIPTION
## Summary of Changes
Wheelchocks and Safety Cones depended on LIGHT BEACON ON
Cabin announcements (Sounds) depended on LIGHT BEACON

LIGHT BEACON == Switch Position
LIGHT BEACON ON == Actual Beacon Light State

This PR fixes this so that:
- Chocks and Cones are gone when the **switch** is on
  - this avoids the case of an unpowered aircraft on the runway or taxiway having them visible
- Cabin announcements only play when beacon lights are **actually on**

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
- Test chocks & cones visibility in powered an unpowered states depending on switch
- Test announcements playing only when aircraft is powered and switch is on. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
