### PR TITLE
docs: Simple fix of link to resources from Contributing.md

### DIFF
--- a/.github/Contributing.md
+++ b/.github/Contributing.md
@@ -47,7 +47,7 @@ As this is an open source project, anyone is free to contribute as much or as li
 
 If you're comfortable contributing to Open Source projects on GitHub please ensure you read our expectations for issue tracking, feature proposals and pull requests.
 
-If you're looking for tools and tips to help you develop, see [Development Resources](fbw-a32nx/docs/resources.md).
+If you're looking for tools and tips to help you develop, see [Development Resources](../fbw-a32nx/docs/resources.md).
 
 **Please avoid** adding features that are not true to life or features without providing supported documentation.
 

--- a/.github/Contributing.md
+++ b/.github/Contributing.md
@@ -47,7 +47,7 @@ As this is an open source project, anyone is free to contribute as much or as li
 
 If you're comfortable contributing to Open Source projects on GitHub please ensure you read our expectations for issue tracking, feature proposals and pull requests.
 
-If you're looking for tools and tips to help you develop, see [Development Resources](../docs/resources.md).
+If you're looking for tools and tips to help you develop, see [Development Resources](fbw-a32nx/docs/resources.md).
 
 **Please avoid** adding features that are not true to life or features without providing supported documentation.
 


### PR DESCRIPTION
## Summary of Changes
Trivial fix of link in .github/Contributing.md 

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
N/A

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
