### PR TITLE
fix(hyd): fixed failing tests that are sensitive to empty brake accumulator

### DIFF
--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/mod.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/hydraulic/mod.rs
@@ -7320,6 +7320,24 @@ mod tests {
                 self
             }
 
+            fn load_brake_accumulator(mut self) -> Self {
+                let mut number_of_loops = 0;
+                while self.get_brake_yellow_accumulator_pressure().get::<psi>() <= 2900. {
+                    self = self
+                        .set_yellow_e_pump(false)
+                        .run_waiting_for(Duration::from_secs(2));
+                    number_of_loops += 1;
+                    assert!(number_of_loops < 50);
+                }
+
+                // Let yellow epump spool down
+                self = self
+                    .set_yellow_e_pump(true)
+                    .run_waiting_for(Duration::from_secs(5));
+
+                self
+            }
+
             fn turn_emergency_gear_extension_n_turns(mut self, number_of_turns: u8) -> Self {
                 self.write_by_name("GRAVITYGEAR_ROTATE_PCT", number_of_turns as f64 * 100.);
                 self
@@ -9048,6 +9066,7 @@ mod tests {
             let mut test_bed = test_bed_on_ground_with()
                 .engines_off()
                 .on_the_ground()
+                .load_brake_accumulator()
                 .set_cold_dark_inputs()
                 .run_one_tick();
 
@@ -9964,6 +9983,7 @@ mod tests {
             let mut test_bed = test_bed_on_ground_with()
                 .engines_off()
                 .on_the_ground()
+                .load_brake_accumulator()
                 .set_cold_dark_inputs()
                 .run_waiting_for(Duration::from_secs(5));
 
@@ -10649,6 +10669,7 @@ mod tests {
                 .on_the_ground()
                 .set_cold_dark_inputs()
                 .set_ptu_state(true)
+                .load_brake_accumulator()
                 .set_yellow_e_pump(false)
                 .set_blue_e_pump_ovrd_pressed(true)
                 .run_one_tick();
@@ -10869,6 +10890,7 @@ mod tests {
                 .engines_off()
                 .on_the_ground()
                 .set_cold_dark_inputs()
+                .load_brake_accumulator()
                 .set_yellow_e_pump(false)
                 .run_one_tick();
 
@@ -11106,6 +11128,7 @@ mod tests {
         fn spoilers_move_to_requested_position() {
             let mut test_bed = test_bed_on_ground_with()
                 .set_cold_dark_inputs()
+                .load_brake_accumulator()
                 .set_blue_e_pump_ovrd_pressed(true)
                 .set_yellow_e_pump(false)
                 .run_waiting_for(Duration::from_secs_f64(5.));


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Accumulator is now loaded in tests that would require it fully loaded.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

Unit tests only

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
