### PR TITLE
fix: increase timeout for simbridge healthcheck

### DIFF
--- a/fbw-a32nx/src/systems/simbridge-client/src/common.ts
+++ b/fbw-a32nx/src/systems/simbridge-client/src/common.ts
@@ -2,7 +2,7 @@ import { NXDataStore } from '@shared/persistence';
 
 export const getSimBridgeUrl = (): string => `http://${NXDataStore.get('CONFIG_SIMBRIDGE_IP', 'localhost')}:${NXDataStore.get('CONFIG_SIMBRIDGE_PORT', '8380')}`;
 
-export const fetchWithTimeout = (resource: RequestInfo, options?: object, timeout: number = 200): Promise<Response> => new Promise((resolve, reject) => {
+export const fetchWithTimeout = (resource: RequestInfo, options?: object, timeout: number = 2000): Promise<Response> => new Promise((resolve, reject) => {
     // AbortController not available in Coherent -_-
     const timer = setTimeout(() => {
         reject(new Error(`Timeout after ${timeout} ms!`));

--- a/fbw-a32nx/src/systems/simbridge-client/src/components/Health.ts
+++ b/fbw-a32nx/src/systems/simbridge-client/src/components/Health.ts
@@ -13,7 +13,7 @@ export class Health {
      * @returns true if service is available, false otherwise
      */
     public static async getHealth(serviceName?: 'api'|'mcdu'): Promise<boolean> {
-        const response = await fetchWithTimeout(`${getSimBridgeUrl()}/health`);
+        const response = await fetchWithTimeout(`${getSimBridgeUrl()}/health`, undefined, 5000);
         if (!response.ok) {
             throw new Error(`SimBridge Error: ${response.status}`);
         }


### PR DESCRIPTION
When the sim stutters the 200ms timeout can be too short and the healthcheck will report false. That will trigger a reconnect with the simbridge and the recurrent popups that have been reported.

A timeout of 5 seconds should mitigate this issue.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
