### PR TITLE
chore: Added the --no-cache parameter to the build scripts for clean build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,7 @@ fi
 # Loop through the arguments
 for arg in "$@"; do
   if [ "$arg" == "--no-cache" ]; then
-    echo "Cleaning build directories"
+    echo "Removing out directories..."
     rm -rf /external/fbw-a32nx/out
     rm -rf /external/fbw-a380x/out
     rm -rf /external/fbw-ingamepanels-checklist-fix/out

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,9 +13,7 @@ fi
 
 # Loop through the arguments
 for arg in "$@"; do
-  # If the argument is not "-clean", add it to the array
   if [ "$arg" == "--no-cache" ]; then
-    # If the argument is "-clean", remove the build directories
     echo "Cleaning build directories"
     rm -rf /external/fbw-a32nx/out
     rm -rf /external/fbw-a380x/out

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,6 +11,18 @@ if [ "${GITHUB_ACTIONS}" == "true" ]; then
   chown -R root:root /external
 fi
 
+# Loop through the arguments
+for arg in "$@"; do
+  # If the argument is not "-clean", add it to the array
+  if [ "$arg" == "--no-cache" ]; then
+    # If the argument is "-clean", remove the build directories
+    echo "Cleaning build directories"
+    rm -rf /external/fbw-a32nx/out
+    rm -rf /external/fbw-a380x/out
+    rm -rf /external/fbw-ingamepanels-checklist-fix/out
+  fi
+done
+
 # run build
 time npx igniter "$@"
 

--- a/scripts/build_a32nx.sh
+++ b/scripts/build_a32nx.sh
@@ -11,6 +11,16 @@ if [ "${GITHUB_ACTIONS}" == "true" ]; then
   chown -R root:root /external
 fi
 
+# Loop through the arguments
+for arg in "$@"; do
+  # If the argument is not "-clean", add it to the array
+  if [ "$arg" == "--no-cache" ]; then
+    # If the argument is "-clean", remove the build directories
+    echo "Cleaning build directories"
+    rm -rf /external/fbw-a32nx/out
+  fi
+done
+
 # run build
 time npx igniter -r a32nx "$@"
 

--- a/scripts/build_a32nx.sh
+++ b/scripts/build_a32nx.sh
@@ -13,9 +13,7 @@ fi
 
 # Loop through the arguments
 for arg in "$@"; do
-  # If the argument is not "-clean", add it to the array
   if [ "$arg" == "--no-cache" ]; then
-    # If the argument is "-clean", remove the build directories
     echo "Cleaning build directories"
     rm -rf /external/fbw-a32nx/out
   fi

--- a/scripts/build_a32nx.sh
+++ b/scripts/build_a32nx.sh
@@ -14,7 +14,7 @@ fi
 # Loop through the arguments
 for arg in "$@"; do
   if [ "$arg" == "--no-cache" ]; then
-    echo "Cleaning build directories"
+    echo "Removing out directory /external/fbw-a32nx/out"
     rm -rf /external/fbw-a32nx/out
   fi
 done

--- a/scripts/build_a380x.sh
+++ b/scripts/build_a380x.sh
@@ -13,9 +13,7 @@ fi
 
 # Loop through the arguments
 for arg in "$@"; do
-  # If the argument is not "-clean", add it to the array
   if [ "$arg" == "--no-cache" ]; then
-    # If the argument is "-clean", remove the build directories
     echo "Cleaning build directories"
     rm -rf /external/fbw-a380x/out
   fi

--- a/scripts/build_a380x.sh
+++ b/scripts/build_a380x.sh
@@ -14,7 +14,7 @@ fi
 # Loop through the arguments
 for arg in "$@"; do
   if [ "$arg" == "--no-cache" ]; then
-    echo "Cleaning build directories"
+    echo "Removing out directory /external/fbw-a380x/out"
     rm -rf /external/fbw-a380x/out
   fi
 done

--- a/scripts/build_a380x.sh
+++ b/scripts/build_a380x.sh
@@ -11,6 +11,16 @@ if [ "${GITHUB_ACTIONS}" == "true" ]; then
   chown -R root:root /external
 fi
 
+# Loop through the arguments
+for arg in "$@"; do
+  # If the argument is not "-clean", add it to the array
+  if [ "$arg" == "--no-cache" ]; then
+    # If the argument is "-clean", remove the build directories
+    echo "Cleaning build directories"
+    rm -rf /external/fbw-a380x/out
+  fi
+done
+
 # run build
 time npx igniter -r a380x "$@"
 

--- a/scripts/build_ingamepanels_checklist_fix.sh
+++ b/scripts/build_ingamepanels_checklist_fix.sh
@@ -13,9 +13,7 @@ fi
 
 # Loop through the arguments
 for arg in "$@"; do
-  # If the argument is not "-clean", add it to the array
   if [ "$arg" == "--no-cache" ]; then
-    # If the argument is "-clean", remove the build directories
     echo "Cleaning build directories"
     rm -rf /external/fbw-ingamepanels-checklist-fix/out
   fi

--- a/scripts/build_ingamepanels_checklist_fix.sh
+++ b/scripts/build_ingamepanels_checklist_fix.sh
@@ -14,7 +14,7 @@ fi
 # Loop through the arguments
 for arg in "$@"; do
   if [ "$arg" == "--no-cache" ]; then
-    echo "Cleaning build directories"
+    echo "Removing out directory /external/fbw-ingamepanels-checklist-fix/out"
     rm -rf /external/fbw-ingamepanels-checklist-fix/out
   fi
 done

--- a/scripts/build_ingamepanels_checklist_fix.sh
+++ b/scripts/build_ingamepanels_checklist_fix.sh
@@ -11,6 +11,16 @@ if [ "${GITHUB_ACTIONS}" == "true" ]; then
   chown -R root:root /external
 fi
 
+# Loop through the arguments
+for arg in "$@"; do
+  # If the argument is not "-clean", add it to the array
+  if [ "$arg" == "--no-cache" ]; then
+    # If the argument is "-clean", remove the build directories
+    echo "Cleaning build directories"
+    rm -rf /external/fbw-ingamepanels-checklist-fix/out
+  fi
+done
+
 # run build
 time npx igniter -r 'ingamepanels-checklist-fix' "$@"
 


### PR DESCRIPTION
## Summary of Changes
With the copying of base files from src/base to out/ files removed from src/base remain in out/ until manually removed in out/ as well our the complete out/ folder is removed. 

This PR changes the build scripts to also use the --no-cache parameter normally used by Igniter to to remove the out/ folder completely therefore forcing a fresh clean build.

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
QA can't test this
Devs can test is the build script respects the new paramter and that it otherwise works as before. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
