### PR TITLE
fix(press): cabin pressure when starting in the air

### DIFF
--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/air_conditioning.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/air_conditioning.rs
@@ -1540,6 +1540,30 @@ mod tests {
         }
 
         #[test]
+        fn pressure_initialization_works() {
+            let test_bed = test_bed()
+                .ambient_pressure_of(InternationalStandardAtmosphere::pressure_at_altitude(
+                    Length::new::<foot>(39000.),
+                ))
+                .ambient_temperature_of(ThermodynamicTemperature::new::<degree_celsius>(-50.))
+                .iterate(2);
+
+            assert!(
+                (test_bed.cabin_altitude() - Length::new::<foot>(7800.)).abs()
+                    < Length::new::<foot>(50.)
+            );
+            assert!(
+                (test_bed.cabin_pressure()
+                    - InternationalStandardAtmosphere::pressure_at_altitude(Length::new::<foot>(
+                        7800.
+                    )))
+                .get::<hectopascal>()
+                .abs()
+                    < 20.
+            );
+        }
+
+        #[test]
         fn positive_cabin_vs_reduces_cabin_pressure() {
             let test_bed = test_bed()
                 .run_and()
@@ -1777,7 +1801,7 @@ mod tests {
 
         #[test]
         fn outflow_valve_stays_open_on_ground() {
-            let mut test_bed = test_bed().set_on_ground();
+            let mut test_bed = test_bed().set_on_ground().iterate(10);
 
             assert_eq!(
                 test_bed.outflow_valve_open_amount(),

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/air_conditioning.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/air_conditioning.rs
@@ -1537,6 +1537,30 @@ mod tests {
         }
 
         #[test]
+        fn pressure_initialization_works() {
+            let test_bed = test_bed()
+                .ambient_pressure_of(InternationalStandardAtmosphere::pressure_at_altitude(
+                    Length::new::<foot>(39000.),
+                ))
+                .ambient_temperature_of(ThermodynamicTemperature::new::<degree_celsius>(-50.))
+                .iterate(2);
+
+            assert!(
+                (test_bed.cabin_altitude() - Length::new::<foot>(7800.)).abs()
+                    < Length::new::<foot>(50.)
+            );
+            assert!(
+                (test_bed.cabin_pressure()
+                    - InternationalStandardAtmosphere::pressure_at_altitude(Length::new::<foot>(
+                        7800.
+                    )))
+                .get::<hectopascal>()
+                .abs()
+                    < 20.
+            );
+        }
+
+        #[test]
         fn positive_cabin_vs_reduces_cabin_pressure() {
             let test_bed = test_bed()
                 .run_and()
@@ -1774,7 +1798,7 @@ mod tests {
 
         #[test]
         fn outflow_valve_stays_open_on_ground() {
-            let mut test_bed = test_bed().set_on_ground();
+            let mut test_bed = test_bed().set_on_ground().iterate(10);
 
             assert_eq!(
                 test_bed.outflow_valve_open_amount(),

--- a/fbw-common/src/wasm/systems/systems/src/air_conditioning/cabin_air.rs
+++ b/fbw-common/src/wasm/systems/systems/src/air_conditioning/cabin_air.rs
@@ -83,6 +83,9 @@ impl<C: PressurizationConstants, const ZONES: usize> CabinAirSimulation<C, ZONES
             let initial_cabin_pressure =
                 self.initialize_cabin_pressure(context, lgciu_gear_compressed);
             self.internal_air.set_pressure(initial_cabin_pressure);
+            let initial_cabin_temperature =
+                self.initialize_cabin_temperature(context, lgciu_gear_compressed);
+            self.internal_air.set_temperature(initial_cabin_temperature);
             self.is_initialised = true;
         }
         self.filtered_flow_in =
@@ -153,6 +156,26 @@ impl<C: PressurizationConstants, const ZONES: usize> CabinAirSimulation<C, ZONES
             Pressure::new::<hectopascal>(
                 -0.0002 * ambient_pressure.powf(2.) + 0.5463 * ambient_pressure + 658.85,
             )
+        }
+    }
+
+    fn initialize_cabin_temperature(
+        &mut self,
+        context: &UpdateContext,
+        lgciu_gear_compressed: bool,
+    ) -> ThermodynamicTemperature {
+        if lgciu_gear_compressed {
+            // If the aircraft is on the ground the cabin starts at the same temperature as ambient
+            self.cabin_zones
+                .iter_mut()
+                .for_each(|zone| zone.set_zone_air_temperature(context.ambient_temperature()));
+            context.ambient_temperature()
+        } else {
+            // If the aircraft is flying we assume the temperature has been stabilized at 24 degrees
+            self.cabin_zones.iter_mut().for_each(|zone| {
+                zone.set_zone_air_temperature(ThermodynamicTemperature::new::<degree_celsius>(24.))
+            });
+            ThermodynamicTemperature::new::<degree_celsius>(24.)
         }
     }
 
@@ -372,6 +395,10 @@ impl<C: PressurizationConstants> CabinZone<C> {
         self.zone_id
     }
 
+    fn set_zone_air_temperature(&mut self, temperature: ThermodynamicTemperature) {
+        self.zone_air.set_zone_air_temperature(temperature);
+    }
+
     pub fn zone_air_temperature(&self) -> ThermodynamicTemperature {
         self.zone_air.zone_air_temperature()
     }
@@ -392,7 +419,6 @@ impl<C: PressurizationConstants> SimulationElement for CabinZone<C> {
 struct ZoneAir {
     flow_out: Air,
     internal_air: Air,
-    is_initialised: bool,
 }
 
 impl ZoneAir {
@@ -413,7 +439,6 @@ impl ZoneAir {
         Self {
             flow_out: Air::new(),
             internal_air: Air::new(),
-            is_initialised: false,
         }
     }
 
@@ -426,12 +451,6 @@ impl ZoneAir {
         number_of_open_doors: u8,
         cabin_pressure: Pressure,
     ) {
-        if !self.is_initialised {
-            self.internal_air
-                .set_temperature(context.ambient_temperature());
-            self.flow_out.set_temperature(context.ambient_temperature());
-            self.is_initialised = true;
-        }
         self.internal_air.set_pressure(cabin_pressure);
 
         let new_equilibrium_temperature = self.equilibrium_temperature_calculation(
@@ -596,6 +615,10 @@ impl ZoneAir {
         }
     }
 
+    fn set_zone_air_temperature(&mut self, temperature: ThermodynamicTemperature) {
+        self.internal_air.set_temperature(temperature);
+    }
+
     fn zone_air_temperature(&self) -> ThermodynamicTemperature {
         self.internal_air.temperature()
     }
@@ -628,13 +651,18 @@ mod cabin_air_tests {
     use super::*;
     use crate::{
         air_conditioning::PackFlow,
+        shared::InternationalStandardAtmosphere,
         simulation::{
             test::{SimulationTestBed, TestBed, WriteByName},
             Aircraft, SimulationElement, SimulationElementVisitor, UpdateContext,
         },
     };
     use std::time::Duration;
-    use uom::si::{pressure::psi, thermodynamic_temperature::degree_celsius};
+    use uom::si::{
+        length::foot,
+        pressure::{hectopascal, psi},
+        thermodynamic_temperature::degree_celsius,
+    };
 
     struct TestAirConditioningSystem {
         duct_demand_temperature: ThermodynamicTemperature,
@@ -718,6 +746,7 @@ mod cabin_air_tests {
 
         number_of_passengers: u8,
         cabin_air_simulation: CabinAirSimulation<TestConstants, 2>,
+        lgciu_gears_compressed: bool,
     }
 
     impl TestAircraft {
@@ -730,6 +759,7 @@ mod cabin_air_tests {
                     context,
                     &[ZoneType::Cockpit, ZoneType::Cabin(1)],
                 ),
+                lgciu_gears_compressed: true,
             }
         }
 
@@ -745,6 +775,10 @@ mod cabin_air_tests {
         fn set_passengers(&mut self, passengers: u8) {
             self.number_of_passengers = passengers;
         }
+
+        fn set_in_the_air(&mut self, in_the_air: bool) {
+            self.lgciu_gears_compressed = !in_the_air;
+        }
     }
     impl Aircraft for TestAircraft {
         fn update_after_power_distribution(&mut self, context: &UpdateContext) {
@@ -753,7 +787,7 @@ mod cabin_air_tests {
                 &self.air_conditioning_system,
                 Ratio::default(),
                 Ratio::default(),
-                true,
+                self.lgciu_gears_compressed,
                 [2, self.number_of_passengers],
                 0u8,
             );
@@ -828,6 +862,20 @@ mod cabin_air_tests {
             self
         }
 
+        fn ambient_pressure_of(mut self, pressure: Pressure) -> Self {
+            self.set_ambient_pressure(pressure);
+            self
+        }
+
+        fn flying(mut self, is_flying: bool) -> Self {
+            self.command(|a| a.set_in_the_air(is_flying));
+            self
+        }
+
+        fn cabin_pressure(&self) -> Pressure {
+            self.query(|a| a.cabin_air_simulation.cabin_pressure())
+        }
+
         fn cabin_temperature(&self) -> ThermodynamicTemperature {
             self.query(|a| a.cabin_air_simulation.cabin_temperature()[1])
         }
@@ -882,6 +930,27 @@ mod cabin_air_tests {
             .iterate(1);
 
         assert!((test_bed.cabin_temperature().get::<degree_celsius>() - 10.) < 1.);
+    }
+
+    #[test]
+    fn cabin_pressure_initialises_correctly() {
+        let test_bed = test_bed_with()
+            .ambient_temperature_of(ThermodynamicTemperature::new::<degree_celsius>(-50.))
+            .ambient_pressure_of(InternationalStandardAtmosphere::pressure_at_altitude(
+                Length::new::<foot>(39000.),
+            ))
+            .flying(true)
+            .iterate(1);
+
+        assert!(
+            (test_bed.cabin_pressure()
+                - InternationalStandardAtmosphere::pressure_at_altitude(Length::new::<foot>(
+                    8000.
+                )))
+            .get::<hectopascal>()
+            .abs()
+                < 50.
+        );
     }
 
     #[test]

--- a/fbw-common/src/wasm/systems/systems/src/air_conditioning/cabin_pressure_controller.rs
+++ b/fbw-common/src/wasm/systems/systems/src/air_conditioning/cabin_pressure_controller.rs
@@ -58,6 +58,7 @@ pub struct CabinPressureController<C: PressurizationConstants> {
     man_mode_duration: Duration,
     manual_to_auto_switch: bool,
 
+    is_initialised: bool,
     constants: PhantomData<C>,
 }
 
@@ -122,6 +123,7 @@ impl<C: PressurizationConstants> CabinPressureController<C> {
             man_mode_duration: Duration::from_secs(0),
             manual_to_auto_switch: false,
 
+            is_initialised: false,
             constants: PhantomData,
         }
     }
@@ -203,19 +205,28 @@ impl<C: PressurizationConstants> CabinPressureController<C> {
         adirs: &impl AdirsToAirCondInterface,
     ) {
         let (_, adirs_ambient_pressure) = self.adirs_values_calculation(adirs);
+        let new_exterior_altitude: Length;
 
-        self.exterior_pressure.update(
-            context.delta(),
-            adirs_ambient_pressure.unwrap_or_else(|| Pressure::new::<hectopascal>(Self::P_0)),
-        );
+        if !self.is_initialised {
+            self.exterior_pressure.reset(
+                adirs_ambient_pressure.unwrap_or_else(|| Pressure::new::<hectopascal>(Self::P_0)),
+            );
+            new_exterior_altitude =
+                self.calculate_altitude(self.exterior_pressure.output(), self.reference_pressure);
+            self.is_initialised = true;
+        } else {
+            self.exterior_pressure.update(
+                context.delta(),
+                adirs_ambient_pressure.unwrap_or_else(|| Pressure::new::<hectopascal>(Self::P_0)),
+            );
 
-        let new_exterior_altitude =
-            self.calculate_altitude(self.exterior_pressure.output(), self.reference_pressure);
-
-        self.exterior_vertical_speed.update(
-            context.delta(),
-            self.calculate_exterior_vertical_speed(context, new_exterior_altitude),
-        );
+            new_exterior_altitude =
+                self.calculate_altitude(self.exterior_pressure.output(), self.reference_pressure);
+            self.exterior_vertical_speed.update(
+                context.delta(),
+                self.calculate_exterior_vertical_speed(context, new_exterior_altitude),
+            );
+        }
 
         self.exterior_flight_altitude = new_exterior_altitude;
     }

--- a/fbw-common/src/wasm/systems/systems/src/air_conditioning/pressure_valve.rs
+++ b/fbw-common/src/wasm/systems/systems/src/air_conditioning/pressure_valve.rs
@@ -32,7 +32,7 @@ impl OutflowValve {
         Self {
             auto_motor: OutflowValveMotor::new(Self::AUTO_TRAVEL_TIME, auto_motor_powered_by),
             manual_motor: OutflowValveMotor::new(Self::MANUAL_TRAVEL_TIME, manual_motor_powered_by),
-            valve: PressureValve::new_open(),
+            valve: PressureValve::new_closed(),
         }
     }
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR fixes an issue introduced in #7804 where spawning in the air was triggering a CAB PRESS EXCESS CAB ALT warning. Three fixes were needed:
- Initialization of cabin temperature: ambient when starting on ground, 24degC when starting in the air.
- Outflow valve starting state: was open, now closed. Note that when starting on the ground the OFV will take a couple of seconds to fully open now as soon as batteries are started.
- ADIRS data capture initialization in the CPCs.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![image](https://user-images.githubusercontent.com/60938089/226145706-558b433c-19eb-42fb-aca8-975f04f4d831.png)


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Commander Ga#1548

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Spawn in the air and ensure the cabin pressure is initialized at a _reasonable_ altitude (see below for guidance):

**Aircraft Alt -> Cabin Alt (ft)**

39000 -> 8000
30000 -> 6000
20000 -> 4000
5000 -> 1000

Spawn C&D and on the runway and ensure the OFV opens as soon as you load the sim or turn on the batteries (of course without power you won't be able to see the ECAM page - if the OFV is open when the ECAM turns on, then it worked - or you can have a look at the simvar).

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
