### PR TITLE
feat: aft fuselage flex on bigger planes

### DIFF
--- a/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/hydraulic/mod.rs
@@ -1966,6 +1966,18 @@ impl A380Hydraulic {
         self.yellow_circuit.reservoir()
     }
 
+    pub fn left_elevator_aero_torques(&self) -> (Torque, Torque) {
+        self.left_elevator.aerodynamic_torques_outter_inner()
+    }
+
+    pub fn right_elevator_aero_torques(&self) -> (Torque, Torque) {
+        self.right_elevator.aerodynamic_torques_outter_inner()
+    }
+
+    pub fn up_down_rudder_aero_torques(&self) -> (Torque, Torque) {
+        self.rudder.aerodynamic_torques_up_down()
+    }
+
     #[cfg(test)]
     fn nose_wheel_steering_pin_is_inserted(&self) -> bool {
         self.pushback_tug.is_nose_wheel_steering_pin_inserted()
@@ -5927,7 +5939,6 @@ struct ElevatorAssembly {
     hydraulic_assemblies: [HydraulicLinearActuatorAssembly<2>; 2],
 
     position_out_id: VariableIdentifier,
-
     position_in_id: VariableIdentifier,
 
     positions: [Ratio; 2],
@@ -5961,6 +5972,7 @@ impl ElevatorAssembly {
                     context.get_identifier("HYD_ELEV_RIGHT_INWARD_DEFLECTION".to_owned())
                 }
             },
+
             positions: [Ratio::new::<ratio>(0.); 2],
             aerodynamic_models: [aerodynamic_model_outter, aerodynamic_model_inner],
         }
@@ -5985,6 +5997,7 @@ impl ElevatorAssembly {
         for idx in 0..2 {
             self.aerodynamic_models[idx]
                 .update_body(context, self.hydraulic_assemblies[idx].body());
+
             self.hydraulic_assemblies[idx].update(
                 context,
                 elevator_controllers[idx],
@@ -5996,6 +6009,14 @@ impl ElevatorAssembly {
 
             self.positions[idx] = self.hydraulic_assemblies[idx].position_normalized();
         }
+    }
+
+    // Returns aerodynamic torques for (outter,inner) control surfaces
+    fn aerodynamic_torques_outter_inner(&self) -> (Torque, Torque) {
+        (
+            self.hydraulic_assemblies[0].aerodynamic_torque(),
+            self.hydraulic_assemblies[1].aerodynamic_torque(),
+        )
     }
 }
 impl SimulationElement for ElevatorAssembly {
@@ -6089,6 +6110,14 @@ impl RudderAssembly {
 
             self.positions[idx] = self.hydraulic_assemblies[idx].position_normalized();
         }
+    }
+
+    // Returns aerodynamic torques for (upper,lower) control surfaces
+    fn aerodynamic_torques_up_down(&self) -> (Torque, Torque) {
+        (
+            self.hydraulic_assemblies[0].aerodynamic_torque(),
+            self.hydraulic_assemblies[1].aerodynamic_torque(),
+        )
     }
 }
 impl SimulationElement for RudderAssembly {

--- a/fbw-a380x/src/wasm/systems/a380_systems/src/lib.rs
+++ b/fbw-a380x/src/wasm/systems/a380_systems/src/lib.rs
@@ -253,7 +253,14 @@ impl Aircraft for A380 {
         );
 
         self.engines_flex_physics.update(context);
-        self.elevators_flex_physics.update(context);
+        self.elevators_flex_physics.update(
+            context,
+            [
+                self.hydraulic.left_elevator_aero_torques(),
+                self.hydraulic.right_elevator_aero_torques(),
+            ],
+            self.hydraulic.up_down_rudder_aero_torques(),
+        );
         self.cds.update();
 
         self.egpwc.update(&self.adirs, self.lgcius.lgciu1());


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

Adds flexible fuselage on bigger planes (changes that I forgot to push in previous elevator flex PR)

Elevators will have wiggle physics plus will bend through aerodynamic torques.
Aft fuselage will have wiggle physics plus will bend from rudder aerodynamic torque.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
