### PR TITLE
feat(bleed): Implement pressure sensors in bleed system

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -120,6 +120,7 @@
 1. [ND] Do not draw background when busses are not powered - @saschl (saschl#9432)
 1. [MODEL] Working windshield wipers - @tracernz (Mike)
 1. [LIGHTS] Redid all cockpit interior lighting and fixed exterior wing lights - @FinalLightNL (FinalLight#2113)
+1. [BLEED] Add pressure sensors to bleed system - @BlueberryKing (BlueberryKing#6641)
 
 ## 0.9.0
 

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@
 /fbw-a32nx/src/systems/instruments/src/EFB/dist
 /fbw-a32nx/src/systems/instruments/src/EFB/web/
 
+/fbw-a32nx/src/wasm/systems/a320_hydraulic_simulation_graphs/*.png
+/fbw-a32nx/src/wasm/systems/a320_pneumatic_simulation_graph_data/*.txt
+
 /fbw-a380x/*
 !/fbw-a380x/README.md
 !/fbw-a380x/docs/

--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -2673,11 +2673,6 @@ In the variables below, {number} should be replaced with one item in the set: { 
         - 1
         - 2
 
-- A32NX_PNEU_ENG_{number}_INTERMEDIATE_TRANSDUCER_PRESSURE:
-    - Pressure measured at the intermediate pressure transducer, -1 if no output
-    - psi
-    - Only on the A380X
-
 - A32NX_PNEU_ENG_{number}_TRANSFER_TRANSDUCER_PRESSURE
     - Pressure measured at the transfer pressure transducer, -1 if no output
     - psi

--- a/fbw-a32nx/docs/a320-simvars.md
+++ b/fbw-a32nx/docs/a320-simvars.md
@@ -2666,27 +2666,6 @@ In the variables below, {number} should be replaced with one item in the set: { 
         - 1
         - 2
 
-- A32NX_PNEU_ENG_{number}_TRANSFER_PRESSURE:
-    - Pressure between IP/HP valves but before the pressure regulating valve
-    - PSI
-    - {number}
-        - 1
-        - 2
-
-- A32NX_PNEU_ENG_{number}_PRECOOLER_INLET_PRESSURE:
-    - Pressure at the precooler inlet for engine bleed system
-    - PSI
-    - {number}
-        - 1
-        - 2
-
-- A32NX_PNEU_ENG_{number}_PRECOOLER_OUTLET_PRESSURE:
-    - Pressure at theh precooler outlet for engine bleed system
-    - PSI
-    - {number}
-        - 1
-        - 2
-
 - A32NX_PNEU_ENG_{number}_STARTER_CONTAINER_PRESSURE:
     - Pressure behind the starter valve of the engine
     - PSI
@@ -2697,21 +2676,19 @@ In the variables below, {number} should be replaced with one item in the set: { 
 - A32NX_PNEU_ENG_{number}_INTERMEDIATE_TRANSDUCER_PRESSURE:
     - Pressure measured at the intermediate pressure transducer, -1 if no output
     - psi
+    - Only on the A380X
 
 - A32NX_PNEU_ENG_{number}_TRANSFER_TRANSDUCER_PRESSURE
     - Pressure measured at the transfer pressure transducer, -1 if no output
     - psi
-    - Only on the A380X
 
 - A32NX_PNEU_ENG_{number}_REGULATED_TRANSDUCER_PRESSURE
     - Pressure measured at the regulated pressure transducer, -1 if no output
     - psi
-    - Only on the A380X
 
 - A32NX_PNEU_ENG_{number}_DIFFERENTIAL_TRANSDUCER_PRESSURE
     - Pressure measured at the differential pressure transducer, -1 if no output
     - psi
-    - Only on the A380X
 
 - A32NX_PNEU_ENG_{number}_IP_TEMPERATURE:
     - Temperature in intermediate pressure compression chamber

--- a/fbw-a32nx/src/systems/instruments/src/SD/Pages/Bleed/elements/EngineBleed.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Pages/Bleed/elements/EngineBleed.tsx
@@ -23,7 +23,7 @@ const EngineBleed: FC<EngineBleedProps> = ({ x, y, engine, sdacDatum, enginePRVa
     const [engineHPValveOpen] = useSimVar(`L:A32NX_PNEU_ENG_${engine}_HP_VALVE_OPEN`, 'bool', 500);
     const [precoolerOutletTemp] = useSimVar(`L:A32NX_PNEU_ENG_${engine}_PRECOOLER_OUTLET_TEMPERATURE`, 'celsius', 100);
     const precoolerOutletTempFive = Math.round(precoolerOutletTemp / 5) * 5;
-    const [precoolerInletPress] = useSimVar(`L:A32NX_PNEU_ENG_${engine}_PRECOOLER_INLET_PRESSURE`, 'psi', 10);
+    const [precoolerInletPress] = useSimVar(`L:A32NX_PNEU_ENG_${engine}_REGULATED_TRANSDUCER_PRESSURE`, 'psi', 10);
     const precoolerInletPressTwo = Math.round(precoolerInletPress / 2) * 2;
 
     const [wingAntiIceValveClosed] = useSimVar(`L:A32NX_PNEU_WING_ANTI_ICE_${engine}_VALVE_CLOSED`, 'bool', 500);

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/pneumatic.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/pneumatic.rs
@@ -1597,7 +1597,7 @@ mod tests {
             Self {
                 bleed_air_valve_signal: ApuBleedAirValveSignal::new_closed(),
                 bleed_air_pressure: Pressure::new::<psi>(14.7),
-                bleed_air_temperature: ThermodynamicTemperature::new::<degree_celsius>(15.),
+                bleed_air_temperature: ThermodynamicTemperature::new::<degree_celsius>(165.),
             }
         }
 
@@ -2336,6 +2336,7 @@ mod tests {
             .idle_eng1()
             .idle_eng2()
             .in_isa_atmosphere(alt)
+            .set_bleed_air_running()
             .cross_bleed_valve_selector_knob(CrossBleedValveSelectorMode::Auto)
             .both_packs_auto();
 
@@ -2363,10 +2364,6 @@ mod tests {
 
         for i in 1..6000 {
             time_points.push(i as f64 * 16.);
-
-            if i == 2000 {
-                test_bed = test_bed.toga_eng1().toga_eng2();
-            }
 
             high_pressures.push(test_bed.hp_pressure(1).get::<psi>());
             intermediate_pressures.push(test_bed.ip_pressure(1).get::<psi>());

--- a/fbw-a32nx/src/wasm/systems/a320_systems/src/pneumatic/wing_anti_ice.rs
+++ b/fbw-a32nx/src/wasm/systems/a320_systems/src/pneumatic/wing_anti_ice.rs
@@ -325,7 +325,7 @@ pub struct WingAntiIceSystem {
 impl WingAntiIceSystem {
     const WAI_MIN_PRESSURE: f64 = 1.; //BAR
     const WAI_MAX_PRESSURE: f64 = 2.1; //BAR
-    const WAI_EXHAUST_SPEED: f64 = 0.1175; // Regulate wing_anti_ice_tweak_exhaust
+    const WAI_EXHAUST_SPEED: f64 = 0.1285; // Regulate wing_anti_ice_tweak_exhaust
     const WAI_VALVE_TRANSFER_SPEED: f64 = 1.3; // Regulate wing_anti_ice_tweak_time_to_open
 
     // Each WAI duct is made of

--- a/fbw-a380x/docs/a380-simvars.md
+++ b/fbw-a380x/docs/a380-simvars.md
@@ -5,6 +5,7 @@
 - [A380 Local SimVars](#a380-local-simvars)
   - [Air Conditioning / Pressurisation / Ventilation ATA21](#air-conditioning-pressurisation-ventilation-ata-21)
   - [Indicating/Recording ATA 31](#indicating-recording-ata-31)
+  - [Bleed Air ATA 36](#bleed-air-ata-36)
   - [Integrated Modular Avionics ATA 42](#integrated-modular-avionics-ata-42)
 
 ## Air Conditioning Pressurisation Ventilation ATA 21
@@ -140,6 +141,12 @@
 - A32NX_CDS_CAN_BUS_2_2
   - ArincWord852<>
   - Second CAN bus of the CDS on the first officer's side
+
+## Bleed Air ATA 36
+
+- A32NX_PNEU_ENG_{number}_INTERMEDIATE_TRANSDUCER_PRESSURE
+  - Psi
+  - Pressure measured at the intermediate pressure transducer at engine {number}, -1 if no output
 
 ## Integrated Modular Avionics ATA 42
 

--- a/fbw-common/src/wasm/systems/systems/src/apu/mod.rs
+++ b/fbw-common/src/wasm/systems/systems/src/apu/mod.rs
@@ -238,7 +238,7 @@ impl<T: ApuGenerator, U: ApuStartMotor> ControllerSignal<TargetPressureTemperatu
         self.turbine.as_ref().map(|s| {
             TargetPressureTemperatureSignal::new(
                 s.bleed_air_pressure(),
-                ThermodynamicTemperature::new::<degree_celsius>(390.),
+                ThermodynamicTemperature::new::<degree_celsius>(165.),
             )
         })
     }


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #7953

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR introduces pressure sensors as components in the bleed system. The BMC reads pressure values from those sensors where needed instead of accessing the physical pressure computed by the simulation. In the future, these components will also be subject to failures.

The pressure regulation setpoints and APU bleed air temperature output have also been adjusted to match real life more closely.

For now, very few visible changes are expected. One of the notable ones is that the bleed pressure indication on the BLEED SD page should properly go to 0 when there is no pressure difference to the atmospheric pressure.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
The usual stuff

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BlueberryKing#6641

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Start cold & dark
- Turn on APU and APU bleed, make sure pressure shown on the BLEED SD page is sensible (20-30psi)
- Start an engine, make sure it's providing around 50 psi after starting. It might creep up rather slowly to 50 psi.
- Start the second engine, after the start, the pressure of both engines should settle around 42 psi.
- Fly around, make sure pressures and temperatures stay in the green through a range of thrust settings and altitudes.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
