### PR TITLE
fix(mcdu): EFOB and FUEL PRED get dashed out at decent

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -60,6 +60,8 @@
 1. [ADIRU] Add baro correction setting to ADIRS - @mjuhe (Miquel Juhe)
 1. [FMGC] Fixed various bugs with thrust reduction and acceleration altitude - @tracernz (Mike)
 1. [FMGC] Change PERF GO AROUND page layout to H3 - @tracernz (Mike)
+1. [MCDU] Fix negative EFOB on FLIGHT PLAN page - @Revyn112 (Revyn112#1010)
+1. [MCDU] Fix EFOB and FUEL PRED get dashed out at TOD - @Revyn112 (Revyn112#1010)
 
 ## 0.9.0
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -683,7 +683,7 @@ class CDUFlightPlanPage {
             let destTimeCell = "----";
             let destDistCell = "---";
             let destEFOBCell = "---";
-            
+
             if (fpm.getDestination()) {
                 if (CDUInitPage.fuelPredConditionsMet(mcdu) && mcdu._fuelPredDone) {
                     mcdu.tryUpdateRouteTrip(isFlying);

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -683,8 +683,12 @@ class CDUFlightPlanPage {
             let destTimeCell = "----";
             let destDistCell = "---";
             let destEFOBCell = "---";
-
+            
             if (fpm.getDestination()) {
+                if (CDUInitPage.fuelPredConditionsMet(mcdu) && mcdu._fuelPredDone) {
+                    mcdu.tryUpdateRouteTrip(isFlying);
+                }
+
                 const destStats = stats.get(fpm.getCurrentFlightPlan().waypoints.length - 1);
                 if (destStats) {
                     destDistCell = destStats.distanceFromPpos.toFixed(0);
@@ -695,11 +699,6 @@ class CDUFlightPlanPage {
                         destTimeCell = FMCMainDisplay.secondsTohhmm(destStats.timeFromPpos);
                     }
                 }
-            }
-            if (CDUInitPage.fuelPredConditionsMet(mcdu) && mcdu._fuelPredDone) {
-                mcdu.tryUpdateRouteTrip(isFlying);
-            } else {
-                destEFOBCell = "---";
             }
 
             destText[0] = ["\xa0DEST", "DIST EFOB", isFlying ? "\xa0UTC{sp}{sp}{sp}{sp}" : "TIME{sp}{sp}{sp}{sp}"];

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -332,7 +332,6 @@ class CDUInitPage {
         return isFinite(mcdu.blockFuel) &&
             isFinite(mcdu.zeroFuelWeightMassCenter) &&
             isFinite(mcdu.zeroFuelWeight) &&
-            mcdu.cruiseFlightLevel &&
             mcdu.flightPlanManager.getWaypointsCount() > 0 &&
             mcdu._zeroFuelWeightZFWCGEntered &&
             mcdu._blockFuelEntered;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #4236

## Summary of Changes
As soon as the decent phase is started the EFOB and FUEL PRED get dashed out. This happens because the FUEL PRED check is based on the cruiselevel, which will reset on decent phase. In this change the check for cruiselevel will be removed.

Additionally the fuel trip update in f-pln page was changed to a bit more logical and efficent way.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

1. Activate DevTools
1. Open Tools -> Behaviors
1. Switch to LocalVariables and monitor "A32NX_DESTINATION_FUEL_ON_BOARD"
1. Init and setup your flight like you always do
1. After FUEL PRED Page is setup and F-PLN / FUEL PRED page is active the "A32NX_DESTINATION_FUEL_ON_BOARD" should be updated as soon as there is fuel consumption (APU/ENGINE).
1. As soon as you're in flight and the F-PLN / FUEL PRED page is active the EFOB should match the "A32NX_DESTINATION_FUEL_ON_BOARD" value. (The EFOB will not change when still on ground).
1. Check if CRZ Flight Level on PROG page is dashed out.
1. When starting DECENT phase check if EFOB and FUEL PRED is still filled with information.  

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
