### PR TITLE
fix(fms): round lowest climb constraint

### DIFF
--- a/fbw-a32nx/src/systems/fmgc/src/flightplanning/ManagedFlightPlan.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/flightplanning/ManagedFlightPlan.ts
@@ -1903,7 +1903,7 @@ export class ManagedFlightPlan {
      * @returns true if a reduction occured
      */
     public reconcileThrustReductionWithConstraints(): boolean {
-        const lowestClimbConstraint = this.lowestClimbConstraint();
+        const lowestClimbConstraint = ManagedFlightPlan.round(this.lowestClimbConstraint(), 10);
         if (isFinite(lowestClimbConstraint) && this.thrustReductionAltitude > lowestClimbConstraint) {
             this.thrustReductionAltitudeDefault = this.thrustReductionAltitudeDefault !== undefined ? Math.min(this.thrustReductionAltitudeDefault, lowestClimbConstraint) : undefined;
             this.thrustReductionAltitudePilot = this.thrustReductionAltitudePilot !== undefined ? Math.min(this.thrustReductionAltitudePilot, lowestClimbConstraint) : undefined;
@@ -1918,7 +1918,7 @@ export class ManagedFlightPlan {
      * @returns true if a reduction occured
      */
     public reconcileAccelerationWithConstraints(): boolean {
-        const lowestClimbConstraint = this.lowestClimbConstraint();
+        const lowestClimbConstraint = ManagedFlightPlan.round(this.lowestClimbConstraint(), 10);
         if (isFinite(lowestClimbConstraint) && this.accelerationAltitude > lowestClimbConstraint) {
             this.accelerationAltitudeDefault = this.accelerationAltitudeDefault !== undefined ? Math.min(this.accelerationAltitudeDefault, lowestClimbConstraint) : undefined;
             this.accelerationAltitudePilot = this.accelerationAltitudePilot !== undefined ? Math.min(this.accelerationAltitudePilot, lowestClimbConstraint) : undefined;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #8057

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Fixes a rare bug where the "NEW ACC ALT-HHHH" repeatedly pops up when the lowest climb constraint and the acceleration- or thrust reduction altitude are the same.

This was essentially a floating point error, fixed by rounding the values involved in the comparison.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BlueberryKing#6641

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Try going through the reproduction steps in #8057, make sure the issue does not occur. Maybe also try a different airport to make sure there are no regressions.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
