### PR TITLE
fix: PA announcement playing twice and without power to PA

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -28,6 +28,7 @@
 1. [HYD] Fix gear sequence starting when failing prox sensor - @Crocket63 (crocket)
 1. [MISC] Added aircraft version check and uer notification - @frankkopp (Frank Kopp) 
 1. [EFB] Added QuickControls to flyPad StatusBar - @Benjozork (Benjamin Dupont) @frankkopp (Frank Kopp)
+1. [SOUND] Fix announcements playing twice and adding check for power to PA - @frankkopp (Frank Kopp)
 
 ## 0.9.0
 
@@ -1163,4 +1164,3 @@
 1. [DCDU] Fixed MSG- and MSG+ button labels - @tyler58546 (tyler58546)
 1. [ISIS] Fixed issue where ISIS was allowing a bug to be set while in the OFF state - Patrick Macken (@Pat M on
    Discord)
-

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -4114,6 +4114,16 @@
             <CameraTitle>ECAM</CameraTitle>
         </Component>
 
+        <!-- CABIN INTERACTION DATA SYS -->
+        <Component ID="Airbus_CIDS">
+            <UseTemplate Name="ASOBO_GT_Update">
+                <FREQUENCY>1</FREQUENCY>
+                <UPDATE_CODE>
+                    (L:A32NX_ELEC_DC_GND_FLT_SVC_BUS_IS_POWERED, Bool) (L:A32NX_ELEC_DC_ESS_BUS_IS_POWERED, Bool) or (&gt;L:A32NX_CIDS_IS_POWERED)
+                </UPDATE_CODE>
+            </UseTemplate>
+        </Component>
+
         <Component ID="Airbus_FDW">
             <DefaultTemplateParameters>
                 <POTENTIOMETER>85</POTENTIOMETER>

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/sound/sound.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/sound/sound.xml
@@ -2275,9 +2275,6 @@
 
         <Sound WwiseEvent="armdoors" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="true" SimVar="LIGHT BEACON" Index="0" Units="Bool">
             <Range LowerBound="1" />
-            <Requires SimVar="LIGHT BEACON" Index="0" Units="Bool">
-                <Range LowerBound="1" />
-            </Requires>
             <Requires LocalVar="A32NX_CIDS_IS_POWERED">
                 <Range LowerBound="1" />
             </Requires>
@@ -2290,9 +2287,6 @@
 
         <Sound WwiseEvent="safetydemo" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="true" SimVar="LIGHT BEACON" Index="0" Units="Bool">
             <Range LowerBound="1" />
-            <Requires SimVar="LIGHT BEACON" Index="0" Units="Bool">
-                <Range LowerBound="1" />
-            </Requires>
             <Requires LocalVar="A32NX_CIDS_IS_POWERED">
                 <Range LowerBound="1" />
             </Requires>

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/sound/sound.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/sound/sound.xml
@@ -2257,7 +2257,7 @@
 
         <Sound WwiseEvent="boardingcompleted" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="false" LocalVar="A32NX_SOUND_BOARDING_COMPLETE">
             <Range LowerBound="1" />
-            <Requires LocalVar="A32NX_ELEC_AC_1_BUS_IS_POWERED">
+            <Requires LocalVar="A32NX_CIDS_IS_POWERED">
                 <Range LowerBound="1" />
             </Requires>
             <WwiseRTPC LocalVar="A32NX_COCKPIT_DOOR_LOCKED" RTPCAttackTime="0.5" RTPCReleaseTime="0.5" Units="bool" Index="1" RTPCName="LOCALVAR_A32NX_COCKPIT_DOOR_LOCKED" />
@@ -2266,10 +2266,7 @@
 
         <Sound WwiseEvent="welcomeonboard" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="false" LocalVar="A32NX_SOUND_BOARDING_COMPLETE">
             <Range LowerBound="1" />
-            <Requires SimVar="LIGHT BEACON" Index="0" Units="Bool">
-                <Range UpperBound="0" />
-            </Requires>
-            <Requires LocalVar="A32NX_ELEC_AC_1_BUS_IS_POWERED">
+            <Requires LocalVar="A32NX_CIDS_IS_POWERED">
                 <Range LowerBound="1" />
             </Requires>
             <WwiseRTPC LocalVar="A32NX_COCKPIT_DOOR_LOCKED" RTPCAttackTime="0.5" RTPCReleaseTime="0.5" Units="bool" Index="1" RTPCName="LOCALVAR_A32NX_COCKPIT_DOOR_LOCKED" />
@@ -2278,7 +2275,10 @@
 
         <Sound WwiseEvent="armdoors" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="true" SimVar="LIGHT BEACON" Index="0" Units="Bool">
             <Range LowerBound="1" />
-            <Requires LocalVar="A32NX_ELEC_AC_1_BUS_IS_POWERED">
+            <Requires SimVar="LIGHT BEACON" Index="0" Units="Bool">
+                <Range LowerBound="1" />
+            </Requires>
+            <Requires LocalVar="A32NX_CIDS_IS_POWERED">
                 <Range LowerBound="1" />
             </Requires>
             <WwiseRTPC LocalVar="A32NX_COCKPIT_DOOR_LOCKED" RTPCAttackTime="0.5" RTPCReleaseTime="0.5" Units="bool" Index="1" RTPCName="LOCALVAR_A32NX_COCKPIT_DOOR_LOCKED" />
@@ -2290,7 +2290,10 @@
 
         <Sound WwiseEvent="safetydemo" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="true" SimVar="LIGHT BEACON" Index="0" Units="Bool">
             <Range LowerBound="1" />
-            <Requires LocalVar="A32NX_ELEC_AC_1_BUS_IS_POWERED">
+            <Requires SimVar="LIGHT BEACON" Index="0" Units="Bool">
+                <Range LowerBound="1" />
+            </Requires>
+            <Requires LocalVar="A32NX_CIDS_IS_POWERED">
                 <Range LowerBound="1" />
             </Requires>
             <WwiseRTPC LocalVar="A32NX_COCKPIT_DOOR_LOCKED" RTPCAttackTime="0.5" RTPCReleaseTime="0.5" Units="bool" Index="1" RTPCName="LOCALVAR_A32NX_COCKPIT_DOOR_LOCKED" />

--- a/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/sound/sound.xml
+++ b/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/sound/sound.xml
@@ -2257,21 +2257,30 @@
 
         <Sound WwiseEvent="boardingcompleted" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="false" LocalVar="A32NX_SOUND_BOARDING_COMPLETE">
             <Range LowerBound="1" />
+            <Requires LocalVar="A32NX_ELEC_AC_1_BUS_IS_POWERED">
+                <Range LowerBound="1" />
+            </Requires>
             <WwiseRTPC LocalVar="A32NX_COCKPIT_DOOR_LOCKED" RTPCAttackTime="0.5" RTPCReleaseTime="0.5" Units="bool" Index="1" RTPCName="LOCALVAR_A32NX_COCKPIT_DOOR_LOCKED" />
             <WwiseRTPC LocalVar="A32NX_SOUND_ANNOUNCEMENTS_ENABLED" Units="number" Index="0" RTPCName="LOCALVAR_A32NX_ANNOUNCEMENT_TOGGLE" />
         </Sound>
 
         <Sound WwiseEvent="welcomeonboard" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="false" LocalVar="A32NX_SOUND_BOARDING_COMPLETE">
             <Range LowerBound="1" />
-            <Requires SimVar="LIGHT BEACON ON" Index="0" Units="Bool">
+            <Requires SimVar="LIGHT BEACON" Index="0" Units="Bool">
                 <Range UpperBound="0" />
+            </Requires>
+            <Requires LocalVar="A32NX_ELEC_AC_1_BUS_IS_POWERED">
+                <Range LowerBound="1" />
             </Requires>
             <WwiseRTPC LocalVar="A32NX_COCKPIT_DOOR_LOCKED" RTPCAttackTime="0.5" RTPCReleaseTime="0.5" Units="bool" Index="1" RTPCName="LOCALVAR_A32NX_COCKPIT_DOOR_LOCKED" />
             <WwiseRTPC LocalVar="A32NX_SOUND_ANNOUNCEMENTS_ENABLED" Units="number" Index="0" RTPCName="LOCALVAR_A32NX_ANNOUNCEMENT_TOGGLE" />
         </Sound>
 
-        <Sound WwiseEvent="armdoors" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="true" SimVar="LIGHT BEACON ON" Index="0" Units="Bool">
+        <Sound WwiseEvent="armdoors" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="true" SimVar="LIGHT BEACON" Index="0" Units="Bool">
             <Range LowerBound="1" />
+            <Requires LocalVar="A32NX_ELEC_AC_1_BUS_IS_POWERED">
+                <Range LowerBound="1" />
+            </Requires>
             <WwiseRTPC LocalVar="A32NX_COCKPIT_DOOR_LOCKED" RTPCAttackTime="0.5" RTPCReleaseTime="0.5" Units="bool" Index="1" RTPCName="LOCALVAR_A32NX_COCKPIT_DOOR_LOCKED" />
             <WwiseRTPC LocalVar="A32NX_SOUND_ANNOUNCEMENTS_ENABLED" Units="number" Index="0" RTPCName="LOCALVAR_A32NX_ANNOUNCEMENT_TOGGLE" />
             <Requires LocalVar="A32NX_FMGC_FLIGHT_PHASE">
@@ -2279,8 +2288,11 @@
             </Requires>
         </Sound>
 
-        <Sound WwiseEvent="safetydemo" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="true" SimVar="LIGHT BEACON ON" Index="0" Units="Bool">
+        <Sound WwiseEvent="safetydemo" WwiseData="true" NodeName="SOUND_FWD_GALLEY" ConeHeading="180" CancelConeHeadingWhenInside="false" Continuous="true" SimVar="LIGHT BEACON" Index="0" Units="Bool">
             <Range LowerBound="1" />
+            <Requires LocalVar="A32NX_ELEC_AC_1_BUS_IS_POWERED">
+                <Range LowerBound="1" />
+            </Requires>
             <WwiseRTPC LocalVar="A32NX_COCKPIT_DOOR_LOCKED" RTPCAttackTime="0.5" RTPCReleaseTime="0.5" Units="bool" Index="1" RTPCName="LOCALVAR_A32NX_COCKPIT_DOOR_LOCKED" />
             <WwiseRTPC LocalVar="A32NX_SOUND_ANNOUNCEMENTS_ENABLED" Units="number" Index="0" RTPCName="LOCALVAR_A32NX_ANNOUNCEMENT_TOGGLE" />
             <Requires LocalVar="A32NX_FMGC_FLIGHT_PHASE">


### PR DESCRIPTION
Fixes #7701

## Summary of Changes
Fixes the cabin crew PA announcements playing twice as described in the issue #7701.
Also adds checks if PA system is powered before playing any announcements. 

## References
Power bus for PA is DC GND/FLT and DC ESS
![image](https://user-images.githubusercontent.com/16833201/212318290-103cd804-86f5-4b4e-b7df-67af9e2cab11.png)

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
- Check that the cabin crew announcements play correctly when triggers are set (BEACON and power to PA)
- Check that no announcement is played without any power (DC GND/FLT and DC ESS => A32NX_CIDS_IS_POWERED) 
- Check that it does not play twice - esp. when switching on Strobe

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
