### PR TITLE
fix: mitigate flyPad fuel page issue for very long translations

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/FuelPage.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EFB/Ground/Pages/FuelPage.tsx
@@ -99,12 +99,7 @@ export const FuelPage = () => {
     const { planRamp } = useAppSelector((state) => state.simbrief.data.fuels);
     const simbriefDataLoaded = isSimbriefDataLoaded();
 
-    const isAirplaneCnD = () => {
-        if (simGroundSpeed > 0.1 || eng1Running || eng2Running || !isOnGround || (!busDC2 && !busDCHot1)) {
-            return false;
-        }
-        return true;
-    };
+    const isAirplaneCnD = () => !(simGroundSpeed > 0.1 || eng1Running || eng2Running || !isOnGround || (!busDC2 && !busDCHot1));
 
     const airplaneCanRefuel = () => {
         if (refuelRate !== '2') {
@@ -119,11 +114,7 @@ export const FuelPage = () => {
             }
 
             // In-flight refueling with GSX Sync enabled
-            if (!isAirplaneCnD() && refuelRate === '2') {
-                return true;
-            }
-
-            return false;
+            return !isAirplaneCnD() && refuelRate === '2';
         }
         return true;
     };
@@ -315,7 +306,7 @@ export const FuelPage = () => {
                     />
                 </div>
                 <div className="flex absolute inset-x-0 top-40 flex-row justify-between">
-                    <div className="overflow-hidden w-min rounded-2xl border-2 divide-y border-theme-accent divide-theme-accent">
+                    <div className="overflow-hidden w-min rounded-2xl border-2 border-theme-accent divide-y divide-theme-accent">
                         <TankReadoutWidget
                             title={t('Ground.Fuel.LeftInnerTank')}
                             current={LInnCurrent}
@@ -335,7 +326,7 @@ export const FuelPage = () => {
                             convertedFuelValue={convertFuelValueCenter(LOutCurrent)}
                         />
                     </div>
-                    <div className="overflow-hidden w-min rounded-2xl border-2 divide-y border-theme-accent divide-theme-accent">
+                    <div className="overflow-hidden w-min rounded-2xl border-2 border-theme-accent divide-y divide-theme-accent">
                         <TankReadoutWidget
                             title={t('Ground.Fuel.RightInnerTank')}
                             current={RInnCurrent}
@@ -384,27 +375,27 @@ export const FuelPage = () => {
                     />
                     {/* tl overlay */}
                     <div
-                        className="absolute z-10 bottom-overlay-t-y left-overlay-tl bg-theme-body -rotate-26.5"
+                        className="absolute bottom-overlay-t-y left-overlay-tl z-10 bg-theme-body -rotate-26.5"
                         style={{ transform: 'rotate(-26.5deg)', width: '490px', height: '140px', bottom: '240px', left: '82px' }}
                     />
                     {/* tr overlay */}
                     <div
-                        className="absolute z-10 right-overlay-tr bottom-overlay-t-y bg-theme-body rotate-26.5"
+                        className="absolute right-overlay-tr bottom-overlay-t-y z-10 bg-theme-body rotate-26.5"
                         style={{ transform: 'rotate(26.5deg)', width: '490px', height: '140px', bottom: '240px', right: '82px' }}
                     />
                     {/* bl overlay */}
                     <div
-                        className="absolute z-10 bottom-overlay-b-y left-overlay-bl bg-theme-body -rotate-18.5"
+                        className="absolute bottom-overlay-b-y left-overlay-bl z-10 bg-theme-body -rotate-18.5"
                         style={{ transform: 'rotate(-18.5deg)', width: '484px', height: '101px', bottom: '78px', left: '144px' }}
                     />
                     {/* br overlay */}
                     <div
-                        className="absolute z-10 right-overlay-br bottom-overlay-b-y bg-theme-body rotate-18.5"
+                        className="absolute right-overlay-br bottom-overlay-b-y z-10 bg-theme-body rotate-18.5"
                         style={{ transform: 'rotate(18.5deg)', width: '484px', height: '101px', bottom: '78px', right: '144px' }}
                     />
                 </div>
 
-                <div className="flex overflow-hidden absolute bottom-0 left-0 flex-row rounded-2xl border border-theme-accent ">
+                <div className="flex overflow-hidden absolute bottom-0 left-0 flex-row max-w-3xl rounded-2xl border border-theme-accentborder-2">
                     <div className="py-3 px-5 space-y-4">
                         <div className="flex flex-row justify-between items-center">
                             <div className="flex flex-row items-center space-x-3">
@@ -435,7 +426,7 @@ export const FuelPage = () => {
                                 {simbriefDataLoaded && (
                                     <TooltipWrapper text={t('Ground.Fuel.TT.FillBlockFuelFromSimBrief')}>
                                         <div
-                                            className="flex justify-center items-center px-2 h-auto rounded-md rounded-l-none border-2 transition duration-100 text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body border-theme-highlight"
+                                            className="flex justify-center items-center px-2 h-auto text-theme-body hover:text-theme-highlight bg-theme-highlight hover:bg-theme-body rounded-md rounded-l-none border-2 border-theme-highlight transition duration-100"
                                             onClick={simbriefDataLoaded ? handleFuelAutoFill : undefined}
                                         >
                                             <CloudArrowDown size={26} />
@@ -457,7 +448,7 @@ export const FuelPage = () => {
                     </div>
                 </div>
 
-                <div className="flex overflow-x-hidden absolute right-6 bottom-0 z-30 flex-col justify-center items-center py-3 px-6 space-y-2 rounded-2xl border border-theme-accent">
+                <div className="flex overflow-x-hidden absolute right-6 bottom-0 flex-col justify-center items-center py-3 px-6 space-y-2 rounded-2xl border border-theme-accent">
                     <h2 className="flex font-medium">{t('Ground.Fuel.RefuelTime')}</h2>
 
                     <SelectGroup>


### PR DESCRIPTION
## Summary of Changes
Very long translations cause issues on the flyPad's fuel page. See screenshots.

This PR adds a max width to at least make the buttons clickable. 
This is a mitigation and not a full fix. The only real fix is to shorten the translations or do a major change to the layout. 

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/16833201/224481144-bbdbf16e-ce42-4d75-998a-1d4a83407ef0.png)
![image](https://user-images.githubusercontent.com/16833201/224481150-3d4ddd17-cab3-44b4-94a4-234767c581e6.png)
![image](https://user-images.githubusercontent.com/16833201/224481157-8bfa9ca4-09a8-4dbe-a24d-eb321b27a8c0.png)

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Check Russian and other languages and make sure the page is still ok and buttons clickable. 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
