### PR TITLE
fix(mcdu): show aircraft status / ident page on startup

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -78,6 +78,7 @@
 1. [MCDU] Implemented TUNE BBB FFF.FF, SPECIF NDB UNAVAIL messages - @tracernz (Mike)
 1. [F/CTL] Add ELAC 2 Emergency Powersupply - @lukecologne (lukecologne#1156)
 1. [HYD] New aerodynamic model for RAT turbine / Added A320 RAT anti stall valve system - @Crocket63 (crocket)
+1. [MCDU] Fix show aircraft status / ident page on startup - @revyn112 (Revyn112#1010)
 
 ## 0.9.0
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -274,7 +274,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this.onOvfy = () => this.scratchpad.addChar('Δ');
         this.onUnload = () => {};
 
-        CDUMenuPage.ShowPage(this);
+        CDUIdentPage.ShowPage(this);
 
         // If the consent is not set, show telex page
         const onlineFeaturesStatus = NXDataStore.get("CONFIG_ONLINE_FEATURES_STATUS", "UNKNOWN");


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
With this change the default page on startup of the aircraft will be set to the Aircraft Status (Ident) Page instead of the MCDU Menu Page.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
FCOM for aircraft equipped with FMS2 Honeywell Release 2 H3 and FG C14.
Ident.: DSC-22_20-50-10-25-00000581.0001001

> AIRCRAFT STATUS PAGE
>
> The system automatically displays this page at power up, but the pilot may also call it up by pressing the DATA key on the MCDU console.

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions

1. Power up the aircraft
2. Check if screens initialize like normally.
3. Check if MCDU initialize with Aircraft Status (Ident) Page.
4. Check if MCDU work like normally.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
