### PR TITLE
chore: Change to workflows to split build step into build+uploads

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,14 +61,17 @@ jobs:
         run: |
           ./scripts/dev-env/run.sh ./scripts/setup.sh
           ./scripts/dev-env/run.sh ./scripts/build.sh --no-tty -j 4
+  pr-artifact:
       - name: Generate install.json
         run: |
           ./scripts/dev-env/run.sh node ./scripts/fragment.js
 
           cp ./fbw-a32nx/out/build-modules/modules.json ./fbw-a32nx/out/flybywire-aircraft-a320-neo/install.json
           ./scripts/dev-env/run.sh node ./scripts/install-source.js
+        needs: build
       - name: Upload PR artifact
         uses: actions/upload-artifact@v2
+        needs: build
         with:
           name: A32NX
           path: ./fbw-a32nx/out/flybywire-aircraft-a320-neo/

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
+        with:
+          persist-credentials: true
       - name: Create .env file
         run: |
           echo A32NX_PRODUCTION_BUILD=1 >> .env
@@ -66,6 +68,10 @@ jobs:
     if: github.event.pull_request.draft == false
     needs: build
     steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: true
       - name: Generate install.json
         run: |
           ./scripts/dev-env/run.sh node ./scripts/fragment.js

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,10 +62,12 @@ jobs:
           ./scripts/dev-env/run.sh ./scripts/setup.sh
           ./scripts/dev-env/run.sh ./scripts/build.sh --no-tty -j 4
   pr-artifact:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
       - name: Generate install.json
         run: |
           ./scripts/dev-env/run.sh node ./scripts/fragment.js
-
           cp ./fbw-a32nx/out/build-modules/modules.json ./fbw-a32nx/out/flybywire-aircraft-a320-neo/install.json
           ./scripts/dev-env/run.sh node ./scripts/install-source.js
         needs: build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,16 +64,15 @@ jobs:
   pr-artifact:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    needs: build
     steps:
       - name: Generate install.json
         run: |
           ./scripts/dev-env/run.sh node ./scripts/fragment.js
           cp ./fbw-a32nx/out/build-modules/modules.json ./fbw-a32nx/out/flybywire-aircraft-a320-neo/install.json
           ./scripts/dev-env/run.sh node ./scripts/install-source.js
-        needs: build
       - name: Upload PR artifact
         uses: actions/upload-artifact@v2
-        needs: build
         with:
           name: A32NX
           path: ./fbw-a32nx/out/flybywire-aircraft-a320-neo/

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -197,7 +197,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
                 break;
             }
             case 'error': {
-                console.log(`[MCDU] Websocket connection to SimBridge error. (${SimBridgeClient.McduServerClient.url()}): ${event.get()}`);
+                console.log(`[MCDU] Websocket connection to SimBridge error. (${SimBridgeClient.McduServerClient.url()})`);
                 break;
             }
             case 'message': {


### PR DESCRIPTION
## Summary of Changes
To allow for re-run of uploads (CDN, artifact) the GitHub workflow build step 

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
n/a - GitHub workflows can't really be tested by QA

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
