### PR TITLE
fix(fwc): Use correct deltaTime for FWC updates

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/EWD/instrument.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EWD/instrument.tsx
@@ -1,4 +1,4 @@
-import { Clock, ClockEvents, EventBus, FSComponent } from 'msfssdk';
+import { Clock, EventBus, FSComponent } from 'msfssdk';
 import { ArincValueProvider } from './shared/ArincValueProvider';
 import { EwdComponent } from './EWD';
 import { EwdSimvarPublisher } from './shared/EwdSimvarPublisher';
@@ -117,9 +117,6 @@ class A32NX_EWD extends BaseInstrument {
         this.simVarPublisher.subscribe('slatsPositionRaw');
 
         FSComponent.render(<EwdComponent bus={this.bus} instrument={this} />, document.getElementById('EWD_CONTENT'));
-
-        const sub = this.bus.getSubscriber<ClockEvents>();
-        sub.on('realTime').handle((deltaTime) => this.pseudoFwc.onUpdate(deltaTime));
     }
 
     public Update(): void {
@@ -134,6 +131,7 @@ class A32NX_EWD extends BaseInstrument {
         } else {
             this.simVarPublisher.onUpdate();
             this.clock.onUpdate();
+            this.pseudoFwc.onUpdate(this.deltaTime);
         }
     }
 }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
When adding the new PseudoFWC to the refactored EWD component, the `realTime` clock event was used as delta time. This event does NOT give delta time, but instead the current unix timestamp, which resulted in massive delta times being given to the PseudoFWC and rendering all timers inaccurate.

This fixes it to use the EWD's actual delta time, as it should have from the beginning.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Eearslya#7831

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
1. Load the aircraft, ensure it has at least 3,000kg of fuel.
2. Power up the aircraft via APU or EXT PWR. Wait for the ECAM displays to be available.
3. Set the aircraft's fuel to 2,700kg.
4. Ensure the `L+R WING TK LO LVL` warning does not appear until approximately 30 seconds have elapsed.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
