### PR TITLE
fix: Fix for nightly GitHub localization action

### DIFF
--- a/fbw-a32nx/src/localization/build-locPak-translation.js
+++ b/fbw-a32nx/src/localization/build-locPak-translation.js
@@ -82,6 +82,17 @@ function processFile(fileName) {
     return true;
 }
 
+// Create folder if it does not exist
+function createFolderIfNotExist(folderPath) {
+    if (!fs.existsSync(folderPath)) {
+        console.log(`Creating folder ${folderPath}...`);
+        fs.mkdirSync(folderPath, { recursive: true });
+        return;
+    }
+    console.log(`Folder ${folderPath} exists.`);
+}
+
+// Copy files to out folder
 function copyFilesToOutFolder() {
     console.log('Copying files to out folder...');
     let dirEntries;
@@ -91,11 +102,13 @@ function copyFilesToOutFolder() {
         console.error(`Error while reading folder "${path.join(workingDir, convertedFilesPath)}": ${e}`);
         process.exit(1);
     }
+    // make sure the out folder exists before copying files - this is important for the nightly Localazy GitHub action
+    createFolderIfNotExist(path.join(workingDir, outFolder));
     for (const dirent of dirEntries) {
         if (dirent.isFile() && dirent.name.endsWith(fileExtension)) {
             const src = path.join(workingDir, convertedFilesPath, dirent.name);
             const dest = path.join(workingDir, outFolder, dirent.name);
-            console.debug(`Copying file ${src} to ${dest}`);
+            console.log(`Copying file ${src} to ${dest}`);
             fs.copyFileSync(src, dest);
         }
     }


### PR DESCRIPTION
## Summary of Changes
The nightly workflow for localization changes does not have the out folder and therefore failed with the new version of the locPak build script.

This PR fixes this.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Cdr_Maverick#6475

## Testing instructions
none

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
