### PR TITLE
chore: Added new arg -clean for build scripts

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,17 +12,23 @@ if [ "${GITHUB_ACTIONS}" == "true" ]; then
 fi
 
 # Loop through the arguments
+args=()
 for arg in "$@"; do
-  if [ "$arg" == "--no-cache" ]; then
+  # If the argument is "-clean", perform some action
+  if [ "$arg" = "-clean" ]; then
     echo "Removing out directories..."
     rm -rf /external/fbw-a32nx/out
+    rm -rf /external/fbw-a32nx/bundles
     rm -rf /external/fbw-a380x/out
     rm -rf /external/fbw-ingamepanels-checklist-fix/out
+  else
+    # Otherwise, add the arg it to the new array
+    args+=("$arg")
   fi
 done
 
-# run build
-time npx igniter "$@"
+# run build with the new arguments
+time npx igniter "${args[@]}"
 
 # restore ownership (when run as github action)
 if [ "${GITHUB_ACTIONS}" == "true" ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,7 @@ fi
 # Loop through the arguments
 for arg in "$@"; do
   if [ "$arg" == "--no-cache" ]; then
-    echo "Cleaning build directories"
+    echo "Removing out directories..."
     rm -rf /external/fbw-a32nx/out
     rm -rf /external/fbw-a380x/out
     rm -rf /external/fbw-ingamepanels-checklist-fix/out

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,9 +13,7 @@ fi
 
 # Loop through the arguments
 for arg in "$@"; do
-  # If the argument is not "-clean", add it to the array
   if [ "$arg" == "--no-cache" ]; then
-    # If the argument is "-clean", remove the build directories
     echo "Cleaning build directories"
     rm -rf /external/fbw-a32nx/out
     rm -rf /external/fbw-a380x/out

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,8 +13,10 @@ fi
 
 # Loop through the arguments
 for arg in "$@"; do
+  # If the argument is not "-clean", add it to the array
   if [ "$arg" == "--no-cache" ]; then
-    echo "Removing out directories..."
+    # If the argument is "-clean", remove the build directories
+    echo "Cleaning build directories"
     rm -rf /external/fbw-a32nx/out
     rm -rf /external/fbw-a380x/out
     rm -rf /external/fbw-ingamepanels-checklist-fix/out

--- a/scripts/build_a32nx.sh
+++ b/scripts/build_a32nx.sh
@@ -12,15 +12,21 @@ if [ "${GITHUB_ACTIONS}" == "true" ]; then
 fi
 
 # Loop through the arguments
+args=()
 for arg in "$@"; do
-  if [ "$arg" == "--no-cache" ]; then
-    echo "Removing out directory /external/fbw-a32nx/out"
+  # If the argument is "-clean", perform some action
+  if [ "$arg" = "-clean" ]; then
+    echo "Removing out directories..."
     rm -rf /external/fbw-a32nx/out
+    rm -rf /external/fbw-a32nx/bundles
+  else
+    # Otherwise, add the arg it to the new array
+    args+=("$arg")
   fi
 done
 
 # run build
-time npx igniter -r a32nx "$@"
+time npx igniter -r a32nx "${args[@]}"
 
 # restore ownership (when run as github action)
 if [ "${GITHUB_ACTIONS}" == "true" ]; then

--- a/scripts/build_a32nx.sh
+++ b/scripts/build_a32nx.sh
@@ -13,9 +13,7 @@ fi
 
 # Loop through the arguments
 for arg in "$@"; do
-  # If the argument is not "-clean", add it to the array
   if [ "$arg" == "--no-cache" ]; then
-    # If the argument is "-clean", remove the build directories
     echo "Cleaning build directories"
     rm -rf /external/fbw-a32nx/out
   fi

--- a/scripts/build_a32nx.sh
+++ b/scripts/build_a32nx.sh
@@ -13,8 +13,10 @@ fi
 
 # Loop through the arguments
 for arg in "$@"; do
+  # If the argument is not "-clean", add it to the array
   if [ "$arg" == "--no-cache" ]; then
-    echo "Removing out directory /external/fbw-a32nx/out"
+    # If the argument is "-clean", remove the build directories
+    echo "Cleaning build directories"
     rm -rf /external/fbw-a32nx/out
   fi
 done

--- a/scripts/build_a32nx.sh
+++ b/scripts/build_a32nx.sh
@@ -14,7 +14,7 @@ fi
 # Loop through the arguments
 for arg in "$@"; do
   if [ "$arg" == "--no-cache" ]; then
-    echo "Cleaning build directories"
+    echo "Removing out directory /external/fbw-a32nx/out"
     rm -rf /external/fbw-a32nx/out
   fi
 done

--- a/scripts/build_a380x.sh
+++ b/scripts/build_a380x.sh
@@ -12,15 +12,20 @@ if [ "${GITHUB_ACTIONS}" == "true" ]; then
 fi
 
 # Loop through the arguments
+args=()
 for arg in "$@"; do
-  if [ "$arg" == "--no-cache" ]; then
-    echo "Removing out directory /external/fbw-a380x/out"
+  # If the argument is "-clean", perform some action
+  if [ "$arg" = "-clean" ]; then
+    echo "Removing out directories..."
     rm -rf /external/fbw-a380x/out
+  else
+    # Otherwise, add the arg it to the new array
+    args+=("$arg")
   fi
 done
 
 # run build
-time npx igniter -r a380x "$@"
+time npx igniter -r a380x "${args[@]}"
 
 # restore ownership (when run as github action)
 if [ "${GITHUB_ACTIONS}" == "true" ]; then

--- a/scripts/build_a380x.sh
+++ b/scripts/build_a380x.sh
@@ -13,9 +13,7 @@ fi
 
 # Loop through the arguments
 for arg in "$@"; do
-  # If the argument is not "-clean", add it to the array
   if [ "$arg" == "--no-cache" ]; then
-    # If the argument is "-clean", remove the build directories
     echo "Cleaning build directories"
     rm -rf /external/fbw-a380x/out
   fi

--- a/scripts/build_a380x.sh
+++ b/scripts/build_a380x.sh
@@ -13,8 +13,10 @@ fi
 
 # Loop through the arguments
 for arg in "$@"; do
+  # If the argument is not "-clean", add it to the array
   if [ "$arg" == "--no-cache" ]; then
-    echo "Removing out directory /external/fbw-a380x/out"
+    # If the argument is "-clean", remove the build directories
+    echo "Cleaning build directories"
     rm -rf /external/fbw-a380x/out
   fi
 done

--- a/scripts/build_a380x.sh
+++ b/scripts/build_a380x.sh
@@ -14,7 +14,7 @@ fi
 # Loop through the arguments
 for arg in "$@"; do
   if [ "$arg" == "--no-cache" ]; then
-    echo "Cleaning build directories"
+    echo "Removing out directory /external/fbw-a380x/out"
     rm -rf /external/fbw-a380x/out
   fi
 done

--- a/scripts/build_ingamepanels_checklist_fix.sh
+++ b/scripts/build_ingamepanels_checklist_fix.sh
@@ -12,15 +12,20 @@ if [ "${GITHUB_ACTIONS}" == "true" ]; then
 fi
 
 # Loop through the arguments
+args=()
 for arg in "$@"; do
-  if [ "$arg" == "--no-cache" ]; then
-    echo "Removing out directory /external/fbw-ingamepanels-checklist-fix/out"
+  # If the argument is "-clean", perform some action
+  if [ "$arg" = "-clean" ]; then
+    echo "Removing out directories..."
     rm -rf /external/fbw-ingamepanels-checklist-fix/out
+  else
+    # Otherwise, add the arg it to the new array
+    args+=("$arg")
   fi
 done
 
 # run build
-time npx igniter -r 'ingamepanels-checklist-fix' "$@"
+time npx igniter -r 'ingamepanels-checklist-fix' "${args[@]}"
 
 # restore ownership (when run as github action)
 if [ "${GITHUB_ACTIONS}" == "true" ]; then

--- a/scripts/build_ingamepanels_checklist_fix.sh
+++ b/scripts/build_ingamepanels_checklist_fix.sh
@@ -13,8 +13,10 @@ fi
 
 # Loop through the arguments
 for arg in "$@"; do
+  # If the argument is not "-clean", add it to the array
   if [ "$arg" == "--no-cache" ]; then
-    echo "Removing out directory /external/fbw-ingamepanels-checklist-fix/out"
+    # If the argument is "-clean", remove the build directories
+    echo "Cleaning build directories"
     rm -rf /external/fbw-ingamepanels-checklist-fix/out
   fi
 done

--- a/scripts/build_ingamepanels_checklist_fix.sh
+++ b/scripts/build_ingamepanels_checklist_fix.sh
@@ -13,9 +13,7 @@ fi
 
 # Loop through the arguments
 for arg in "$@"; do
-  # If the argument is not "-clean", add it to the array
   if [ "$arg" == "--no-cache" ]; then
-    # If the argument is "-clean", remove the build directories
     echo "Cleaning build directories"
     rm -rf /external/fbw-ingamepanels-checklist-fix/out
   fi

--- a/scripts/build_ingamepanels_checklist_fix.sh
+++ b/scripts/build_ingamepanels_checklist_fix.sh
@@ -14,7 +14,7 @@ fi
 # Loop through the arguments
 for arg in "$@"; do
   if [ "$arg" == "--no-cache" ]; then
-    echo "Cleaning build directories"
+    echo "Removing out directory /external/fbw-ingamepanels-checklist-fix/out"
     rm -rf /external/fbw-ingamepanels-checklist-fix/out
   fi
 done


### PR DESCRIPTION
## Summary of Changes
The recent PR for adding a clean option to build scripts had the flaw that --no-cache could not be used any more while the sim was running (due to locked sound files which couldn't be removed).

This PR adds a separate arg `-clean` for removing the out/ folders. 

It also removes the /fbw-a32nx/bundles folder which was introduced by the Mach build introduction. 

All convenience build scripts got updated:
build.sh
build_a32nx.sh
build_a380x.sh
build_ingamepanels_checklist_fix.sh

It is still possible to use all args as before:
E.g:
`.\scripts\dev-env\run.cmd ./scripts/build.sh -r a32nx --no-cache`
`.\scripts\dev-env\run.cmd ./scripts/build.sh -r a380x -clean`
...


Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Devs: Try to use the build scripts as before with sim off or on. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
