### PR TITLE
chore: New dev-env including previously missing header file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "msfs"
 version = "0.1.0"
-source = "git+https://github.com/flybywiresim/msfs-rs?branch=main#f5ebb3d75f5a64fcd4e542129584ca0ee1ef0ebe"
+source = "git+https://github.com/flybywiresim/msfs-rs?branch=main#53ba9a5539d11401eb6c43d3c69f24311a9f321d"
 dependencies = [
  "bindgen",
  "cc",
@@ -512,10 +512,9 @@ dependencies = [
 
 [[package]]
 name = "msfs_derive"
-version = "0.1.0"
-source = "git+https://github.com/flybywiresim/msfs-rs?branch=main#f5ebb3d75f5a64fcd4e542129584ca0ee1ef0ebe"
+version = "0.2.0"
+source = "git+https://github.com/flybywiresim/msfs-rs?branch=main#53ba9a5539d11401eb6c43d3c69f24311a9f321d"
 dependencies = [
- "msfs_sdk",
  "quote",
  "syn",
 ]
@@ -523,7 +522,7 @@ dependencies = [
 [[package]]
 name = "msfs_sdk"
 version = "0.1.0"
-source = "git+https://github.com/flybywiresim/msfs-rs?branch=main#f5ebb3d75f5a64fcd4e542129584ca0ee1ef0ebe"
+source = "git+https://github.com/flybywiresim/msfs-rs?branch=main#53ba9a5539d11401eb6c43d3c69f24311a9f321d"
 
 [[package]]
 name = "nalgebra"

--- a/scripts/dev-env/run.cmd
+++ b/scripts/dev-env/run.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set image="ghcr.io/flybywiresim/dev-env@sha256:05a7914c72ff38fd712c2c9dfe58d5bc08caf6dbe15c008f684bb3e966591a0e"
+set image="ghcr.io/flybywiresim/dev-env@sha256:2f49994adc8ff96ed5917dee69d4ea4ab956737fc6249272c63593e6aa0e259e"
 
 docker image inspect %image% 1> nul || docker system prune --filter label=flybywiresim=true -f
 docker run --rm -it -v "%cd%:/external" %image% %*

--- a/scripts/dev-env/run.sh
+++ b/scripts/dev-env/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE="ghcr.io/flybywiresim/dev-env@sha256:05a7914c72ff38fd712c2c9dfe58d5bc08caf6dbe15c008f684bb3e966591a0e"
+IMAGE="ghcr.io/flybywiresim/dev-env@sha256:2f49994adc8ff96ed5917dee69d4ea4ab956737fc6249272c63593e6aa0e259e"
 
 # only set `-it` if there is a tty
 if [ -t 0 ] && [ -t 1 ];


### PR DESCRIPTION
## Summary of Changes
Added previously missing MSFS_Network.h header file.

Update to cmake version (not in use currently).

No other updates to versions as updating rust, wasi, binaryen were not working and require additional time to investigate.
Also SU12 it is expected to have a new SDK version which might require a new dev-env anyway. 

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Dev only - build and aircraft should work as before. No issues expected. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
