### PR TITLE
fix: placement of "5" and "10" scale on EWD N1 gauges (#7849)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,7 +7,6 @@
 
 ## 0.10.0
 
-1. [EWD] Fix placement of "5" and "10" scale on EWD N1 gauges - @flogross89 (Flo)
 1. [ADIRU] Implemented wind speed computation from TAS/GS/HDG - @tracernz (Mike)
 1. [FMGC] Show proper transition names and final approach slope from AAU1 - @tracernz (Mike)
 1. [FMGC] Don't accept blank input or / for hold distance - @tracernz (Mike)
@@ -61,6 +60,7 @@
 1. [ADIRU] Add baro correction setting to ADIRS - @mjuhe (Miquel Juhe)
 1. [FMGC] Fixed various bugs with thrust reduction and acceleration altitude - @tracernz (Mike)
 1. [FMGC] Change PERF GO AROUND page layout to H3 - @tracernz (Mike)
+1. [EWD] Fix placement of "5" and "10" scale on EWD N1 gauges - @flogross89 (Flo)
 
 ## 0.9.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## 0.10.0
 
+1. [EWD] Fix placement of "5" and "10" scale on EWD N1 gauges - @flogross89 (Flo)
 1. [ADIRU] Implemented wind speed computation from TAS/GS/HDG - @tracernz (Mike)
 1. [FMGC] Show proper transition names and final approach slope from AAU1 - @tracernz (Mike)
 1. [FMGC] Don't accept blank input or / for hold distance - @tracernz (Mike)

--- a/fbw-a32nx/src/systems/instruments/src/EWD/N1.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EWD/N1.tsx
@@ -352,7 +352,7 @@ export class N1 extends DisplayComponent<N1Props> {
                             useCentralAlignmentBaseline={false}
                             showValue
                             textNudgeY={17}
-                            textNudgeX={13}
+                            textNudgeX={8}
                             multiplierInner={0.9}
                         />
                         <GaugeMarkerComponent
@@ -416,8 +416,8 @@ export class N1 extends DisplayComponent<N1Props> {
                             textClass="Standard"
                             useCentralAlignmentBaseline={false}
                             showValue
-                            textNudgeY={16}
-                            textNudgeX={-14}
+                            textNudgeY={15}
+                            textNudgeX={-28}
                             multiplierInner={0.9}
                         />
                         <GaugeMarkerComponent


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #7849 

## Summary of Changes
Changed the position of 5 and 10 scales on EWD N1 gauges to reflect RL example given in issue

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before: 
![ewd-before](https://user-images.githubusercontent.com/119708186/222960017-b4fc21a7-6854-4929-8f53-644a2e1a20ad.PNG)

After:
![ewd-scale-fix](https://user-images.githubusercontent.com/63071941/226223272-b3614b82-b320-4d14-b3ad-5620d60aa079.png)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
(from #7251)
![reference](https://user-images.githubusercontent.com/119708186/222960261-b0853416-d9a9-46e0-b484-b50f97bcfc8e.png)
(negative N2, could that be a new bug?)

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->
My first PR here 👋 

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
floridude#7158

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Load aircraft, power on, turn up brightness on EWD

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
