### PR TITLE
fix(sd): ISA deviation fix

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/SD/StatusArea/StatusArea.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/SD/StatusArea/StatusArea.tsx
@@ -31,7 +31,7 @@ export const StatusArea = () => {
     const sat = useArinc429Var(`L:A32NX_ADIRS_ADR_${airDataReferenceSource}_STATIC_AIR_TEMPERATURE`, 6000);
     const tat = useArinc429Var(`L:A32NX_ADIRS_ADR_${airDataReferenceSource}_TOTAL_AIR_TEMPERATURE`, 6000);
     const zp = useArinc429Var(`L:A32NX_ADIRS_ADR_${airDataReferenceSource}_ALTITUDE`, 6000);
-    const isa = sat.valueOr(0) + (zp.valueOr(0) / 500) - 15;
+    const isa = sat.valueOr(0) + (Math.min(36089, zp.valueOr(0)) / 500) - 15;
     const loadFactor = useArinc429Var(`L:A32NX_ADIRS_IR_${inertialReferenceSource}_BODY_NORMAL_ACC`, 300);
 
     const [loadFactorSet] = useState(new NXLogicConfirmNode(2));


### PR DESCRIPTION
## Summary of Changes
Tropopause is capped at 36089ft as per irl references.

## References
IRL pictures, ISA table

![image](https://user-images.githubusercontent.com/78908672/226206909-2b887881-70d3-45ca-be9f-9a3800a01c6d.png)


Discord username (if different from GitHub): mico#3145

## Testing instructions
Climb above FL360 and ISA deviation should be SAT+56 at all altitudes above FL360 (see ISA table above).

## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page