### PR TITLE
feat: GSX Config

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -31,6 +31,7 @@
 1. [SOUND] Fix announcements playing twice and adding check for power to PA - @frankkopp (Frank Kopp)
 1. [ENG] Adjust oil pressure table - @tracernz (Mike)
 1. [FBW] Added option to have two axis for rudder e.g. racing pedals - @frankkopp (Frank Kopp)
+1. [MODEL] Add GSX Config - @Lucky38i (Alex)
 
 ## 0.9.0
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/GSX.cfg
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/SimObjects/AirPlanes/FlyByWire_A320_NEO/GSX.cfg
@@ -1,0 +1,63 @@
+[aircraft]
+icaotype = A20N
+parkingbrakestest = (L:A32NX_PARK_BRAKE_LEVER_POS,number)
+nosegear = 8.26
+refueling = 0
+battery = 1
+pushbackraise = 1
+pushbackdummyevent = 0
+pushbackcheckengines = 0
+iscargo = 0
+trafficcones = 1
+preferredexit =  0
+wingrootpos = 2.36 -1.89 0.85
+wingtippos = 15.70 -7.41 1.84
+fuelpos = 9.63 -3.39 0.88
+waterpos = 1.28 -18.07 0.52
+lavatorypos = 0.59 -18.07 0.12
+gpupos = 3.29 11.06 -1.56
+bypasspinpos = 0.08 8.45 -1.42
+engine1pos = -5.67 0.50 -0.81
+engine2pos = 5.67 0.50 -0.80
+engine3pos = 0.00 0.00 0.00
+engine4pos = 0.00 0.00 0.00
+
+[exit1]
+pos = -1.88 8.51 0.86 4.00
+code = 1
+name = Passenger Door
+embeddedStair = 0
+
+[exit2]
+remove = 1
+
+[exit3]
+remove = 1
+
+[exit4]
+remove = 1
+
+[service1]
+pos = 2.01 8.50 0.99 -5.00
+code = 4
+name = Service Door
+embeddedStair = 0
+
+[service2]
+pos = 1.80 -16.15 1.03 12.00
+code = 4
+name = Service Door AFT
+embeddedStair = 0
+
+[cargo1]
+pos = 0.85 5.50 -0.40 -0.39
+code = 6
+name = Cargo Door
+embeddedStair = 0
+uldcode = BELT
+
+[cargo2]
+remove = 1
+
+[cargomain]
+remove = 1


### PR DESCRIPTION
Added config that fixes parking brake test and removes non-functioning doors

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Added GSX Config that fixes parking brake test and removes non-functioning doors. No actions is required by users, this is automatically picked up by GSX and is shown as `Developer provided config` in the `Customise Airplane` GSX Screen.
## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Lucky38i

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Make sure your customise airplane screen correctly shows `Developer provided`. 
2. Ensure you don't get the `Release parking brake` loop when attempting to pushback. **1. MUST BEconfirmed otherwise you will get the loop.**
3. Ensure only the _functioning_ doors are received by boarding, catering and cargo vehicles. This should be the FWD Passenger Door, FWD Service Door, FWD Cargo Door and AFT Service Door. You can enable the other doors if you'd like later on, but they won't open of course.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
