### PR TITLE
fix: remote mcdu not building properly

### DIFF
--- a/fbw-a32nx/src/systems/simbridge-client/build.js
+++ b/fbw-a32nx/src/systems/simbridge-client/build.js
@@ -25,7 +25,7 @@ esbuild.build({
     outfile: path.join(rootDir, outFile),
 
     format: 'iife',
-    globalName: 'SimBridgeClient'
+    globalName: 'SimBridgeClient',
 
     sourcemap: isProductionBuild ? 'linked' : undefined,
 

--- a/fbw-a32nx/src/systems/simbridge-client/build.js
+++ b/fbw-a32nx/src/systems/simbridge-client/build.js
@@ -25,6 +25,7 @@ esbuild.build({
     outfile: path.join(rootDir, outFile),
 
     format: 'iife',
+    globalName: 'SimBridgeClient'
 
     sourcemap: isProductionBuild ? 'linked' : undefined,
 


### PR DESCRIPTION
## Summary of Changes
Fixes remote mcdu not functioning because it isn't building (after #8073) 

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->
- Run SimBridge
- Load aircraft (cold & dark or in runway)
- Power aircraft
- Check Remote MCDU works 

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
