### PR TITLE
fix(sd): fuel xfr valve amber logic

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,7 @@
 1. [FMS] Implement vertical navigation functions - @BlueberryKing (BlueberryKing)
 1. [EFB] Added pause at T/D function - @2hwk (2Cas#1022)
 1. [FMS] Add a default RNP of 0.3 for RNP AR procedure legs - @tracernz (Mike)
+1. [SD] Corrected fuel transfer valve amber logic - @tracernz (Mike)
 
 ## 0.10.0
 

--- a/fbw-a32nx/src/systems/instruments/src/SD/Pages/Fuel/Fuel.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Pages/Fuel/Fuel.tsx
@@ -421,7 +421,7 @@ const CentreToInnerTransfer: FC<CentreToInnerTransferProps> = ({ side, centreTan
         const fault = transferValveFullyOpen && transferValveFullyClosed; // FIXME also data valid, or neither state for >= 6 seconds
 
         const amber = !fault && (
-            (transferValveFullyClosed && !(!modeSelectManual && (!centreTankLowLevel || onGround) && transferValveSwitch > 0 && autoShutoffRequired))
+            (transferValveFullyClosed && (!modeSelectManual && transferValveSwitch > 0 && !autoShutoffRequired))
             || (!transferValveFullyClosed && (transferValveSwitch === 0 || (!modeSelectManual && autoShutoffRequired)))
         );
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #7968

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fix amber logic for centre tank xfr valves.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Spawn in the air with centre tanks empty. Ensure centre transfer valves are green when closed in auto and manual transfer mode.
![image](https://github.com/flybywiresim/a32nx/assets/9995998/621e5c3f-5c93-4a39-aa22-ed537e2ebdb2)


<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
