### PR TITLE
fix(behaviours): remove unused asobo template

### DIFF
--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/ModelBehaviorDefs/A32NX/AirlinerCommon.xml
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/ModelBehaviorDefs/A32NX/AirlinerCommon.xml
@@ -4,64 +4,6 @@
 <ModelBehaviors>
     <Include ModelBehaviorFile="Asobo\TRANSPONDER\Transponder.xml"/>
 
-    <Template Name="ASOBO_AIRLINER_ATC_Transponder_Mode_Knob_Template">
-        <DefaultTemplateParameters>
-            <NODE_ID>AIRLINER_ATC_Transponder_Mode_Knob</NODE_ID>
-            <ANIM_NAME>AIRLINER_ATC_Transponder_Mode_Knob</ANIM_NAME>
-            <SET_TRANSPONDER_STATE>(&gt;A:TRANSPONDER STATE:1, Enum)</SET_TRANSPONDER_STATE>
-            <GET_TRANSPONDER_STATE>(A:TRANSPONDER STATE:1, Enum)</GET_TRANSPONDER_STATE>
-            <ENUM_VAL_STBY>1</ENUM_VAL_STBY>
-            <ENUM_VAL_ALT>4</ENUM_VAL_ALT>
-            <ENUM_VAL_ON>3</ENUM_VAL_ON>
-            <CODE_POS_STBY>0</CODE_POS_STBY>
-            <CODE_POS_XPNDR>1</CODE_POS_XPNDR>
-            <CODE_POS_TA>2</CODE_POS_TA>
-            <CODE_POS_TARA>3</CODE_POS_TARA>
-            <CODE_POS_ALT>4</CODE_POS_ALT>
-        </DefaultTemplateParameters>
-
-        <Component ID="#NODE_ID#" Node="#NODE_ID#">
-            <UseTemplate Name="ASOBO_GT_Switch_5States">
-                <SWITCH_DIRECTION>Horizontal</SWITCH_DIRECTION>
-                <LEFTARROW>TurnLeft</LEFTARROW>
-                <RIGHTARROW>TurnRight</RIGHTARROW>
-                <CODE_POS_#CODE_POS_STBY#>
-                #ENUM_VAL_STBY# #SET_TRANSPONDER_STATE#
-                0 (&gt;I:XMLVAR_IDENT_Shutdown_Time)
-                0 (&gt;L:XMLVAR_Transponder_Mode)
-                </CODE_POS_#CODE_POS_STBY#>
-                <CODE_POS_#CODE_POS_XPNDR#>
-                #ENUM_VAL_ALT# #SET_TRANSPONDER_STATE#
-                1 (&gt;L:XMLVAR_Transponder_Mode)
-                </CODE_POS_#CODE_POS_XPNDR#>
-                <CODE_POS_#CODE_POS_TA#>
-                #ENUM_VAL_ALT# #SET_TRANSPONDER_STATE#
-                2 (&gt;L:XMLVAR_Transponder_Mode)
-                </CODE_POS_#CODE_POS_TA#>
-                <CODE_POS_#CODE_POS_TARA#>
-                #ENUM_VAL_ALT# #SET_TRANSPONDER_STATE#
-                3 (&gt;L:XMLVAR_Transponder_Mode)
-                </CODE_POS_#CODE_POS_TARA#>
-                <CODE_POS_#CODE_POS_ALT#>
-                #ENUM_VAL_ON# #SET_TRANSPONDER_STATE#
-                0 (&gt;L:XMLVAR_Transponder_Mode)
-                </CODE_POS_#CODE_POS_ALT#>
-                <STATE#CODE_POS_STBY#_TEST>#GET_TRANSPONDER_STATE# #ENUM_VAL_STBY# ==</STATE#CODE_POS_STBY#_TEST>
-                <STATE#CODE_POS_XPNDR#_TEST>#GET_TRANSPONDER_STATE# #ENUM_VAL_ALT# == (L:XMLVAR_Transponder_Mode) 1 == and</STATE#CODE_POS_XPNDR#_TEST>
-                <STATE#CODE_POS_TA#_TEST>#GET_TRANSPONDER_STATE# #ENUM_VAL_ALT# == (L:XMLVAR_Transponder_Mode) 2 == and</STATE#CODE_POS_TA#_TEST>
-                <STATE#CODE_POS_TARA#_TEST>#GET_TRANSPONDER_STATE# #ENUM_VAL_ALT# == (L:XMLVAR_Transponder_Mode) 3 == and</STATE#CODE_POS_TARA#_TEST>
-                <STATE#CODE_POS_ALT#_TEST>#GET_TRANSPONDER_STATE# #ENUM_VAL_ON# ==</STATE#CODE_POS_ALT#_TEST>
-
-                <ANIMTIP_#CODE_POS_STBY#>TT:COCKPIT.TOOLTIPS.XPDR_SBY</ANIMTIP_#CODE_POS_STBY#>
-                <ANIMTIP_#CODE_POS_XPNDR#>TT:COCKPIT.TOOLTIPS.XPDR_XPDR</ANIMTIP_#CODE_POS_XPNDR#>
-                <ANIMTIP_#CODE_POS_TA#>TT:COCKPIT.TOOLTIPS.XPDR_TA_ONLY</ANIMTIP_#CODE_POS_TA#>
-                <ANIMTIP_#CODE_POS_TARA#>TT:COCKPIT.TOOLTIPS.XPDR_TA_RA</ANIMTIP_#CODE_POS_TARA#>
-                <ANIMTIP_#CODE_POS_ALT#>TT:COCKPIT.TOOLTIPS.XPDR_ALT_RPTG_OFF</ANIMTIP_#CODE_POS_ALT#>
-            </UseTemplate>
-            <PartID>TRANSPONDER_KNOB</PartID>
-        </Component>
-    </Template>
-
     <!-- Never call this template directly -->
     <Template Name="FBW_AIRLINER_SubNodes_Setter_Template">
         <DefaultTemplateParameters>


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Following up on https://devsupport.flightsimulator.com/idea/14546/prevent-addons-using-default-template-names.html I audited A32NX for any templates with ASOBO prefix (bad!). We don't overwrite any of the Asobo templates in the VFS (good!), but we do have one with a name that clashes with theirs. This shouldn't be a problem for other add-ons unless they try to include our templates from the VFS, but still not great. We actually don't even use it anymore so I've simply removed it.

No functional change => no changelog.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Check that the transponder still works properly.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
