### PR TITLE
feat(EFB): Added new slider for cabin announcement volume

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/FlyPadPage.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Settings/Pages/FlyPadPage.tsx
@@ -25,6 +25,14 @@ export const FlyPadPage = () => {
     const [language, setLanguage] = usePersistentProperty('EFB_LANGUAGE', 'en');
     const [keyboardLayout, setKeyboardLayout] = usePersistentProperty('EFB_KEYBOARD_LAYOUT_IDENT', 'english');
     const [batteryLifeEnabled, setBatteryLifeEnabled] = usePersistentNumberProperty('EFB_BATTERY_LIFE_ENABLED', 1);
+    const [cabinAnnouncementVolume, setCabinAnnouncementVolume] = usePersistentNumberProperty('CABIN_ANNOUNCEMENT_VOLUME', 50);
+    const [cabinAnnouncementVolumeLevel] = useSimVar('CABIN_ANNOUNCEMENT_VOLUME_LEVEL', 'number', 50);
+    const cabinAnnouncementSliderRef = useRef<any>(null);
+    const handleCabinAnnouncementVolumeChange = (volume: number) => {
+        setCabinAnnouncementVolume(volume);
+        // update the cabin announcement volume level
+        // based on the new volume set by the slider
+    };
 
     // the tt() is a special case to update the page with the correct language after user
     // changes the language. the change to simvar hooks changed timing/order of updates.
@@ -102,6 +110,13 @@ export const FlyPadPage = () => {
                                     value={usingAutobrightness ? brightness : brightnessSetting}
                                     onChange={setBrightnessSetting}
                                     onAfterChange={() => brightnessSliderRef.current.blur()}
+                                    
+                                    ref={cabinAnnouncementSliderRef}
+                                    value={cabinAnnouncementVolume}
+                                    onChange={handleCabinAnnouncementVolumeChange}
+                                    onAfterChange={() => cabinAnnouncementSliderRef.current.blur()}
+                                    min={0}
+                                    max={100}
                                 />
                                 <SimpleInput
                                     min={1}


### PR DESCRIPTION
First time attempting any contributions. Please let me know if I did something wrong. Attempted to add a custom slider that allows the user to control the audio level of the cabin crew announcements. (Saw this as a request and wanted to give it a try)

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[7760]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
The new lines of code create a new slider called cabinAnnouncementSlider and use it to control the volume of cabin announcement audio. The slider is set up with a minimum value of 0 and a maximum value of 1, and its initial value is set to 0.5. The value of the slider is used as the volume of the cabin announcement audio when it is played.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/116454351/217134171-ccbb3fe7-9471-49ca-b59c-4776660874c8.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): shadowsurfer#0815

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
