### PR TITLE
fix: Fixing localization build script for local builds

### DIFF
--- a/fbw-a32nx/src/localization/README.md
+++ b/fbw-a32nx/src/localization/README.md
@@ -61,8 +61,11 @@ folder of the flyPad or locPak folder.
 
 It checks the JSON syntax and writes new JSON files for each language to their respective target folder:
 
-flyPad: `sfbw-a32nx/src/localization/flypad`
-msfs locPak: `fbw-a32nx/src/localization/msfs` and `out/flybywire-aircraft-a320-neo/`
+flyPad: 
+`fbw-a32nx/src/localization/flypad`
+
+msfs locPak: 
+`fbw-a32nx/src/localization/msfs` and `out/flybywire-aircraft-a320-neo/`
 
 ## Update Source File
 
@@ -76,6 +79,10 @@ ANY CHANGES TO THE SOURCE FILES ON LOCALAZY WILL BE IMMEDIATELY BE VISIBLE IN EV
 THE A32NX - INDEPENDENT OF EDITION. 
 
 ### Using Localazy CLI
+                           
+Install the Localazy CLI via `npm install -g @localazy/cli` and then use the following commands to upload the source.
+
+[Localazy CLI Documentation](https://localazy.com/docs/cli/command-line-options)
 
 Use the option `-s` for a test run. Remove this option to actually upload the file.
 
@@ -83,16 +90,20 @@ The `deprecate` version of the configuration files will deprecate keys which are
 with caution.
 
 flyPad:
+
+`cd fbw-a32nx/src/localization`
+
 `localazy upload -w <writeKey> -c localazy-flypad-upload-config.json -d flypad`
-`localazy upload -w <writeKey> -c localazy-flypad-upload-deprecate-config.json -d flypad`
 
 MSFS locPak:
-`localazy upload -w <writeKey> -c localazy-flypad-upload-config.json -d flypad`
-`localazy upload -w <writeKey> -c localazy-flypad-upload-deprecate-config.json -d flypad`
+
+`cd fbw-a32nx/src/localization`
+
+`localazy upload -w <writeKey> -c localazy-locPak-upload-config.json -d msfs`
 
 The writeKey can be found in the Localazy project settings which are accessible by the Owners/Managers of the project.
 
-### Using en.json and Localazy Website
+### Using the English source file and Localazy Website
                                                
 #### flyPad:
 
@@ -114,6 +125,8 @@ The writeKey can be found in the Localazy project settings which are accessible 
 #### MSFS locPak:
          
 Same process as for flyPad but within the respective MSFS lokPak project.
+
+Localazy filename is `flybywire.locPak`.
 
 ### Manually via Localazy Website
 

--- a/fbw-a32nx/src/localization/build-locPak-translation.js
+++ b/fbw-a32nx/src/localization/build-locPak-translation.js
@@ -14,21 +14,23 @@ const localazyConfigFile = 'localazy-locPak-download-config.json';
 const workingDir = path.resolve('msfs');
 const langFilesPath = 'downloaded';
 const convertedFilesPath = '.';
-const outFolder = '../../out/flybywire-aircraft-a320-neo';
+const outFolder = '../../../out/flybywire-aircraft-a320-neo';
 
 let UPDATE_LOCAL = false;
 
-// Quick exit if run locally to not change the local files automatically.
-// Will then only run within a GitHub action or when started manually.
-// If run with option "local" then it will also update languages files locally.
+// Process command line arguments
 process.argv.forEach((val) => {
     if (val === 'local') {
         UPDATE_LOCAL = true;
     }
 });
+
+// Only download translations on GitHub actions to avoid changing local files
+// automatically when running locally.
+// If run with option "local" then it will also update languages files locally.
 if (!process.env.GITHUB_ACTIONS && !UPDATE_LOCAL) {
-    console.warn('Error: Only runs on github actions. Add "local" as parameter to run locally.');
-    // exit with '0' to show build as successful to not confuse devs
+    console.warn('Error: Downloading translations only happens on github actions. Add "local" as parameter to download locally.');
+    copyFilesToOutFolder();
     process.exit(0);
 }
 
@@ -76,16 +78,27 @@ function processFile(fileName) {
         return false;
     }
 
-    console.log(`Copying file ${fileName} to ${outFolder}`);
-    try {
-        fs.copyFileSync(path.join(workingDir, convertedFilesPath, `${fileName}`), path.join(outFolder, `${fileName}`));
-    } catch (e) {
-        console.error(`Error while copying file "${fileName}": ${e}`);
-        return false;
-    }
-
     console.log(`Successfully completed file: ${fileName}`);
     return true;
+}
+
+function copyFilesToOutFolder() {
+    console.log('Copying files to out folder...');
+    let dirEntries;
+    try {
+        dirEntries = fs.readdirSync(path.join(workingDir, convertedFilesPath), { withFileTypes: true });
+    } catch (e) {
+        console.error(`Error while reading folder "${path.join(workingDir, convertedFilesPath)}": ${e}`);
+        process.exit(1);
+    }
+    for (const dirent of dirEntries) {
+        if (dirent.isFile() && dirent.name.endsWith(fileExtension)) {
+            const src = path.join(workingDir, convertedFilesPath, dirent.name);
+            const dest = path.join(workingDir, outFolder, dirent.name);
+            console.debug(`Copying file ${src} to ${dest}`);
+            fs.copyFileSync(src, dest);
+        }
+    }
 }
 
 // Remove old files as otherwise disabled language files will remain in the folder and
@@ -124,7 +137,6 @@ exec(localazyCommand,
         });
 
         console.log('Files successfully downloaded. Processing...');
-        let result = true;
         let readdirSync;
         try {
             readdirSync = fs.readdirSync(path.join(workingDir, langFilesPath), { withFileTypes: true });
@@ -136,18 +148,10 @@ exec(localazyCommand,
             if (dirent.isFile() && dirent.name.endsWith(fileExtension)) {
                 const fileName = dirent.name;
                 if (!processFile(fileName)) {
-                    result = false;
+                    console.error(`Error while processing file "${dirent.name}"`);
                 }
             }
         }
 
-        console.log('Copying en-US.locPak to out folder');
-        try {
-            fs.copyFileSync(path.join(workingDir, convertedFilesPath, 'en-US.locPak'), path.join(outFolder, 'en-US.locPak'));
-        } catch (e) {
-            console.error(`Error while copying file "en-US.locPak": ${e}`);
-            result = false;
-        }
-
-        process.exit(result ? 0 : 1);
+        copyFilesToOutFolder();
     });

--- a/fbw-a32nx/src/localization/flypad/README.md
+++ b/fbw-a32nx/src/localization/flypad/README.md
@@ -9,10 +9,17 @@ The other files are generated automatically from Localazy and any changes will b
 Add new keys to the `en.json` file. 
 Make changes to default texts in the `en.json` file.
 
-Use one of the following commands to upload the file to Localazy:
+Change to the localization folder:
 
-localazy upload -w <writeKey> -c localazy-flypad-upload-config.json -d flypad
-localazy upload -w <writeKey> -c localazy-flypad-upload-deprecate-config.json -d flypad
+`cd fbw-a32nx/src/localization`
+
+Use one of the following commands to upload the file to Localazy (Localazy CLI npm package is required):
+
+`localazy upload -w <writeKey> -c localazy-flypad-upload-config.json -d flypad`
+
+CAUTION: Use this command if you want to deprecate keys which are not present in the source file.
+
+`localazy upload -w <writeKey> -c localazy-flypad-upload-deprecate-config.json -d flypad`
 
 Use the option `-s` for a test run. Remove this option to actually upload the file.
 

--- a/fbw-a32nx/src/localization/msfs/README.md
+++ b/fbw-a32nx/src/localization/msfs/README.md
@@ -8,11 +8,18 @@ The other files are generated automatically from Localazy and any changes will b
 
 Add new keys to the `en.json` file.
 Make changes to default texts in the `en.json` file.
+                               
+Change to the localization folder:
 
-Use one of the following commands to upload the file to Localazy:
+`cd fbw-a32nx/src/localization`
 
-localazy upload -w <writeKey> -c localazy-locPak-upload-config.json -d msfs
-localazy upload -w <writeKey> -c localazy-locPak-upload-deprecate-config.json -d msfs
+Use the following commands to upload the file to Localazy (Localazy CLI npm package is required):
+
+`localazy upload -w <writeKey> -c localazy-locPak-upload-config.json -d msfs`
+
+CAUTION: Use this command if you want to deprecate keys which are not present in the source file. 
+
+`localazy upload -w <writeKey> -c localazy-locPak-upload-deprecate-config.json -d msfs`
 
 Use the option `-s` for a test run. Remove this option to actually upload the file.
 


### PR DESCRIPTION
## Summary of Changes
#7862 changed localization build - unfortunately it did not copy the locPak files to the out folder when build locally as the localization build script only runs on GitHub actions (or with argument `local`).

This PR fixes this so that these files always get copied to the out folder no matter if build is done locally or on GitHub.

Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
Translations for flyPad and locPak (MSFS - e.g. A32NX loading tips, etc.) are possibly impacted. 
Both should still work when build via GitHub action or locally.  

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
