### PR TITLE
feat(fm): add default rnp 0.3 for ar procedures

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,10 @@
 <!-- Use the following format below -->
 <!--  1. [Changed Area] Title of changes - @github username (Name)  -->
 
+## 0.11.0
+
+1. [FMS] Add a default RNP of 0.3 for RNP AR procedure legs - @tracernz (Mike)
+
 ## 0.10.0
 
 1. [PFD] Corrected low VLS near max flight level - @lukecologne (luke)

--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/LegsProcedure.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/LegsProcedure.ts
@@ -249,6 +249,7 @@ export class LegsProcedure {
                   mappedLeg.additionalData.thetaTrue = A32NX_Util.magneticToTrue(currentLeg.theta, magCorrection);
                   mappedLeg.additionalData.annotation = currentAnnotation;
                   mappedLeg.additionalData.verticalAngle = currentLeg.verticalAngle ? currentLeg.verticalAngle - 360 : undefined;
+                  mappedLeg.additionalData.rnp = currentLeg.rnp;
               }
 
               this._currentIndex++;

--- a/fbw-a32nx/src/systems/fmgc/src/navigation/RequiredPerformance.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/navigation/RequiredPerformance.ts
@@ -15,6 +15,8 @@ const rnpDefaults: Record<FlightArea, number> = {
     [FlightArea.NonPrecisionApproach]: 0.5,
 };
 
+// FIXME RNP-related scratchpad messages
+
 export class RequiredPerformance {
     activeRnp: number | undefined;
 
@@ -43,6 +45,17 @@ export class RequiredPerformance {
     private updateAutoRnp(): void {
         if (this.manualRnp) {
             return;
+        }
+
+        const plan = this.flightPlanManager.activeFlightPlan;
+        if (plan && plan.activeWaypoint) {
+            const legRnp = plan.activeWaypoint.additionalData.rnp;
+            if (legRnp !== undefined) {
+                if (legRnp !== this.activeRnp) {
+                    this.setActiveRnp(legRnp);
+                }
+                return;
+            }
         }
 
         const area = this.flightPlanManager.activeArea;

--- a/fbw-a32nx/src/systems/fmgc/src/types/fstypes/FSTypes.d.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/types/fstypes/FSTypes.d.ts
@@ -118,11 +118,11 @@ declare global {
 
         namedFrequencies: any[];
 
-        departures: any[];
+        departures: RawDeparture[];
 
         approaches: RawApproach[];
 
-        arrivals: any[];
+        arrivals: RawArrival[];
 
         runways: any[];
 
@@ -195,6 +195,8 @@ declare global {
         originIcao: string;
         // distance to originIcao in metres
         rho: number;
+        /** Leg RNP, added by RawDataMapper for AR/SAAR procs as MSFS does not have RNP data */
+        rnp?: number;
         // knots
         speedRestriction: number;
         // heading to originIcao, megnetic unless trueDegrees is true?
@@ -266,6 +268,8 @@ declare global {
 
     interface RawRunwayTransition {
         legs: RawProcedureLeg[];
+        /** Added by RawDataMapper */
+        name?: string;
         runwayDesignation: RunwayDesignatorChar;
         runwayNumber: number;
         __Type: 'JS_RunwayTransition';


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
MSFS does not give us RNP data. This patch adds a default RNP of 0.3 for RNP AR procedures so we get correct L/DEV indications etc.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Fly an RNP AR SID and make sure default RNP is 0.3 (PROG page) and L/DEV shows on the PFD during the departure. Do the same for an RNP AR approach. Make sure no L/DEV higher RNP for non-AR/SAAR procedures.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
