### PR TITLE
fix(eis): show constraint circles in preflight phase

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/efis/EfisSymbols.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/efis/EfisSymbols.ts
@@ -383,7 +383,7 @@ export class EfisSymbols {
                         if (!isSelectedVerticalModeActive && shouldShowConstraintCircleInPhase(flightPhase, wp)) {
                             type |= NdSymbolTypeFlags.Constraint;
 
-                            const predictionAtWaypoint = waypointPredictions.get(i);
+                            const predictionAtWaypoint = waypointPredictions?.get(i);
                             if (predictionAtWaypoint?.isAltitudeConstraintMet) {
                                 type |= NdSymbolTypeFlags.MagentaColor;
                             } else if (predictionAtWaypoint) {

--- a/fbw-a32nx/src/systems/fmgc/src/efis/EfisSymbols.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/efis/EfisSymbols.ts
@@ -315,6 +315,7 @@ export class EfisSymbols {
             }
 
             const isInLatAutoControl = this.guidanceController.vnavDriver.isLatAutoControlActive();
+            const isNavArmedWithIntercept = this.guidanceController.vnavDriver.isLatAutoControlArmedWithIntercept();
             const waypointPredictions = this.guidanceController.vnavDriver.mcduProfile?.waypointPredictions;
             const isSelectedVerticalModeActive = this.guidanceController.vnavDriver.isSelectedVerticalModeActive();
             const flightPhase = getFlightPhaseManager().phase;
@@ -378,7 +379,7 @@ export class EfisSymbols {
                         direction = wp.additionalData.course;
                     }
 
-                    if (isInLatAutoControl && !isFromWp && wp.legAltitudeDescription > 0 && wp.legAltitudeDescription < 6) {
+                    if ((isInLatAutoControl || isNavArmedWithIntercept) && !isFromWp && wp.legAltitudeDescription > 0 && wp.legAltitudeDescription < 6) {
                         if (!isSelectedVerticalModeActive && shouldShowConstraintCircleInPhase(flightPhase, wp)) {
                             type |= NdSymbolTypeFlags.Constraint;
 
@@ -596,7 +597,7 @@ export class EfisSymbols {
 }
 
 const shouldShowConstraintCircleInPhase = (phase: FmgcFlightPhase, waypoint: WayPoint) => (
-    (phase === FmgcFlightPhase.Takeoff || phase === FmgcFlightPhase.Climb) && waypoint.additionalData.constraintType === WaypointConstraintType.CLB
+    (phase <= FmgcFlightPhase.Climb) && waypoint.additionalData.constraintType === WaypointConstraintType.CLB
 ) || (
     (phase === FmgcFlightPhase.Cruise || phase === FmgcFlightPhase.Descent || phase === FmgcFlightPhase.Approach) && waypoint.additionalData.constraintType === WaypointConstraintType.DES
 );

--- a/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VnavDriver.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/guidance/vnav/VnavDriver.ts
@@ -4,7 +4,7 @@
 import { GuidanceController } from '@fmgc/guidance/GuidanceController';
 import { AtmosphericConditions } from '@fmgc/guidance/vnav/AtmosphericConditions';
 import { FlightPlanManager } from '@fmgc/flightplanning/FlightPlanManager';
-import { VerticalMode, LateralMode } from '@shared/autopilot';
+import { VerticalMode, LateralMode, isArmed, ArmedLateralMode } from '@shared/autopilot';
 import { VerticalProfileComputationParameters, VerticalProfileComputationParametersObserver } from '@fmgc/guidance/vnav/VerticalProfileComputationParameters';
 import { VnavConfig } from '@fmgc/guidance/vnav/VnavConfig';
 import { McduSpeedProfile, ManagedSpeedType } from '@fmgc/guidance/vnav/climb/SpeedProfile';
@@ -159,6 +159,13 @@ export class VnavDriver implements GuidanceComponent {
             || fcuLateralMode === LateralMode.LOC_CPT
             || fcuLateralMode === LateralMode.LOC_TRACK
             || fcuLateralMode === LateralMode.RWY;
+    }
+
+    isLatAutoControlArmedWithIntercept(): boolean {
+        const { fcuArmedLateralMode } = this.computationParametersObserver.get();
+
+        // FIXME: Figure out if intercept exists
+        return isArmed(fcuArmedLateralMode, ArmedLateralMode.NAV);
     }
 
     isSelectedVerticalModeActive(): boolean {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
#7080 introduced logic to hide magenta/amber constraint circles on the ND in certain flight phases. This also meant that no constraint circles showed up during preflight. This PR makes sure that constraint circles for climb constraints show up in the preflight phase.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
After the change
![](https://media.discordapp.net/attachments/754130199804772372/1114144066561646662/image.png?width=726&height=702)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->
![](https://cdn.discordapp.com/attachments/754130199804772372/1114046628224053358/image.png)

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BlueberryKing#6641

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Try a departure with an altitude constraint on it. Make sure there is an amber/magenta circle around the waypoint on the ND.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
