### PR TITLE
feat(sd/ewd): improve visual accuracy for static components

### DIFF
--- a/fbw-a32nx/src/systems/instruments/src/Common/definitions.scss
+++ b/fbw-a32nx/src/systems/instruments/src/Common/definitions.scss
@@ -8,8 +8,6 @@ $font-size-title: 24px;
 
 $display-white: #ffffff;
 $display-grey: #787878;
-$display-dark-grey: #b3b3b3;
-$display-light-grey: lightgray;
 $display-amber: #e68000;
 $display-cyan: #00ffff;
 $display-green: #00ff00;

--- a/fbw-a32nx/src/systems/instruments/src/EWD/EWD.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EWD/EWD.tsx
@@ -35,10 +35,10 @@ export class EwdComponent extends DisplayComponent<EwdProps> {
             <DisplayUnit bus={this.props.bus} normDmc={1} brightness={this.ewdPotentiometer} powered={this.acEssBus}>
                 <svg class="ewd-svg" version="1.1" viewBox="0 0 768 768" xmlns="http://www.w3.org/2000/svg">
                     <UpperDisplay bus={this.props.bus} />
-                    <line class="Separator" x1="4" y1="520" x2="444" y2="520" strokeLinecap="round" />
-                    <line class="Separator" x1="522" y1="520" x2="764" y2="520" strokeLinecap="round" />
+                    <line class="Separator" x1="4" y1="520" x2="444" y2="520" />
+                    <line class="Separator" x1="522" y1="520" x2="764" y2="520" />
                     <LowerLeftDisplay bus={this.props.bus} />
-                    <line class="Separator" x1="484" y1="540" x2="484" y2="730" strokeLinecap="round" />
+                    <line class="Separator" x1="484" y1="540" x2="484" y2="730" />
                     <LowerRightDisplay bus={this.props.bus} />
                 </svg>
             </DisplayUnit>

--- a/fbw-a32nx/src/systems/instruments/src/EWD/UpperDisplay.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/EWD/UpperDisplay.tsx
@@ -53,8 +53,8 @@ export class UpperDisplay extends DisplayComponent<UpperDisplayProps> {
                     <N2 bus={this.props.bus} engine={2} x={493} y={0} />
                     <text class="Large Center" x={386} y={33}>N2</text>
                     <text class="Medium Center Cyan" x={385} y={53}>%</text>
-                    <line class="Separator" x1={311} y1={37} x2={343} y2={28} strokeLinecap="round" />
-                    <line class="Separator" x1={424} y1={28} x2={456} y2={37} strokeLinecap="round" />
+                    <line class="Separator" x1={311} y1={37} x2={343} y2={28} />
+                    <line class="Separator" x1={424} y1={28} x2={456} y2={37} />
                 </Layer>
 
                 <Layer x={0} y={380}>
@@ -65,8 +65,8 @@ export class UpperDisplay extends DisplayComponent<UpperDisplayProps> {
                         {this.usingMetric.map((m) => (m ? 'KG' : 'LBS'))}
                         /H
                     </text>
-                    <line class="Separator" x1={311} y1={-11} x2={343} y2={-20} strokeLinecap="round" />
-                    <line class="Separator" x1={424} y1={-20} x2={456} y2={-11} strokeLinecap="round" />
+                    <line class="Separator" x1={311} y1={-11} x2={343} y2={-20} />
+                    <line class="Separator" x1={424} y1={-20} x2={456} y2={-11} />
                 </Layer>
 
                 <FOB bus={this.props.bus} x={40} y={490} metric={this.usingMetric} />

--- a/fbw-a32nx/src/systems/instruments/src/EWD/style.scss
+++ b/fbw-a32nx/src/systems/instruments/src/EWD/style.scss
@@ -214,8 +214,7 @@ animation: pulsingS 1s step-end infinite;
 
     .LightGreyBox {
         stroke: none;
-        fill: $display-light-grey;
-        opacity: 0.2
+        fill: $display-grey;
     }
 
     .SlatsSmallWhite, .FlapsSmallWhite {

--- a/fbw-a32nx/src/systems/instruments/src/EWD/style.scss
+++ b/fbw-a32nx/src/systems/instruments/src/EWD/style.scss
@@ -114,9 +114,10 @@ animation: pulsingS 1s step-end infinite;
     }
 
     .Separator {
-      stroke: $display-light-grey;
+      stroke: $display-grey;
       stroke-width: 4;
       fill: none;
+      stroke-linecap: round;
     }
 
     .AmberLine {

--- a/fbw-a32nx/src/systems/instruments/src/MsfsAvionicsCommon/definitions.scss
+++ b/fbw-a32nx/src/systems/instruments/src/MsfsAvionicsCommon/definitions.scss
@@ -8,8 +8,6 @@ $font-size-title: 24px;
 
 $display-white: #ffffff;
 $display-grey: #787878;
-$display-dark-grey: #b3b3b3;
-$display-light-grey: lightgray;
 $display-amber: #e68000;
 $display-cyan: #00ffff;
 $display-green: #00ff00;

--- a/fbw-a32nx/src/systems/instruments/src/NDv2/FmMessages.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/NDv2/FmMessages.tsx
@@ -91,7 +91,7 @@ export class FmMessages extends DisplayComponent<FmMessagesProps> {
                     stroke="none"
                 />
 
-                <rect ref={this.boxRef} x={0} y={0} width={440} height={27} class="White BackgroundFill" stroke-width={1.75} />
+                <rect ref={this.boxRef} x={0} y={0} width={440} height={27} class="Grey BackgroundFill" stroke-width={1.75} />
 
                 { /* the text message is offset from centre on the real one...
                  guess by the width of the multiple message arrow... */ }

--- a/fbw-a32nx/src/systems/instruments/src/NDv2/TcasWxrMessages.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/NDv2/TcasWxrMessages.tsx
@@ -64,7 +64,7 @@ export class TcasWxrMessages extends DisplayComponent<TcasWXMessagesProps> {
                     y={0}
                     width={440}
                     height={27}
-                    class="White BackgroundFill"
+                    class="Grey BackgroundFill"
                     stroke-width={1.75}
                 />
 

--- a/fbw-a32nx/src/systems/instruments/src/PFD/shared/definitions.scss
+++ b/fbw-a32nx/src/systems/instruments/src/PFD/shared/definitions.scss
@@ -8,8 +8,6 @@ $font-size-title: 24px;
 
 $display-white: #ffffff;
 $display-grey: #787878;
-$display-dark-grey: #b3b3b3;
-$display-light-grey: lightgray;
 $display-amber: #e68000;
 $display-cyan: #00ffff;
 $display-green: #00ff00;

--- a/fbw-a32nx/src/systems/instruments/src/SD/Common/definitions.scss
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Common/definitions.scss
@@ -8,8 +8,6 @@ $font-size-title: 24px;
 
 $display-white: #ffffff;
 $display-grey: #787878;
-$display-dark-grey: #b3b3b3;
-$display-light-grey: lightgray;
 $display-amber: #e68000;
 $display-cyan: #00ffff;
 $display-green: #00ff00;

--- a/fbw-a32nx/src/systems/instruments/src/SD/Pages/Apu/Apu.scss
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Pages/Apu/Apu.scss
@@ -2,7 +2,7 @@
 
 #main-apu {
     .Box {
-        stroke: $display-light-grey;
+        stroke: $display-grey;
         fill: none;
         stroke-width: 2.5px;
     }
@@ -71,7 +71,7 @@
         }
 
         &.Grey {
-            stroke: $display-light-grey;
+            stroke: $display-grey;
         }
 
         &.Amber {

--- a/fbw-a32nx/src/systems/instruments/src/SD/Pages/Bleed/Bleed.scss
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Pages/Bleed/Bleed.scss
@@ -62,7 +62,7 @@
 
     .GreyStroke {
         fill: none;
-        stroke: $display-light-grey;
+        stroke: $display-grey;
     }
 
     .WhiteStroke {

--- a/fbw-a32nx/src/systems/instruments/src/SD/Pages/Bleed/elements/EngineBleed.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Pages/Bleed/elements/EngineBleed.tsx
@@ -42,10 +42,10 @@ const EngineBleed: FC<EngineBleedProps> = ({ x, y, engine, sdacDatum, enginePRVa
         <g id={`bleed-${engine}`}>
 
             {/* Air Cond shape and labels */}
-            <path className="GreyStroke Stroke1" d={`M ${x},${y} l -47,10 l 0,123 l 14,0`} />
-            <path className="GreyStroke Stroke1" d={`M ${x - 47},${y + 64} l 14,0`} />
-            <path className="GreyStroke Stroke1" d={`M ${x},${y} l +47,10 l 0,123 l -14,0`} />
-            <path className="GreyStroke Stroke1" d={`M ${x + 47},${y + 64} l -14,0`} />
+            <path className="GreyStroke Stroke2" d={`M ${x},${y} l -47,10 l 0,123 l 14,0`} />
+            <path className="GreyStroke Stroke2" d={`M ${x - 47},${y + 64} l 14,0`} />
+            <path className="GreyStroke Stroke2" d={`M ${x},${y} l +47,10 l 0,123 l -14,0`} />
+            <path className="GreyStroke Stroke2" d={`M ${x + 47},${y + 64} l -14,0`} />
             <text x={x - 56} y={y + 64} className="White Standard End">C</text>
             <text x={x + 58} y={y + 64} className="White Standard">H</text>
             <text x={x - 55} y={y + 132} className="White Standard End">LO</text>

--- a/fbw-a32nx/src/systems/instruments/src/SD/Pages/Door/Door.scss
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Pages/Door/Door.scss
@@ -16,7 +16,7 @@
 
     .MainShape {
         fill: transparent;
-        stroke: $display-light-grey;
+        stroke: $display-grey;
         stroke-width: 2;
     }
 

--- a/fbw-a32nx/src/systems/instruments/src/SD/Pages/Elec/Elec.scss
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Pages/Elec/Elec.scss
@@ -3,13 +3,13 @@
 
 #main-elec {
   .Box {
-    stroke: #EEEEEE;
+    stroke: $display-grey;
     fill: none;
     stroke-width: 2.5px;
   }
 
   path {
-    stroke: #EEEEEE;
+    stroke: $display-white;
     stroke-width: 2.25px;
     stroke-linecap: square;
     stroke-linejoin: miter;
@@ -24,11 +24,11 @@
   }
 
   rect.Bus {
-      fill: #636363;
+      fill: $display-grey;
   }
 
   text {
-    fill: #EEEEEE;
+    fill: $display-white;
     font-size: 19px;
 
     &.ExtraLarge {

--- a/fbw-a32nx/src/systems/instruments/src/SD/Pages/Fuel/Fuel.scss
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Pages/Fuel/Fuel.scss
@@ -42,7 +42,7 @@
   }
 
   .EngineLine {
-    stroke: $display-white;
+    stroke: $display-grey;
     stroke-width: 2.5;
   }
 
@@ -54,7 +54,7 @@
   }
 
   .ThickShape {
-    stroke: $display-light-grey;
+    stroke: $display-grey;
     stroke-width: 2.5;
     fill: none;
   }

--- a/fbw-a32nx/src/systems/instruments/src/SD/Pages/Status/Status.scss
+++ b/fbw-a32nx/src/systems/instruments/src/SD/Pages/Status/Status.scss
@@ -100,10 +100,9 @@
     }
 
     .Separator {
-        stroke: $display-light-grey;
+        stroke: $display-grey;
         stroke-width: 3;
         fill: none;
-        stroke-linecap: "round"
+        stroke-linecap: round;
     }
-
-    }
+}

--- a/fbw-a32nx/src/systems/instruments/src/SD/StatusArea/StatusArea.scss
+++ b/fbw-a32nx/src/systems/instruments/src/SD/StatusArea/StatusArea.scss
@@ -1,6 +1,9 @@
+@import "../../MsfsAvionicsCommon/definitions";
+
 .sd-status-line {
-  stroke: white;
-  stroke-width: 3;
+  stroke: $display-grey;
+  stroke-width: 4;
+  stroke-linecap: round;
 }
 
 #StatusArea {

--- a/fbw-a32nx/src/systems/instruments/src/SD/StatusArea/StatusArea.tsx
+++ b/fbw-a32nx/src/systems/instruments/src/SD/StatusArea/StatusArea.tsx
@@ -114,9 +114,9 @@ export const StatusArea = () => {
         <div id="StatusArea">
             <svg viewBox="0 0 600 150" xmlns="http://www.w3.org/2000/svg">
                 <g>
-                    <path className="sd-status-line" d="M 0   40 h 600" />
-                    <path className="sd-status-line" d="M 200 40 v 125" />
-                    <path className="sd-status-line" d="M 400 40 v 125" />
+                    <path className="sd-status-line" d="M 4   40 h 592" />
+                    <path className="sd-status-line" d="M 200 40 v 75" />
+                    <path className="sd-status-line" d="M 400 40 v 75" />
 
                     {/* Temperatures */}
 


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
 Fixes #8036 

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
This PR primarily aims to improve the accuracy of static components (lines, boxes, aircraft shapes etc.) on the SD, EWD and ND. See the screenshots and the mentioned issue for a list of changes. Also note that there may be other inaccuracies on some of the affected SD pages,
but only the issue with grey lines is addressed here.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
| Before  | After  |
|---|---|
| ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/08903676-a327-4118-ab59-8d0e3918e57c) | ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/fbe63251-b230-4ef2-af75-d2ba5d203fca)  |
| ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/2e29271a-81c7-43ed-b42a-46cfe5bb2848) | ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/49da697b-93e6-498c-b0ce-98a585739a7d) |
| ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/3642106a-4d5f-410d-b73b-719c5f9f96bb)  | ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/68b621c9-d4bc-4253-8d56-e014d9c8180b)  |
| ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/1e6a2f89-de20-40f1-970b-9ccbcaff8700)  | ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/5d66363a-725f-4ef8-b7ff-32a536c6a2b4)  |
| ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/8bf1c3b8-63a9-4ff4-bd37-a1ba25d2c5b4)  | ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/0122115f-ca78-4ace-8c97-a538a7c40232)  |
| ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/264494fb-4050-4312-a83f-745181f3edea)  | ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/cc2d42c0-c15b-4c48-9bfe-3d7a806b42fa)  |
| ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/c46669cc-92d7-45a2-9548-186acfdf4340)  | ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/fd670dbb-df9f-41b9-92e8-6656daeab37a)  |
| ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/88e1015b-3224-462d-9dfe-338cbae95d6a) | ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/10475282-981d-4cef-8ac7-444e50c2a5a0) |
| ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/cf1150c8-bbdf-4055-b25b-c682ba373350) | ![grafik](https://github.com/flybywiresim/a32nx/assets/39596827/c955a0c5-7f74-44d3-8a32-3d2ea0656720) |


## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
