### PR TITLE
fix(fuel): Dev States effect on fuel management

### DIFF
--- a/src/fadec/a320_fadec/src/EngineControl.h
+++ b/src/fadec/a320_fadec/src/EngineControl.h
@@ -45,6 +45,7 @@ class EngineControl {
   double ambientPressure;
   double simOnGround;
   double devState;
+  double isReady;
 
   int engine;
   int egtImbalance;
@@ -662,7 +663,7 @@ class EngineControl {
   /// </summary>
   void checkPayload() {
     double fuelWeightGallon = simVars->getFuelWeightGallon();
-    double aircraftEmptyWeight = simVars->getEmptyWeight();                                   // in LBS
+    double aircraftEmptyWeight = simVars->getEmptyWeight();  // in LBS
     double conversionFactor = simVars->getConversionFactor();
     double perPaxWeightLbs = simVars->getPerPaxWeight() / conversionFactor;                   // in LBS
     double aircraftTotalWeight = simVars->getTotalWeight();                                   // in LBS
@@ -760,7 +761,8 @@ class EngineControl {
     double engine1State = simVars->getEngine1State();
     double engine2State = simVars->getEngine2State();
 
-    // Check Development State for UI
+    // Check Ready & Development State for UI
+    isReady = simVars->getIsReady();
     devState = simVars->getDeveloperState();
 
     deltaTime = deltaTime / 3600;
@@ -806,48 +808,53 @@ class EngineControl {
     }
 
     // Checking for in-game UI Fuel tampering
-    if ((refuelStartedByUser == 0 && deltaFuelRate > FUEL_THRESHOLD) ||
-        (refuelStartedByUser == 1 && deltaFuelRate > FUEL_THRESHOLD && refuelRate < 2)) {
+    if ((isReady == 1 && refuelStartedByUser == 0 && deltaFuelRate > FUEL_THRESHOLD) ||
+        (isReady == 1 && refuelStartedByUser == 1 && deltaFuelRate > FUEL_THRESHOLD && refuelRate < 2)) {
       uiFuelTamper = true;
     }
 
-    if (simPaused || uiFuelTamper) {                 // Detects whether the Sim is paused or the Fuel UI is being tampered with
+    if (simPaused || uiFuelTamper && devState == 0) {  // Detects whether the Sim is paused or the Fuel UI is being tampered with
       simVars->setFuelLeftPre(fuelLeftPre);          // in LBS
       simVars->setFuelRightPre(fuelRightPre);        // in LBS
       simVars->setFuelAuxLeftPre(fuelAuxLeftPre);    // in LBS
       simVars->setFuelAuxRightPre(fuelAuxRightPre);  // in LBS
       simVars->setFuelCenterPre(fuelCenterPre);      // in LBS
-      if (devState == 0) {
-        fuelLeft = (fuelLeftPre / fuelWeightGallon);          // USG
-        fuelRight = (fuelRightPre / fuelWeightGallon);        // USG
-        fuelCenter = (fuelCenterPre / fuelWeightGallon);      // USG
-        fuelLeftAux = (fuelAuxLeftPre / fuelWeightGallon);    // USG
-        fuelRightAux = (fuelAuxRightPre / fuelWeightGallon);  // USG
 
-        SimConnect_SetDataOnSimObject(hSimConnect, DataTypesID::FuelCenterMain, SIMCONNECT_OBJECT_ID_USER, 0, 0, sizeof(double),
-                                      &fuelCenter);
-        SimConnect_SetDataOnSimObject(hSimConnect, DataTypesID::FuelLeftMain, SIMCONNECT_OBJECT_ID_USER, 0, 0, sizeof(double), &fuelLeft);
-        SimConnect_SetDataOnSimObject(hSimConnect, DataTypesID::FuelRightMain, SIMCONNECT_OBJECT_ID_USER, 0, 0, sizeof(double), &fuelRight);
-        SimConnect_SetDataOnSimObject(hSimConnect, DataTypesID::FuelLeftAux, SIMCONNECT_OBJECT_ID_USER, 0, 0, sizeof(double), &fuelLeftAux);
-        SimConnect_SetDataOnSimObject(hSimConnect, DataTypesID::FuelRightAux, SIMCONNECT_OBJECT_ID_USER, 0, 0, sizeof(double),
-                                      &fuelRightAux);
-      }
+      fuelLeft = (fuelLeftPre / fuelWeightGallon);          // USG
+      fuelRight = (fuelRightPre / fuelWeightGallon);        // USG
+      fuelCenter = (fuelCenterPre / fuelWeightGallon);      // USG
+      fuelLeftAux = (fuelAuxLeftPre / fuelWeightGallon);    // USG
+      fuelRightAux = (fuelAuxRightPre / fuelWeightGallon);  // USG
+
+      SimConnect_SetDataOnSimObject(hSimConnect, DataTypesID::FuelCenterMain, SIMCONNECT_OBJECT_ID_USER, 0, 0, sizeof(double), &fuelCenter);
+      SimConnect_SetDataOnSimObject(hSimConnect, DataTypesID::FuelLeftMain, SIMCONNECT_OBJECT_ID_USER, 0, 0, sizeof(double), &fuelLeft);
+      SimConnect_SetDataOnSimObject(hSimConnect, DataTypesID::FuelRightMain, SIMCONNECT_OBJECT_ID_USER, 0, 0, sizeof(double), &fuelRight);
+      SimConnect_SetDataOnSimObject(hSimConnect, DataTypesID::FuelLeftAux, SIMCONNECT_OBJECT_ID_USER, 0, 0, sizeof(double), &fuelLeftAux);
+      SimConnect_SetDataOnSimObject(hSimConnect, DataTypesID::FuelRightAux, SIMCONNECT_OBJECT_ID_USER, 0, 0, sizeof(double), &fuelRightAux);
     } else if (!uiFuelTamper && refuelStartedByUser == 1) {  // Detects refueling from the EFB
-      simVars->setFuelLeftPre(leftQuantity);                 // in LBS
-      simVars->setFuelRightPre(rightQuantity);               // in LBS
-      simVars->setFuelAuxLeftPre(leftAuxQuantity);           // in LBS
-      simVars->setFuelAuxRightPre(rightAuxQuantity);         // in LBS
-      simVars->setFuelCenterPre(centerQuantity);             // in LBS
+      simVars->setFuelLeftPre(leftQuantity);          // in LBS
+      simVars->setFuelRightPre(rightQuantity);        // in LBS
+      simVars->setFuelAuxLeftPre(leftAuxQuantity);    // in LBS
+      simVars->setFuelAuxRightPre(rightAuxQuantity);  // in LBS
+      simVars->setFuelCenterPre(centerQuantity);      // in LBS
     } else {
+      if (uiFuelTamper == 1) {
+        fuelLeftPre = leftQuantity;          // LBS
+        fuelRightPre = rightQuantity;        // LBS
+        fuelAuxLeftPre = leftAuxQuantity;    // LBS
+        fuelAuxRightPre = rightAuxQuantity;  // LBS
+        fuelCenterPre = centerQuantity;      // LBS
+      }
       //--------------------------------------------
-      // Left Engine and Wing routine
+      //  Left Engine and Wing routine
       //--------------------------------------------
       if (fuelLeftPre > 0) {
         // Cycle Fuel Burn for Engine 1
-        m = (engine1FF - engine1PreFF) / deltaTime;
-        b = engine1PreFF;
-        fuelBurn1 = (m * pow(deltaTime, 2) / 2) + (b * deltaTime);  // KG
-
+        if (devState != 2) {
+          m = (engine1FF - engine1PreFF) / deltaTime;
+          b = engine1PreFF;
+          fuelBurn1 = (m * pow(deltaTime, 2) / 2) + (b * deltaTime);  // KG
+        }
         // Fuel Used Accumulators - Engine 1
         fuelUsedLeft += fuelBurn1;
 
@@ -868,10 +875,11 @@ class EngineControl {
       //--------------------------------------------
       if (fuelRightPre > 0) {
         // Cycle Fuel Burn for Engine 2
-        m = (engine2FF - engine2PreFF) / deltaTime;
-        b = engine2PreFF;
-        fuelBurn2 = (m * pow(deltaTime, 2) / 2) + (b * deltaTime);  // KG
-
+        if (devState != 2) {
+          m = (engine2FF - engine2PreFF) / deltaTime;
+          b = engine2PreFF;
+          fuelBurn2 = (m * pow(deltaTime, 2) / 2) + (b * deltaTime);  // KG
+        }
         // Fuel Used Accumulators - Engine 2
         fuelUsedRight += fuelBurn2;
 
@@ -894,9 +902,6 @@ class EngineControl {
         xfrCenter = fuelCenterPre - centerQuantity;
       }
 
-      //--------------------------------------------
-      // Main Fuel Logic
-      //--------------------------------------------
       fuelLeft = (fuelLeftPre - (fuelBurn1 * KGS_TO_LBS)) + xfrAuxLeft + (xfrCenter / 2);     // LBS
       fuelRight = (fuelRightPre - (fuelBurn2 * KGS_TO_LBS)) + xfrAuxRight + (xfrCenter / 2);  // LBS
 
@@ -1064,7 +1069,7 @@ class EngineControl {
   /// </summary>
   void initialize(const char* acftRegistration) {
     srand((int)time(0));
-	
+
     std::cout << "FADEC: Initializing EngineControl" << std::endl;
 
     simVars = new SimVars();
@@ -1166,7 +1171,6 @@ class EngineControl {
   /// Update cycle at deltaTime
   /// </summary>
   void update(double deltaTime, double simulationTime) {
-    double animationDeltaTime;
     double prevAnimationDeltaTime;
     double simN1highest = 0;
 

--- a/src/fadec/a320_fadec/src/EngineControl.h
+++ b/src/fadec/a320_fadec/src/EngineControl.h
@@ -846,7 +846,7 @@ class EngineControl {
         fuelCenterPre = centerQuantity;      // LBS
       }
       //--------------------------------------------
-      //  Left Engine and Wing routine
+      // Left Engine and Wing routine
       //--------------------------------------------
       if (fuelLeftPre > 0) {
         // Cycle Fuel Burn for Engine 1

--- a/src/fadec/a320_fadec/src/SimVars.h
+++ b/src/fadec/a320_fadec/src/SimVars.h
@@ -114,6 +114,7 @@ class SimVars {
   /// Collection of LVars for the A32NX
   /// </summary>
   ID DevVar;
+  ID IsReady;
   ID FlexTemp;
   ID Engine1N2;
   ID Engine2N2;
@@ -184,6 +185,7 @@ class SimVars {
 
   void initializeVars() {
     DevVar = register_named_variable("A32NX_DEVELOPER_STATE");
+    IsReady = register_named_variable("A32NX_IS_READY");
     FlexTemp = register_named_variable("AIRLINER_TO_FLEX_TEMP");
     Engine1N2 = register_named_variable("A32NX_ENGINE_N2:1");
     Engine2N2 = register_named_variable("A32NX_ENGINE_N2:2");
@@ -333,6 +335,7 @@ class SimVars {
 
   // Collection of SimVar/LVar 'get' Functions
   FLOAT64 getDeveloperState() { return get_named_variable_value(DevVar); }
+  FLOAT64 getIsReady() { return get_named_variable_value(IsReady); }
   FLOAT64 getFlexTemp() { return get_named_variable_value(FlexTemp); }
   FLOAT64 getEngine1N2() { return get_named_variable_value(Engine1N2); }
   FLOAT64 getEngine2N2() { return get_named_variable_value(Engine2N2); }

--- a/src/fadec/a320_fadec/src/ThrustLimits.h
+++ b/src/fadec/a320_fadec/src/ThrustLimits.h
@@ -221,12 +221,20 @@ limitN1(int type, double altitude, double ambientTemp, double ambientPressure, d
   cn1Last = interpolate(altitude, limits[loAltRow][0], limits[hiAltRow][0], limits[loAltRow][4], limits[hiAltRow][4]);
   cn1Flex = interpolate(altitude, limits[loAltRow][0], limits[hiAltRow][0], limits[loAltRow][5], limits[hiAltRow][5]);
 
-  // Calculating  CN1 for all cases
-  if (flexTemp > lp && type <= 1) {  // Flexible TO Case
-    m = (cn1Flex - cn1Last) / (100 - lp);
-    b = cn1Flex - m * 100;
-    cn1 = (m * flexTemp) + b;
-  } else {
+  if (flexTemp > 0 && type <= 1) { // CN1 for Flex Case
+    if (flexTemp <= cp) {
+      cn1 = cn1Flat;
+    } else if (flexTemp > lp) {
+      m = (cn1Flex - cn1Last) / (100 - lp);
+      b = cn1Flex - m * 100;
+      cn1 = (m * flexTemp) + b;
+    } else {
+      m = (cn1Last - cn1Flat) / (lp - cp);
+      b = cn1Last - m * lp;
+      cn1 = (m * flexTemp) + b;
+    }
+  }
+  else { // CN1 for All other cases
     if (ambientTemp <= cp) {
       cn1 = cn1Flat;
     } else {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
At some point, the **developer state** variable failed to work as it should (discovered by @donstim and lately ratified by @Gurgel100). This PR fixes and makes the **developer state** LVar (A32NX_DEVELOPER_STATE) usable again with these three states:

- **A32NX_DEVELOPER_STATE = 0**, does not allow to change Fuel settings from the Sim's Fuel UI (only the EFB)
- **A32NX_DEVELOPER_STATE = 1**, allows to change Fuel settings from the Sim's Fuel UI and EFB (useful for development purposes)
- **A32NX_DEVELOPER_STATE = 2**, just like state '1', but without fuel burn. Useful for testing FCOM conditions which requires static weight measurements.

Note: This PR also introduces the small fix that was set on PR#7565 (https://github.com/flybywiresim/a32nx/pull/7565) and was somehow overridden.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): TazX [Z+2]

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
With the aircraft set on the runway, open up the **Behavior Debug Windows** and go over the **LocalVariables** tab. Filter for DEVELOPER so you have the A32NX_DEVELOPER_STATE variable ready to be written.

Also, click and show the **Weight&Balance** UI.

**Test A32NX_DEVELOPER_STATE = 0**
1. Enter '0' in the A32NX_DEVELOPER_STATE variable
2. Check that the Fuel in the W&B UI is being burnt as expected
3. Try to change Fuel from the sliders and/ or entering values
4. Check that Fuel **CANNOT** be changed from the UI

**Test A32NX_DEVELOPER_STATE = 1**
1. Enter '1' in the A32NX_DEVELOPER_STATE variable
2. Check that the Fuel in the W&B UI is being burnt as expected
3. Try to change Fuel from the sliders and/ or entering values
4. Check that Fuel **CAN** be changed from the UI

**Test A32NX_DEVELOPER_STATE = 2**
1. Enter '2' in the A32NX_DEVELOPER_STATE variable
2. Check that the Fuel in the W&B UI is not decreasing (not being burnt)
3. Try to change Fuel from the sliders and/ or entering values
4. Check that Fuel **CAN** be changed from the UI but Fuel is not being burnt

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
