### PR TITLE
fix(fm): ils auto-selection robustness

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -17,6 +17,7 @@
 1. [HYD] Added hydraulic reverser actuators - @Crocket63 (crocket)
 1. [EIS] Added > character to the font - @KiloEchoVictor (Kevin)
 1. [ND] Mask the map below the TCAS/WXR and FM messages - @tracernz (Mike)
+1. [FMS] Improved robustness of ILS selection - @tracernz (Mike)
 
 ## 0.10.0
 

--- a/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_SelectedNavaids.js
+++ b/fbw-a32nx/src/base/flybywire-aircraft-a320-neo/html_ui/Pages/VCockpit/Instruments/Airliners/FlyByWire_A320_Neo/CDU/A320_Neo_CDU_SelectedNavaids.js
@@ -53,7 +53,7 @@ class CDUSelectedNavaids {
         const selectedNavaids = mcdu.getSelectedNavaids();
 
         for (const [i, navaid] of selectedNavaids.entries()) {
-            if (navaid.frequency === null) {
+            if (navaid.frequency < 1) {
                 continue;
             }
 

--- a/fbw-a32nx/src/systems/fmgc/src/navigation/LandingSystemSelectionManager.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/navigation/LandingSystemSelectionManager.ts
@@ -70,11 +70,15 @@ export class LandingSystemSelectionManager {
                     await this.selectDepartureIls();
                 } else if (phase >= FmgcFlightPhase.Descent) {
                     await this.selectApproachIls();
-                } else if (this.pposValid) {
+                } else if (this.pposValid && phase >= FmgcFlightPhase.Cruise) {
                     const destination = this.fpm.getDestination(FlightPlans.Active);
                     if (destination && distanceTo(this.ppos, destination.infos.coordinates) <= LandingSystemSelectionManager.DESTINATION_TUNING_DISTANCE) {
                         await this.selectApproachIls();
+                    } else if (this._selectedIls !== null) {
+                        this.resetSelectedIls();
                     }
+                } else if (this._selectedIls !== null) {
+                    this.resetSelectedIls();
                 }
             } catch (e) {
                 console.error('Failed to select ILS', e);
@@ -117,8 +121,8 @@ export class LandingSystemSelectionManager {
         const airport = this.fpm.getDestination(FlightPlans.Active);
         const approach = this.fpm.getApproach(FlightPlans.Active);
 
-        if (this.isTunableApproach(approach?.approachType) && this.setIlsFromApproach(airport, approach, true)) {
-            return true;
+        if (this.isTunableApproach(approach?.approachType)) {
+            return this.setIlsFromApproach(airport, approach, true);
         }
 
         // if we got here there wasn't a suitable ILS

--- a/fbw-a32nx/src/systems/fmgc/src/navigation/NavaidTuner.ts
+++ b/fbw-a32nx/src/systems/fmgc/src/navigation/NavaidTuner.ts
@@ -386,7 +386,7 @@ export class NavaidTuner {
         for (const [i, mmr] of this.mmrTuningStatus.entries()) {
             const autoFacility = this.landingSystemSelectionManager.selectedIls ?? undefined;
             const autoCourse = this.landingSystemSelectionManager.selectedLocCourse;
-            if (!mmr.manual && mmr.facility?.icao !== autoFacility?.icao && autoCourse !== null) {
+            if (!mmr.manual && mmr.facility?.icao !== autoFacility?.icao && (autoCourse !== null || autoFacility === undefined)) {
                 mmr.databaseCourse = autoCourse;
                 mmr.databaseBackcourse = this.landingSystemSelectionManager.selectedApprBackcourse;
                 mmr.course = mmr.databaseCourse;


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Make ILS auto-selection more robust, in particular de-tuning when no longer needed. Also fixed a small bug where empty selected navaid lines could show up with a frequency of 0.0 only (the blank type changed on the TS side in a refactor, but was missed here in raw JS with no types).

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
Check that ILS auto-tuning works in a full flight at both ends. Check that switching from an ILS approach to an RNP approach de-selects the ILS.

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
